### PR TITLE
Modify genomic constraint components

### DIFF
--- a/browser/help/topics/genomic-constraint.md
+++ b/browser/help/topics/genomic-constraint.md
@@ -5,10 +5,12 @@ title: 'Genomic constraint'
 
 ### Overall interpretation
 
-A genomic constraint metric is now available on the gnomAD browser.
+We quantify the depletion of variation (constraint) at a 1kb scale with a signed Z score by comparing the observed variation to an expectation. In each tiling 1kb genomic region, the expected number of variants is predicted using an improved mutational model that takes into account both local sequence context and a variety of genomic features. A higher positive Z score (i.e., observing fewer variants than expected) indicates higher constraint.
 
-We quantify the depletion of variation (constraint) at a 1kb scale with a signed Z score by comparing the observed variation to an expectation. In each tiling 1kb genomic region, the expected number of variants is predicted using an improved mutional model that takes into account both local sequence context and a variety of genomic features. A higher positive Z score (i.e., observing fewer variants than expectation) indicates higher constraint.
+This genomic constraint metric is only available for the gnomAD v3 dataset, as it is based on GRCh38.
 
-This genomic constraint metric is only available for the gnomAD v3 dataset, as it is based on GRCh38. The track only displays if the region is 150kb or less, and the Z scores render as text in the track if the scale allows. Gaps in the genomic constract track represent regions that did not pass QC.
+The genomic constraint track only displays if the region is 150kb or less, and the Z scores only render as text in the track if the scale allows.
 
-More details can be found in the [preprint on bioRxiv](https://www.biorxiv.org/content/10.1101/2022.03.20.485034v2).
+Gaps in the genomic constract track represent regions that did not pass quality control, e.g., sequencing coverage outliers or low variant quality scores.
+
+More details can be found in the [preprint on bioRxiv](https://www.biorxiv.org/content/10.1101/2022.03.20.485034).

--- a/browser/src/ConstraintTable/GnomadNonCodingConstraintTableVariant.tsx
+++ b/browser/src/ConstraintTable/GnomadNonCodingConstraintTableVariant.tsx
@@ -8,9 +8,13 @@ import Link from '../Link'
 import { NonCodingConstraint } from '../VariantPage/VariantPage'
 import { renderRoundedNumber } from './constraintMetrics'
 
+import { regionColor } from '../RegionalGenomicConstraintTrack'
+import { Legend } from '../RegionalGenomicConstraintTrack'
+
 const Table = styled(BaseTable)`
   width: 100%;
   margin-top: 1rem;
+  margin-bottom: 1rem;
 
   @media (max-width: 600px) {
     td,
@@ -50,7 +54,14 @@ const GnomadNonCodingConstraintTableVariant = ({
       <div>
         <p>{`Genomic constraint values displayed are for the region: ${chrom}-${nonCodingConstraint.start}-${nonCodingConstraint.stop}`}</p>
         <p>
-          <a href={'https://gnomad.broadinstitute.org/news/2022-10-the-addition-of-a-genomic-constraint-metric-to-gnomad/'}>Read more</a> about this constraint.
+          <a
+            href={
+              'https://gnomad.broadinstitute.org/news/2022-10-the-addition-of-a-genomic-constraint-metric-to-gnomad/'
+            }
+          >
+            Read more
+          </a>{' '}
+          about this constraint.
         </p>
       </div>
       <Table>
@@ -58,7 +69,7 @@ const GnomadNonCodingConstraintTableVariant = ({
           <tr>
             <th scope="col">
               {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
-              <TooltipAnchor tooltip="The expected number of variants is predicted using an improved mutional model that takes into account both local sequence context and a variety of genomic features.">
+              <TooltipAnchor tooltip="The expected number of variants is predicted using an improved mutational model that takes into account both local sequence context and a variety of genomic features.">
                 {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
                 <TooltipHint>Expected</TooltipHint>
               </TooltipAnchor>
@@ -82,7 +93,7 @@ const GnomadNonCodingConstraintTableVariant = ({
               {renderRoundedNumber(nonCodingConstraint.z, {
                 precision: 2,
                 tooltipPrecision: 3,
-                highlightColor: null,
+                highlightColor: regionColor(nonCodingConstraint),
               })}
               <br />
               o/e ={' '}
@@ -95,6 +106,7 @@ const GnomadNonCodingConstraintTableVariant = ({
           </tr>
         </tbody>
       </Table>
+      <Legend />
       <ViewSurroundingRegion>
         <p>
           {`View the genomic constraint values for the ${

--- a/browser/src/ConstraintTable/GnomadNonCodingConstraintTableVariant.tsx
+++ b/browser/src/ConstraintTable/GnomadNonCodingConstraintTableVariant.tsx
@@ -6,7 +6,6 @@ import { BaseTable, TooltipAnchor, TooltipHint } from '@gnomad/ui'
 import Link from '../Link'
 
 import { NonCodingConstraint } from '../VariantPage/VariantPage'
-
 import { renderRoundedNumber } from './constraintMetrics'
 
 const Table = styled(BaseTable)`
@@ -51,7 +50,7 @@ const GnomadNonCodingConstraintTableVariant = ({
       <div>
         <p>{`Genomic constraint values displayed are for the region: ${chrom}-${nonCodingConstraint.start}-${nonCodingConstraint.stop}`}</p>
         <p>
-          <a href={'https://gnomad.broadinstitute.org/news/2022-10-24-the-addition-of-a-genomic-constraint-metric-to-gnomad/'}>Read more</a> about this constraint.
+          <a href={'https://gnomad.broadinstitute.org/news/2022-10-the-addition-of-a-genomic-constraint-metric-to-gnomad/'}>Read more</a> about this constraint.
         </p>
       </div>
       <Table>
@@ -97,13 +96,12 @@ const GnomadNonCodingConstraintTableVariant = ({
         </tbody>
       </Table>
       <ViewSurroundingRegion>
-        <p>{`View the genomic constraint values for the ${
-          (regionBuffer * 2) / 1000
-        }kb region surrounding this variant`}</p>
         <p>
+          {`View the genomic constraint values for the ${
+            (regionBuffer * 2) / 1000
+          }kb region surrounding this variant: `}
           <Link
-            to={`/region/${surroundingLocation}?variant=${variantId}&dataset=gnomad_r3`}
-            preserveSelectedDataset={false}
+            to={{ pathname: `/region/${surroundingLocation}`, search: `variant=${variantId}`}}
           >
             {surroundingLocation}
           </Link>

--- a/browser/src/DownloadsPage/DownloadsPage.tsx
+++ b/browser/src/DownloadsPage/DownloadsPage.tsx
@@ -49,6 +49,8 @@ const DownloadsPage = ({ location }: Props) => {
       setActiveTab('v3')
     } else if (location.hash.startsWith('#exac-')) {
       setActiveTab('exac')
+    } else if (location.hash.startsWith('#research-')) {
+      setActiveTab('research')
     }
   }, [location.hash])
 

--- a/browser/src/DownloadsPage/ResearchDownloads.tsx
+++ b/browser/src/DownloadsPage/ResearchDownloads.tsx
@@ -13,7 +13,7 @@ const ResearchDownloads = () => {
         accompanying README file explaining what it contains.
       </p>
       <section>
-        <SectionTitle id="v3-genomic-constraint">Non-coding and Genomic constraint</SectionTitle>
+        <SectionTitle id="research-genomic-constraint">Genomic constraint</SectionTitle>
         <p>For more information about these files, see the README included in the download.</p>
         <FileList>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
@@ -29,9 +29,9 @@ const ResearchDownloads = () => {
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
             <GenericDownloadLinks
-              label="Non coding constraint for gene tissue enhancers"
+              label="Raw genomic constraint by 1kb regions"
               gcsBucket="gnomad-nc-constraint-v31-paper"
-              path="/download_files/constraint_z_enh_gene_roadmaplinks.all.download.txt.gz"
+              path="/download_files/constraint_z_genome_1kb.raw.download.txt.gz"
               includeAWS={false}
               includeAzure={false}
             />
@@ -39,7 +39,7 @@ const ResearchDownloads = () => {
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
             <GenericDownloadLinks
-              label="QCd genomic constraint by 1kb regions"
+              label="QCed genomic constraint by 1kb regions"
               gcsBucket="gnomad-nc-constraint-v31-paper"
               path="/download_files/constraint_z_genome_1kb.qc.download.txt.gz"
               includeAWS={false}
@@ -49,9 +49,9 @@ const ResearchDownloads = () => {
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
             <GenericDownloadLinks
-              label="Raw genomic constraint by 1kb regions"
+              label="Non-coding constraint for gene tissue enhancers"
               gcsBucket="gnomad-nc-constraint-v31-paper"
-              path="/download_files/constraint_z_genome_1kb.raw.download.txt.gz"
+              path="/download_files/constraint_z_enh_gene_roadmaplinks.all.download.txt.gz"
               includeAWS={false}
               includeAzure={false}
             />

--- a/browser/src/RegionalGenomicConstraintTrack.tsx
+++ b/browser/src/RegionalGenomicConstraintTrack.tsx
@@ -134,7 +134,7 @@ const RegionTooltip = ({ region }: RegionTooltipProps) => (
       <dd>{renderNumber(region.z)}</dd>
     </div>
     <div>
-      <dt>O/E:</dt>
+      <dt>o/e:</dt>
       <dd>{renderNumber(region.obs_exp)}</dd>
     </div>
   </RegionAttributeList>
@@ -276,7 +276,7 @@ const RegionalGenomicConstraintTrack = ({
                           fill={regionColor(region)}
                           stroke="black"
                         />
-                        {regionWidth > 30 && (
+                        {regionWidth > 32 && (
                           <text x={(startX + stopX) / 2} y={30} dy="0.33em" textAnchor="middle">
                             {region.z.toFixed(2)}
                           </text>

--- a/browser/src/RegionalGenomicConstraintTrack.tsx
+++ b/browser/src/RegionalGenomicConstraintTrack.tsx
@@ -8,6 +8,9 @@ import { Track } from '@gnomad/region-viewer'
 import { TooltipAnchor } from '@gnomad/ui'
 import Link from './Link'
 
+// @ts-expect-error
+import QuestionMarkIcon from '@fortawesome/fontawesome-free/svgs/solid/question-circle.svg'
+
 import InfoButton from './help/InfoButton'
 
 const Wrapper = styled.div`
@@ -40,24 +43,15 @@ const RegionAttributeList = styled.dl`
   }
 `
 
-function regionColor(region: any) {
+export function regionColor(region: any) {
   // http://colorbrewer2.org/#type=sequential&scheme=YlOrRd&n=3
-  // https://colorbrewer2.org/#type=sequential&scheme=PuBu&n=4
   let color
-  if (region.z > 2.5) {
+  if (region.z > 4.0) {
     color = '#f03b20'
-  } else if (region.z > 1.2) {
-    color = '#feb24c'
-  } else if (region.z > 0.6) {
+  } else if (region.z > 2.18) {
     color = '#ffeda0'
-  } else if (region.z > -0.6) {
-    color = '#e2e2e2'
-  } else if (region.z > -1.2) {
-    color = '#bdc9e1'
-  } else if (region.z > -2.5) {
-    color = '#74a9cf'
   } else {
-    color = '#0570b0'
+    color = '#e2e2e2'
   }
   return color
 }
@@ -71,7 +65,13 @@ const LegendWrapper = styled.div`
   }
 `
 
-const Legend = () => {
+const LegendTooltip = () => (
+  <>
+    {`The Z score ranges from -10 to 10. Z >= 2.18 (yellow) and Z >= 4.0 (red) represent the top 10% and top 1% of constrained non-coding regions, respectively.`}
+  </>
+)
+
+export const Legend = () => {
   const currentParams = queryString.parse(location.search)
 
   return (
@@ -79,38 +79,33 @@ const Legend = () => {
       {currentParams.variant && (
         <>
           <span>Selected Variant</span>
-          <svg width={30} height={25}>
+          <svg width={40} height={25}>
             <rect x={10} y={0} width={2} height={20} fill="#000" />
           </svg>
         </>
       )}
-      <span>Z Score</span>
-      <svg width={185} height={25}>
-        <rect x={10} y={0} width={25} height={10} stroke="#000" fill="#0570b0" />
-        <rect x={35} y={0} width={25} height={10} stroke="#000" fill="#74a9cf" />
-        <rect x={60} y={0} width={25} height={10} stroke="#000" fill="#bdc9e1" />
-        <rect x={85} y={0} width={25} height={10} stroke="#000" fill="#e2e2e2" />
-        <rect x={110} y={0} width={25} height={10} stroke="#000" fill="#ffeda0" />
-        <rect x={135} y={0} width={25} height={10} stroke="#000" fill="#feb24c" />
-        <rect x={160} y={0} width={25} height={10} stroke="#000" fill="#f03b20" />
-
-        <text x={35} y={10} fontSize="10" dy="1.2em" textAnchor="middle">
-          -2.5
+      <span>
+        Z Score{' '}
+        <TooltipAnchor key={`Legend`} tooltipComponent={LegendTooltip}>
+          <img src={QuestionMarkIcon} height={'12'} alt="" aria-hidden="true" />
+        </TooltipAnchor>
+      </span>
+      <svg width={330} height={25}>
+        <text x={15} y={-4} fontSize="10" dy="1.2em">
+          not constrained
         </text>
-        <text x={60} y={10} fontSize="10" dy="1.2em" textAnchor="middle">
-          -1.2
+        <rect x={95} y={0} width={40} height={10} stroke="#000" fill="#e2e2e2" />
+        <rect x={135} y={0} width={40} height={10} stroke="#000" fill="#ffeda0" />
+        <rect x={175} y={0} width={40} height={10} stroke="#000" fill="#f03b20" />
+        <text x={220} y={-4} fontSize="10" dy="1.2em">
+          constrained
         </text>
-        <text x={85} y={10} fontSize="10" dy="1.2em" textAnchor="middle">
-          -0.6
-        </text>
-        <text x={110} y={10} fontSize="10" dy="1.2em" textAnchor="middle">
-          0.6
-        </text>
+        <text x={110} y={10} fontSize="10" dy="1.2em" textAnchor="middle"></text>
         <text x={135} y={10} fontSize="10" dy="1.2em" textAnchor="middle">
-          1.2
+          2.18
         </text>
-        <text x={160} y={10} fontSize="10" dy="1.2em" textAnchor="middle">
-          2.5
+        <text x={175} y={10} fontSize="10" dy="1.2em" textAnchor="middle">
+          4.0
         </text>
       </svg>
     </LegendWrapper>


### PR DESCRIPTION
Minor modifications to genomic constraint components pre Siwei's ASHG talk.

- Modification to order of downloads page, adds conditional to let `#research-genomic-constraint` link directly to section
- Modification to display of regional genomic constraint track, negative z scores such as `-0.65` could slightly overlap with the edges of a genomic constraint z score box when rendered at minimum of `30`, minimum width increased as a result
  ![Screen Shot 2022-10-25 at 14 07 33](https://user-images.githubusercontent.com/59549713/197860567-b3e7561c-4041-4c42-94cf-7ee7733103e9.jpg)
- Modified help text of genomic constraint region (`?` button displays this)
- Minorly change URL of variant table link to blog post to no longer include date (`2022-10-24` -> `2022-10`)