### PR TITLE
Don't lint snapshots in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,5 @@
 ---
+exclude: '\.snap$'
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1
@@ -7,7 +8,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.0.5  # This should be kept in sync with the version in package.json
+    rev: v2.0.5 # This should be kept in sync with the version in package.json
     hooks:
       - id: prettier
   - repo: https://github.com/psf/black


### PR DESCRIPTION
Technically a snapshot file is valid JS source code, but doesn't and shouldn't adhere to customary JS formatting conventions.