### PR TITLE
Fix vep annotations section of variant coocurrence page

### DIFF
--- a/browser/src/VariantCooccurrencePage/VariantCooccurrencePage.tsx
+++ b/browser/src/VariantCooccurrencePage/VariantCooccurrencePage.tsx
@@ -339,7 +339,6 @@ const VariantCoocurrenceContainer = ({
       {({ data }: any) => {
         const genesInCommon = [data.variant1, data.variant2]
           .map((v) => new Set(v.transcript_consequences.map((csq: any) => csq.gene_id)))
-          // @ts-expect-error TS(2802) FIXME: Type 'Set<unknown>' can only be iterated through w... Remove this comment to see the full error message
           .reduce((acc, genes) => new Set([...acc].filter((geneId) => genes.has(geneId))))
 
         // @ts-expect-error TS(7006) FIXME: Parameter 'acc' implicitly has an 'any' type.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -54,7 +54,7 @@
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
     // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
-    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+    "downlevelIteration": true /* Emit more compliant, but verbose and less performant JavaScript for iteration. */,
     // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
     // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */


### PR DESCRIPTION
Resolves #1014 

Enables `downlevelIteration` in `tsconfig.json` to allow for iterating over a Set, restoring the prior functionality of the VEP Annotations section of the Variant Cooccurence page.

