### PR TITLE
Add robots.txt

### DIFF
--- a/browser/src/robots.txt
+++ b/browser/src/robots.txt
@@ -1,0 +1,12 @@
+User-Agent: *
+Disallow: *
+Allow: /$
+Allow: /about/
+Allow: /team/
+Allow: /news/
+Allow: /news/changelog/
+Allow: /downloads/
+Allow: /policies/
+Allow: /publications/
+Allow: /feedback/
+Allow: /help/

--- a/browser/webpack.config.js
+++ b/browser/webpack.config.js
@@ -91,6 +91,9 @@ const config = {
     new CopyWebpackPlugin({
       patterns: [path.resolve(__dirname, './src/opensearch.xml')],
     }),
+    new CopyWebpackPlugin({
+      patterns: [path.resolve(__dirname, './src/robots.txt')],
+    }),
     new EnvironmentPlugin({
       REPORT_VARIANT_URL: null,
       REPORT_VARIANT_VARIANT_ID_PARAMETER: null,


### PR DESCRIPTION
As written, this `robots.txt` allows bots access to any page in the top black navbar, and nothing else.