### PR TITLE
Add quotes to kubectl command in ElasticsearchConnection.md

### DIFF
--- a/deploy/docs/ElasticsearchConnection.md
+++ b/deploy/docs/ElasticsearchConnection.md
@@ -25,7 +25,7 @@
 - Dataproc clusters must connect to Elasticsearch through the internal load balancer. Get its IP address with:
 
   ```
-  ELASTICSEARCH_IP=$(kubectl get service gnomad-elasticsearch-lb --output=jsonpath={.status.loadBalancer.ingress[0].ip})
+  ELASTICSEARCH_IP=$(kubectl get service gnomad-elasticsearch-lb --output=jsonpath="{.status.loadBalancer.ingress[0].ip}")
   ```
 
 - Store the Elasticsearch password in [Secret Manager](https://cloud.google.com/secret-manager/docs).


### PR DESCRIPTION
Add quotes to kubectl command in [ElasticsearchConnection.md](https://github.com/broadinstitute/gnomad-browser/blob/main/deploy/docs/ElasticsearchConnection.md)