### PR TITLE
Pin node version for volta

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,5 +55,8 @@
     "webpack": "^5.24.2",
     "webpack-cli": "^4.5.0",
     "webpack-dev-server": "^3.11.2"
+  },
+  "volta": {
+    "node": "14.20.0"
   }
 }


### PR DESCRIPTION
The root package json in `gnomad-browser` has an `engines` field that specifies `node >=14.15.2 <15.0.0`. 

Volta (https://volta.sh) is JavaScript tool manager. It's useful for setting Node versions on a per-project basis, making it easy to use the Node version required here. Volta relies on a specific Node version being pinned in the package json, which this pull request adds.





