### PR TITLE
Set up for snapshot testing, add example test

### DIFF
--- a/browser/src/DatasetSelector.spec.jsx
+++ b/browser/src/DatasetSelector.spec.jsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import { Router } from 'react-router'
+import renderer from 'react-test-renderer'
+import DatasetSelector from './DatasetSelector'
+import { createBrowserHistory } from 'history'
+
+import { allDatasetIds } from './datasets'
+
+describe.each(allDatasetIds)('DataSelector with "%s" dataset selected', (datasetId) => {
+  test('has no unexpected changes', () => {
+    const tree = renderer.create(
+      <Router history={createBrowserHistory()}>
+        <DatasetSelector selectedDataset={datasetId} datasetOptions={{}} />
+      </Router>
+    )
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/browser/src/__snapshots__/DatasetSelector.spec.jsx.snap
+++ b/browser/src/__snapshots__/DatasetSelector.spec.jsx.snap
@@ -1,0 +1,5251 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DataSelector with "exac" dataset selected has no unexpected changes 1`] = `
+<ul
+  className="DatasetSelector__NavigationMenuWrapper-sc-1x96sz-0 dOhyHC"
+>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 eioFKY"
+  >
+    <a
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="current_short_variant"
+      href="/?dataset=exac"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+    >
+      ExAC v1.0
+    </a>
+  </li>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 eioFKY"
+  >
+    <a
+      aria-expanded={false}
+      aria-haspopup="true"
+      aria-label="More datasets"
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="other_short_variant"
+      href="/"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+    >
+      <span
+        className="DatasetSelector__MoreIcon-sc-1x96sz-3 iAlUbC"
+      >
+        <img
+          alt=""
+          aria-hidden="true"
+          src="test-file-stub"
+        />
+      </span>
+    </a>
+    <ul
+      className="DatasetSelector__SubNavigationMenu-sc-1x96sz-4 gbhOxb"
+    >
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3"
+          href="/?dataset=gnomad_r3"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            76,156 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_cancer"
+          href="/?dataset=gnomad_r3_non_cancer"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-cancer)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            74,023 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_neuro"
+          href="/?dataset=gnomad_r3_non_neuro"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-neuro)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            67,442 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_v2"
+          href="/?dataset=gnomad_r3_non_v2"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-v2)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            57,344 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_topmed"
+          href="/?dataset=gnomad_r3_non_topmed"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-TOPMed)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            40,433 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_controls_and_biobanks"
+          href="/?dataset=gnomad_r3_controls_and_biobanks"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (controls/biobanks)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            16,465 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1"
+          href="/?dataset=gnomad_r2_1"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            141,456 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_non_topmed"
+          href="/?dataset=gnomad_r2_1_non_topmed"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (non-TOPMed)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            135,743 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_non_cancer"
+          href="/?dataset=gnomad_r2_1_non_cancer"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (non-cancer)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            134,187 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_non_neuro"
+          href="/?dataset=gnomad_r2_1_non_neuro"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (non-neuro)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            114,704 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_controls"
+          href="/?dataset=gnomad_r2_1_controls"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (controls)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            60,146 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="exac"
+          href="/?dataset=exac"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          ExAC v1.0
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            60,706 samples
+          </div>
+        </a>
+      </li>
+    </ul>
+  </li>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 hxGlCv"
+  >
+    <a
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="current_sv_dataset"
+      href="/?dataset=gnomad_sv_r2_1"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+    >
+      gnomAD SVs v2.1
+    </a>
+  </li>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 hxGlCv"
+  >
+    <a
+      aria-expanded={false}
+      aria-haspopup="true"
+      aria-label="More datasets"
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="other_structural_variant"
+      href="/"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+    >
+      <span
+        className="DatasetSelector__MoreIcon-sc-1x96sz-3 iAlUbC"
+      >
+        <img
+          alt=""
+          aria-hidden="true"
+          src="test-file-stub"
+        />
+      </span>
+    </a>
+    <ul
+      className="DatasetSelector__SubNavigationMenu-sc-1x96sz-4 gbhOxb"
+    >
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_sv_r2_1"
+          href="/?dataset=gnomad_sv_r2_1"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD SVs v2.1
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            10,847 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_sv_r2_1_non_neuro"
+          href="/?dataset=gnomad_sv_r2_1_non_neuro"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD SVs v2.1 (non-neuro)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            8,342 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_sv_r2_1_controls"
+          href="/?dataset=gnomad_sv_r2_1_controls"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD SVs v2.1 (controls)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            5,192 samples
+          </div>
+        </a>
+      </li>
+    </ul>
+  </li>
+</ul>
+`;
+
+exports[`DataSelector with "gnomad_r2_1" dataset selected has no unexpected changes 1`] = `
+<ul
+  className="DatasetSelector__NavigationMenuWrapper-sc-1x96sz-0 dOhyHC"
+>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 eioFKY"
+  >
+    <a
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="current_short_variant"
+      href="/?dataset=gnomad_r2_1"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+    >
+      gnomAD v2.1.1
+    </a>
+  </li>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 eioFKY"
+  >
+    <a
+      aria-expanded={false}
+      aria-haspopup="true"
+      aria-label="More datasets"
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="other_short_variant"
+      href="/"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+    >
+      <span
+        className="DatasetSelector__MoreIcon-sc-1x96sz-3 iAlUbC"
+      >
+        <img
+          alt=""
+          aria-hidden="true"
+          src="test-file-stub"
+        />
+      </span>
+    </a>
+    <ul
+      className="DatasetSelector__SubNavigationMenu-sc-1x96sz-4 gbhOxb"
+    >
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3"
+          href="/?dataset=gnomad_r3"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            76,156 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_cancer"
+          href="/?dataset=gnomad_r3_non_cancer"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-cancer)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            74,023 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_neuro"
+          href="/?dataset=gnomad_r3_non_neuro"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-neuro)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            67,442 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_v2"
+          href="/?dataset=gnomad_r3_non_v2"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-v2)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            57,344 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_topmed"
+          href="/?dataset=gnomad_r3_non_topmed"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-TOPMed)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            40,433 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_controls_and_biobanks"
+          href="/?dataset=gnomad_r3_controls_and_biobanks"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (controls/biobanks)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            16,465 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1"
+          href="/?dataset=gnomad_r2_1"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            141,456 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_non_topmed"
+          href="/?dataset=gnomad_r2_1_non_topmed"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (non-TOPMed)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            135,743 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_non_cancer"
+          href="/?dataset=gnomad_r2_1_non_cancer"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (non-cancer)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            134,187 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_non_neuro"
+          href="/?dataset=gnomad_r2_1_non_neuro"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (non-neuro)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            114,704 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_controls"
+          href="/?dataset=gnomad_r2_1_controls"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (controls)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            60,146 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="exac"
+          href="/?dataset=exac"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          ExAC v1.0
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            60,706 samples
+          </div>
+        </a>
+      </li>
+    </ul>
+  </li>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 hxGlCv"
+  >
+    <a
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="current_sv_dataset"
+      href="/?dataset=gnomad_sv_r2_1"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+    >
+      gnomAD SVs v2.1
+    </a>
+  </li>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 hxGlCv"
+  >
+    <a
+      aria-expanded={false}
+      aria-haspopup="true"
+      aria-label="More datasets"
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="other_structural_variant"
+      href="/"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+    >
+      <span
+        className="DatasetSelector__MoreIcon-sc-1x96sz-3 iAlUbC"
+      >
+        <img
+          alt=""
+          aria-hidden="true"
+          src="test-file-stub"
+        />
+      </span>
+    </a>
+    <ul
+      className="DatasetSelector__SubNavigationMenu-sc-1x96sz-4 gbhOxb"
+    >
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_sv_r2_1"
+          href="/?dataset=gnomad_sv_r2_1"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD SVs v2.1
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            10,847 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_sv_r2_1_non_neuro"
+          href="/?dataset=gnomad_sv_r2_1_non_neuro"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD SVs v2.1 (non-neuro)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            8,342 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_sv_r2_1_controls"
+          href="/?dataset=gnomad_sv_r2_1_controls"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD SVs v2.1 (controls)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            5,192 samples
+          </div>
+        </a>
+      </li>
+    </ul>
+  </li>
+</ul>
+`;
+
+exports[`DataSelector with "gnomad_r2_1_controls" dataset selected has no unexpected changes 1`] = `
+<ul
+  className="DatasetSelector__NavigationMenuWrapper-sc-1x96sz-0 dOhyHC"
+>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 eioFKY"
+  >
+    <a
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="current_short_variant"
+      href="/?dataset=gnomad_r2_1_controls"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+    >
+      gnomAD v2.1.1 (controls)
+    </a>
+  </li>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 eioFKY"
+  >
+    <a
+      aria-expanded={false}
+      aria-haspopup="true"
+      aria-label="More datasets"
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="other_short_variant"
+      href="/"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+    >
+      <span
+        className="DatasetSelector__MoreIcon-sc-1x96sz-3 iAlUbC"
+      >
+        <img
+          alt=""
+          aria-hidden="true"
+          src="test-file-stub"
+        />
+      </span>
+    </a>
+    <ul
+      className="DatasetSelector__SubNavigationMenu-sc-1x96sz-4 gbhOxb"
+    >
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3"
+          href="/?dataset=gnomad_r3"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            76,156 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_cancer"
+          href="/?dataset=gnomad_r3_non_cancer"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-cancer)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            74,023 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_neuro"
+          href="/?dataset=gnomad_r3_non_neuro"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-neuro)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            67,442 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_v2"
+          href="/?dataset=gnomad_r3_non_v2"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-v2)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            57,344 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_topmed"
+          href="/?dataset=gnomad_r3_non_topmed"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-TOPMed)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            40,433 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_controls_and_biobanks"
+          href="/?dataset=gnomad_r3_controls_and_biobanks"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (controls/biobanks)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            16,465 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1"
+          href="/?dataset=gnomad_r2_1"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            141,456 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_non_topmed"
+          href="/?dataset=gnomad_r2_1_non_topmed"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (non-TOPMed)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            135,743 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_non_cancer"
+          href="/?dataset=gnomad_r2_1_non_cancer"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (non-cancer)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            134,187 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_non_neuro"
+          href="/?dataset=gnomad_r2_1_non_neuro"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (non-neuro)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            114,704 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_controls"
+          href="/?dataset=gnomad_r2_1_controls"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (controls)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            60,146 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="exac"
+          href="/?dataset=exac"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          ExAC v1.0
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            60,706 samples
+          </div>
+        </a>
+      </li>
+    </ul>
+  </li>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 hxGlCv"
+  >
+    <a
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="current_sv_dataset"
+      href="/?dataset=gnomad_sv_r2_1"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+    >
+      gnomAD SVs v2.1
+    </a>
+  </li>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 hxGlCv"
+  >
+    <a
+      aria-expanded={false}
+      aria-haspopup="true"
+      aria-label="More datasets"
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="other_structural_variant"
+      href="/"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+    >
+      <span
+        className="DatasetSelector__MoreIcon-sc-1x96sz-3 iAlUbC"
+      >
+        <img
+          alt=""
+          aria-hidden="true"
+          src="test-file-stub"
+        />
+      </span>
+    </a>
+    <ul
+      className="DatasetSelector__SubNavigationMenu-sc-1x96sz-4 gbhOxb"
+    >
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_sv_r2_1"
+          href="/?dataset=gnomad_sv_r2_1"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD SVs v2.1
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            10,847 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_sv_r2_1_non_neuro"
+          href="/?dataset=gnomad_sv_r2_1_non_neuro"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD SVs v2.1 (non-neuro)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            8,342 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_sv_r2_1_controls"
+          href="/?dataset=gnomad_sv_r2_1_controls"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD SVs v2.1 (controls)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            5,192 samples
+          </div>
+        </a>
+      </li>
+    </ul>
+  </li>
+</ul>
+`;
+
+exports[`DataSelector with "gnomad_r2_1_non_cancer" dataset selected has no unexpected changes 1`] = `
+<ul
+  className="DatasetSelector__NavigationMenuWrapper-sc-1x96sz-0 dOhyHC"
+>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 eioFKY"
+  >
+    <a
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="current_short_variant"
+      href="/?dataset=gnomad_r2_1_non_cancer"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+    >
+      gnomAD v2.1.1 (non-cancer)
+    </a>
+  </li>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 eioFKY"
+  >
+    <a
+      aria-expanded={false}
+      aria-haspopup="true"
+      aria-label="More datasets"
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="other_short_variant"
+      href="/"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+    >
+      <span
+        className="DatasetSelector__MoreIcon-sc-1x96sz-3 iAlUbC"
+      >
+        <img
+          alt=""
+          aria-hidden="true"
+          src="test-file-stub"
+        />
+      </span>
+    </a>
+    <ul
+      className="DatasetSelector__SubNavigationMenu-sc-1x96sz-4 gbhOxb"
+    >
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3"
+          href="/?dataset=gnomad_r3"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            76,156 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_cancer"
+          href="/?dataset=gnomad_r3_non_cancer"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-cancer)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            74,023 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_neuro"
+          href="/?dataset=gnomad_r3_non_neuro"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-neuro)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            67,442 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_v2"
+          href="/?dataset=gnomad_r3_non_v2"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-v2)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            57,344 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_topmed"
+          href="/?dataset=gnomad_r3_non_topmed"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-TOPMed)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            40,433 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_controls_and_biobanks"
+          href="/?dataset=gnomad_r3_controls_and_biobanks"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (controls/biobanks)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            16,465 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1"
+          href="/?dataset=gnomad_r2_1"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            141,456 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_non_topmed"
+          href="/?dataset=gnomad_r2_1_non_topmed"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (non-TOPMed)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            135,743 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_non_cancer"
+          href="/?dataset=gnomad_r2_1_non_cancer"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (non-cancer)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            134,187 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_non_neuro"
+          href="/?dataset=gnomad_r2_1_non_neuro"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (non-neuro)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            114,704 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_controls"
+          href="/?dataset=gnomad_r2_1_controls"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (controls)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            60,146 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="exac"
+          href="/?dataset=exac"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          ExAC v1.0
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            60,706 samples
+          </div>
+        </a>
+      </li>
+    </ul>
+  </li>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 hxGlCv"
+  >
+    <a
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="current_sv_dataset"
+      href="/?dataset=gnomad_sv_r2_1"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+    >
+      gnomAD SVs v2.1
+    </a>
+  </li>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 hxGlCv"
+  >
+    <a
+      aria-expanded={false}
+      aria-haspopup="true"
+      aria-label="More datasets"
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="other_structural_variant"
+      href="/"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+    >
+      <span
+        className="DatasetSelector__MoreIcon-sc-1x96sz-3 iAlUbC"
+      >
+        <img
+          alt=""
+          aria-hidden="true"
+          src="test-file-stub"
+        />
+      </span>
+    </a>
+    <ul
+      className="DatasetSelector__SubNavigationMenu-sc-1x96sz-4 gbhOxb"
+    >
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_sv_r2_1"
+          href="/?dataset=gnomad_sv_r2_1"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD SVs v2.1
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            10,847 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_sv_r2_1_non_neuro"
+          href="/?dataset=gnomad_sv_r2_1_non_neuro"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD SVs v2.1 (non-neuro)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            8,342 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_sv_r2_1_controls"
+          href="/?dataset=gnomad_sv_r2_1_controls"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD SVs v2.1 (controls)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            5,192 samples
+          </div>
+        </a>
+      </li>
+    </ul>
+  </li>
+</ul>
+`;
+
+exports[`DataSelector with "gnomad_r2_1_non_neuro" dataset selected has no unexpected changes 1`] = `
+<ul
+  className="DatasetSelector__NavigationMenuWrapper-sc-1x96sz-0 dOhyHC"
+>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 eioFKY"
+  >
+    <a
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="current_short_variant"
+      href="/?dataset=gnomad_r2_1_non_neuro"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+    >
+      gnomAD v2.1.1 (non-neuro)
+    </a>
+  </li>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 eioFKY"
+  >
+    <a
+      aria-expanded={false}
+      aria-haspopup="true"
+      aria-label="More datasets"
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="other_short_variant"
+      href="/"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+    >
+      <span
+        className="DatasetSelector__MoreIcon-sc-1x96sz-3 iAlUbC"
+      >
+        <img
+          alt=""
+          aria-hidden="true"
+          src="test-file-stub"
+        />
+      </span>
+    </a>
+    <ul
+      className="DatasetSelector__SubNavigationMenu-sc-1x96sz-4 gbhOxb"
+    >
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3"
+          href="/?dataset=gnomad_r3"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            76,156 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_cancer"
+          href="/?dataset=gnomad_r3_non_cancer"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-cancer)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            74,023 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_neuro"
+          href="/?dataset=gnomad_r3_non_neuro"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-neuro)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            67,442 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_v2"
+          href="/?dataset=gnomad_r3_non_v2"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-v2)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            57,344 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_topmed"
+          href="/?dataset=gnomad_r3_non_topmed"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-TOPMed)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            40,433 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_controls_and_biobanks"
+          href="/?dataset=gnomad_r3_controls_and_biobanks"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (controls/biobanks)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            16,465 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1"
+          href="/?dataset=gnomad_r2_1"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            141,456 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_non_topmed"
+          href="/?dataset=gnomad_r2_1_non_topmed"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (non-TOPMed)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            135,743 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_non_cancer"
+          href="/?dataset=gnomad_r2_1_non_cancer"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (non-cancer)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            134,187 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_non_neuro"
+          href="/?dataset=gnomad_r2_1_non_neuro"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (non-neuro)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            114,704 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_controls"
+          href="/?dataset=gnomad_r2_1_controls"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (controls)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            60,146 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="exac"
+          href="/?dataset=exac"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          ExAC v1.0
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            60,706 samples
+          </div>
+        </a>
+      </li>
+    </ul>
+  </li>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 hxGlCv"
+  >
+    <a
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="current_sv_dataset"
+      href="/?dataset=gnomad_sv_r2_1"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+    >
+      gnomAD SVs v2.1
+    </a>
+  </li>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 hxGlCv"
+  >
+    <a
+      aria-expanded={false}
+      aria-haspopup="true"
+      aria-label="More datasets"
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="other_structural_variant"
+      href="/"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+    >
+      <span
+        className="DatasetSelector__MoreIcon-sc-1x96sz-3 iAlUbC"
+      >
+        <img
+          alt=""
+          aria-hidden="true"
+          src="test-file-stub"
+        />
+      </span>
+    </a>
+    <ul
+      className="DatasetSelector__SubNavigationMenu-sc-1x96sz-4 gbhOxb"
+    >
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_sv_r2_1"
+          href="/?dataset=gnomad_sv_r2_1"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD SVs v2.1
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            10,847 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_sv_r2_1_non_neuro"
+          href="/?dataset=gnomad_sv_r2_1_non_neuro"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD SVs v2.1 (non-neuro)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            8,342 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_sv_r2_1_controls"
+          href="/?dataset=gnomad_sv_r2_1_controls"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD SVs v2.1 (controls)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            5,192 samples
+          </div>
+        </a>
+      </li>
+    </ul>
+  </li>
+</ul>
+`;
+
+exports[`DataSelector with "gnomad_r2_1_non_topmed" dataset selected has no unexpected changes 1`] = `
+<ul
+  className="DatasetSelector__NavigationMenuWrapper-sc-1x96sz-0 dOhyHC"
+>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 eioFKY"
+  >
+    <a
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="current_short_variant"
+      href="/?dataset=gnomad_r2_1_non_topmed"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+    >
+      gnomAD v2.1.1 (non-TOPMed)
+    </a>
+  </li>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 eioFKY"
+  >
+    <a
+      aria-expanded={false}
+      aria-haspopup="true"
+      aria-label="More datasets"
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="other_short_variant"
+      href="/"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+    >
+      <span
+        className="DatasetSelector__MoreIcon-sc-1x96sz-3 iAlUbC"
+      >
+        <img
+          alt=""
+          aria-hidden="true"
+          src="test-file-stub"
+        />
+      </span>
+    </a>
+    <ul
+      className="DatasetSelector__SubNavigationMenu-sc-1x96sz-4 gbhOxb"
+    >
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3"
+          href="/?dataset=gnomad_r3"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            76,156 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_cancer"
+          href="/?dataset=gnomad_r3_non_cancer"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-cancer)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            74,023 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_neuro"
+          href="/?dataset=gnomad_r3_non_neuro"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-neuro)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            67,442 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_v2"
+          href="/?dataset=gnomad_r3_non_v2"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-v2)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            57,344 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_topmed"
+          href="/?dataset=gnomad_r3_non_topmed"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-TOPMed)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            40,433 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_controls_and_biobanks"
+          href="/?dataset=gnomad_r3_controls_and_biobanks"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (controls/biobanks)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            16,465 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1"
+          href="/?dataset=gnomad_r2_1"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            141,456 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_non_topmed"
+          href="/?dataset=gnomad_r2_1_non_topmed"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (non-TOPMed)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            135,743 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_non_cancer"
+          href="/?dataset=gnomad_r2_1_non_cancer"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (non-cancer)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            134,187 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_non_neuro"
+          href="/?dataset=gnomad_r2_1_non_neuro"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (non-neuro)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            114,704 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_controls"
+          href="/?dataset=gnomad_r2_1_controls"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (controls)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            60,146 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="exac"
+          href="/?dataset=exac"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          ExAC v1.0
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            60,706 samples
+          </div>
+        </a>
+      </li>
+    </ul>
+  </li>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 hxGlCv"
+  >
+    <a
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="current_sv_dataset"
+      href="/?dataset=gnomad_sv_r2_1"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+    >
+      gnomAD SVs v2.1
+    </a>
+  </li>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 hxGlCv"
+  >
+    <a
+      aria-expanded={false}
+      aria-haspopup="true"
+      aria-label="More datasets"
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="other_structural_variant"
+      href="/"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+    >
+      <span
+        className="DatasetSelector__MoreIcon-sc-1x96sz-3 iAlUbC"
+      >
+        <img
+          alt=""
+          aria-hidden="true"
+          src="test-file-stub"
+        />
+      </span>
+    </a>
+    <ul
+      className="DatasetSelector__SubNavigationMenu-sc-1x96sz-4 gbhOxb"
+    >
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_sv_r2_1"
+          href="/?dataset=gnomad_sv_r2_1"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD SVs v2.1
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            10,847 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_sv_r2_1_non_neuro"
+          href="/?dataset=gnomad_sv_r2_1_non_neuro"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD SVs v2.1 (non-neuro)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            8,342 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_sv_r2_1_controls"
+          href="/?dataset=gnomad_sv_r2_1_controls"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD SVs v2.1 (controls)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            5,192 samples
+          </div>
+        </a>
+      </li>
+    </ul>
+  </li>
+</ul>
+`;
+
+exports[`DataSelector with "gnomad_r3" dataset selected has no unexpected changes 1`] = `
+<ul
+  className="DatasetSelector__NavigationMenuWrapper-sc-1x96sz-0 dOhyHC"
+>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 eioFKY"
+  >
+    <a
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="current_short_variant"
+      href="/?dataset=gnomad_r3"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+    >
+      gnomAD v3.1.2
+    </a>
+  </li>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 eioFKY"
+  >
+    <a
+      aria-expanded={false}
+      aria-haspopup="true"
+      aria-label="More datasets"
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="other_short_variant"
+      href="/"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+    >
+      <span
+        className="DatasetSelector__MoreIcon-sc-1x96sz-3 iAlUbC"
+      >
+        <img
+          alt=""
+          aria-hidden="true"
+          src="test-file-stub"
+        />
+      </span>
+    </a>
+    <ul
+      className="DatasetSelector__SubNavigationMenu-sc-1x96sz-4 gbhOxb"
+    >
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3"
+          href="/?dataset=gnomad_r3"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            76,156 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_cancer"
+          href="/?dataset=gnomad_r3_non_cancer"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-cancer)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            74,023 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_neuro"
+          href="/?dataset=gnomad_r3_non_neuro"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-neuro)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            67,442 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_v2"
+          href="/?dataset=gnomad_r3_non_v2"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-v2)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            57,344 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_topmed"
+          href="/?dataset=gnomad_r3_non_topmed"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-TOPMed)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            40,433 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_controls_and_biobanks"
+          href="/?dataset=gnomad_r3_controls_and_biobanks"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (controls/biobanks)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            16,465 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1"
+          href="/?dataset=gnomad_r2_1"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            141,456 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_non_topmed"
+          href="/?dataset=gnomad_r2_1_non_topmed"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (non-TOPMed)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            135,743 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_non_cancer"
+          href="/?dataset=gnomad_r2_1_non_cancer"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (non-cancer)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            134,187 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_non_neuro"
+          href="/?dataset=gnomad_r2_1_non_neuro"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (non-neuro)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            114,704 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_controls"
+          href="/?dataset=gnomad_r2_1_controls"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (controls)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            60,146 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="exac"
+          href="/?dataset=exac"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          ExAC v1.0
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            60,706 samples
+          </div>
+        </a>
+      </li>
+    </ul>
+  </li>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 hxGlCv"
+  >
+    <a
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="current_sv_dataset"
+      href="/?dataset=gnomad_sv_r2_1"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+    >
+      gnomAD SVs v2.1
+    </a>
+  </li>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 hxGlCv"
+  >
+    <a
+      aria-expanded={false}
+      aria-haspopup="true"
+      aria-label="More datasets"
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="other_structural_variant"
+      href="/"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+    >
+      <span
+        className="DatasetSelector__MoreIcon-sc-1x96sz-3 iAlUbC"
+      >
+        <img
+          alt=""
+          aria-hidden="true"
+          src="test-file-stub"
+        />
+      </span>
+    </a>
+    <ul
+      className="DatasetSelector__SubNavigationMenu-sc-1x96sz-4 gbhOxb"
+    >
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_sv_r2_1"
+          href="/?dataset=gnomad_sv_r2_1"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD SVs v2.1
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            10,847 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_sv_r2_1_non_neuro"
+          href="/?dataset=gnomad_sv_r2_1_non_neuro"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD SVs v2.1 (non-neuro)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            8,342 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_sv_r2_1_controls"
+          href="/?dataset=gnomad_sv_r2_1_controls"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD SVs v2.1 (controls)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            5,192 samples
+          </div>
+        </a>
+      </li>
+    </ul>
+  </li>
+</ul>
+`;
+
+exports[`DataSelector with "gnomad_r3_controls_and_biobanks" dataset selected has no unexpected changes 1`] = `
+<ul
+  className="DatasetSelector__NavigationMenuWrapper-sc-1x96sz-0 dOhyHC"
+>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 eioFKY"
+  >
+    <a
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="current_short_variant"
+      href="/?dataset=gnomad_r3_controls_and_biobanks"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+    >
+      gnomAD v3.1.2 (controls/biobanks)
+    </a>
+  </li>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 eioFKY"
+  >
+    <a
+      aria-expanded={false}
+      aria-haspopup="true"
+      aria-label="More datasets"
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="other_short_variant"
+      href="/"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+    >
+      <span
+        className="DatasetSelector__MoreIcon-sc-1x96sz-3 iAlUbC"
+      >
+        <img
+          alt=""
+          aria-hidden="true"
+          src="test-file-stub"
+        />
+      </span>
+    </a>
+    <ul
+      className="DatasetSelector__SubNavigationMenu-sc-1x96sz-4 gbhOxb"
+    >
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3"
+          href="/?dataset=gnomad_r3"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            76,156 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_cancer"
+          href="/?dataset=gnomad_r3_non_cancer"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-cancer)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            74,023 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_neuro"
+          href="/?dataset=gnomad_r3_non_neuro"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-neuro)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            67,442 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_v2"
+          href="/?dataset=gnomad_r3_non_v2"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-v2)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            57,344 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_topmed"
+          href="/?dataset=gnomad_r3_non_topmed"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-TOPMed)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            40,433 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_controls_and_biobanks"
+          href="/?dataset=gnomad_r3_controls_and_biobanks"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (controls/biobanks)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            16,465 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1"
+          href="/?dataset=gnomad_r2_1"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            141,456 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_non_topmed"
+          href="/?dataset=gnomad_r2_1_non_topmed"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (non-TOPMed)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            135,743 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_non_cancer"
+          href="/?dataset=gnomad_r2_1_non_cancer"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (non-cancer)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            134,187 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_non_neuro"
+          href="/?dataset=gnomad_r2_1_non_neuro"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (non-neuro)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            114,704 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_controls"
+          href="/?dataset=gnomad_r2_1_controls"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (controls)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            60,146 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="exac"
+          href="/?dataset=exac"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          ExAC v1.0
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            60,706 samples
+          </div>
+        </a>
+      </li>
+    </ul>
+  </li>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 hxGlCv"
+  >
+    <a
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="current_sv_dataset"
+      href="/?dataset=gnomad_sv_r2_1"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+    >
+      gnomAD SVs v2.1
+    </a>
+  </li>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 hxGlCv"
+  >
+    <a
+      aria-expanded={false}
+      aria-haspopup="true"
+      aria-label="More datasets"
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="other_structural_variant"
+      href="/"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+    >
+      <span
+        className="DatasetSelector__MoreIcon-sc-1x96sz-3 iAlUbC"
+      >
+        <img
+          alt=""
+          aria-hidden="true"
+          src="test-file-stub"
+        />
+      </span>
+    </a>
+    <ul
+      className="DatasetSelector__SubNavigationMenu-sc-1x96sz-4 gbhOxb"
+    >
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_sv_r2_1"
+          href="/?dataset=gnomad_sv_r2_1"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD SVs v2.1
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            10,847 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_sv_r2_1_non_neuro"
+          href="/?dataset=gnomad_sv_r2_1_non_neuro"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD SVs v2.1 (non-neuro)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            8,342 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_sv_r2_1_controls"
+          href="/?dataset=gnomad_sv_r2_1_controls"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD SVs v2.1 (controls)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            5,192 samples
+          </div>
+        </a>
+      </li>
+    </ul>
+  </li>
+</ul>
+`;
+
+exports[`DataSelector with "gnomad_r3_non_cancer" dataset selected has no unexpected changes 1`] = `
+<ul
+  className="DatasetSelector__NavigationMenuWrapper-sc-1x96sz-0 dOhyHC"
+>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 eioFKY"
+  >
+    <a
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="current_short_variant"
+      href="/?dataset=gnomad_r3_non_cancer"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+    >
+      gnomAD v3.1.2 (non-cancer)
+    </a>
+  </li>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 eioFKY"
+  >
+    <a
+      aria-expanded={false}
+      aria-haspopup="true"
+      aria-label="More datasets"
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="other_short_variant"
+      href="/"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+    >
+      <span
+        className="DatasetSelector__MoreIcon-sc-1x96sz-3 iAlUbC"
+      >
+        <img
+          alt=""
+          aria-hidden="true"
+          src="test-file-stub"
+        />
+      </span>
+    </a>
+    <ul
+      className="DatasetSelector__SubNavigationMenu-sc-1x96sz-4 gbhOxb"
+    >
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3"
+          href="/?dataset=gnomad_r3"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            76,156 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_cancer"
+          href="/?dataset=gnomad_r3_non_cancer"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-cancer)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            74,023 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_neuro"
+          href="/?dataset=gnomad_r3_non_neuro"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-neuro)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            67,442 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_v2"
+          href="/?dataset=gnomad_r3_non_v2"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-v2)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            57,344 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_topmed"
+          href="/?dataset=gnomad_r3_non_topmed"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-TOPMed)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            40,433 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_controls_and_biobanks"
+          href="/?dataset=gnomad_r3_controls_and_biobanks"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (controls/biobanks)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            16,465 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1"
+          href="/?dataset=gnomad_r2_1"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            141,456 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_non_topmed"
+          href="/?dataset=gnomad_r2_1_non_topmed"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (non-TOPMed)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            135,743 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_non_cancer"
+          href="/?dataset=gnomad_r2_1_non_cancer"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (non-cancer)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            134,187 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_non_neuro"
+          href="/?dataset=gnomad_r2_1_non_neuro"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (non-neuro)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            114,704 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_controls"
+          href="/?dataset=gnomad_r2_1_controls"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (controls)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            60,146 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="exac"
+          href="/?dataset=exac"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          ExAC v1.0
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            60,706 samples
+          </div>
+        </a>
+      </li>
+    </ul>
+  </li>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 hxGlCv"
+  >
+    <a
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="current_sv_dataset"
+      href="/?dataset=gnomad_sv_r2_1"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+    >
+      gnomAD SVs v2.1
+    </a>
+  </li>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 hxGlCv"
+  >
+    <a
+      aria-expanded={false}
+      aria-haspopup="true"
+      aria-label="More datasets"
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="other_structural_variant"
+      href="/"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+    >
+      <span
+        className="DatasetSelector__MoreIcon-sc-1x96sz-3 iAlUbC"
+      >
+        <img
+          alt=""
+          aria-hidden="true"
+          src="test-file-stub"
+        />
+      </span>
+    </a>
+    <ul
+      className="DatasetSelector__SubNavigationMenu-sc-1x96sz-4 gbhOxb"
+    >
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_sv_r2_1"
+          href="/?dataset=gnomad_sv_r2_1"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD SVs v2.1
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            10,847 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_sv_r2_1_non_neuro"
+          href="/?dataset=gnomad_sv_r2_1_non_neuro"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD SVs v2.1 (non-neuro)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            8,342 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_sv_r2_1_controls"
+          href="/?dataset=gnomad_sv_r2_1_controls"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD SVs v2.1 (controls)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            5,192 samples
+          </div>
+        </a>
+      </li>
+    </ul>
+  </li>
+</ul>
+`;
+
+exports[`DataSelector with "gnomad_r3_non_neuro" dataset selected has no unexpected changes 1`] = `
+<ul
+  className="DatasetSelector__NavigationMenuWrapper-sc-1x96sz-0 dOhyHC"
+>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 eioFKY"
+  >
+    <a
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="current_short_variant"
+      href="/?dataset=gnomad_r3_non_neuro"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+    >
+      gnomAD v3.1.2 (non-neuro)
+    </a>
+  </li>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 eioFKY"
+  >
+    <a
+      aria-expanded={false}
+      aria-haspopup="true"
+      aria-label="More datasets"
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="other_short_variant"
+      href="/"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+    >
+      <span
+        className="DatasetSelector__MoreIcon-sc-1x96sz-3 iAlUbC"
+      >
+        <img
+          alt=""
+          aria-hidden="true"
+          src="test-file-stub"
+        />
+      </span>
+    </a>
+    <ul
+      className="DatasetSelector__SubNavigationMenu-sc-1x96sz-4 gbhOxb"
+    >
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3"
+          href="/?dataset=gnomad_r3"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            76,156 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_cancer"
+          href="/?dataset=gnomad_r3_non_cancer"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-cancer)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            74,023 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_neuro"
+          href="/?dataset=gnomad_r3_non_neuro"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-neuro)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            67,442 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_v2"
+          href="/?dataset=gnomad_r3_non_v2"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-v2)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            57,344 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_topmed"
+          href="/?dataset=gnomad_r3_non_topmed"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-TOPMed)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            40,433 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_controls_and_biobanks"
+          href="/?dataset=gnomad_r3_controls_and_biobanks"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (controls/biobanks)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            16,465 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1"
+          href="/?dataset=gnomad_r2_1"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            141,456 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_non_topmed"
+          href="/?dataset=gnomad_r2_1_non_topmed"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (non-TOPMed)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            135,743 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_non_cancer"
+          href="/?dataset=gnomad_r2_1_non_cancer"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (non-cancer)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            134,187 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_non_neuro"
+          href="/?dataset=gnomad_r2_1_non_neuro"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (non-neuro)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            114,704 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_controls"
+          href="/?dataset=gnomad_r2_1_controls"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (controls)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            60,146 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="exac"
+          href="/?dataset=exac"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          ExAC v1.0
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            60,706 samples
+          </div>
+        </a>
+      </li>
+    </ul>
+  </li>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 hxGlCv"
+  >
+    <a
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="current_sv_dataset"
+      href="/?dataset=gnomad_sv_r2_1"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+    >
+      gnomAD SVs v2.1
+    </a>
+  </li>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 hxGlCv"
+  >
+    <a
+      aria-expanded={false}
+      aria-haspopup="true"
+      aria-label="More datasets"
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="other_structural_variant"
+      href="/"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+    >
+      <span
+        className="DatasetSelector__MoreIcon-sc-1x96sz-3 iAlUbC"
+      >
+        <img
+          alt=""
+          aria-hidden="true"
+          src="test-file-stub"
+        />
+      </span>
+    </a>
+    <ul
+      className="DatasetSelector__SubNavigationMenu-sc-1x96sz-4 gbhOxb"
+    >
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_sv_r2_1"
+          href="/?dataset=gnomad_sv_r2_1"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD SVs v2.1
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            10,847 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_sv_r2_1_non_neuro"
+          href="/?dataset=gnomad_sv_r2_1_non_neuro"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD SVs v2.1 (non-neuro)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            8,342 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_sv_r2_1_controls"
+          href="/?dataset=gnomad_sv_r2_1_controls"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD SVs v2.1 (controls)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            5,192 samples
+          </div>
+        </a>
+      </li>
+    </ul>
+  </li>
+</ul>
+`;
+
+exports[`DataSelector with "gnomad_r3_non_topmed" dataset selected has no unexpected changes 1`] = `
+<ul
+  className="DatasetSelector__NavigationMenuWrapper-sc-1x96sz-0 dOhyHC"
+>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 eioFKY"
+  >
+    <a
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="current_short_variant"
+      href="/?dataset=gnomad_r3_non_topmed"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+    >
+      gnomAD v3.1.2 (non-TOPMed)
+    </a>
+  </li>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 eioFKY"
+  >
+    <a
+      aria-expanded={false}
+      aria-haspopup="true"
+      aria-label="More datasets"
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="other_short_variant"
+      href="/"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+    >
+      <span
+        className="DatasetSelector__MoreIcon-sc-1x96sz-3 iAlUbC"
+      >
+        <img
+          alt=""
+          aria-hidden="true"
+          src="test-file-stub"
+        />
+      </span>
+    </a>
+    <ul
+      className="DatasetSelector__SubNavigationMenu-sc-1x96sz-4 gbhOxb"
+    >
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3"
+          href="/?dataset=gnomad_r3"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            76,156 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_cancer"
+          href="/?dataset=gnomad_r3_non_cancer"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-cancer)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            74,023 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_neuro"
+          href="/?dataset=gnomad_r3_non_neuro"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-neuro)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            67,442 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_v2"
+          href="/?dataset=gnomad_r3_non_v2"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-v2)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            57,344 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_topmed"
+          href="/?dataset=gnomad_r3_non_topmed"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-TOPMed)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            40,433 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_controls_and_biobanks"
+          href="/?dataset=gnomad_r3_controls_and_biobanks"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (controls/biobanks)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            16,465 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1"
+          href="/?dataset=gnomad_r2_1"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            141,456 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_non_topmed"
+          href="/?dataset=gnomad_r2_1_non_topmed"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (non-TOPMed)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            135,743 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_non_cancer"
+          href="/?dataset=gnomad_r2_1_non_cancer"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (non-cancer)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            134,187 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_non_neuro"
+          href="/?dataset=gnomad_r2_1_non_neuro"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (non-neuro)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            114,704 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_controls"
+          href="/?dataset=gnomad_r2_1_controls"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (controls)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            60,146 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="exac"
+          href="/?dataset=exac"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          ExAC v1.0
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            60,706 samples
+          </div>
+        </a>
+      </li>
+    </ul>
+  </li>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 hxGlCv"
+  >
+    <a
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="current_sv_dataset"
+      href="/?dataset=gnomad_sv_r2_1"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+    >
+      gnomAD SVs v2.1
+    </a>
+  </li>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 hxGlCv"
+  >
+    <a
+      aria-expanded={false}
+      aria-haspopup="true"
+      aria-label="More datasets"
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="other_structural_variant"
+      href="/"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+    >
+      <span
+        className="DatasetSelector__MoreIcon-sc-1x96sz-3 iAlUbC"
+      >
+        <img
+          alt=""
+          aria-hidden="true"
+          src="test-file-stub"
+        />
+      </span>
+    </a>
+    <ul
+      className="DatasetSelector__SubNavigationMenu-sc-1x96sz-4 gbhOxb"
+    >
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_sv_r2_1"
+          href="/?dataset=gnomad_sv_r2_1"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD SVs v2.1
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            10,847 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_sv_r2_1_non_neuro"
+          href="/?dataset=gnomad_sv_r2_1_non_neuro"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD SVs v2.1 (non-neuro)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            8,342 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_sv_r2_1_controls"
+          href="/?dataset=gnomad_sv_r2_1_controls"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD SVs v2.1 (controls)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            5,192 samples
+          </div>
+        </a>
+      </li>
+    </ul>
+  </li>
+</ul>
+`;
+
+exports[`DataSelector with "gnomad_r3_non_v2" dataset selected has no unexpected changes 1`] = `
+<ul
+  className="DatasetSelector__NavigationMenuWrapper-sc-1x96sz-0 dOhyHC"
+>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 eioFKY"
+  >
+    <a
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="current_short_variant"
+      href="/?dataset=gnomad_r3_non_v2"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+    >
+      gnomAD v3.1.2 (non-v2)
+    </a>
+  </li>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 eioFKY"
+  >
+    <a
+      aria-expanded={false}
+      aria-haspopup="true"
+      aria-label="More datasets"
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="other_short_variant"
+      href="/"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+    >
+      <span
+        className="DatasetSelector__MoreIcon-sc-1x96sz-3 iAlUbC"
+      >
+        <img
+          alt=""
+          aria-hidden="true"
+          src="test-file-stub"
+        />
+      </span>
+    </a>
+    <ul
+      className="DatasetSelector__SubNavigationMenu-sc-1x96sz-4 gbhOxb"
+    >
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3"
+          href="/?dataset=gnomad_r3"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            76,156 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_cancer"
+          href="/?dataset=gnomad_r3_non_cancer"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-cancer)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            74,023 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_neuro"
+          href="/?dataset=gnomad_r3_non_neuro"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-neuro)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            67,442 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_v2"
+          href="/?dataset=gnomad_r3_non_v2"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-v2)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            57,344 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_topmed"
+          href="/?dataset=gnomad_r3_non_topmed"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-TOPMed)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            40,433 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_controls_and_biobanks"
+          href="/?dataset=gnomad_r3_controls_and_biobanks"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (controls/biobanks)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            16,465 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1"
+          href="/?dataset=gnomad_r2_1"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            141,456 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_non_topmed"
+          href="/?dataset=gnomad_r2_1_non_topmed"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (non-TOPMed)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            135,743 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_non_cancer"
+          href="/?dataset=gnomad_r2_1_non_cancer"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (non-cancer)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            134,187 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_non_neuro"
+          href="/?dataset=gnomad_r2_1_non_neuro"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (non-neuro)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            114,704 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_controls"
+          href="/?dataset=gnomad_r2_1_controls"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (controls)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            60,146 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="exac"
+          href="/?dataset=exac"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          ExAC v1.0
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            60,706 samples
+          </div>
+        </a>
+      </li>
+    </ul>
+  </li>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 hxGlCv"
+  >
+    <a
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="current_sv_dataset"
+      href="/?dataset=gnomad_sv_r2_1"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+    >
+      gnomAD SVs v2.1
+    </a>
+  </li>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 hxGlCv"
+  >
+    <a
+      aria-expanded={false}
+      aria-haspopup="true"
+      aria-label="More datasets"
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="other_structural_variant"
+      href="/"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+    >
+      <span
+        className="DatasetSelector__MoreIcon-sc-1x96sz-3 iAlUbC"
+      >
+        <img
+          alt=""
+          aria-hidden="true"
+          src="test-file-stub"
+        />
+      </span>
+    </a>
+    <ul
+      className="DatasetSelector__SubNavigationMenu-sc-1x96sz-4 gbhOxb"
+    >
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_sv_r2_1"
+          href="/?dataset=gnomad_sv_r2_1"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD SVs v2.1
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            10,847 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_sv_r2_1_non_neuro"
+          href="/?dataset=gnomad_sv_r2_1_non_neuro"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD SVs v2.1 (non-neuro)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            8,342 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_sv_r2_1_controls"
+          href="/?dataset=gnomad_sv_r2_1_controls"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD SVs v2.1 (controls)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            5,192 samples
+          </div>
+        </a>
+      </li>
+    </ul>
+  </li>
+</ul>
+`;
+
+exports[`DataSelector with "gnomad_sv_r2_1" dataset selected has no unexpected changes 1`] = `
+<ul
+  className="DatasetSelector__NavigationMenuWrapper-sc-1x96sz-0 dOhyHC"
+>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 hxGlCv"
+  >
+    <a
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="current_short_variant"
+      href="/?dataset=gnomad_r2_1"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+    >
+      gnomAD v2.1.1
+    </a>
+  </li>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 hxGlCv"
+  >
+    <a
+      aria-expanded={false}
+      aria-haspopup="true"
+      aria-label="More datasets"
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="other_short_variant"
+      href="/"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+    >
+      <span
+        className="DatasetSelector__MoreIcon-sc-1x96sz-3 iAlUbC"
+      >
+        <img
+          alt=""
+          aria-hidden="true"
+          src="test-file-stub"
+        />
+      </span>
+    </a>
+    <ul
+      className="DatasetSelector__SubNavigationMenu-sc-1x96sz-4 gbhOxb"
+    >
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3"
+          href="/?dataset=gnomad_r3"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            76,156 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_cancer"
+          href="/?dataset=gnomad_r3_non_cancer"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-cancer)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            74,023 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_neuro"
+          href="/?dataset=gnomad_r3_non_neuro"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-neuro)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            67,442 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_v2"
+          href="/?dataset=gnomad_r3_non_v2"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-v2)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            57,344 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_topmed"
+          href="/?dataset=gnomad_r3_non_topmed"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-TOPMed)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            40,433 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_controls_and_biobanks"
+          href="/?dataset=gnomad_r3_controls_and_biobanks"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (controls/biobanks)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            16,465 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1"
+          href="/?dataset=gnomad_r2_1"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            141,456 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_non_topmed"
+          href="/?dataset=gnomad_r2_1_non_topmed"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (non-TOPMed)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            135,743 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_non_cancer"
+          href="/?dataset=gnomad_r2_1_non_cancer"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (non-cancer)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            134,187 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_non_neuro"
+          href="/?dataset=gnomad_r2_1_non_neuro"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (non-neuro)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            114,704 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_controls"
+          href="/?dataset=gnomad_r2_1_controls"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (controls)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            60,146 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="exac"
+          href="/?dataset=exac"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          ExAC v1.0
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            60,706 samples
+          </div>
+        </a>
+      </li>
+    </ul>
+  </li>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 eioFKY"
+  >
+    <a
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="current_sv_dataset"
+      href="/?dataset=gnomad_sv_r2_1"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+    >
+      gnomAD SVs v2.1
+    </a>
+  </li>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 eioFKY"
+  >
+    <a
+      aria-expanded={false}
+      aria-haspopup="true"
+      aria-label="More datasets"
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="other_structural_variant"
+      href="/"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+    >
+      <span
+        className="DatasetSelector__MoreIcon-sc-1x96sz-3 iAlUbC"
+      >
+        <img
+          alt=""
+          aria-hidden="true"
+          src="test-file-stub"
+        />
+      </span>
+    </a>
+    <ul
+      className="DatasetSelector__SubNavigationMenu-sc-1x96sz-4 gbhOxb"
+    >
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_sv_r2_1"
+          href="/?dataset=gnomad_sv_r2_1"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD SVs v2.1
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            10,847 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_sv_r2_1_non_neuro"
+          href="/?dataset=gnomad_sv_r2_1_non_neuro"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD SVs v2.1 (non-neuro)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            8,342 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_sv_r2_1_controls"
+          href="/?dataset=gnomad_sv_r2_1_controls"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD SVs v2.1 (controls)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            5,192 samples
+          </div>
+        </a>
+      </li>
+    </ul>
+  </li>
+</ul>
+`;
+
+exports[`DataSelector with "gnomad_sv_r2_1_controls" dataset selected has no unexpected changes 1`] = `
+<ul
+  className="DatasetSelector__NavigationMenuWrapper-sc-1x96sz-0 dOhyHC"
+>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 hxGlCv"
+  >
+    <a
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="current_short_variant"
+      href="/?dataset=gnomad_r2_1"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+    >
+      gnomAD v2.1.1
+    </a>
+  </li>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 hxGlCv"
+  >
+    <a
+      aria-expanded={false}
+      aria-haspopup="true"
+      aria-label="More datasets"
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="other_short_variant"
+      href="/"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+    >
+      <span
+        className="DatasetSelector__MoreIcon-sc-1x96sz-3 iAlUbC"
+      >
+        <img
+          alt=""
+          aria-hidden="true"
+          src="test-file-stub"
+        />
+      </span>
+    </a>
+    <ul
+      className="DatasetSelector__SubNavigationMenu-sc-1x96sz-4 gbhOxb"
+    >
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3"
+          href="/?dataset=gnomad_r3"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            76,156 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_cancer"
+          href="/?dataset=gnomad_r3_non_cancer"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-cancer)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            74,023 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_neuro"
+          href="/?dataset=gnomad_r3_non_neuro"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-neuro)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            67,442 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_v2"
+          href="/?dataset=gnomad_r3_non_v2"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-v2)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            57,344 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_topmed"
+          href="/?dataset=gnomad_r3_non_topmed"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-TOPMed)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            40,433 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_controls_and_biobanks"
+          href="/?dataset=gnomad_r3_controls_and_biobanks"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (controls/biobanks)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            16,465 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1"
+          href="/?dataset=gnomad_r2_1"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            141,456 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_non_topmed"
+          href="/?dataset=gnomad_r2_1_non_topmed"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (non-TOPMed)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            135,743 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_non_cancer"
+          href="/?dataset=gnomad_r2_1_non_cancer"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (non-cancer)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            134,187 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_non_neuro"
+          href="/?dataset=gnomad_r2_1_non_neuro"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (non-neuro)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            114,704 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_controls"
+          href="/?dataset=gnomad_r2_1_controls"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (controls)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            60,146 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="exac"
+          href="/?dataset=exac"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          ExAC v1.0
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            60,706 samples
+          </div>
+        </a>
+      </li>
+    </ul>
+  </li>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 eioFKY"
+  >
+    <a
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="current_sv_dataset"
+      href="/?dataset=gnomad_sv_r2_1_controls"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+    >
+      gnomAD SVs v2.1 (controls)
+    </a>
+  </li>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 eioFKY"
+  >
+    <a
+      aria-expanded={false}
+      aria-haspopup="true"
+      aria-label="More datasets"
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="other_structural_variant"
+      href="/"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+    >
+      <span
+        className="DatasetSelector__MoreIcon-sc-1x96sz-3 iAlUbC"
+      >
+        <img
+          alt=""
+          aria-hidden="true"
+          src="test-file-stub"
+        />
+      </span>
+    </a>
+    <ul
+      className="DatasetSelector__SubNavigationMenu-sc-1x96sz-4 gbhOxb"
+    >
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_sv_r2_1"
+          href="/?dataset=gnomad_sv_r2_1"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD SVs v2.1
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            10,847 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_sv_r2_1_non_neuro"
+          href="/?dataset=gnomad_sv_r2_1_non_neuro"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD SVs v2.1 (non-neuro)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            8,342 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_sv_r2_1_controls"
+          href="/?dataset=gnomad_sv_r2_1_controls"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD SVs v2.1 (controls)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            5,192 samples
+          </div>
+        </a>
+      </li>
+    </ul>
+  </li>
+</ul>
+`;
+
+exports[`DataSelector with "gnomad_sv_r2_1_non_neuro" dataset selected has no unexpected changes 1`] = `
+<ul
+  className="DatasetSelector__NavigationMenuWrapper-sc-1x96sz-0 dOhyHC"
+>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 hxGlCv"
+  >
+    <a
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="current_short_variant"
+      href="/?dataset=gnomad_r2_1"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+    >
+      gnomAD v2.1.1
+    </a>
+  </li>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 hxGlCv"
+  >
+    <a
+      aria-expanded={false}
+      aria-haspopup="true"
+      aria-label="More datasets"
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="other_short_variant"
+      href="/"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+    >
+      <span
+        className="DatasetSelector__MoreIcon-sc-1x96sz-3 iAlUbC"
+      >
+        <img
+          alt=""
+          aria-hidden="true"
+          src="test-file-stub"
+        />
+      </span>
+    </a>
+    <ul
+      className="DatasetSelector__SubNavigationMenu-sc-1x96sz-4 gbhOxb"
+    >
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3"
+          href="/?dataset=gnomad_r3"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            76,156 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_cancer"
+          href="/?dataset=gnomad_r3_non_cancer"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-cancer)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            74,023 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_neuro"
+          href="/?dataset=gnomad_r3_non_neuro"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-neuro)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            67,442 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_v2"
+          href="/?dataset=gnomad_r3_non_v2"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-v2)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            57,344 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_non_topmed"
+          href="/?dataset=gnomad_r3_non_topmed"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (non-TOPMed)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            40,433 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r3_controls_and_biobanks"
+          href="/?dataset=gnomad_r3_controls_and_biobanks"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v3.1.2 (controls/biobanks)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            16,465 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1"
+          href="/?dataset=gnomad_r2_1"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            141,456 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_non_topmed"
+          href="/?dataset=gnomad_r2_1_non_topmed"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (non-TOPMed)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            135,743 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_non_cancer"
+          href="/?dataset=gnomad_r2_1_non_cancer"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (non-cancer)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            134,187 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_non_neuro"
+          href="/?dataset=gnomad_r2_1_non_neuro"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (non-neuro)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            114,704 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_r2_1_controls"
+          href="/?dataset=gnomad_r2_1_controls"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD v2.1.1 (controls)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            60,146 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="exac"
+          href="/?dataset=exac"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          ExAC v1.0
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            60,706 samples
+          </div>
+        </a>
+      </li>
+    </ul>
+  </li>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 eioFKY"
+  >
+    <a
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="current_sv_dataset"
+      href="/?dataset=gnomad_sv_r2_1_non_neuro"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+    >
+      gnomAD SVs v2.1 (non-neuro)
+    </a>
+  </li>
+  <li
+    className="DatasetSelector__NavigationMenuItem-sc-1x96sz-2 eioFKY"
+  >
+    <a
+      aria-expanded={false}
+      aria-haspopup="true"
+      aria-label="More datasets"
+      className="DatasetSelector__TopLevelNavigationLink-sc-1x96sz-1-Link hSieFP"
+      data-item="other_structural_variant"
+      href="/"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+    >
+      <span
+        className="DatasetSelector__MoreIcon-sc-1x96sz-3 iAlUbC"
+      >
+        <img
+          alt=""
+          aria-hidden="true"
+          src="test-file-stub"
+        />
+      </span>
+    </a>
+    <ul
+      className="DatasetSelector__SubNavigationMenu-sc-1x96sz-4 gbhOxb"
+    >
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_sv_r2_1"
+          href="/?dataset=gnomad_sv_r2_1"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD SVs v2.1
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            10,847 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_sv_r2_1_non_neuro"
+          href="/?dataset=gnomad_sv_r2_1_non_neuro"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD SVs v2.1 (non-neuro)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            8,342 samples
+          </div>
+        </a>
+      </li>
+      <li>
+        <a
+          className="DatasetSelector__SubNavigationLink-sc-1x96sz-5-Link faaHrH"
+          data-item="gnomad_sv_r2_1_controls"
+          href="/?dataset=gnomad_sv_r2_1_controls"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          gnomAD SVs v2.1 (controls)
+          <div
+            className="DatasetSelector__ItemDescription-sc-1x96sz-6 QZZIO"
+          >
+            5,192 samples
+          </div>
+        </a>
+      </li>
+    </ul>
+  </li>
+</ul>
+`;

--- a/browser/src/datasets.js
+++ b/browser/src/datasets.js
@@ -24,6 +24,8 @@ const datasetLabels = {
   gnomad_sv_r2_1_non_neuro: 'gnomAD SVs v2.1 (non-neuro)',
 }
 
+export const allDatasetIds = Object.keys(datasetLabels)
+
 export const labelForDataset = datasetId => datasetLabels[datasetId] || 'Unknown'
 
 export const isSubset = datasetId =>

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,7 +8,7 @@ module.exports = {
         '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
           '<rootDir>/tests/__mocks__/fileMock.js',
       },
-      testMatch: ['<rootDir>/browser/**/*.spec.js'],
+      testMatch: ['<rootDir>/browser/**/*.spec.js?(x)'],
       setupFilesAfterEnv: ['@testing-library/jest-dom'],
     },
     {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "jest": "^26.1.0",
     "nodemon": "^2.0.4",
     "prettier": "2.0.5",
+    "react-test-renderer": "^16.14.0",
     "stylelint": "^13.6.1",
     "stylelint-config-standard": "^20.0.0",
     "stylelint-config-styled-components": "^0.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7979,7 +7979,7 @@ react-hot-loader@^4.12.21:
     shallowequal "^1.1.0"
     source-map "^0.7.3"
 
-react-is@^16.12.0, react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
+react-is@^16.12.0, react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.6:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -8056,6 +8056,16 @@ react-slider@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/react-slider/-/react-slider-1.3.1.tgz#41dd88f7c67520811a4114d6f8f49d186268d9da"
   integrity sha512-bD8hHJJUgAHI8g1F6PY6432l+Dmcs2fqzUwDhd+0HWDdvfjwNoXRNC2cL9OWyGTjYlJM92A8nF/w1X4pyHfytQ==
+
+react-test-renderer@^16.14.0:
+  version "16.14.0"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.14.0.tgz#e98360087348e260c56d4fe2315e970480c228ae"
+  integrity sha512-L8yPjqPE5CZO6rKsKXRO/rVPiaCOy0tQQJbC+UjPNlobl5mad59lvPjwFsQHTvL03caVDIVr9x9/OSgDe6I5Eg==
+  dependencies:
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    react-is "^16.8.6"
+    scheduler "^0.19.1"
 
 react-window@^1.7.1:
   version "1.8.5"


### PR DESCRIPTION
resolves #930 

@mattsolo1 @rileyhgrant for this, I used the snapshot capabilities built into the Jest testing library that we're already using: https://jestjs.io/docs/snapshot-testing. 

The snapshot file, `browser/src/__snapshots__/DatasetSelector.spec.jsx.snap`, is checked into version control as I mentioned earlier today. If you read it carefully, you'll see that it's a funny-looking but vaild JS module that exports a bunch of long string literals containing HTML. Behind the scenes, when we call `expect(tree).toMatchSnapshot()`, `toMatchSnapshot` automatically figures out which of those literals goes with the current test, renders the `tree` of React components to HTML, and compares the rendered HTML to the snapshot. If they don't match, the test fails, and the test output will show diffs of the actual versus expected markup to help you diagnose.

When a snapshot test fails, this doesn't always mean there is a bug. Consider that the rendered markup might not match the snapshot due to a deliberate change you made to the code, or due to an unintentional but benign side-effect of such a change. In that case, the thing to do is to update the snapshot by running `yarn test -u`, as opposed to just `yarn test`.

Similarly, when you write a new snapshot test, there won't be a corresponding snapshot in the codebase yet. The first time you actually run the new test, Jest assumes that the result of rendering `tree` gives the correct markup, the new test passes, and it creates the appropriate snapshot. Due to that, when your aim as in this PR is to prevent regressions rather than to cover new features, it's important to run the test and create that "before" snapshot before you start changing the code proper.

Finally, I want to caution one more time against using snapshot tests and only snapshot tests. They're useful, but best when complemented by well-chosen unit tests. In the current situation though, where we're interested in quickly growing a test suite on a complicated codebase from basically nothing, they're an excellent place to start.