### PR TITLE
Fix help page

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,7 +8,7 @@ module.exports = {
   rules: {
     'prettier/prettier': 'error',
     'func-names': ['warn', 'as-needed'],
-    'react/jsx-filename-extension': ['error', { extensions: ['.js'] }],
+    'react/jsx-filename-extension': ['error', { extensions: ['.js', '.jsx', 'ts', '.tsx'] }],
     'import/prefer-default-export': 0,
     // https://github.com/airbnb/javascript/blob/6d05dd898acfec3299cc2be8b6188be542824965/packages/eslint-config-airbnb/rules/react.js#L489
     'react/static-property-placement': ['error', 'static public field'],

--- a/browser/build/buildHelp.js
+++ b/browser/build/buildHelp.js
@@ -28,7 +28,7 @@ const helpTopics = `
   const topics = [${helpTopicFiles.map((_, i) => `topic${i}`).join(',')}];
 `
 
-const faqFiles = glob.sync(`${path.resolve(__dirname, '../help/faq')}/**/*.@(js|md)`, {
+const faqFiles = glob.sync(`${path.resolve(__dirname, '../help/faq')}/**/*.@(js|tsx|md)`, {
   matchBase: true,
   absolute: true,
 })
@@ -36,8 +36,8 @@ const faqFiles = glob.sync(`${path.resolve(__dirname, '../help/faq')}/**/*.@(js|
 const faqImports = faqFiles
   .map((f, i) => {
     const importPath = path.relative(path.dirname(OUTPUT_PATH), f)
-    if (f.endsWith('.js')) {
-      return `import * as faqEntry${i} from '${importPath.replace(/\.js$/, '')}'`
+    if (f.endsWith('.js') || f.endsWith('.tsx')) {
+      return `import * as faqEntry${i} from '${importPath.replace(/\.(js|tsx)$/, '')}'`
     }
 
     return `import faqEntry${i} from '${importPath}'`
@@ -47,7 +47,7 @@ const faqImports = faqFiles
 const faqEntries = `
   const faqEntries = [${faqFiles
     .map((f, i) => {
-      const id = path.basename(f).replace(/\.(js|md)$/, '')
+      const id = path.basename(f).replace(/\.(js|tsx|md)$/, '')
       return `{id: '${id}', ...faqEntry${i}}`
     })
     .join(',')}];


### PR DESCRIPTION
Update `buildHelp.js` so that it correctly imports `.tsx` files to be used in the FAQ.

Add unrelated edit to `eslintrc.js` to allow JSX syntax in `.ts` and `.tsx` files