### PR TITLE
Non-coding Constraint MVP

### DIFF
--- a/browser/help/topics/genomic-constraint.md
+++ b/browser/help/topics/genomic-constraint.md
@@ -1,0 +1,14 @@
+---
+id: genomic-constraint
+title: 'Genomic constraint'
+---
+
+### Overall interpretation
+
+A genomic constraint metric is now available on the gnomAD browser.
+
+We quantify the depletion of variation (constraint) at a 1kb scale with a signed Z score by comparing the observed variation to an expectation. In each tiling 1kb genomic region, the expected number of variants is predicted using an improved mutional model that takes into account both local sequence context and a variety of genomic features. A higher positive Z score (i.e., observing fewer variants than expectation) indicates higher constraint.
+
+This genomic constraint metric is only available for the gnomAD v3 dataset, as it is based on GRCh38. The track only displays if the region is 150kb or less, and the Z scores render as text in the track if the scale allows. Gaps in the genomic constract track represent regions that did not pass QC.
+
+More details can be found in the [preprint on bioRxiv](https://www.biorxiv.org/content/10.1101/2022.03.20.485034v2).

--- a/browser/src/ConstraintTable/GnomadNonCodingConstraintTableVariant.tsx
+++ b/browser/src/ConstraintTable/GnomadNonCodingConstraintTableVariant.tsx
@@ -1,0 +1,116 @@
+import React from 'react'
+import styled from 'styled-components'
+
+import { BaseTable, TooltipAnchor, TooltipHint } from '@gnomad/ui'
+
+import Link from '../Link'
+
+import { NonCodingConstraint } from '../VariantPage/VariantPage'
+
+import { renderRoundedNumber } from './constraintMetrics'
+
+const Table = styled(BaseTable)`
+  width: 100%;
+  margin-top: 1rem;
+
+  @media (max-width: 600px) {
+    td,
+    th {
+      padding-right: 10px;
+    }
+  }
+`
+
+const ViewSurroundingRegion = styled.div`
+  margin-top: 1rem;
+`
+
+type Props = {
+  variantId: string
+  chrom: string
+  nonCodingConstraint: NonCodingConstraint | null
+}
+
+const GnomadNonCodingConstraintTableVariant = ({
+  variantId,
+  chrom,
+  nonCodingConstraint,
+}: Props) => {
+  if (nonCodingConstraint === null) {
+    return <>This variant does not have non coding constraint data for the surrounding region.</>
+  }
+
+  const regionBuffer = 20_000
+  const variantLocation = parseInt(variantId.split('-')[1], 10)
+  const surroundingLocation = `${chrom}-${variantLocation - regionBuffer}-${
+    variantLocation + regionBuffer
+  }`
+
+  return (
+    <>
+      <div>
+        <p>{`Genomic constraint values displayed are for the region: ${chrom}-${nonCodingConstraint.start}-${nonCodingConstraint.stop}`}</p>
+        <p>
+          <a href={'https://gnomad.broadinstitute.org/news/2022-10-24-the-addition-of-a-genomic-constraint-metric-to-gnomad/'}>Read more</a> about this constraint.
+        </p>
+      </div>
+      <Table>
+        <thead>
+          <tr>
+            <th scope="col">
+              {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+              <TooltipAnchor tooltip="The expected number of variants is predicted using an improved mutional model that takes into account both local sequence context and a variety of genomic features.">
+                {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+                <TooltipHint>Expected</TooltipHint>
+              </TooltipAnchor>
+            </th>
+            <th scope="col">
+              {/* @ts-expect-error TS(2322) FIXME: Type '{ children: Element; tooltip: string; }' is ... Remove this comment to see the full error message */}
+              <TooltipAnchor tooltip="The observed number of variants is the count of rare (MAF<=1%) varaints in this 1kb window as identified in gnomAD v3.1.2">
+                {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+                <TooltipHint>Observed</TooltipHint>
+              </TooltipAnchor>
+            </th>
+            <th scope="col">Constraint</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>{renderRoundedNumber(nonCodingConstraint.expected)}</td>
+            <td>{nonCodingConstraint.observed}</td>
+            <td>
+              Z ={' '}
+              {renderRoundedNumber(nonCodingConstraint.z, {
+                precision: 2,
+                tooltipPrecision: 3,
+                highlightColor: null,
+              })}
+              <br />
+              o/e ={' '}
+              {renderRoundedNumber(nonCodingConstraint.oe, {
+                precision: 2,
+                tooltipPrecision: 3,
+                highlightColor: null,
+              })}
+            </td>
+          </tr>
+        </tbody>
+      </Table>
+      <ViewSurroundingRegion>
+        <p>{`View the genomic constraint values for the ${
+          (regionBuffer * 2) / 1000
+        }kb region surrounding this variant`}</p>
+        <p>
+          <Link
+            to={`/region/${surroundingLocation}?variant=${variantId}&dataset=gnomad_r3`}
+            preserveSelectedDataset={false}
+          >
+            {surroundingLocation}
+          </Link>
+        </p>
+      </ViewSurroundingRegion>
+    </>
+  )
+}
+
+export default GnomadNonCodingConstraintTableVariant

--- a/browser/src/DownloadsPage/DownloadsPage.tsx
+++ b/browser/src/DownloadsPage/DownloadsPage.tsx
@@ -11,6 +11,7 @@ import GnomadV2Downloads from './GnomadV2Downloads'
 import GnomadV2LiftoverDownloads from './GnomadV2LiftoverDownloads'
 import GnomadV3Downloads from './GnomadV3Downloads'
 import ExacDownloads from './ExacDownloads'
+import ResearchDownloads from './ResearchDownloads'
 
 const CodeBlock = styled.code`
   display: inline-block;
@@ -181,22 +182,27 @@ const DownloadsPage = ({ location }: Props) => {
           {
             id: 'v2',
             label: 'gnomAD v2',
-            render: () => <GnomadV2Downloads />,
+            render: GnomadV2Downloads,
           },
           {
             id: 'v2-liftover',
             label: 'gnomAD v2 liftover',
-            render: () => <GnomadV2LiftoverDownloads />,
+            render: GnomadV2LiftoverDownloads,
           },
           {
             id: 'v3',
             label: 'gnomAD v3',
-            render: () => <GnomadV3Downloads />,
+            render: GnomadV3Downloads,
           },
           {
             id: 'exac',
             label: 'ExAC',
-            render: () => <ExacDownloads />,
+            render: ExacDownloads,
+          },
+          {
+            id: 'research',
+            label: 'Research',
+            render: ResearchDownloads,
           },
         ]}
         onChange={setActiveTab}

--- a/browser/src/DownloadsPage/ResearchDownloads.tsx
+++ b/browser/src/DownloadsPage/ResearchDownloads.tsx
@@ -1,0 +1,65 @@
+import React from 'react'
+
+import { ListItem } from '@gnomad/ui'
+
+import { FileList, GenericDownloadLinks, SectionTitle } from './downloadsPageStyles'
+
+const ResearchDownloads = () => {
+  return (
+    <>
+      <p>
+        The research data set contains data from various research projects that are relevant to
+        gnomAD, and the datasets are not curated by the gnomAD Production Team. Each dataset has an
+        accompanying README file explaining what it contains.
+      </p>
+      <section>
+        <SectionTitle id="v3-genomic-constraint">Non-coding and Genomic constraint</SectionTitle>
+        <p>For more information about these files, see the README included in the download.</p>
+        <FileList>
+          {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+          <ListItem>
+            <GenericDownloadLinks
+              label="README"
+              gcsBucket="gnomad-nc-constraint-v31-paper"
+              path="/download_files/nc_constraint_gnomad_v31_README.docx"
+              includeAWS={false}
+              includeAzure={false}
+            />
+          </ListItem>
+          {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+          <ListItem>
+            <GenericDownloadLinks
+              label="Non coding constraint for gene tissue enhancers"
+              gcsBucket="gnomad-nc-constraint-v31-paper"
+              path="/download_files/constraint_z_enh_gene_roadmaplinks.all.download.txt.gz"
+              includeAWS={false}
+              includeAzure={false}
+            />
+          </ListItem>
+          {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+          <ListItem>
+            <GenericDownloadLinks
+              label="QCd genomic constraint by 1kb regions"
+              gcsBucket="gnomad-nc-constraint-v31-paper"
+              path="/download_files/constraint_z_genome_1kb.qc.download.txt.gz"
+              includeAWS={false}
+              includeAzure={false}
+            />
+          </ListItem>
+          {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+          <ListItem>
+            <GenericDownloadLinks
+              label="Raw genomic constraint by 1kb regions"
+              gcsBucket="gnomad-nc-constraint-v31-paper"
+              path="/download_files/constraint_z_genome_1kb.raw.download.txt.gz"
+              includeAWS={false}
+              includeAzure={false}
+            />
+          </ListItem>
+        </FileList>
+      </section>
+    </>
+  )
+}
+
+export default ResearchDownloads

--- a/browser/src/Query.tsx
+++ b/browser/src/Query.tsx
@@ -208,7 +208,7 @@ Query.defaultProps = {
   success: () => true,
   url: '/api/',
   variables: {},
-  operatioName: null,
+  operationName: null,
 }
 
 export default Query

--- a/browser/src/RegionPage/RegionPage.tsx
+++ b/browser/src/RegionPage/RegionPage.tsx
@@ -7,6 +7,7 @@ import { DatasetId, labelForDataset } from '@gnomad/dataset-metadata/metadata'
 import DocumentTitle from '../DocumentTitle'
 import GnomadPageHeading from '../GnomadPageHeading'
 import Link from '../Link'
+import RegionalGenomicConstraintTrack from '../RegionalGenomicConstraintTrack'
 import RegionViewer from '../RegionViewer/RegionViewer'
 import { TrackPage, TrackPageSection } from '../TrackPage'
 import { useWindowSize } from '../windowSize'
@@ -20,6 +21,8 @@ import RegionCoverageTrack from './RegionCoverageTrack'
 import RegionInfo from './RegionInfo'
 import VariantsInRegion from './VariantsInRegion'
 import StructuralVariantsInRegion from './StructuralVariantsInRegion'
+
+import { hasNonCodingConstraints } from '@gnomad/dataset-metadata/metadata'
 
 const RegionInfoColumnWrapper = styled.div`
   display: flex;
@@ -44,6 +47,13 @@ const RegionControlsWrapper = styled.div`
   }
 `
 
+type NonCodingConstraint = {
+  start: number
+  stop: number
+  oe: number
+  z: number
+}
+
 type Props = {
   datasetId: DatasetId
   region: {
@@ -55,6 +65,7 @@ type Props = {
     short_tandem_repeats?: {
       id: string
     }[]
+    non_coding_constraints: NonCodingConstraint[] | null
   }
 }
 
@@ -67,6 +78,15 @@ const RegionPage = ({ datasetId, region }: Props) => {
 
   // Subtract 30px for padding on Page component
   const regionViewerWidth = windowWidth - 30
+
+  const nccToRegion = (ncc: NonCodingConstraint) => {
+    return {
+      start: ncc.start,
+      stop: ncc.stop,
+      z: ncc.z,
+      obs_exp: ncc.oe,
+    }
+  }
 
   return (
     <TrackPage>
@@ -133,6 +153,20 @@ const RegionPage = ({ datasetId, region }: Props) => {
         )}
 
         <GenesInRegionTrack genes={region.genes} region={region} />
+
+        {hasNonCodingConstraints(datasetId) && (
+          <>
+            <RegionalGenomicConstraintTrack
+              start={region.start}
+              stop={region.stop}
+              regions={
+                region.non_coding_constraints !== null
+                  ? region.non_coding_constraints.map(nccToRegion)
+                  : null
+              }
+            />
+          </>
+        )}
 
         {/* eslint-disable-next-line no-nested-ternary */}
         {datasetId.startsWith('gnomad_sv') ? (

--- a/browser/src/RegionPage/RegionPageContainer.tsx
+++ b/browser/src/RegionPage/RegionPageContainer.tsx
@@ -31,6 +31,12 @@ const query = `
           }
         }
       }
+      non_coding_constraints {
+        start
+        stop
+        oe
+        z
+      }
       short_tandem_repeats(dataset: $shortTandemRepeatDatasetId) @include(if: $includeShortTandemRepeats) {
         id
       }

--- a/browser/src/RegionalGenomicConstraintTrack.tsx
+++ b/browser/src/RegionalGenomicConstraintTrack.tsx
@@ -1,0 +1,301 @@
+import React from 'react'
+import styled from 'styled-components'
+
+import queryString from 'query-string'
+
+// @ts-expect-error TS(7016) FIXME: Could not find a declaration file for module '@gno... Remove this comment to see the full error message
+import { Track } from '@gnomad/region-viewer'
+import { TooltipAnchor } from '@gnomad/ui'
+import Link from './Link'
+
+import InfoButton from './help/InfoButton'
+
+const Wrapper = styled.div`
+  display: flex;
+  margin-bottom: 1em;
+`
+
+const PlotWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  height: 100%;
+`
+
+const RegionAttributeList = styled.dl`
+  margin: 0;
+
+  div {
+    margin-bottom: 0.25em;
+  }
+
+  dt {
+    display: inline;
+    font-weight: bold;
+  }
+
+  dd {
+    display: inline;
+    margin-left: 0.5em;
+  }
+`
+
+function regionColor(region: any) {
+  // http://colorbrewer2.org/#type=sequential&scheme=YlOrRd&n=3
+  // https://colorbrewer2.org/#type=sequential&scheme=PuBu&n=4
+  let color
+  if (region.z > 2.5) {
+    color = '#f03b20'
+  } else if (region.z > 1.2) {
+    color = '#feb24c'
+  } else if (region.z > 0.6) {
+    color = '#ffeda0'
+  } else if (region.z > -0.6) {
+    color = '#e2e2e2'
+  } else if (region.z > -1.2) {
+    color = '#bdc9e1'
+  } else if (region.z > -2.5) {
+    color = '#74a9cf'
+  } else {
+    color = '#0570b0'
+  }
+  return color
+}
+
+const LegendWrapper = styled.div`
+  display: flex;
+
+  @media (max-width: 600px) {
+    flex-direction: column;
+    align-items: center;
+  }
+`
+
+const Legend = () => {
+  const currentParams = queryString.parse(location.search)
+
+  return (
+    <LegendWrapper>
+      {currentParams.variant && (
+        <>
+          <span>Selected Variant</span>
+          <svg width={30} height={25}>
+            <rect x={10} y={0} width={2} height={20} fill="#000" />
+          </svg>
+        </>
+      )}
+      <span>Z Score</span>
+      <svg width={185} height={25}>
+        <rect x={10} y={0} width={25} height={10} stroke="#000" fill="#0570b0" />
+        <rect x={35} y={0} width={25} height={10} stroke="#000" fill="#74a9cf" />
+        <rect x={60} y={0} width={25} height={10} stroke="#000" fill="#bdc9e1" />
+        <rect x={85} y={0} width={25} height={10} stroke="#000" fill="#e2e2e2" />
+        <rect x={110} y={0} width={25} height={10} stroke="#000" fill="#ffeda0" />
+        <rect x={135} y={0} width={25} height={10} stroke="#000" fill="#feb24c" />
+        <rect x={160} y={0} width={25} height={10} stroke="#000" fill="#f03b20" />
+
+        <text x={35} y={10} fontSize="10" dy="1.2em" textAnchor="middle">
+          -2.5
+        </text>
+        <text x={60} y={10} fontSize="10" dy="1.2em" textAnchor="middle">
+          -1.2
+        </text>
+        <text x={85} y={10} fontSize="10" dy="1.2em" textAnchor="middle">
+          -0.6
+        </text>
+        <text x={110} y={10} fontSize="10" dy="1.2em" textAnchor="middle">
+          0.6
+        </text>
+        <text x={135} y={10} fontSize="10" dy="1.2em" textAnchor="middle">
+          1.2
+        </text>
+        <text x={160} y={10} fontSize="10" dy="1.2em" textAnchor="middle">
+          2.5
+        </text>
+      </svg>
+    </LegendWrapper>
+  )
+}
+
+const renderNumber = (number: number | null | undefined) =>
+  number === undefined || number === null ? '-' : number.toPrecision(4)
+
+type RegionTooltipProps = {
+  region: {
+    z: number
+    obs_exp: number
+  }
+}
+
+const RegionTooltip = ({ region }: RegionTooltipProps) => (
+  <RegionAttributeList>
+    <div>
+      <dt>Z:</dt>
+      <dd>{renderNumber(region.z)}</dd>
+    </div>
+    <div>
+      <dt>O/E:</dt>
+      <dd>{renderNumber(region.obs_exp)}</dd>
+    </div>
+  </RegionAttributeList>
+)
+
+const renderTrackLeftPanel = (constraintWidth: number) => {
+  return (
+    <SidePanel>
+      <span>{`Regional genomic constraint (${constraintWidth / 1000}kb scale)`}</span>
+      <InfoButton topic="genomic-constraint" />
+    </SidePanel>
+  )
+}
+
+const SidePanel = styled.div`
+  display: flex;
+  align-items: center;
+  height: 100%;
+`
+
+const TopPanel = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  width: 100%;
+  margin-bottom: 5px;
+`
+
+type TrackProps = {
+  scalePosition: (input: string) => number
+  width: number
+}
+
+type Region = {
+  start: number
+  stop: number
+  z: number
+}
+
+type OwnRegionalConstraintTrackProps = {
+  height?: number
+  start: number
+  stop: number
+  regions: Region[] | null
+}
+
+// @ts-expect-error TS(2456) FIXME: Type alias 'RegionalConstraintTrackProps' circular... Remove this comment to see the full error message
+type RegionalConstraintTrackProps = OwnRegionalConstraintTrackProps &
+  typeof RegionalGenomicConstraintTrack.defaultProps
+
+// @ts-expect-error TS(7022) FIXME: 'RegionalConstraintTrack' implicitly has type 'any... Remove this comment to see the full error message
+const RegionalGenomicConstraintTrack = ({
+  height,
+  start,
+  stop,
+  regions,
+}: RegionalConstraintTrackProps) => {
+  const returnConstraintsThreshold = 150_000
+  const constraintRegionSize = 1_000
+
+  if (regions === null) {
+    return (
+      <Wrapper>
+        <Track renderLeftPanel={() => renderTrackLeftPanel(constraintRegionSize)}>
+          {({ width }: { width: number }) => (
+            <>
+              <PlotWrapper>
+                <svg height={height} width={width}>
+                  <text x={width / 2} y={height / 2} dy="0.33rem" textAnchor="middle">
+                    {`The genomic constraint track is only displayed for regions with a size of ${
+                      returnConstraintsThreshold / 1000
+                    }kb or smaller. Zoom in or adjust the region to see this track.`}
+                  </text>
+                </svg>
+              </PlotWrapper>
+            </>
+          )}
+        </Track>
+      </Wrapper>
+    )
+  }
+
+  const currentParams = queryString.parse(location.search)
+  const variantId = currentParams.variant
+
+  return (
+    <Wrapper>
+      <Track renderLeftPanel={() => renderTrackLeftPanel(constraintRegionSize)}>
+        {({ scalePosition, width }: TrackProps) => (
+          <>
+            <TopPanel>
+              <Legend />
+            </TopPanel>
+            <PlotWrapper>
+              <svg height={height} width={width}>
+                <rect
+                  x={scalePosition(start)}
+                  y={30}
+                  width={scalePosition(stop) - scalePosition(start)}
+                  height={1}
+                  fill="#000"
+                />
+                {typeof variantId === 'string' && (
+                  <>
+                    <rect
+                      x={scalePosition(variantId.split('-')[1])}
+                      y={15}
+                      width={2}
+                      height={30}
+                      fill="#000"
+                    />
+                    <text
+                      x={scalePosition(variantId.split('-')[1])}
+                      y={9}
+                      dy="0.33rem"
+                      textAnchor="middle"
+                    >
+                      <Link to={`/variant/${variantId}`}>{variantId}</Link>
+                    </text>
+                  </>
+                )}
+                {regions.map((region: Region) => {
+                  const startX = scalePosition(region.start.toString())
+                  const stopX = scalePosition(region.stop.toString())
+                  const regionWidth = stopX - startX
+
+                  return (
+                    <TooltipAnchor
+                      key={`${region.start}-${region.stop}`}
+                      // @ts-expect-error TS(2322) FIXME: Type '{ children: Element; key: string; region: an... Remove this comment to see the full error message
+                      region={region}
+                      tooltipComponent={RegionTooltip}
+                    >
+                      <g>
+                        <rect
+                          x={startX}
+                          y={22.5}
+                          width={regionWidth}
+                          height={15}
+                          fill={regionColor(region)}
+                          stroke="black"
+                        />
+                        {regionWidth > 30 && (
+                          <text x={(startX + stopX) / 2} y={30} dy="0.33em" textAnchor="middle">
+                            {region.z.toFixed(2)}
+                          </text>
+                        )}
+                      </g>
+                    </TooltipAnchor>
+                  )
+                })}
+              </svg>
+            </PlotWrapper>
+          </>
+        )}
+      </Track>
+    </Wrapper>
+  )
+}
+
+RegionalGenomicConstraintTrack.defaultProps = {
+  height: 45,
+}
+
+export default RegionalGenomicConstraintTrack

--- a/data-pipeline/requirements.txt
+++ b/data-pipeline/requirements.txt
@@ -1,2 +1,3 @@
 elasticsearch~=6.8
 hail
+tqdm

--- a/data-pipeline/src/data_pipeline/datasets/gnomad_v3/gnomad_v3_genomic_constraint_regions.py
+++ b/data-pipeline/src/data_pipeline/datasets/gnomad_v3/gnomad_v3_genomic_constraint_regions.py
@@ -1,0 +1,24 @@
+import hail as hl
+
+
+def prepare_gnomad_v3_genomic_constraint_regions(genomic_constraint_region_table_path):
+    ds = hl.import_table(genomic_constraint_region_table_path, force=True)
+
+    ds = ds.select_globals()
+
+    ds = ds.select(
+        chrom=hl.str(ds.chrom),
+        start=hl.int(ds.start),
+        stop=hl.int(ds.end),
+        element_id=hl.str(ds.element_id),
+        possible=hl.float(ds.possible),
+        observed=hl.float(ds.observed),
+        expected=hl.float(ds.expected),
+        oe=hl.float(ds.oe),
+        z=hl.float(ds.z),
+        coding_prop=hl.float(ds.coding_prop),
+    )
+
+    ds = ds.key_by("element_id")
+
+    return ds

--- a/data-pipeline/src/data_pipeline/pipelines/export_to_elasticsearch.py
+++ b/data-pipeline/src/data_pipeline/pipelines/export_to_elasticsearch.py
@@ -24,6 +24,9 @@ from data_pipeline.pipelines.gnomad_v2_variant_cooccurrence import pipeline as g
 from data_pipeline.pipelines.gnomad_v3_coverage import pipeline as gnomad_v3_coverage_pipeline
 from data_pipeline.pipelines.gnomad_v3_variants import pipeline as gnomad_v3_variants_pipeline
 from data_pipeline.pipelines.gnomad_v3_local_ancestry import pipeline as gnomad_v3_local_ancestry_pipeline
+from data_pipeline.pipelines.gnomad_v3_genomic_constraint_regions import (
+    pipeline as gnomad_v3_genomic_constraint_regions_pipeline,
+)
 from data_pipeline.pipelines.liftover import pipeline as liftover_pipeline
 from data_pipeline.pipelines.gnomad_v3_mitochondrial_variants import (
     pipeline as gnomad_v3_mitochondrial_variants_pipeline,
@@ -360,6 +363,22 @@ DATASETS_CONFIG = {
             "id_field": "document_id",
             "num_shards": 8,
             "block_size": 1_000,
+        },
+    },
+    ##############################################################################################################
+    # Genomic / Non Coding Constraints
+    ##############################################################################################################
+    "gnomad_v3_genomic_constraint_regions": {
+        "get_table": lambda: subset_table(
+            hl.read_table(
+                gnomad_v3_genomic_constraint_regions_pipeline.get_output(
+                    "gnomad_v3_genomic_constraint_regions"
+                ).get_output_path()
+            )
+        ),
+        "args": {
+            "index": "gnomad_v3_genomic_constraint_regions",
+            "id_field": "element_id",
         },
     },
 }

--- a/data-pipeline/src/data_pipeline/pipelines/gnomad_v3_genomic_constraint_regions.py
+++ b/data-pipeline/src/data_pipeline/pipelines/gnomad_v3_genomic_constraint_regions.py
@@ -1,0 +1,29 @@
+from data_pipeline.pipeline import Pipeline, run_pipeline
+
+from data_pipeline.datasets.gnomad_v3.gnomad_v3_genomic_constraint_regions import (
+    prepare_gnomad_v3_genomic_constraint_regions,
+)
+
+pipeline = Pipeline()
+
+pipeline.add_task(
+    "prepare_gnomad_v3_genomic_constraint_regions",
+    prepare_gnomad_v3_genomic_constraint_regions,
+    "/constraint/gnomad_v3_genomic_constraint_regions.ht",
+    {
+        "genomic_constraint_region_table_path": "gs://gnomad-browser-data-pipeline/output/2022-10-14-ncc/constraint_z_genome_1kb_filtered.browser.txt"
+    },
+)
+
+###############################################
+# Outputs
+###############################################
+
+pipeline.set_outputs({"gnomad_v3_genomic_constraint_regions": "prepare_gnomad_v3_genomic_constraint_regions"})
+
+###############################################
+# Run
+###############################################
+
+if __name__ == "__main__":
+    run_pipeline(pipeline)

--- a/dataset-metadata/metadata.ts
+++ b/dataset-metadata/metadata.ts
@@ -33,6 +33,7 @@ export type DatasetMetadata = {
   hasShortVariants: boolean
   hasStructuralVariants: boolean
   hasConstraints: boolean
+  hasNonCodingConstraints: boolean
   hasExomeCoverage: boolean
   referenceGenome: ReferenceGenome
 }
@@ -47,6 +48,7 @@ const metadataForDataset = (datasetId: DatasetId): DatasetMetadata => ({
   hasShortVariants: !structuralVariantDatasetIds.includes(datasetId),
   hasStructuralVariants: structuralVariantDatasetIds.includes(datasetId),
   hasConstraints: !datasetId.startsWith('gnomad_r3'),
+  hasNonCodingConstraints: datasetId.startsWith('gnomad_r3'),
   referenceGenome: datasetId.startsWith('gnomad_r3') ? 'GRCh38' : 'GRCh37',
   hasExomeCoverage: !datasetId.startsWith('gnomad_r3'),
 })
@@ -69,6 +71,9 @@ export const isSubset = (datasetId: DatasetId) => getMetadata(datasetId, 'isSubs
 export const labelForDataset = (datasetId: DatasetId) => getMetadata(datasetId, 'label')
 
 export const hasConstraints = (datsetId: DatasetId) => getMetadata(datsetId, 'hasConstraints')
+
+export const hasNonCodingConstraints = (datasetId: DatasetId) =>
+  getMetadata(datasetId, 'hasNonCodingConstraints')
 
 export const hasExomeCoverage = (datsetId: DatasetId) => getMetadata(datsetId, 'hasExomeCoverage')
 

--- a/graphql-api/src/elasticsearch.js
+++ b/graphql-api/src/elasticsearch.js
@@ -112,6 +112,7 @@ const limitedElastic = {
       return response
     }),
   get: (...args) => scheduleElasticsearchRequest(() => elastic.get(...args)),
+  mget: (...args) => scheduleElasticsearchRequest(() => elastic.mget(...args)),
 }
 
 module.exports = {

--- a/graphql-api/src/graphql/resolvers/region-fields.js
+++ b/graphql-api/src/graphql/resolvers/region-fields.js
@@ -1,11 +1,17 @@
 const { fetchGenesByRegion } = require('../../queries/gene-queries')
+const { fetchNccConstraintsByRegion } = require('../../queries/genomic-constraint-queries')
 
 const resolveGenesInRegion = (obj, args, ctx) => {
   return fetchGenesByRegion(ctx.esClient, obj)
 }
 
+const resolveNCCsInRegion = (obj, args, ctx) => {
+  return fetchNccConstraintsByRegion(ctx.esClient, obj)
+}
+
 module.exports = {
   Region: {
     genes: resolveGenesInRegion,
+    non_coding_constraints: resolveNCCsInRegion,
   },
 }

--- a/graphql-api/src/graphql/types/region.graphql
+++ b/graphql-api/src/graphql/types/region.graphql
@@ -26,6 +26,7 @@ type Region {
   stop: Int!
 
   genes: [RegionGene!]! @cost(value: 5)
+  non_coding_constraints: [NonCodingConstraintRegion!] @cost(value: 3)
 
   variants(dataset: DatasetId!): [Variant!]! @cost(value: 10)
   structural_variants(dataset: StructuralVariantDatasetId!): [StructuralVariant!]! @cost(value: 10)

--- a/graphql-api/src/graphql/types/variant.graphql
+++ b/graphql-api/src/graphql/types/variant.graphql
@@ -116,6 +116,19 @@ type VariantSequencingTypeData {
   ac_hemi: Int
 }
 
+type NonCodingConstraintRegion {
+  chrom: String!
+  start: Int!
+  stop: Int!
+  element_id: String!
+  possible: Float!
+  observed: Float!
+  expected: Float!
+  oe: Float!
+  z: Float!
+  coding_prop: Float!
+}
+
 type Variant {
   variant_id: String!
   reference_genome: ReferenceGenomeId!
@@ -201,9 +214,9 @@ type VariantDetailsSequencingTypeData {
 }
 
 type MultiNucleotideVariantSummary {
-  combined_variant_id: String!,
+  combined_variant_id: String!
   changes_amino_acids: Boolean!
-  n_individuals: Int!,
+  n_individuals: Int!
   other_constituent_snvs: [String!]!
 }
 
@@ -231,6 +244,8 @@ type VariantDetails {
   flags: [String!]
   transcript_consequences: [TranscriptConsequence!]
   in_silico_predictors: [VariantInSilicoPredictor!]
+
+  non_coding_constraint: NonCodingConstraintRegion
 
   # Deprecated - use rsids
   rsid: String

--- a/graphql-api/src/queries/genomic-constraint-queries.js
+++ b/graphql-api/src/queries/genomic-constraint-queries.js
@@ -1,0 +1,51 @@
+const fetchNccConstraintRegionById = async (esClient, nccId) => {
+  try {
+    const response = await esClient.get({
+      index: 'gnomad_v3_genomic_constraint_regions',
+      type: '_doc',
+      id: nccId,
+    })
+    return response.body._source
+  } catch (err) {
+    return null
+  }
+}
+
+const returnConstraintsThreshold = 150_000
+
+const fetchNccConstraintsByRegion = async (esClient, region) => {
+  // eslint-disable-next-line no-unused-vars
+  const { reference_genome: referenceGenome, chrom, start, stop } = region
+
+  const constraintRegionSize = 1_000
+
+  // This data becomes incomprehensible if the region is too large
+  if (stop - start > returnConstraintsThreshold) return null
+
+  let curr = Math.floor(start / 1000) * 1000
+  const allIds = []
+  while (curr < stop - constraintRegionSize) {
+    const currVariantNCCId = `chr${chrom}-${curr}-${curr + constraintRegionSize}`
+    allIds.push(currVariantNCCId)
+    curr += constraintRegionSize
+  }
+
+  try {
+    const response = await esClient.mget({
+      index: 'gnomad_v3_genomic_constraint_regions',
+      body: {
+        ids: allIds,
+      },
+    })
+    const toReturn = response.body.docs.filter((doc) => doc.found).map((doc) => doc._source)
+    return toReturn
+  } catch (err) {
+    return null
+  }
+}
+
+module.exports = {
+  returnConstraintsThreshold,
+  fetchNccConstraintRegionById,
+  fetchNccConstraintsByRegion,
+}


### PR DESCRIPTION
MVP of the features for the non-coding / genomic constraint analysis that Siwei and Konrad have been working on.

Resolves #837. New issue to be opened for further development of this feature.
Resolves #1011 

A demo deployment up at [the ip 34.149.180.53](http://34.149.180.53). I've clicked around to the the pages I can think of, and believe it is stable. Some pages that have changes with the non-coding / genomic are:

- [An example of a region page](http://34.149.180.53/region/1-55039447-55064852?dataset=gnomad_r3) that has the genomic constraint track
- [A variant page](http://34.149.180.53/variant/1-55040049-G-A?dataset=gnomad_r3) that falls into a region with non-coding constrained data
- [A region page](http://34.149.180.53/region/1-55020049-55060049?variant=1-55040049-G-A&dataset=gnomad_r3) with a variant selected

This is an MVP, some of the tooltips aren't quite perfect, there is currently not a blog post to go along with this feature, and Siwei is unsure if she'll have one in time for ASHG, and the table on the Gene page with the enhancers and tissues got postponed to discuss more.