### PR TITLE
Remove eck maintenance banner

### DIFF
--- a/browser/src/App.tsx
+++ b/browser/src/App.tsx
@@ -71,7 +71,7 @@ const Banner = styled.div`
   }
 `
 
-const BANNER_CONTENT = `gnomAD will be undergoing maintenance on November 18th between 3-4PM EST. Search may be unavailable during that time.`
+const BANNER_CONTENT = null
 
 const App = () => {
   const [isLoading, setIsLoading] = useState(true)

--- a/browser/src/PublicationsPage.tsx
+++ b/browser/src/PublicationsPage.tsx
@@ -17,7 +17,7 @@ export default () => (
     <PageHeading>Publications</PageHeading>
     <p>
       This page lists publications by the gnomAD group. For information on how to cite gnomAD data,
-      see
+      see{' '}
       <Link to="/help/how-should-i-cite-discoveries-made-using-gnomad-data">
         &ldquo;How should I cite discoveries made using gnomAD data&rdquo;
       </Link>

--- a/deploy/deployctl/subcommands/ingress_production.py
+++ b/deploy/deployctl/subcommands/ingress_production.py
@@ -87,6 +87,8 @@ def apply_services(browser_deployment: str = None, reads_deployment: str = None)
 
     kubectl(["apply", "-f", "-"], input=manifest)
 
+    print(f"Updated production ingresses. browser: '{browser_deployment}', reads: '{reads_deployment}' ")
+
 
 def apply_ingress(browser_deployment: str = None, reads_deployment: str = None) -> None:
     apply_services(browser_deployment, reads_deployment)


### PR DESCRIPTION
To be merged and deployed once maintenance is complete later today.

Short one liner to remove the banner from the site.

![Screen Shot 2022-11-18 at 11 55 43](https://user-images.githubusercontent.com/59549713/202770921-0fb0fc1f-c982-43ed-80d3-8e5be2ba66a5.jpg)

Related blog PR [here](https://github.com/broadinstitute/gnomad-blog/pull/98).

---

* Includes an unrelated change to add text output to `deployctl production update`.
* Includes an unrelated change to fix a typo of a lack of a space on the research page 
  * it seems some, but not all of the spaces written as `{' '}` were removed as part of `ts-migrate` doing its thing. So these are being corrected as they're noticed.