### PR TITLE
Add Hail to pipeline requirements.txt

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,9 +25,7 @@ This should be enough to use the Docker Compose development environment. However
 - For data pipeline development, install [Python](https://www.python.org/), dependencies, and development tools.
 
   ```
-  pip install hail
   pip install -r data-pipeline/requirements.txt
-
   pip install -r requirements-dev.txt
   ```
 

--- a/data-pipeline/requirements.txt
+++ b/data-pipeline/requirements.txt
@@ -1,1 +1,2 @@
 elasticsearch~=6.8
+hail


### PR DESCRIPTION
CONTRIBUTING.md called for Hail to be installed manually separately, but it seems to work fine when specified as a dependency in data-pipeline/requirements.txt.