### PR TITLE
Update clinvar.py to allow ingesting of ClinVar data

### DIFF
--- a/data-pipeline/src/data_pipeline/datasets/clinvar.py
+++ b/data-pipeline/src/data_pipeline/datasets/clinvar.py
@@ -105,8 +105,18 @@ def _parse_variant(variant_element):
     location_elements = variant_element.findall("./InterpretedRecord/SimpleAllele/Location/SequenceLocation")
     for element in location_elements:
         try:
+            chromosome = element.attrib["Chr"]
+            # A release in August 2022 introduced several Variants with a Chromosome of 'Un'
+            #   which caused failure of this pipeline when compared to the reference genome
+            if chromosome == "Un":
+                variant["locations"] = {}
+                allele_element = variant_element.findall("./InterpretedRecord/SimpleAllele")
+                print(
+                    f'Skipping variant with Allele ID: {allele_element.attrib["AlleleID"]} due to anomalous Chromosome value of "Un"'
+                )
+                break
             variant["locations"][element.attrib["Assembly"]] = {
-                "locus": element.attrib["Chr"] + ":" + element.attrib["positionVCF"],
+                "locus": chromosome + ":" + element.attrib["positionVCF"],
                 "alleles": [element.attrib["referenceAlleleVCF"], element.attrib["alternateAlleleVCF"]],
             }
         except KeyError:

--- a/deploy/deployctl/subcommands/setup.py
+++ b/deploy/deployctl/subcommands/setup.py
@@ -131,7 +131,8 @@ def create_cluster_service_account() -> None:
         # Deleting and recreating a service account with the same name can lead to unexpected behavior
         # https://cloud.google.com/iam/docs/understanding-service-accounts#deleting_and_recreating_service_accounts
         gcloud(
-            ["iam", "service-accounts", "describe", config.gke_service_account_full_name], stderr=subprocess.DEVNULL,
+            ["iam", "service-accounts", "describe", config.gke_service_account_full_name],
+            stderr=subprocess.DEVNULL,
         )
         print("Service account already exists")
         return
@@ -139,7 +140,13 @@ def create_cluster_service_account() -> None:
         pass
 
     gcloud(
-        ["iam", "service-accounts", "create", config.gke_service_account_name, "--display-name=gnomAD GKE nodes",]
+        [
+            "iam",
+            "service-accounts",
+            "create",
+            config.gke_service_account_name,
+            "--display-name=gnomAD GKE nodes",
+        ]
     )
 
     # GKE requires logging.logWriter, monitoring.metricWriter, and monitoring.viewer
@@ -218,6 +225,7 @@ def create_cluster() -> None:
             "--enable-stackdriver-kubernetes",
             "--enable-shielded-nodes",
             "--shielded-secure-boot",
+            "--shielded-integrity-monitoring",
             "--metadata=disable-legacy-endpoints=true",
             "--no-enable-basic-auth",
             "--no-enable-legacy-authorization",
@@ -266,6 +274,7 @@ def create_node_pool(node_pool_name: str, node_pool_args: typing.List[str]) -> N
             "--enable-autoupgrade",
             f"--service-account={config.gke_service_account_full_name}",
             "--shielded-secure-boot",
+            "--shielded-integrity-monitoring",
             "--metadata=disable-legacy-endpoints=true",
         ]
         + node_pool_args

--- a/deploy/docs/ElasticsearchConnection.md
+++ b/deploy/docs/ElasticsearchConnection.md
@@ -46,7 +46,7 @@
 - Specify the service account when creating the Dataproc cluster. The secret value can be accessed from the Dataproc cluster using:
 
   ```
-  gcloud secrets versions access latest --secret=gnomad-elasticsearch-password"
+  gcloud secrets versions access latest --secret="gnomad-elasticsearch-password"
   ```
 
 - Make a request.

--- a/deploy/docs/ElasticsearchIndexAliases.md
+++ b/deploy/docs/ElasticsearchIndexAliases.md
@@ -4,7 +4,15 @@ https://www.elastic.co/guide/en/elasticsearch/reference/6.8/indices-aliases.html
 
 Follow the steps in [ElasticsearchConnection.md](./ElasticsearchConnection.md) for accessing the Elasticsearch API.
 
-### Viewing aliases
+### Viewing indices and aliases
+
+To view indices
+
+```
+curl -u "elastic:$ELASTICSEARCH_PASSWORD" http://localhost:9200/_cat/indices
+```
+
+To view aliases
 
 ```
 curl -u "elastic:$ELASTICSEARCH_PASSWORD" http://localhost:9200/_cat/aliases
@@ -12,13 +20,17 @@ curl -u "elastic:$ELASTICSEARCH_PASSWORD" http://localhost:9200/_cat/aliases
 
 ### Changing an alias
 
+Use "remove" and "add" as needed to modify indices and their aliases.
+
 ```
 curl -u "elastic:$ELASTICSEARCH_PASSWORD" -XPOST http://localhost:9200/_aliases --header "Content-Type: application/json" --data @- <<EOF
 {
    "actions": [
-      {"remove": {"index": "<old_index>", "alias": "alias"}},
-      {"add": {"index": "<new_index>", "alias": "alias"}}
+      {"remove": {"index": "<old_index_id>", "alias": "<old_alias_name>"}},
+      {"add": {"index": "<new_index_id>", "alias": "<new_alias_name"}}
    ]
 }
 EOF
 ```
+
+This action is atomic, as such you can safely use this to replace the index associated with a given alias.


### PR DESCRIPTION
Add a fix to `clinvar.py` that allows the pipeline to be run despite two anomalous variants with Chromosome "Un" that were included in ClinVar releases since at least August.

Includes additional documentation for the processing of updating ClinVar variants.

Includes additional flags in `setup.py` to allow clusters to be created successfully. 

Resolves #961 