### PR TITLE
Fix faulty GraphQL queries

### DIFF
--- a/browser/src/GenePage/MitochondrialGeneCoverageTrack.tsx
+++ b/browser/src/GenePage/MitochondrialGeneCoverageTrack.tsx
@@ -37,6 +37,7 @@ const MitochondrialGeneCoverageTrack = ({ datasetId, geneId }: Props) => {
 
   return (
     <Query
+      operationName={operationName}
       query={query}
       variables={{ geneId, datasetId, referenceGenome: referenceGenome(datasetId) }}
       loadingMessage="Loading coverage"

--- a/browser/src/MNVPage/MNVDetailsQuery.tsx
+++ b/browser/src/MNVPage/MNVDetailsQuery.tsx
@@ -2,8 +2,9 @@ import React from 'react'
 
 import { BaseQuery } from '../Query'
 
+const operationName = 'MultiNucleotideVariant'
 const query = `
-query MultiNucleotideVariant($variantId: String!, $datasetId: DatasetId!) {
+query ${operationName}($variantId: String!, $datasetId: DatasetId!) {
   multiNucleotideVariant(variant_id: $variantId, dataset: $datasetId) {
     variant_id
     chrom
@@ -66,7 +67,7 @@ type Props = {
 
 const MNVDetailsQuery = ({ children, datasetId, variantId }: Props) => (
   // @ts-expect-error TS(2769) FIXME: No overload matches this call.
-  <BaseQuery query={query} variables={{ datasetId, variantId }}>
+  <BaseQuery operationName={operationName} query={query} variables={{ datasetId, variantId }}>
     {children}
   </BaseQuery>
 )

--- a/browser/src/Query.tsx
+++ b/browser/src/Query.tsx
@@ -38,7 +38,7 @@ const cancelable = (promise: any) => {
 }
 
 type OwnBaseQueryProps = {
-  operationName: string
+  operationName: string | null
   query: string
   url?: string
   variables?: any
@@ -51,7 +51,7 @@ type BaseQueryProps = OwnBaseQueryProps & typeof BaseQuery.defaultProps
 export class BaseQuery extends Component<BaseQueryProps, BaseQueryState> {
   static defaultProps = {
     url: '/api/',
-    operationName: '',
+    operationName: null,
     variables: {},
   }
 
@@ -97,7 +97,7 @@ export class BaseQuery extends Component<BaseQueryProps, BaseQueryState> {
     this.currentRequest = cancelable(
       fetch(url, {
         body: JSON.stringify({
-          operationName,
+          // operationName,
           query,
           variables,
         }),
@@ -145,7 +145,7 @@ type OwnQueryProps = {
   errorMessage?: string
   loadingMessage?: string
   loadingPlaceholderHeight?: number
-  operationName: string
+  operationName: string | null
   query: string
   success?: (...args: any[]) => any
   url?: string
@@ -208,7 +208,7 @@ Query.defaultProps = {
   success: () => true,
   url: '/api/',
   variables: {},
-  operatioName: '',
+  operatioName: null,
 }
 
 export default Query

--- a/browser/src/RegionPage/VariantsInRegion.tsx
+++ b/browser/src/RegionPage/VariantsInRegion.tsx
@@ -81,7 +81,7 @@ VariantsInRegion.defaultProps = {
 
 const operationName = 'VariantInRegion'
 const query = `
-query VariantInRegion($chrom: String!, $start: Int!, $stop: Int!, $datasetId: DatasetId!, $referenceGenome: ReferenceGenomeId!) {
+query ${operationName}($chrom: String!, $start: Int!, $stop: Int!, $datasetId: DatasetId!, $referenceGenome: ReferenceGenomeId!) {
   meta {
     clinvar_release_date
   }

--- a/browser/src/ShortTandemRepeatsPage/ShortTandemRepeatsPage.tsx
+++ b/browser/src/ShortTandemRepeatsPage/ShortTandemRepeatsPage.tsx
@@ -90,8 +90,9 @@ const ShortTandemRepeatsPage = ({ shortTandemRepeats }: ShortTandemRepeatsPagePr
   )
 }
 
+const operationName = 'ShortTandemRepeats'
 const query = `
-query ShortTandemRepeats($datasetId: DatasetId!) {
+query ${operationName}($datasetId: DatasetId!) {
   short_tandem_repeats(dataset: $datasetId) {
     id
     gene {
@@ -134,6 +135,7 @@ const ShortTandemRepeatsPageContainer = ({ datasetId }: ShortTandemRepeatsPageCo
       </GnomadPageHeading>
       {datasetId === 'gnomad_r3' ? (
         <Query
+          operationName={operationName}
           query={query}
           variables={{ datasetId }}
           loadingMessage="Loading short tandem repeats"

--- a/browser/src/VariantPage/VariantPage.tsx
+++ b/browser/src/VariantPage/VariantPage.tsx
@@ -202,8 +202,9 @@ const VariantPageContent = ({ datasetId, variant }: VariantPageContentProps) => 
   )
 }
 
+const operationName = 'GnomadVariant'
 const variantQuery = `
-query GnomadVariant($variantId: String!, $datasetId: DatasetId!, $referenceGenome: ReferenceGenomeId!, $includeLocalAncestry: Boolean!, $includeLiftoverAsSource: Boolean!, $includeLiftoverAsTarget: Boolean!) {
+query ${operationName}($variantId: String!, $datasetId: DatasetId!, $referenceGenome: ReferenceGenomeId!, $includeLocalAncestry: Boolean!, $includeLiftoverAsSource: Boolean!, $includeLiftoverAsTarget: Boolean!) {
   variant(variantId: $variantId, dataset: $datasetId) {
     variant_id
     reference_genome
@@ -471,9 +472,10 @@ const VariantPage = ({ datasetId, variantId }: VariantPageProps) => {
     // @ts-expect-error TS(2746) FIXME: This JSX tag's 'children' prop expects a single ch... Remove this comment to see the full error message
     <Page>
       <DocumentTitle title={`${variantId} | ${labelForDataset(datasetId)}`} />
-      {/* @ts-expect-error TS(2769) FIXME: No overload matches this call. */}
       <BaseQuery
         key={datasetId}
+        // @ts-expect-error TS(2769) FIXME: No overload matches this call.
+        operationName={operationName}
         query={variantQuery}
         variables={{
           datasetId,


### PR DESCRIPTION
Fixes several faulty GraphQL queries that caused variant pages network requests to fail (and displayed "`Unknown operation ""`) , and changes the default behavior of GraphQL queries to succeed if `operationName` is not provided.

When doing minor refactoring of GraphQL queries to include the `operationName` field in the body, which helps helps with mocking out network requests in tests, a few queries were missed due to an incomplete method of finding all files that use `BaseQuery`. The default `operationName` prop of an empty string (`""`) caused these queries that were not included in the refactoring to fail. 

The field `operationName` has been added to these queries, and the default prop has been changed to `null`, which causes the queries to act exactly as before in the case that an `operationName` is not provided as a prop to `BaseQuery`.