### PR TITLE
Modify header routes and order

### DIFF
--- a/browser/about/contributors/funding.md
+++ b/browser/about/contributors/funding.md
@@ -3,7 +3,7 @@
 - NIH/NHGRI U24HG011450<br/>(MPIs: Rehm and Daly)
 - NIH/NHGRI U01HG011755<br/>(MPIs: O’Donnell-Luria, Rehm and Talkowski)
 - NIMH MH115957<br/>(PI: Talkowski)
-- NIHCHD HD081256<br/>(PI: Talkowski)
+- NICHD HD081256<br/>(PI: Talkowski)
 - Broad Institute contributes data storage, computing resources, and human effort
 
 <br/>

--- a/browser/src/NavBar.tsx
+++ b/browser/src/NavBar.tsx
@@ -109,9 +109,12 @@ const NavBar = () => {
             Team
           </Link>
         </li>
+        {/* two <a> tags instead of <Link>s because the blog is a separate application */}
         <li>
-          {/* a instead of Link because the blog is a separate application */}
-          <a href="/news/">News</a>
+          <a href="https://gnomad.broadinstitute.org/news/">News</a>
+        </li>
+        <li>
+          <a href="https://gnomad.broadinstitute.org/news/changelog/">Changelog</a>
         </li>
         <li>
           <Link to="/downloads" onClick={closeMenu}>
@@ -132,10 +135,6 @@ const NavBar = () => {
           <Link to="/feedback" onClick={closeMenu}>
             Feedback
           </Link>
-        </li>
-        <li>
-          {/* a instead of Link because the blog is a separate application */}
-          <a href="/news/changelog/">Changelog</a>
         </li>
         <li>
           <Link to="/help" onClick={closeMenu}>


### PR DESCRIPTION
Resolves broadinstitute/gnomad-blog#76

Modify the header routes so `Changelog` is to the left of `News`, keeping the two blog/news related pages together in the header.

Modifies the routes of `Changelog` and `News` to point to the live site (`https://gnomad.broadinstitute.org/news/` rather than `/news/`), allowing for one-way correct navigation in dev environments and demo deployments, rather than relying on the production site re-direct alone.

Unrelated - correct a mistake in the acroynm for a current funding source (NIHCHD -> NICHD)