### PR TITLE
Remove hiring banner

### DIFF
--- a/browser/src/App.tsx
+++ b/browser/src/App.tsx
@@ -71,13 +71,7 @@ const Banner = styled.div`
   }
 `
 
-const BANNER_CONTENT = (
-  <>
-    We&apos;re hiring! {' • '}
-    {/* @ts-expect-error TS(2786) FIXME: 'ExternalLink' cannot be used as a JSX component. */}
-    <ExternalLink href="https://broad.io/gnomad-cs">Computational scientist</ExternalLink>
-  </>
-)
+const BANNER_CONTENT = null
 
 const App = () => {
   const [isLoading, setIsLoading] = useState(true)

--- a/browser/src/HomePage.tsx
+++ b/browser/src/HomePage.tsx
@@ -91,7 +91,7 @@ export default () => (
     <List>
       {/* @ts-expect-error TS(2746) FIXME: This JSX tag's 'children' prop expects a single ch... Remove this comment to see the full error message */}
       <ListItem>
-        Gene:
+        Gene:{' '}
         <Link preserveSelectedDataset={false} to="/gene/ENSG00000169174">
           PCSK9
         </Link>
@@ -136,7 +136,7 @@ export default () => (
         <ExternalLink href="https://gnomad.broadinstitute.org/short-tandem-repeats?dataset=gnomad_r3">
           short tandem repeat
         </ExternalLink>{' '}
-        locus:
+        locus:{' '}
         <Link
           preserveSelectedDataset={false}
           to={{
@@ -231,7 +231,7 @@ export default () => (
     <h2>About gnomAD</h2>
 
     <p>
-      The
+      The{' '}
       <Link preserveSelectedDataset={false} to="/about">
         Genome Aggregation Database
       </Link>{' '}


### PR DESCRIPTION
Removes hiring banner stating that gnomAD is hiring a Computational Scientist, as this is no longer the case.

Adds spaces to the home page of gnomAD where they were removed.