### PR TITLE
Set Clinvar as optional for region

### DIFF
--- a/projects/gnomad/src/client/RegionPage/VariantsInRegion.js
+++ b/projects/gnomad/src/client/RegionPage/VariantsInRegion.js
@@ -21,7 +21,7 @@ import VariantTrack from '../VariantList/VariantTrack'
 
 class VariantsInRegion extends Component {
   static propTypes = {
-    clinvarVariants: PropTypes.arrayOf(PropTypes.object).isRequired,
+    clinvarVariants: PropTypes.arrayOf(PropTypes.object),
     datasetId: PropTypes.string.isRequired,
     region: PropTypes.shape({
       chrom: PropTypes.string.isRequired,
@@ -186,11 +186,13 @@ class VariantsInRegion extends Component {
 
     return (
       <div>
-        <ClinvarVariantTrack
-          selectedGnomadVariants={renderedVariants}
-          variants={clinvarVariants}
-          variantFilter={filter}
-        />
+        {clinvarVariants && (
+          <ClinvarVariantTrack
+            selectedGnomadVariants={renderedVariants}
+            variants={clinvarVariants}
+            variantFilter={filter}
+          />
+        )}
 
         <VariantTrack
           title={`${datasetLabel}\n(${renderedVariants.length})`}

--- a/projects/gnomad/src/client/RegionPage/VariantsInRegion.js
+++ b/projects/gnomad/src/client/RegionPage/VariantsInRegion.js
@@ -32,6 +32,10 @@ class VariantsInRegion extends Component {
     width: PropTypes.number.isRequired,
   }
 
+  static defaultProps = {
+    clinvarVariants: null,
+  }
+  
   constructor(props) {
     super(props)
 


### PR DESCRIPTION
Similar to `VariantsInGene.js`, I set clinvarVariants as optional in `VariantsInRegion.js`, and displayed only if present