### PR TITLE
Update ClinVar vep101 cluster's initialization file reference

### DIFF
--- a/deploy/docs/UpdateClinvarVariants.md
+++ b/deploy/docs/UpdateClinvarVariants.md
@@ -24,7 +24,7 @@
 
       ```
       ./deployctl dataproc-cluster start vep101 \
-         --init=gs://gnomad-browser-data-pipeline/init-vep101.sh \
+         --init=gs://gcp-public-data--gnomad/resources/vep/v101/init-vep101.sh \
          --metadata=VEP_CONFIG_PATH=/vep_data/vep-gcloud.json,VEP_CONFIG_URI=file:///vep_data/vep-gcloud.json,VEP_REPLICATE=us \
          --master-machine-type n1-highmem-8 \
          --worker-machine-type n1-highmem-8 \


### PR DESCRIPTION
As part of updating the ClinVar variants, a dataproc cluster with the necessary resources to run VEP101 is created. This Dataproc cluster requires both a Docker Image and an initialization script. These [originally came from](https://atgu.slack.com/archives/CNE92QZMF/p1611329365001300) the methods team in Jan 2022, and were copied to the `gnomad-browser`'s Container Registry and GCS, respectively.

Per broadinstitute/gnomad_methods#475
and broadinstitute/gnomad_methods#488

The shell command outlined in the `UpdateClinvarVariants.md` file has been updated to use the methods team's init script located in their public bucket. 

We could also replicate the changes into the init script located in the browser's bucket, if that is a better solution. It seems to me that switching referencing the public script that we originally duplicated is a fine way to go about it - just less things to keep in sync manually, but of course, always open to suggestions / thoughts.

Resolves #984 
Resolves #925 