### PR TITLE
WIP: add cloudbuild configs for docker images

### DIFF
--- a/.cloudbuild/blog-docker.cloudbuild.yaml
+++ b/.cloudbuild/blog-docker.cloudbuild.yaml
@@ -1,16 +1,18 @@
 steps:
 - name: 'gcr.io/kaniko-project/executor:latest'
   args:
-  - "--destination=gcr.io/$PROJECT_ID/gnomad-blog:$COMMIT_SHA"
-  - "--dockerfile=deploy/dockerfiles/blog/blog.dockerfile"
-  - "--cache=true"
-  - "--cache-ttl=168h"
+    - "--destination=gcr.io/$PROJECT_ID/gnomad-blog:$COMMIT_SHA"
+    - "--destination=gcr.io/$PROJECT_ID/gnomad-blog:latest"
+    - "--dockerfile=deploy/dockerfiles/blog/blog.dockerfile"
+    - "--cache=true"
+    - "--cache-ttl=168h"
 - name: 'gcr.io/kaniko-project/executor:latest'
   args:
-  - "--destination=gcr.io/$PROJECT_ID/gnomad-blog-auth:$COMMIT_SHA"
-  - "--dockerfile=deploy/dockerfiles/blog/auth.dockerfile"
-  - "--cache=true"
-  - "--cache-ttl=168h"
+    - "--destination=gcr.io/$PROJECT_ID/gnomad-blog-auth:$COMMIT_SHA"
+    - "--destination=gcr.io/$PROJECT_ID/gnomad-blog-auth:latest"
+    - "--dockerfile=deploy/dockerfiles/blog/auth.dockerfile"
+    - "--cache=true"
+    - "--cache-ttl=168h"
   waitFor: ['-'] # this tells cloudbuild to run this step concurrently with the blog build
 
 timeout: 1800s

--- a/.cloudbuild/blog-docker.cloudbuild.yaml
+++ b/.cloudbuild/blog-docker.cloudbuild.yaml
@@ -1,0 +1,16 @@
+steps:
+- name: 'gcr.io/kaniko-project/executor:latest'
+  args:
+  - "--destination=gcr.io/$PROJECT_ID/gnomad-blog:$COMMIT_SHA"
+  - "--dockerfile=deploy/dockerfiles/blog/blog.dockerfile"
+  - "--cache=true"
+  - "--cache-ttl=168h"
+- name: 'gcr.io/kaniko-project/executor:latest'
+  args:
+  - "--destination=gcr.io/$PROJECT_ID/gnomad-blog-auth:$COMMIT_SHA"
+  - "--dockerfile=deploy/dockerfiles/blog/auth.dockerfile"
+  - "--cache=true"
+  - "--cache-ttl=168h"
+  waitFor: ['-'] # this tells cloudbuild to run this step concurrently with the blog build
+
+timeout: 1800s

--- a/.cloudbuild/browser-and-api-docker.cloudbuild.yaml
+++ b/.cloudbuild/browser-and-api-docker.cloudbuild.yaml
@@ -1,0 +1,16 @@
+steps:
+- name: 'gcr.io/kaniko-project/executor:latest'
+  args:
+  - "--destination=gcr.io/$PROJECT_ID/gnomad-browser:$COMMIT_SHA"
+  - "--dockerfile=deploy/dockerfiles/browser/browser.dockerfile"
+  - "--cache=true"
+  - "--cache-ttl=168h"
+- name: 'gcr.io/kaniko-project/executor:latest'
+  args:
+  - "--destination=gcr.io/exac-gnomad/gnomad-api:$COMMIT_SHA"
+  - "--dockerfile=deploy/dockerfiles/browser/api.dockerfile"
+  - "--cache=true"
+  - "--cache-ttl=168h"
+  waitFor: ['-'] # this tells cloudbuild to run this step concurrently with the browser build
+
+timeout: 1800s

--- a/.cloudbuild/browser-and-api-docker.cloudbuild.yaml
+++ b/.cloudbuild/browser-and-api-docker.cloudbuild.yaml
@@ -1,16 +1,18 @@
 steps:
-- name: 'gcr.io/kaniko-project/executor:latest'
-  args:
-  - "--destination=gcr.io/$PROJECT_ID/gnomad-browser:$COMMIT_SHA"
-  - "--dockerfile=deploy/dockerfiles/browser/browser.dockerfile"
-  - "--cache=true"
-  - "--cache-ttl=168h"
-- name: 'gcr.io/kaniko-project/executor:latest'
-  args:
-  - "--destination=gcr.io/exac-gnomad/gnomad-api:$COMMIT_SHA"
-  - "--dockerfile=deploy/dockerfiles/browser/api.dockerfile"
-  - "--cache=true"
-  - "--cache-ttl=168h"
-  waitFor: ['-'] # this tells cloudbuild to run this step concurrently with the browser build
+  - name: 'gcr.io/kaniko-project/executor:latest'
+    args:
+      - '--destination=gcr.io/$PROJECT_ID/gnomad-browser:$COMMIT_SHA'
+      - '--destination=gcr.io/$PROJECT_ID/gnomad-browser:latest'
+      - '--dockerfile=deploy/dockerfiles/browser/browser.dockerfile'
+      - '--cache=true'
+      - '--cache-ttl=168h'
+  - name: 'gcr.io/kaniko-project/executor:latest'
+    args:
+      - '--destination=gcr.io/exac-gnomad/gnomad-api:$COMMIT_SHA'
+      - '--destination=gcr.io/exac-gnomad/gnomad-api:latest'
+      - '--dockerfile=deploy/dockerfiles/browser/api.dockerfile'
+      - '--cache=true'
+      - '--cache-ttl=168h'
+    waitFor: ['-'] # this tells cloudbuild to run this step concurrently with the browser build
 
 timeout: 1800s

--- a/.cloudbuild/reads-docker.cloudbuild.yaml
+++ b/.cloudbuild/reads-docker.cloudbuild.yaml
@@ -1,16 +1,18 @@
 steps:
-- name: 'gcr.io/kaniko-project/executor:latest'
-  args:
-  - "--destination=gcr.io/$PROJECT_ID/reads-server:$COMMIT_SHA"
-  - "--dockerfile=deploy/dockerfiles/reads/reads-server.dockerfile"
-  - "--cache=true"
-  - "--cache-ttl=168h"
-- name: 'gcr.io/kaniko-project/executor:latest'
-  args:
-  - "--destination=gcr.io/$PROJECT_ID/reads-api:$COMMIT_SHA"
-  - "--dockerfile=deploy/dockerfiles/reads/reads-api.dockerfile"
-  - "--cache=true"
-  - "--cache-ttl=168h"
-  waitFor: ['-'] # this tells cloudbuild to run this step concurrently with the server build
+  - name: 'gcr.io/kaniko-project/executor:latest'
+    args:
+      - '--destination=gcr.io/$PROJECT_ID/reads-server:$COMMIT_SHA'
+      - '--destination=gcr.io/$PROJECT_ID/reads-server:latest'
+      - '--dockerfile=deploy/dockerfiles/reads/reads-server.dockerfile'
+      - '--cache=true'
+      - '--cache-ttl=168h'
+  - name: 'gcr.io/kaniko-project/executor:latest'
+    args:
+      - '--destination=gcr.io/$PROJECT_ID/reads-api:$COMMIT_SHA'
+      - '--destination=gcr.io/$PROJECT_ID/reads-api:latest'
+      - '--dockerfile=deploy/dockerfiles/reads/reads-api.dockerfile'
+      - '--cache=true'
+      - '--cache-ttl=168h'
+    waitFor: ['-'] # this tells cloudbuild to run this step concurrently with the server build
 
 timeout: 1800s

--- a/.cloudbuild/reads-docker.cloudbuild.yaml
+++ b/.cloudbuild/reads-docker.cloudbuild.yaml
@@ -1,0 +1,16 @@
+steps:
+- name: 'gcr.io/kaniko-project/executor:latest'
+  args:
+  - "--destination=gcr.io/$PROJECT_ID/reads-server:$COMMIT_SHA"
+  - "--dockerfile=deploy/dockerfiles/reads/reads-server.dockerfile"
+  - "--cache=true"
+  - "--cache-ttl=168h"
+- name: 'gcr.io/kaniko-project/executor:latest'
+  args:
+  - "--destination=gcr.io/$PROJECT_ID/reads-api:$COMMIT_SHA"
+  - "--dockerfile=deploy/dockerfiles/reads/reads-api.dockerfile"
+  - "--cache=true"
+  - "--cache-ttl=168h"
+  waitFor: ['-'] # this tells cloudbuild to run this step concurrently with the server build
+
+timeout: 1800s


### PR DESCRIPTION
This PR will start implementing the scaffolding for automating builds of the gnomad docker images. Still need to work out the minute details, but my view of the changes that should trigger which builds:

#### browser

- package.json (top-level)
- yarn.lock
- babel.config.js
- dataset-metadata/*
- browser/*
- dockerfiles/browser/browser.nginx.conf

#### api

- yarn.lock (top-level)
- dataset-metadata/*
- graphql-api/*

#### reads-api

- yarn.lock (top-level)
- reads/*

#### reads-server

- dockerfiles/reads/reads.nginx.conf

#### blog

- dockerfiles/blog/gcs-proxy.conf
- dockerfiles/blog/blog.nginx.conf

#### auth

- dockerfiles/blog/auth-requirements.txt
- dockerfiles/blog/auth.py