### PR TITLE
adds a dependabot config for yarn security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+#  - Disables non-security update PRs
+#  - Schedules security update PRs daily
+#  - Auto assigns PRs to the gnomad-browser team
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    # Disable version updates for npm dependencies
+    open-pull-requests-limit: 0
+    reviewers:
+      - "broadinstitute/gnomad-browser"


### PR DESCRIPTION
By default, dependabot opens pull requests with no assignee. This adds a config file which sets the gnomad-browser team as the reviewer. When tagged in this way, the gnomad-browser github team selects a single member of the team to review the PR, in a round-robin format.

The config here sets the open-pull-requests-limit to 0, which makes dependabot open PRs _only_ for security updates, and will not generate PRs for non-security package updates (see, [docs](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file))