### PR TITLE
Add additional GraphQL query details to google cloud logging

### DIFF
--- a/browser/src/Query.tsx
+++ b/browser/src/Query.tsx
@@ -97,7 +97,7 @@ export class BaseQuery extends Component<BaseQueryProps, BaseQueryState> {
     this.currentRequest = cancelable(
       fetch(url, {
         body: JSON.stringify({
-          // operationName,
+          operationName,
           query,
           variables,
         }),

--- a/deploy/deployctl/subcommands/browser_deployments.py
+++ b/deploy/deployctl/subcommands/browser_deployments.py
@@ -93,7 +93,7 @@ def create_deployment(name: str, browser_tag: str = None, api_tag: str = None) -
 
         kustomization_file.write(kustomization)
 
-    print(f"configured deployment '{name}'")
+    print(f"configured local deployment manifest '{name}'")
 
 
 def apply_deployment(name: str) -> None:
@@ -103,6 +103,8 @@ def apply_deployment(name: str) -> None:
         raise RuntimeError(f"no configuration for deployment '{name}'")
 
     kubectl(["apply", "-k", deployment_directory])
+
+    print(f"applied deployment '{name}' to new pods in the cluster")
 
 
 def delete_deployment(name: str, clean: bool = False) -> None:
@@ -116,11 +118,15 @@ def delete_deployment(name: str, clean: bool = False) -> None:
         create_deployment(name)
         delete_deployment(name, clean=True)
 
+    print(f"deleted deployment '{name}'s corresponding pods from the cluster")
+
 
 def clean_deployment(name: str) -> None:
     deployment_directory = os.path.join(deployments_directory(), name)
     os.remove(os.path.join(deployment_directory, "kustomization.yaml"))
     os.rmdir(deployment_directory)
+
+    print(f"removed local deployment manifest '{name}'")
 
 
 def main(argv: typing.List[str]) -> None:

--- a/deploy/deployctl/subcommands/ingress_demo.py
+++ b/deploy/deployctl/subcommands/ingress_demo.py
@@ -130,6 +130,8 @@ def apply_ingress(name: str, browser_deployment: str = None, reads_deployment: s
 
     kubectl(["apply", "-f", "-"], input=manifest)
 
+    print(f"applied ingress to deployment '{name}'")
+
 
 def delete_ingress_and_services(name: str) -> None:
     kubectl(["delete", f"ingress/gnomad-ingress-demo-{name}"])

--- a/graphql-api/src/app.js
+++ b/graphql-api/src/app.js
@@ -62,6 +62,12 @@ app.use(function requestLogMiddleware(request, response, next) {
             : undefined,
         protocol: `HTTP/${request.httpVersionMajor}.${request.httpVersionMinor}`,
       },
+      graphqlRequest: {
+        graphqlQueryOperationName: request.graphqlParams.operationName,
+        graphqlQueryString: request.graphqlParams.query,
+        graphqlQueryVariables: request.graphqlParams.variables,
+        graphqlQueryCost: request.graphqlQueryCost,
+      },
     })
   })
 

--- a/graphql-api/src/graphql/graphql-api.js
+++ b/graphql-api/src/graphql/graphql-api.js
@@ -119,6 +119,7 @@ module.exports = ({ context }) =>
         createError: queryComplexityCreateError,
         onComplete: (cost) => {
           request.graphqlQueryCost = cost
+          request.graphqlParams = requestParams
         },
       }),
     ],


### PR DESCRIPTION
Per the action items determined as part of the [petalbot postmortem](https://docs.google.com/document/d/1Vx5m-v3ZGnAyxMGThbKqH37rF2Qiuesmjog4myp6CDM/edit#).

Adds additional fields in the `jsonPayload` field of the google logs, allowing for seeing what querys were run, what the internal associated cost was, and things of that nature. This gives more observability in the logs of what is actually being requested, and will aid in diagnosing and fixing the issues of slowness.

[Here is a link](https://console.cloud.google.com/logs/query;cursorTimestamp=2022-11-02T17:30:13.825557713Z;query=resource.type%3D%22k8s_container%22%0Aresource.labels.cluster_name%3D%22gnomad%22%0Aresource.labels.container_name%3D%22app%22%0Aresource.labels.namespace_name%3D%22default%22%0AlogName%3D%2528%22projects%2Fexac-gnomad%2Flogs%2Fcontainer-runtime%22%20OR%20%22projects%2Fexac-gnomad%2Flogs%2Fdocker%22%20OR%20%22projects%2Fexac-gnomad%2Flogs%2Fevents%22%20OR%20%22projects%2Fexac-gnomad%2Flogs%2FGCEGuestAgent%22%20OR%20%22projects%2Fexac-gnomad%2Flogs%2Fkube-container-runtime-monitor%22%20OR%20%22projects%2Fexac-gnomad%2Flogs%2Fkube-node-configuration%22%20OR%20%22projects%2Fexac-gnomad%2Flogs%2Fkube-node-installation%22%20OR%20%22projects%2Fexac-gnomad%2Flogs%2Fkube-proxy%22%20OR%20%22projects%2Fexac-gnomad%2Flogs%2Fkubelet%22%20OR%20%22projects%2Fexac-gnomad%2Flogs%2Fkubelet-monitor%22%20OR%20%22projects%2Fexac-gnomad%2Flogs%2Fnode-problem-detector%22%20OR%20%22projects%2Fexac-gnomad%2Flogs%2FOSConfigAgent%22%20OR%20%22projects%2Fexac-gnomad%2Flogs%2Frequests%22%20OR%20%22projects%2Fexac-gnomad%2Flogs%2Fstderr%22%20OR%20%22projects%2Fexac-gnomad%2Flogs%2Fstdout%22%2529%0Aresource.labels.container_name%3D%22app%22%0Atimestamp%3D%222022-11-02T17:30:13.825557713Z%22%0AinsertId%3D%22v3d4aueybh2ml7jj%22;timeRange=2022-11-02T17:28:53.000Z%2F2022-11-02T17:32:26.000Z?project=exac-gnomad) to a logs view that only shows one of these logs from the demo instance, with the new fields.

![Screen Shot 2022-11-02 at 13 03 28](https://user-images.githubusercontent.com/59549713/199568011-67422b77-db84-4554-a510-341eaa556692.jpg)

It's a bit hard to read in the screenshot, the additional information included in the `jsonPayload` for the first request sent from the PCSK9 gene page is:

```
"jsonPayload": {
    "graphqlRequest": {
      "graphqlQueryOperationName": "Gene",
      "graphqlQueryString": "\nquery Gene($geneId: String, $geneSymbol: String, $referenceGenome: ReferenceGenomeId!, $shortTandemRepeatDatasetId: DatasetId!, $includeShortTandemRepeats: Boolean!) {\n  gene(gene_id: $geneId, gene_symbol: $geneSymbol, reference_genome: $referenceGenome) {\n    reference_genome\n    gene_id\n    gene_version\n    symbol\n    gencode_symbol\n    name\n    canonical_transcript_id\n    mane_select_transcript {\n      ensembl_id\n      ensembl_version\n      refseq_id\n      refseq_version\n    }\n    hgnc_id\n    ncbi_id\n    omim_id\n    chrom\n    start\n    stop\n    strand\n    exons {\n      feature_type\n      start\n      stop\n    }\n    flags\n    gnomad_constraint {\n      exp_lof\n      exp_mis\n      exp_syn\n      obs_lof\n      obs_mis\n      obs_syn\n      oe_lof\n      oe_lof_lower\n      oe_lof_upper\n      oe_mis\n      oe_mis_lower\n      oe_mis_upper\n      oe_syn\n      oe_syn_lower\n      oe_syn_upper\n      lof_z\n      mis_z\n      syn_z\n      pLI\n      flags\n    }\n    exac_constraint {\n      exp_syn\n      obs_syn\n      syn_z\n      exp_mis\n      obs_mis\n      mis_z\n      exp_lof\n      obs_lof\n      lof_z\n      pLI\n    }\n    transcripts {\n      transcript_id\n      transcript_version\n      strand\n      exons {\n        feature_type\n        start\n        stop\n      }\n      gtex_tissue_expression {\n        adipose_subcutaneous\n        adipose_visceral_omentum\n        adrenal_gland\n        artery_aorta\n        artery_coronary\n        artery_tibial\n        bladder\n        brain_amygdala\n        brain_anterior_cingulate_cortex_ba24\n        brain_caudate_basal_ganglia\n        brain_cerebellar_hemisphere\n        brain_cerebellum\n        brain_cortex\n        brain_frontal_cortex_ba9\n        brain_hippocampus\n        brain_hypothalamus\n        brain_nucleus_accumbens_basal_ganglia\n        brain_putamen_basal_ganglia\n        brain_spinal_cord_cervical_c_1\n        brain_substantia_nigra\n        breast_mammary_tissue\n        cells_ebv_transformed_lymphocytes\n        cells_transformed_fibroblasts\n        cervix_ectocervix\n        cervix_endocervix\n        colon_sigmoid\n        colon_transverse\n        esophagus_gastroesophageal_junction\n        esophagus_mucosa\n        esophagus_muscularis\n        fallopian_tube\n        heart_atrial_appendage\n        heart_left_ventricle\n        kidney_cortex\n        liver\n        lung\n        minor_salivary_gland\n        muscle_skeletal\n        nerve_tibial\n        ovary\n        pancreas\n        pituitary\n        prostate\n        skin_not_sun_exposed_suprapubic\n        skin_sun_exposed_lower_leg\n        small_intestine_terminal_ileum\n        spleen\n        stomach\n        testis\n        thyroid\n        uterus\n        vagina\n        whole_blood\n      }\n    }\n    pext {\n      regions {\n        start\n        stop\n        mean\n        tissues {\n          adipose_subcutaneous\n          adipose_visceral_omentum\n          adrenal_gland\n          artery_aorta\n          artery_coronary\n          artery_tibial\n          bladder\n          brain_amygdala\n          brain_anterior_cingulate_cortex_ba24\n          brain_caudate_basal_ganglia\n          brain_cerebellar_hemisphere\n          brain_cerebellum\n          brain_cortex\n          brain_frontal_cortex_ba9\n          brain_hippocampus\n          brain_hypothalamus\n          brain_nucleus_accumbens_basal_ganglia\n          brain_putamen_basal_ganglia\n          brain_spinal_cord_cervical_c_1\n          brain_substantia_nigra\n          breast_mammary_tissue\n          cells_ebv_transformed_lymphocytes\n          cells_transformed_fibroblasts\n          cervix_ectocervix\n          cervix_endocervix\n          colon_sigmoid\n          colon_transverse\n          esophagus_gastroesophageal_junction\n          esophagus_mucosa\n          esophagus_muscularis\n          fallopian_tube\n          heart_atrial_appendage\n          heart_left_ventricle\n          kidney_cortex\n          liver\n          lung\n          minor_salivary_gland\n          muscle_skeletal\n          nerve_tibial\n          ovary\n          pancreas\n          pituitary\n          prostate\n          skin_not_sun_exposed_suprapubic\n          skin_sun_exposed_lower_leg\n          small_intestine_terminal_ileum\n          spleen\n          stomach\n          testis\n          thyroid\n          uterus\n          vagina\n          whole_blood\n        }\n      }\n      flags\n    }\n    exac_regional_missense_constraint_regions {\n      start\n      stop\n      obs_mis\n      exp_mis\n      obs_exp\n      chisq_diff_null\n    }\n    short_tandem_repeats(dataset: $shortTandemRepeatDatasetId) @include(if: $includeShortTandemRepeats) {\n      id\n    }\n  }\n}\n",
      "graphqlQueryVariables": {
        "geneId": "ENSG00000169174",
        "referenceGenome": "GRCh37",
        "shortTandemRepeatDatasetId": "gnomad_r3",
        "includeShortTandemRepeats": false
      },
      "graphqlQueryCost": 1
    }
```

(also - this PR no longer nests the `jsonPayload` object inside a wrapper object also named `jsonPayload`, the best way I could figure to get live logs on google was to deploy a demo, and this unintended nesting has been fixed since this screenshot was taken on that demo)

---

Also includes a commit that adds more text output to `deployctl` commands that were lacking confirmation of the command being issued.