### PR TITLE
Refactor isSubset to expedite adding future datasets

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,5 @@
 ---
+exclude: '\.snap$'
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1
@@ -7,7 +8,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.0.5  # This should be kept in sync with the version in package.json
+    rev: v2.0.5 # This should be kept in sync with the version in package.json
     hooks:
       - id: prettier
   - repo: https://github.com/psf/black

--- a/browser/src/ReadData/IGVBrowser.js
+++ b/browser/src/ReadData/IGVBrowser.js
@@ -75,19 +75,21 @@ class IGVBrowser extends Component {
       promisified: true,
     }
 
-    igv.createBrowser(this.el, browserConfig).then(browser => {
-      if (this.mounted === false) {
-        igv.removeBrowser(browser)
-        return
-      }
+    igv
+      .createBrowser(this.el, browserConfig)
+      .then(browser => {
+        if (this.mounted === false) {
+          igv.removeBrowser(browser)
+          return
+        }
 
-      this.browser = browser
+        this.browser = browser
 
-      const resetButton = document.createElement('i')
-      resetButton.className = 'igv-app-icon'
-      resetButton.innerText = '⟲'
-      resetButton.title = 'Reset'
-      resetButton.style.cssText = `
+        const resetButton = document.createElement('i')
+        resetButton.className = 'igv-app-icon'
+        resetButton.innerText = '⟲'
+        resetButton.title = 'Reset'
+        resetButton.style.cssText = `
         position: relative;
         top: -1px;
         font-style: normal;
@@ -95,14 +97,15 @@ class IGVBrowser extends Component {
         font-weight: bold;
         margin: 0 10px;
       `
-      resetButton.addEventListener('click', () => {
-        browser.search(config.locus)
+        resetButton.addEventListener('click', () => {
+          browser.search(config.locus)
+        })
+
+        this.el.querySelector('.igv-search-container').appendChild(resetButton)
+
+        onCreateBrowser(browser)
       })
-
-      this.el.querySelector('.igv-search-container').appendChild(resetButton)
-
-      onCreateBrowser(browser)
-    })
+      .catch(reason => console.error(`failed to create IGV browser: "${reason}"`)) // eslint-disable-line no-console
   }
 
   componentWillUnmount() {

--- a/browser/src/ReadData/ReadData.js
+++ b/browser/src/ReadData/ReadData.js
@@ -4,7 +4,7 @@ import styled from 'styled-components'
 
 import { Badge, Button, ExternalLink } from '@gnomad/ui'
 
-import { isSubset } from '../datasets'
+import { isSubset } from '../../../dataset-metadata/metadata'
 import { BaseQuery } from '../Query'
 import StatusMessage from '../StatusMessage'
 

--- a/browser/src/ReadData/ReadData.spec.jsx
+++ b/browser/src/ReadData/ReadData.spec.jsx
@@ -1,0 +1,48 @@
+import React from 'react'
+import { Router } from 'react-router'
+import renderer from 'react-test-renderer'
+import { createBrowserHistory } from 'history'
+
+import { readsApiOutputFactory, exomeReadApiOutputFactory } from '../__factories__/ReadData'
+import ReadDataContainer from './ReadData'
+import { allDatasetIds } from '../datasets'
+
+const variantId = '123-45-A-G'
+
+jest.mock('../../../graphql-api/src/cache', () => ({
+  withCache: (wrappedFunction) => wrappedFunction,
+}))
+
+let mockGraphqlResponse = undefined
+
+const mockEndpoints = {
+  '/reads/': readsApiOutputFactory.params({
+    variant_0: { exome: exomeReadApiOutputFactory.buildList(1) },
+  }),
+}
+
+jest.mock('../Query', () => ({
+  BaseQuery: ({ children, url }) => {
+    const mockEndpoint = mockEndpoints[url]
+    if (mockEndpoint) {
+      const result = mockEndpoint.build()
+      mockGraphqlResponse = { data: result }
+      return children(mockGraphqlResponse)
+    } else {
+      throw `mocked BaseQuery got unexpected URL "${url}"`
+    }
+  },
+}))
+
+jest.mock('./IGVBrowser', () => () => null)
+
+describe.each(allDatasetIds)('ReadData with "%s" dataset selected', (datasetId) => {
+  test('has no unexpected changes', () => {
+    const tree = renderer.create(
+      <Router history={createBrowserHistory()}>
+        <ReadDataContainer datasetId={datasetId} variantIds={[variantId]} />
+      </Router>
+    )
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/browser/src/ReadData/__snapshots__/ReadData.spec.jsx.snap
+++ b/browser/src/ReadData/__snapshots__/ReadData.spec.jsx.snap
@@ -1,0 +1,1224 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ReadData with "exac" dataset selected has no unexpected changes 1`] = `
+<div>
+  <p>
+    This interactive
+     
+    <a
+      className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+      href="https://github.com/igvteam/igv.js"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      IGV.js
+    </a>
+     visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
+  </p>
+  <p>
+    These are reassembled reads produced by
+     
+    <a
+      className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+      href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      GATK HaplotypeCaller --bamOutput
+    </a>
+    , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
+  </p>
+  <div
+    className="ReadData__ControlContainer-sc-10qachg-0 dgUgCF"
+  >
+    <strong>
+      Exomes:
+    </strong>
+    <button
+      className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+      disabled={true}
+      onClick={[Function]}
+      type="button"
+    >
+      Load +1 
+      het
+    </button>
+    <button
+      className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+      disabled={false}
+      onClick={[Function]}
+      type="button"
+    >
+      Load +1 
+      hom
+    </button>
+  </div>
+  <div
+    className="ReadData__ControlContainer-sc-10qachg-0 dgUgCF"
+  >
+    <button
+      className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+      disabled={false}
+      onClick={[Function]}
+      style={
+        Object {
+          "marginLeft": "80px",
+        }
+      }
+      type="button"
+    >
+      Load all
+    </button>
+  </div>
+</div>
+`;
+
+exports[`ReadData with "gnomad_r2_1" dataset selected has no unexpected changes 1`] = `
+<div>
+  <p>
+    This interactive
+     
+    <a
+      className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+      href="https://github.com/igvteam/igv.js"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      IGV.js
+    </a>
+     visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
+  </p>
+  <p>
+    These are reassembled reads produced by
+     
+    <a
+      className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+      href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      GATK HaplotypeCaller --bamOutput
+    </a>
+    , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
+  </p>
+  <p>
+    <span
+      className="Badge__BadgeWrapper-j4izdp-1 cJObdY"
+    >
+      Note
+    </span>
+     Reads shown here may include low quality genotypes that were excluded from allele counts.
+  </p>
+  <div
+    className="ReadData__ControlContainer-sc-10qachg-0 dgUgCF"
+  >
+    <strong>
+      Exomes:
+    </strong>
+    <button
+      className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+      disabled={true}
+      onClick={[Function]}
+      type="button"
+    >
+      Load +1 
+      het
+    </button>
+    <button
+      className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+      disabled={false}
+      onClick={[Function]}
+      type="button"
+    >
+      Load +1 
+      hom
+    </button>
+  </div>
+  <div
+    className="ReadData__ControlContainer-sc-10qachg-0 dgUgCF"
+  >
+    <button
+      className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+      disabled={false}
+      onClick={[Function]}
+      style={
+        Object {
+          "marginLeft": "80px",
+        }
+      }
+      type="button"
+    >
+      Load all
+    </button>
+  </div>
+</div>
+`;
+
+exports[`ReadData with "gnomad_r2_1_controls" dataset selected has no unexpected changes 1`] = `
+<div>
+  <p>
+    This interactive
+     
+    <a
+      className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+      href="https://github.com/igvteam/igv.js"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      IGV.js
+    </a>
+     visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
+  </p>
+  <p>
+    These are reassembled reads produced by
+     
+    <a
+      className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+      href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      GATK HaplotypeCaller --bamOutput
+    </a>
+    , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
+  </p>
+  <p>
+    <span
+      className="Badge__BadgeWrapper-j4izdp-1 cJObdY"
+    >
+      Note
+    </span>
+     Reads shown here may include low quality genotypes that were excluded from allele counts.
+  </p>
+  <p>
+    <span
+      className="Badge__BadgeWrapper-j4izdp-1 cJObdY"
+    >
+      Note
+    </span>
+     Samples shown below are not guaranteed to be part of the selected subset.
+  </p>
+  <div
+    className="ReadData__ControlContainer-sc-10qachg-0 dgUgCF"
+  >
+    <strong>
+      Exomes:
+    </strong>
+    <button
+      className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+      disabled={true}
+      onClick={[Function]}
+      type="button"
+    >
+      Load +1 
+      het
+    </button>
+    <button
+      className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+      disabled={false}
+      onClick={[Function]}
+      type="button"
+    >
+      Load +1 
+      hom
+    </button>
+  </div>
+  <div
+    className="ReadData__ControlContainer-sc-10qachg-0 dgUgCF"
+  >
+    <button
+      className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+      disabled={false}
+      onClick={[Function]}
+      style={
+        Object {
+          "marginLeft": "80px",
+        }
+      }
+      type="button"
+    >
+      Load all
+    </button>
+  </div>
+</div>
+`;
+
+exports[`ReadData with "gnomad_r2_1_non_cancer" dataset selected has no unexpected changes 1`] = `
+<div>
+  <p>
+    This interactive
+     
+    <a
+      className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+      href="https://github.com/igvteam/igv.js"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      IGV.js
+    </a>
+     visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
+  </p>
+  <p>
+    These are reassembled reads produced by
+     
+    <a
+      className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+      href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      GATK HaplotypeCaller --bamOutput
+    </a>
+    , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
+  </p>
+  <p>
+    <span
+      className="Badge__BadgeWrapper-j4izdp-1 cJObdY"
+    >
+      Note
+    </span>
+     Reads shown here may include low quality genotypes that were excluded from allele counts.
+  </p>
+  <p>
+    <span
+      className="Badge__BadgeWrapper-j4izdp-1 cJObdY"
+    >
+      Note
+    </span>
+     Samples shown below are not guaranteed to be part of the selected subset.
+  </p>
+  <div
+    className="ReadData__ControlContainer-sc-10qachg-0 dgUgCF"
+  >
+    <strong>
+      Exomes:
+    </strong>
+    <button
+      className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+      disabled={true}
+      onClick={[Function]}
+      type="button"
+    >
+      Load +1 
+      het
+    </button>
+    <button
+      className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+      disabled={false}
+      onClick={[Function]}
+      type="button"
+    >
+      Load +1 
+      hom
+    </button>
+  </div>
+  <div
+    className="ReadData__ControlContainer-sc-10qachg-0 dgUgCF"
+  >
+    <button
+      className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+      disabled={false}
+      onClick={[Function]}
+      style={
+        Object {
+          "marginLeft": "80px",
+        }
+      }
+      type="button"
+    >
+      Load all
+    </button>
+  </div>
+</div>
+`;
+
+exports[`ReadData with "gnomad_r2_1_non_neuro" dataset selected has no unexpected changes 1`] = `
+<div>
+  <p>
+    This interactive
+     
+    <a
+      className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+      href="https://github.com/igvteam/igv.js"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      IGV.js
+    </a>
+     visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
+  </p>
+  <p>
+    These are reassembled reads produced by
+     
+    <a
+      className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+      href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      GATK HaplotypeCaller --bamOutput
+    </a>
+    , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
+  </p>
+  <p>
+    <span
+      className="Badge__BadgeWrapper-j4izdp-1 cJObdY"
+    >
+      Note
+    </span>
+     Reads shown here may include low quality genotypes that were excluded from allele counts.
+  </p>
+  <p>
+    <span
+      className="Badge__BadgeWrapper-j4izdp-1 cJObdY"
+    >
+      Note
+    </span>
+     Samples shown below are not guaranteed to be part of the selected subset.
+  </p>
+  <div
+    className="ReadData__ControlContainer-sc-10qachg-0 dgUgCF"
+  >
+    <strong>
+      Exomes:
+    </strong>
+    <button
+      className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+      disabled={true}
+      onClick={[Function]}
+      type="button"
+    >
+      Load +1 
+      het
+    </button>
+    <button
+      className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+      disabled={false}
+      onClick={[Function]}
+      type="button"
+    >
+      Load +1 
+      hom
+    </button>
+  </div>
+  <div
+    className="ReadData__ControlContainer-sc-10qachg-0 dgUgCF"
+  >
+    <button
+      className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+      disabled={false}
+      onClick={[Function]}
+      style={
+        Object {
+          "marginLeft": "80px",
+        }
+      }
+      type="button"
+    >
+      Load all
+    </button>
+  </div>
+</div>
+`;
+
+exports[`ReadData with "gnomad_r2_1_non_topmed" dataset selected has no unexpected changes 1`] = `
+<div>
+  <p>
+    This interactive
+     
+    <a
+      className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+      href="https://github.com/igvteam/igv.js"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      IGV.js
+    </a>
+     visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
+  </p>
+  <p>
+    These are reassembled reads produced by
+     
+    <a
+      className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+      href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      GATK HaplotypeCaller --bamOutput
+    </a>
+    , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
+  </p>
+  <p>
+    <span
+      className="Badge__BadgeWrapper-j4izdp-1 cJObdY"
+    >
+      Note
+    </span>
+     Reads shown here may include low quality genotypes that were excluded from allele counts.
+  </p>
+  <p>
+    <span
+      className="Badge__BadgeWrapper-j4izdp-1 cJObdY"
+    >
+      Note
+    </span>
+     Samples shown below are not guaranteed to be part of the selected subset.
+  </p>
+  <div
+    className="ReadData__ControlContainer-sc-10qachg-0 dgUgCF"
+  >
+    <strong>
+      Exomes:
+    </strong>
+    <button
+      className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+      disabled={true}
+      onClick={[Function]}
+      type="button"
+    >
+      Load +1 
+      het
+    </button>
+    <button
+      className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+      disabled={false}
+      onClick={[Function]}
+      type="button"
+    >
+      Load +1 
+      hom
+    </button>
+  </div>
+  <div
+    className="ReadData__ControlContainer-sc-10qachg-0 dgUgCF"
+  >
+    <button
+      className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+      disabled={false}
+      onClick={[Function]}
+      style={
+        Object {
+          "marginLeft": "80px",
+        }
+      }
+      type="button"
+    >
+      Load all
+    </button>
+  </div>
+</div>
+`;
+
+exports[`ReadData with "gnomad_r3" dataset selected has no unexpected changes 1`] = `
+<div>
+  <p>
+    This interactive
+     
+    <a
+      className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+      href="https://github.com/igvteam/igv.js"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      IGV.js
+    </a>
+     visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
+  </p>
+  <p>
+    These are reassembled reads produced by
+     
+    <a
+      className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+      href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      GATK HaplotypeCaller --bamOutput
+    </a>
+    , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
+  </p>
+  <div
+    className="ReadData__ControlContainer-sc-10qachg-0 dgUgCF"
+  >
+    <strong>
+      Exomes:
+    </strong>
+    <button
+      className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+      disabled={true}
+      onClick={[Function]}
+      type="button"
+    >
+      Load +1 
+      het
+    </button>
+    <button
+      className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+      disabled={false}
+      onClick={[Function]}
+      type="button"
+    >
+      Load +1 
+      hom
+    </button>
+  </div>
+  <div
+    className="ReadData__ControlContainer-sc-10qachg-0 dgUgCF"
+  >
+    <button
+      className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+      disabled={false}
+      onClick={[Function]}
+      style={
+        Object {
+          "marginLeft": "80px",
+        }
+      }
+      type="button"
+    >
+      Load all
+    </button>
+  </div>
+</div>
+`;
+
+exports[`ReadData with "gnomad_r3_controls_and_biobanks" dataset selected has no unexpected changes 1`] = `
+<div>
+  <p>
+    This interactive
+     
+    <a
+      className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+      href="https://github.com/igvteam/igv.js"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      IGV.js
+    </a>
+     visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
+  </p>
+  <p>
+    These are reassembled reads produced by
+     
+    <a
+      className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+      href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      GATK HaplotypeCaller --bamOutput
+    </a>
+    , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
+  </p>
+  <p>
+    <span
+      className="Badge__BadgeWrapper-j4izdp-1 cJObdY"
+    >
+      Note
+    </span>
+     Samples shown below are not guaranteed to be part of the selected subset.
+  </p>
+  <div
+    className="ReadData__ControlContainer-sc-10qachg-0 dgUgCF"
+  >
+    <strong>
+      Exomes:
+    </strong>
+    <button
+      className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+      disabled={true}
+      onClick={[Function]}
+      type="button"
+    >
+      Load +1 
+      het
+    </button>
+    <button
+      className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+      disabled={false}
+      onClick={[Function]}
+      type="button"
+    >
+      Load +1 
+      hom
+    </button>
+  </div>
+  <div
+    className="ReadData__ControlContainer-sc-10qachg-0 dgUgCF"
+  >
+    <button
+      className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+      disabled={false}
+      onClick={[Function]}
+      style={
+        Object {
+          "marginLeft": "80px",
+        }
+      }
+      type="button"
+    >
+      Load all
+    </button>
+  </div>
+</div>
+`;
+
+exports[`ReadData with "gnomad_r3_non_cancer" dataset selected has no unexpected changes 1`] = `
+<div>
+  <p>
+    This interactive
+     
+    <a
+      className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+      href="https://github.com/igvteam/igv.js"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      IGV.js
+    </a>
+     visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
+  </p>
+  <p>
+    These are reassembled reads produced by
+     
+    <a
+      className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+      href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      GATK HaplotypeCaller --bamOutput
+    </a>
+    , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
+  </p>
+  <p>
+    <span
+      className="Badge__BadgeWrapper-j4izdp-1 cJObdY"
+    >
+      Note
+    </span>
+     Samples shown below are not guaranteed to be part of the selected subset.
+  </p>
+  <div
+    className="ReadData__ControlContainer-sc-10qachg-0 dgUgCF"
+  >
+    <strong>
+      Exomes:
+    </strong>
+    <button
+      className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+      disabled={true}
+      onClick={[Function]}
+      type="button"
+    >
+      Load +1 
+      het
+    </button>
+    <button
+      className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+      disabled={false}
+      onClick={[Function]}
+      type="button"
+    >
+      Load +1 
+      hom
+    </button>
+  </div>
+  <div
+    className="ReadData__ControlContainer-sc-10qachg-0 dgUgCF"
+  >
+    <button
+      className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+      disabled={false}
+      onClick={[Function]}
+      style={
+        Object {
+          "marginLeft": "80px",
+        }
+      }
+      type="button"
+    >
+      Load all
+    </button>
+  </div>
+</div>
+`;
+
+exports[`ReadData with "gnomad_r3_non_neuro" dataset selected has no unexpected changes 1`] = `
+<div>
+  <p>
+    This interactive
+     
+    <a
+      className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+      href="https://github.com/igvteam/igv.js"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      IGV.js
+    </a>
+     visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
+  </p>
+  <p>
+    These are reassembled reads produced by
+     
+    <a
+      className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+      href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      GATK HaplotypeCaller --bamOutput
+    </a>
+    , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
+  </p>
+  <p>
+    <span
+      className="Badge__BadgeWrapper-j4izdp-1 cJObdY"
+    >
+      Note
+    </span>
+     Samples shown below are not guaranteed to be part of the selected subset.
+  </p>
+  <div
+    className="ReadData__ControlContainer-sc-10qachg-0 dgUgCF"
+  >
+    <strong>
+      Exomes:
+    </strong>
+    <button
+      className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+      disabled={true}
+      onClick={[Function]}
+      type="button"
+    >
+      Load +1 
+      het
+    </button>
+    <button
+      className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+      disabled={false}
+      onClick={[Function]}
+      type="button"
+    >
+      Load +1 
+      hom
+    </button>
+  </div>
+  <div
+    className="ReadData__ControlContainer-sc-10qachg-0 dgUgCF"
+  >
+    <button
+      className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+      disabled={false}
+      onClick={[Function]}
+      style={
+        Object {
+          "marginLeft": "80px",
+        }
+      }
+      type="button"
+    >
+      Load all
+    </button>
+  </div>
+</div>
+`;
+
+exports[`ReadData with "gnomad_r3_non_topmed" dataset selected has no unexpected changes 1`] = `
+<div>
+  <p>
+    This interactive
+     
+    <a
+      className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+      href="https://github.com/igvteam/igv.js"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      IGV.js
+    </a>
+     visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
+  </p>
+  <p>
+    These are reassembled reads produced by
+     
+    <a
+      className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+      href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      GATK HaplotypeCaller --bamOutput
+    </a>
+    , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
+  </p>
+  <p>
+    <span
+      className="Badge__BadgeWrapper-j4izdp-1 cJObdY"
+    >
+      Note
+    </span>
+     Samples shown below are not guaranteed to be part of the selected subset.
+  </p>
+  <div
+    className="ReadData__ControlContainer-sc-10qachg-0 dgUgCF"
+  >
+    <strong>
+      Exomes:
+    </strong>
+    <button
+      className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+      disabled={true}
+      onClick={[Function]}
+      type="button"
+    >
+      Load +1 
+      het
+    </button>
+    <button
+      className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+      disabled={false}
+      onClick={[Function]}
+      type="button"
+    >
+      Load +1 
+      hom
+    </button>
+  </div>
+  <div
+    className="ReadData__ControlContainer-sc-10qachg-0 dgUgCF"
+  >
+    <button
+      className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+      disabled={false}
+      onClick={[Function]}
+      style={
+        Object {
+          "marginLeft": "80px",
+        }
+      }
+      type="button"
+    >
+      Load all
+    </button>
+  </div>
+</div>
+`;
+
+exports[`ReadData with "gnomad_r3_non_v2" dataset selected has no unexpected changes 1`] = `
+<div>
+  <p>
+    This interactive
+     
+    <a
+      className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+      href="https://github.com/igvteam/igv.js"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      IGV.js
+    </a>
+     visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
+  </p>
+  <p>
+    These are reassembled reads produced by
+     
+    <a
+      className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+      href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      GATK HaplotypeCaller --bamOutput
+    </a>
+    , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
+  </p>
+  <p>
+    <span
+      className="Badge__BadgeWrapper-j4izdp-1 cJObdY"
+    >
+      Note
+    </span>
+     Samples shown below are not guaranteed to be part of the selected subset.
+  </p>
+  <div
+    className="ReadData__ControlContainer-sc-10qachg-0 dgUgCF"
+  >
+    <strong>
+      Exomes:
+    </strong>
+    <button
+      className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+      disabled={true}
+      onClick={[Function]}
+      type="button"
+    >
+      Load +1 
+      het
+    </button>
+    <button
+      className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+      disabled={false}
+      onClick={[Function]}
+      type="button"
+    >
+      Load +1 
+      hom
+    </button>
+  </div>
+  <div
+    className="ReadData__ControlContainer-sc-10qachg-0 dgUgCF"
+  >
+    <button
+      className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+      disabled={false}
+      onClick={[Function]}
+      style={
+        Object {
+          "marginLeft": "80px",
+        }
+      }
+      type="button"
+    >
+      Load all
+    </button>
+  </div>
+</div>
+`;
+
+exports[`ReadData with "gnomad_sv_r2_1" dataset selected has no unexpected changes 1`] = `
+<div>
+  <p>
+    This interactive
+     
+    <a
+      className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+      href="https://github.com/igvteam/igv.js"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      IGV.js
+    </a>
+     visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
+  </p>
+  <p>
+    These are reassembled reads produced by
+     
+    <a
+      className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+      href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      GATK HaplotypeCaller --bamOutput
+    </a>
+    , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
+  </p>
+  <div
+    className="ReadData__ControlContainer-sc-10qachg-0 dgUgCF"
+  >
+    <strong>
+      Exomes:
+    </strong>
+    <button
+      className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+      disabled={true}
+      onClick={[Function]}
+      type="button"
+    >
+      Load +1 
+      het
+    </button>
+    <button
+      className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+      disabled={false}
+      onClick={[Function]}
+      type="button"
+    >
+      Load +1 
+      hom
+    </button>
+  </div>
+  <div
+    className="ReadData__ControlContainer-sc-10qachg-0 dgUgCF"
+  >
+    <button
+      className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+      disabled={false}
+      onClick={[Function]}
+      style={
+        Object {
+          "marginLeft": "80px",
+        }
+      }
+      type="button"
+    >
+      Load all
+    </button>
+  </div>
+</div>
+`;
+
+exports[`ReadData with "gnomad_sv_r2_1_controls" dataset selected has no unexpected changes 1`] = `
+<div>
+  <p>
+    This interactive
+     
+    <a
+      className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+      href="https://github.com/igvteam/igv.js"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      IGV.js
+    </a>
+     visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
+  </p>
+  <p>
+    These are reassembled reads produced by
+     
+    <a
+      className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+      href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      GATK HaplotypeCaller --bamOutput
+    </a>
+    , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
+  </p>
+  <p>
+    <span
+      className="Badge__BadgeWrapper-j4izdp-1 cJObdY"
+    >
+      Note
+    </span>
+     Samples shown below are not guaranteed to be part of the selected subset.
+  </p>
+  <div
+    className="ReadData__ControlContainer-sc-10qachg-0 dgUgCF"
+  >
+    <strong>
+      Exomes:
+    </strong>
+    <button
+      className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+      disabled={true}
+      onClick={[Function]}
+      type="button"
+    >
+      Load +1 
+      het
+    </button>
+    <button
+      className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+      disabled={false}
+      onClick={[Function]}
+      type="button"
+    >
+      Load +1 
+      hom
+    </button>
+  </div>
+  <div
+    className="ReadData__ControlContainer-sc-10qachg-0 dgUgCF"
+  >
+    <button
+      className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+      disabled={false}
+      onClick={[Function]}
+      style={
+        Object {
+          "marginLeft": "80px",
+        }
+      }
+      type="button"
+    >
+      Load all
+    </button>
+  </div>
+</div>
+`;
+
+exports[`ReadData with "gnomad_sv_r2_1_non_neuro" dataset selected has no unexpected changes 1`] = `
+<div>
+  <p>
+    This interactive
+     
+    <a
+      className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+      href="https://github.com/igvteam/igv.js"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      IGV.js
+    </a>
+     visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
+  </p>
+  <p>
+    These are reassembled reads produced by
+     
+    <a
+      className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+      href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      GATK HaplotypeCaller --bamOutput
+    </a>
+    , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
+  </p>
+  <p>
+    <span
+      className="Badge__BadgeWrapper-j4izdp-1 cJObdY"
+    >
+      Note
+    </span>
+     Samples shown below are not guaranteed to be part of the selected subset.
+  </p>
+  <div
+    className="ReadData__ControlContainer-sc-10qachg-0 dgUgCF"
+  >
+    <strong>
+      Exomes:
+    </strong>
+    <button
+      className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+      disabled={true}
+      onClick={[Function]}
+      type="button"
+    >
+      Load +1 
+      het
+    </button>
+    <button
+      className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+      disabled={false}
+      onClick={[Function]}
+      type="button"
+    >
+      Load +1 
+      hom
+    </button>
+  </div>
+  <div
+    className="ReadData__ControlContainer-sc-10qachg-0 dgUgCF"
+  >
+    <button
+      className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+      disabled={false}
+      onClick={[Function]}
+      style={
+        Object {
+          "marginLeft": "80px",
+        }
+      }
+      type="button"
+    >
+      Load all
+    </button>
+  </div>
+</div>
+`;

--- a/browser/src/__factories__/ReadData.js
+++ b/browser/src/__factories__/ReadData.js
@@ -1,0 +1,16 @@
+import { Factory } from 'fishery' // eslint-disable-line import/no-extraneous-dependencies
+
+export const exomeReadApiOutputFactory = Factory.define(({ sequence }) => ({
+  category: 'hom',
+  bamPath: `dummy_bampath_${sequence}`,
+  indexPath: `dummy_indexpath_${sequence}`,
+  readGroup: `dummy_readgroup_${sequence}`,
+}))
+
+export const readsApiOutputFactory = Factory.define(({ sequence }) => ({
+  variant_0: {
+    variantId: `123-${45 + sequence}-A-C`,
+    exome: [],
+    genome: [],
+  },
+}))

--- a/browser/src/datasets.js
+++ b/browser/src/datasets.js
@@ -6,7 +6,7 @@ export const referenceGenomeForDataset = datasetId => {
   return 'GRCh37'
 }
 
-const datasetLabels = {
+export const datasetLabels = {
   exac: 'ExAC v1.0',
   gnomad_r2_1: 'gnomAD v2.1.1',
   gnomad_r2_1_controls: 'gnomAD v2.1.1 (controls)',
@@ -27,8 +27,3 @@ const datasetLabels = {
 export const allDatasetIds = Object.keys(datasetLabels)
 
 export const labelForDataset = datasetId => datasetLabels[datasetId] || 'Unknown'
-
-export const isSubset = datasetId =>
-  (datasetId.startsWith('gnomad_r2') && datasetId !== 'gnomad_r2_1') ||
-  (datasetId.startsWith('gnomad_sv_r2_1') && datasetId !== 'gnomad_sv_r2_1') ||
-  (datasetId.startsWith('gnomad_r3') && datasetId !== 'gnomad_r3')

--- a/dataset-metadata/metadata.js
+++ b/dataset-metadata/metadata.js
@@ -1,0 +1,7 @@
+import { datasetLabels } from '../browser/src/datasets'
+
+const fullDatasetIds = Object.getOwnPropertyNames(datasetLabels).filter(
+  (datasetId) => datasetId === 'exac' || datasetId.match(/_r\d+(_\d+)*$/)
+)
+
+export const isSubset = (datasetId) => !fullDatasetIds.includes(datasetId)

--- a/dataset-metadata/metadata.spec.js
+++ b/dataset-metadata/metadata.spec.js
@@ -1,0 +1,23 @@
+import { isSubset } from './metadata'
+
+describe.each([
+  ['exac', false],
+  ['gnomad_r2_1', false],
+  ['gnomad_r2_1_controls', true],
+  ['gnomad_r2_1_non_cancer', true],
+  ['gnomad_r2_1_non_neuro', true],
+  ['gnomad_r2_1_non_topmed', true],
+  ['gnomad_r3', false],
+  ['gnomad_r3_controls_and_biobanks', true],
+  ['gnomad_r3_non_cancer', true],
+  ['gnomad_r3_non_neuro', true],
+  ['gnomad_r3_non_topmed', true],
+  ['gnomad_r3_non_v2', true],
+  ['gnomad_sv_r2_1', false],
+  ['gnomad_sv_r2_1_controls', true],
+  ['gnomad_sv_r2_1_non_neuro', true],
+])('isSubset(%s)', (datasetName, expectedResult) => {
+  const verb = expectedResult ? 'is' : 'is not'
+  test(`${datasetName} ${verb} a subset`, () =>
+    expect(isSubset(datasetName)).toEqual(expectedResult))
+})

--- a/graphql-api/package.json
+++ b/graphql-api/package.json
@@ -22,5 +22,8 @@
     "on-finished": "^2.3.0",
     "on-headers": "^1.0.2",
     "redis": "^3.1.1"
+  },
+  "devDependencies": {
+    "fishery": "^2.2.2"
   }
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -16,6 +16,11 @@ module.exports = {
       testEnvironment: 'node',
       testMatch: ['<rootDir>/graphql-api/**/*.spec.js'],
     },
+    {
+      displayName: 'dataset-metadata',
+      testEnvironment: 'node',
+      testMatch: ['<rootDir>/dataset-metadata/**/*.spec.js'],
+    },
   ],
   roots: ['<rootDir>', '<rootDir>/tests'],
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4382,6 +4382,13 @@ find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
+fishery@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/fishery/-/fishery-2.2.2.tgz#94d3d9380295dd3ce555021e9353c5348b8beb77"
+  integrity sha512-jeU0nDhPHJkupmjX+r9niKgVMTBDB8X+U/pktoGHAiWOSyNlMd0HhmqnjrpjUOCDPJYaSSu4Ze16h6dZOKSp2w==
+  dependencies:
+    lodash.mergewith "^4.6.2"
+
 flat-cache@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-2.0.1.tgz#5d296d6f04bda44a4630a301413bdbc2ec085ec0"
@@ -6343,6 +6350,11 @@ lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
+
+lodash.mergewith@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz#617121f89ac55f59047c7aec1ccd6654c6590f55"
+  integrity sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==
 
 lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0:
   version "4.17.21"


### PR DESCRIPTION
@mattsolo1 @rileyhgrant I opened this PR not because the refactoring in it is particularly interesting, but because the tests include some more new things that I'd like to make standard practice.

Looking at those in turn:

The `ReadData` component that I snapshot in this PR needs data from the API to render, but clearly I don't want a real network call in a test suite, so I've mocked it using again the functionality built into Jest: https://jestjs.io/docs/mock-functions. @rileyhgrant not sure if this technique is something you would know so if this sounds new to you let's talk about that in a different thread, it's important and there are subtleties and traps in it.

Furthermore, to write an effective test I need my mock API to respond with data that's up to some minimal standard of realism, and we're dealing with complex object graphs here that are a pain to write out by hand. Enter the Fishery library from the good folks at Thoughtbot: https://github.com/thoughtbot/fishery. Fishery gives you a concise API to write factory functions that spare you from most of the pain of setting up dummy test data, as you can see in `graphql-api/src/graphql/factories.js`.

Speaking of "minimal standard of realism", you may notice that the factories defined here are bare-bones in terms of their contents, and you might think that for realism it would be better to populate these factories with some data copied from production. In practice though it turns out to be best to start with very minimal factories like we have here, that have just enough to them that code using dummy data from these factories won't crash. Once you've made a factory, it's easy to specialize it further, for instance the classic example of an `adminFactory` that is equivalent to a `userFactory` except for setting a superuser flag on the returned data.

Finally, as I've said a couple of times snapshot tests are good but shouldn't be your only tool: the unit tests in `dataset-metadata/metadata.spec.js` are an example of what I have in mind when I say that snapshot tests need something to complement them. Notice too how I've made use of `describe.each` to effectively get 15 tests for the price of one: judicious use of `each` in tests can help cover a lot of ground quickly.