### PR TITLE
Add buttons to select only a single consequence category

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "stylelint-config-standard": "^17.0.0",
     "stylelint-config-styled-components": "^0.1.1",
     "stylelint-processor-styled-components": "^0.4.0",
+    "svg-inline-loader": "^0.8.0",
     "watch": "^1.0.2",
     "webpack": "^3.6.0",
     "webpack-bundle-analyzer": "^2.9.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -7,6 +7,7 @@
     "lib"
   ],
   "dependencies": {
+    "@fortawesome/fontawesome-free": "^5.3.1",
     "mousetrap": "^1.6.1",
     "polished": "^1.9.3",
     "prop-types": "^15.5.10",

--- a/packages/ui/src/ConsequenceCategoriesControl.js
+++ b/packages/ui/src/ConsequenceCategoriesControl.js
@@ -1,3 +1,4 @@
+import Check from 'svg-inline-loader!@fortawesome/fontawesome-free/svgs/solid/check.svg'
 import { darken, hideVisually, transparentize } from 'polished'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
@@ -41,18 +42,33 @@ const Button = styled.button`
   &:focus {
     box-shadow: 0 0 0 0.2em ${transparentize(0.5, '#ddd')};
   }
+
+  ::-moz-focus-inner {
+    border: 0;
+  }
+`
+
+const CheckboxIcon = styled.span`
+  display: inline-block;
+  box-sizing: border-box;
+  width: 14px;
+  height: 14px;
+  padding: 1px;
+  border-width: 1px;
+  margin: 0 0.7em;
+  border-color: #000;
+  border-radius: 3px;
+  border-style: solid;
+  font-size: 10px;
 `
 
 const Checkbox = styled.input.attrs({ type: 'checkbox' })`
   ${hideVisually()};
-`
 
-const CheckboxIcon = styled.span`
-  position: relative;
-  top: 1px;
-  left: 1px;
-  width: 1em;
-  padding: 0.375em 0.5em;
+  :focus + ${CheckboxIcon} {
+    border-color: #428bca;
+    box-shadow: 0 0 0 0.2em #428bca;
+  }
 `
 
 const CategoryWrapper = styled.span`
@@ -62,14 +78,6 @@ const CategoryWrapper = styled.span`
   border-color: ${props => props.borderColor};
   border-style: solid;
   border-width: 1px;
-  background: ${props =>
-    `linear-gradient(to right, ${props.backgroundColor}, ${
-      props.backgroundColor
-    } 2em, rgba(0, 0, 0, 0) 2em, rgba(0, 0, 0, 0))`};
-
-  &:focus-within {
-    box-shadow: ${props => `0 0 0 0.2em ${transparentize(0.5, props.borderColor)}`};
-  }
 
   &:first-child {
     border-top-left-radius: 0.5em;
@@ -83,7 +91,13 @@ const CategoryWrapper = styled.span`
 `
 
 const Label = styled.label`
+  display: inline-flex;
+  align-items: center;
   margin: 0; /* Override Bootstrap in gnomad_browser */
+  background: ${props =>
+    `linear-gradient(to right, ${props.backgroundColor}, ${
+      props.backgroundColor
+    } 2em, rgba(0, 0, 0, 0) 2em, rgba(0, 0, 0, 0))`};
   font-size: 14px;
   font-weight: normal; /* Override Bootstrap in gnomad_browser */
   user-select: none;
@@ -135,12 +149,11 @@ export class ConsequenceCategoriesControl extends Component {
     return (
       <div>
         {categories.map(category => (
-          <CategoryWrapper
-            key={category}
-            backgroundColor={transparentize(0.5, categoryColors[category])}
-            borderColor={categoryColors[category]}
-          >
-            <Label htmlFor={`${id}-${category}`}>
+          <CategoryWrapper key={category} borderColor={categoryColors[category]}>
+            <Label
+              htmlFor={`${id}-${category}`}
+              backgroundColor={transparentize(0.5, categoryColors[category])}
+            >
               <Checkbox
                 checked={categorySelections[category]}
                 id={`${id}-${category}`}
@@ -149,9 +162,9 @@ export class ConsequenceCategoriesControl extends Component {
               />
               <CheckboxIcon
                 aria-hidden
-                className={`fa ${
-                  categorySelections[category] ? 'fa-check-square-o' : 'fa-square-o'
-                }`}
+                dangerouslySetInnerHTML={{
+                  __html: categorySelections[category] ? Check : null,
+                }}
               />
               <LabelText>{categoryLabels[category]}</LabelText>
             </Label>

--- a/yarn.lock
+++ b/yarn.lock
@@ -38,6 +38,10 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
+"@fortawesome/fontawesome-free@^5.3.1":
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-5.3.1.tgz#5466b8f31c1f493a96754c1426c25796d0633dd9"
+
 "@types/async@2.0.45":
   version "2.0.45"
   resolved "https://registry.yarnpkg.com/@types/async/-/async-2.0.45.tgz#0cfe971d7ed5542695740338e0455c91078a0e83"
@@ -6430,7 +6434,7 @@ loader-runner@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.3.0.tgz#f482aea82d543e07921700d5a46ef26fdac6b8a2"
 
-loader-utils@^0.2.15, loader-utils@^0.2.16:
+loader-utils@^0.2.11, loader-utils@^0.2.15, loader-utils@^0.2.16:
   version "0.2.17"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-0.2.17.tgz#f86e6374d43205a6e6c60e9196f17c0299bfb348"
   dependencies:
@@ -9957,6 +9961,10 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
+simple-html-tokenizer@^0.1.1:
+  version "0.1.1"
+  resolved "http://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.1.1.tgz#05c2eec579ffffe145a030ac26cfea61b980fabe"
+
 sisteransi@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-0.1.1.tgz#5431447d5f7d1675aac667ccd0b865a4994cb3ce"
@@ -10682,6 +10690,14 @@ supports-color@^5.4.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   dependencies:
     has-flag "^3.0.0"
+
+svg-inline-loader@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/svg-inline-loader/-/svg-inline-loader-0.8.0.tgz#7e9d905d80d0b4e68d2df21afcd08ee9e9a3ea6e"
+  dependencies:
+    loader-utils "^0.2.11"
+    object-assign "^4.0.1"
+    simple-html-tokenizer "^0.1.1"
 
 svg-tags@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Switching from radio buttons to checkboxes for the consequence category filter made it more difficult to view variants of _only_ a single category. This adds buttons to select a category and unselect all other categories.

<img width="590" alt="screen shot 2018-09-26 at 4 18 05 pm" src="https://user-images.githubusercontent.com/1156625/46106842-c98d9b00-c1a7-11e8-87fd-126bce260c4f.png">


