### PR TITLE
Split up one question in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_Report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.md
@@ -17,8 +17,11 @@ about: Report a bug or unexpected behavior
 ### What you did:
 <!-- What you were doing. Include a link to the page you were viewing. -->
 
-### What happened:
-<!--
+### What you expected to see after you did that:
+<!-- What would have been on the screen after your interaction, if everything had gone according to your expectations. -->
+
+### What you actually saw after you did that:
+<!-- What was actually on the screen after your interaction, focusing on the difference between that and the expected state above. -->
 
 Any of the following information will be helpful:
 


### PR DESCRIPTION
Per some conversation with @sjahl and @mattsolo1 I propose we go from asking "What happened?" in the bug report to "What did you expect to see?" and "What did you actually see?". I've found it's best to pose the question this way because it inclines the user to give you a plain straightforward description of the evidence, rather than following their natural inclination to make sense of it and supply an explanation of their own, which can be misleading.

Also I don't love the language I put in for the longer descriptions of those questions, feedback even more welcome than usual. /cc @rileyhgrant if you'd like to take a swing too.