### PR TITLE
Allow use of interactive debugger in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "format": "prettier --write './**/*.js'",
     "lint:css": "stylelint './**/*.js'",
     "lint:js": "eslint .",
-    "test": "jest"
+    "test": "jest",
+    "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand"
   },
   "engines": {
     "node": ">=14.15.2 <15.0.0"


### PR DESCRIPTION
Chrome has an interactive Node debugger built in, see https://jestjs.io/docs/troubleshooting for instructions on how to access it. The script added here runs the test suite under that debugger.

See https://jestjs.io/docs/troubleshooting.