### PR TITLE
migrate to new ingress api and enable http->https redirect

### DIFF
--- a/deploy/manifests/ingress/gnomad.frontendconfig.yaml
+++ b/deploy/manifests/ingress/gnomad.frontendconfig.yaml
@@ -1,0 +1,7 @@
+apiVersion: networking.gke.io/v1beta1
+kind: FrontendConfig
+metadata:
+  name: gnomad-frontend-config
+spec:
+  redirectToHttps:
+    enabled: true

--- a/deploy/manifests/ingress/gnomad.ingress.yaml
+++ b/deploy/manifests/ingress/gnomad.ingress.yaml
@@ -1,5 +1,4 @@
----
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: gnomad-ingress
@@ -8,36 +7,57 @@ metadata:
   annotations:
     kubernetes.io/ingress.global-static-ip-name: exac-gnomad-prod
     ingress.gcp.kubernetes.io/pre-shared-cert: gnomad-browser-cert
+    networking.gke.io/v1beta1.FrontendConfig: "gnomad-frontend-config"
 spec:
   rules:
-    - host: gnomad.broadinstitute.org
-      http:
-        paths:
-          - path: /reads
-            backend:
-              serviceName: gnomad-reads
-              servicePort: 80
-          - path: /reads/*
-            backend:
-              serviceName: gnomad-reads
-              servicePort: 80
-          - path: /blog
-            backend:
-              serviceName: gnomad-blog
-              servicePort: 80
-          - path: /blog/*
-            backend:
-              serviceName: gnomad-blog
-              servicePort: 80
-          - path: /news
-            backend:
-              serviceName: gnomad-blog
-              servicePort: 80
-          - path: /news/*
-            backend:
-              serviceName: gnomad-blog
-              servicePort: 80
-          - path:
-            backend:
-              serviceName: gnomad-browser
-              servicePort: 80
+  - host: gnomad.broadinstitute.org
+    http:
+      paths:
+      - backend:
+          service:
+            name: gnomad-reads
+            port:
+              number: 80
+        path: /reads
+        pathType: ImplementationSpecific
+      - backend:
+          service:
+            name: gnomad-reads
+            port:
+              number: 80
+        path: /reads/*
+        pathType: ImplementationSpecific
+      - backend:
+          service:
+            name: gnomad-blog
+            port:
+              number: 80
+        path: /blog
+        pathType: ImplementationSpecific
+      - backend:
+          service:
+            name: gnomad-blog
+            port:
+              number: 80
+        path: /blog/*
+        pathType: ImplementationSpecific
+      - backend:
+          service:
+            name: gnomad-blog
+            port:
+              number: 80
+        path: /news
+        pathType: ImplementationSpecific
+      - backend:
+          service:
+            name: gnomad-blog
+            port:
+              number: 80
+        path: /news/*
+        pathType: ImplementationSpecific
+      - backend:
+          service:
+            name: gnomad-browser
+            port:
+              number: 80
+        pathType: ImplementationSpecific


### PR DESCRIPTION
Two changes of note here:

* I used `kubectl convert` to upgrade our ingress manifest from extensions/v1beta1 to networking.k8s.io/v1
* I added a frontend config that enables the built-in http to https redirect feature on the Ingress, since we're on a supported version of GKE now, according to the documentation.

Closes #790 , Closes #680 

I'm going to leave this in draft state for now, I just want to confirm that the stable channel of GKE has this api version upgrade available.