### PR TITLE
Display all variants at stop position in variant list

### DIFF
--- a/browser/src/RegionViewer/filterVariantsInZoomRegion.ts
+++ b/browser/src/RegionViewer/filterVariantsInZoomRegion.ts
@@ -1,4 +1,4 @@
-import { sortedIndexBy } from 'lodash-es'
+import { sortedIndexBy, sortedLastIndexBy } from 'lodash-es'
 
 const filterVariantsInZoomRegion = (variants: any, zoomRegion: any) => {
   if (!zoomRegion) {
@@ -6,7 +6,7 @@ const filterVariantsInZoomRegion = (variants: any, zoomRegion: any) => {
   }
   const { start, stop } = zoomRegion
   const startIndex = sortedIndexBy(variants, { pos: start }, (variant: any) => variant.pos)
-  const stopIndex = sortedIndexBy(variants, { pos: stop }, (variant: any) => variant.pos)
+  const stopIndex = sortedLastIndexBy(variants, { pos: stop }, (variant: any) => variant.pos)
   return variants.slice(startIndex, stopIndex + 1)
 }
 

--- a/browser/src/RegionalGenomicConstraintTrack.tsx
+++ b/browser/src/RegionalGenomicConstraintTrack.tsx
@@ -198,9 +198,10 @@ const RegionalGenomicConstraintTrack = ({
               <PlotWrapper>
                 <svg height={height} width={width}>
                   <text x={width / 2} y={height / 2} dy="0.33rem" textAnchor="middle">
-                    {`The genomic constraint track is only displayed for regions with a size of ${
+                    {(stop - start > returnConstraintsThreshold) && `The genomic constraint track is only displayed for regions with a size of ${
                       returnConstraintsThreshold / 1000
                     }kb or smaller. Zoom in or adjust the region to see this track.`}
+                    {(stop - start <= returnConstraintsThreshold) && `There is no genomic constraint data for this region`}
                   </text>
                 </svg>
               </PlotWrapper>


### PR DESCRIPTION
Per user email and related discussion in this [slack thread](https://atgu.slack.com/archives/CNL7NA6H2/p1667939930278419?thread_ts=1667886205.261139&cid=CNL7NA6H2).

The frontend performs some logic to filter the list of variants recieved down to only variants in specific regions. This PR changes the `Lodash` function used in the stop index of that filtering from `sortedIndexBy` to `sortedLastIndexBy` so that lists of variants that are filtered include all variants that occur at the last position, instead of just the first one.

The example in the email now correctly shows all 3 variants when the region is specified as the single location

![Screen Shot 2022-11-08 at 16 05 45](https://user-images.githubusercontent.com/59549713/200686309-531d5cb9-aed4-48d0-9913-74e4eef7acb0.jpg)


---

Includes unrelated change to the regional genomic constraint track, previously tiny regions that did not have genomic constraint data would use the same message as regions that are too large. Now small regions without data show a message that correctly describes why nothing is shown.