### PR TITLE
Add eck update notice banner

### DIFF
--- a/browser/src/App.tsx
+++ b/browser/src/App.tsx
@@ -71,7 +71,7 @@ const Banner = styled.div`
   }
 `
 
-const BANNER_CONTENT = null
+const BANNER_CONTENT = `gnomAD will be undergoing maintenance on November 18th between 3-4PM EST. Search may be unavailable during that time.`
 
 const App = () => {
   const [isLoading, setIsLoading] = useState(true)


### PR DESCRIPTION
One liner to update banner message ahead of the ECK update.

Corresponding PR on `gnomad-blog` [here](https://github.com/broadinstitute/gnomad-blog/pull/97).

![Screen Shot 2022-11-17 at 15 38 18](https://user-images.githubusercontent.com/59549713/202565295-8bf3255a-219e-444e-a800-e1953fe1b326.jpg)
