### PR TITLE
Fix undefined error in GA logs

### DIFF
--- a/graphql-api/src/app.js
+++ b/graphql-api/src/app.js
@@ -62,12 +62,14 @@ app.use(function requestLogMiddleware(request, response, next) {
             : undefined,
         protocol: `HTTP/${request.httpVersionMajor}.${request.httpVersionMinor}`,
       },
-      graphqlRequest: {
-        graphqlQueryOperationName: request.graphqlParams.operationName,
-        graphqlQueryString: request.graphqlParams.query,
-        graphqlQueryVariables: request.graphqlParams.variables,
-        graphqlQueryCost: request.graphqlQueryCost,
-      },
+      graphqlRequest: request.graphqlParams
+        ? {
+            graphqlQueryOperationName: request.graphqlParams.operationName,
+            graphqlQueryString: request.graphqlParams.query,
+            graphqlQueryVariables: request.graphqlParams.variables,
+            graphqlQueryCost: request.graphqlQueryCost,
+          }
+        : undefined,
     })
   })
 


### PR DESCRIPTION
After deploying changes that include the addition of logging GraphQL fields to the google analytics logs, there are a small portion (as of now seems like <1 per hour) of requests that seemingly do not contain any information pertinent to GraphQL, causing the logs to throw an error when it tries to look for their fields.

https://console.cloud.google.com/errors/detail/CJDX9din8ZeCfw;time=P30D?project=exac-gnomad

This PR is a simple one liner that adds a ternary to check if there is GraphQL information in the response, before adding it to the log. This way, if there is no `response.graphqlParams`, it will not try and use `response.graphqlParams.operationName` or any other field of `graphqlParams` in the log itself. Instead, if there `response.graphqlParams` is falsy, it will log `undefined` for the graphql relevant information.

This should fix this error seen in the logs.