### PR TITLE
Fix docker image creation

### DIFF
--- a/deploy/dockerfiles/browser/browser.dockerfile
+++ b/deploy/dockerfiles/browser/browser.dockerfile
@@ -16,6 +16,8 @@ RUN yarn install --production false --frozen-lockfile && yarn cache clean
 
 # Copy source
 COPY --chown=node:node babel.config.js .
+COPY --chown=node:node tsconfig.json .
+COPY --chown=node:node tsconfig.build.json .
 COPY --chown=node:node dataset-metadata dataset-metadata
 COPY --chown=node:node browser browser
 

--- a/deploy/dockerfiles/browser/browser.dockerfile.dockerignore
+++ b/deploy/dockerfiles/browser/browser.dockerfile.dockerignore
@@ -1,5 +1,7 @@
 *
 !babel.config.js
+!tsconfig.json
+!tsconfig.build.json
 !package.json
 !yarn.lock
 !browser/.browserslistrc

--- a/development/browser.docker-compose.yaml
+++ b/development/browser.docker-compose.yaml
@@ -7,7 +7,7 @@ services:
     command:
       - sh
       - -c
-      - ./browser/build/buildHelp.js && yarn workspace '@gnomad/browser' run webpack serve --host '0.0.0.0'
+      - ./browser/build/buildHelp.ts && yarn workspace '@gnomad/browser' run webpack serve --host '0.0.0.0'
     environment:
       - NODE_ENV=development
       - GNOMAD_API_URL


### PR DESCRIPTION
Resolves #997

Adds additional imports in the browser dockerfile so that building the image correctly has the requisite TypeScript configurations.
