### PR TITLE
Fix external dbSNP link

### DIFF
--- a/browser/src/MitochondrialVariantPage/MitochondrialVariantDetailPropType.ts
+++ b/browser/src/MitochondrialVariantPage/MitochondrialVariantDetailPropType.ts
@@ -1,5 +1,23 @@
 import PropTypes from 'prop-types'
 
+type ClinvarVariant = {
+  clinical_significance: string
+  clinvar_variation_id: string
+  gold_stars: number
+  last_evaluated: string
+  review_status: string
+  submissions: {
+    clinical_significance: string
+    conditions: {
+      name: string
+      medgen_id: string
+    }[]
+    last_evaluated: string
+    review_status: string
+    submitter_name: string
+  }
+}
+
 type MitochondrialVariantDetailPropType = {
   alt: string
   an: number
@@ -26,6 +44,8 @@ type MitochondrialVariantDetailPropType = {
   ref: string
   reference_genome: string
   variant_id: string
+  rsids?: string[]
+  clinvar: ClinvarVariant
 }
 
 // @ts-expect-error TS(2322) FIXME: Type 'Requireable<InferProps<{ alt: Validator<stri... Remove this comment to see the full error message

--- a/browser/src/MitochondrialVariantPage/MitochondrialVariantReferenceList.tsx
+++ b/browser/src/MitochondrialVariantPage/MitochondrialVariantReferenceList.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { ExternalLink, List, ListItem } from '@gnomad/ui'
+import { ncbiReference, clinvarReference } from '../VariantPage/ReferenceList'
 
 import MitochondrialVariantDetailPropType from './MitochondrialVariantDetailPropType'
 
@@ -24,38 +25,7 @@ const MitochondrialVariantReferenceList = ({ variant }: Props) => {
   return (
     // @ts-expect-error TS(2746) FIXME: This JSX tag's 'children' prop expects a single ch... Remove this comment to see the full error message
     <List>
-      {((variant as any).rsids || []).length === 1 && (
-        // @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message
-        <ListItem>
-          {/* @ts-expect-error TS(2769) FIXME: No overload matches this call. */}
-          <ExternalLink
-            href={`https://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=${
-              (variant as any).rsids[0]
-            }`}
-          >
-            dbSNP ({(variant as any).rsids[0]})
-          </ExternalLink>
-        </ListItem>
-      )}
-      {((variant as any).rsids || []).length > 1 && (
-        // @ts-expect-error TS(2746) FIXME: This JSX tag's 'children' prop expects a single ch... Remove this comment to see the full error message
-        <ListItem>
-          dbSNP (
-          {(variant as any).rsids
-            .map((rsid: any) => (
-              // @ts-expect-error TS(2786) FIXME: 'ExternalLink' cannot be used as a JSX component.
-              <ExternalLink
-                key={rsid}
-                href={`https://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=${rsid}`}
-              >
-                {rsid}
-              </ExternalLink>
-            ))
-            .reduce((acc: any, el: any) => [...acc, ', ', el], [])
-            .slice(1)}
-          )
-        </ListItem>
-      )}
+      {variant.rsids && ncbiReference(variant.rsids)}
       {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
       <ListItem>
         {/* @ts-expect-error TS(2786) FIXME: 'ExternalLink' cannot be used as a JSX component. */}
@@ -83,19 +53,7 @@ const MitochondrialVariantReferenceList = ({ variant }: Props) => {
           </ExternalLink>
         </ListItem>
       )}
-      {(variant as any).clinvar && (
-        // @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message
-        <ListItem>
-          {/* @ts-expect-error TS(2769) FIXME: No overload matches this call. */}
-          <ExternalLink
-            href={`https://www.ncbi.nlm.nih.gov/clinvar/variation/${
-              (variant as any).clinvar.clinvar_variation_id
-            }/`}
-          >
-            ClinVar ({(variant as any).clinvar.clinvar_variation_id})
-          </ExternalLink>
-        </ListItem>
-      )}
+      {variant.clinvar && clinvarReference(variant.clinvar.clinvar_variation_id)}
     </List>
   )
 }

--- a/browser/src/MitochondrialVariantPage/MitochondrialVariantReferenceList.tsx
+++ b/browser/src/MitochondrialVariantPage/MitochondrialVariantReferenceList.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { ExternalLink, List, ListItem } from '@gnomad/ui'
-import { ncbiReference, clinvarReference } from '../VariantPage/ReferenceList'
+import { NcbiReference, ClinvarReference } from '../VariantPage/ReferenceList'
 
 import MitochondrialVariantDetailPropType from './MitochondrialVariantDetailPropType'
 
@@ -25,7 +25,7 @@ const MitochondrialVariantReferenceList = ({ variant }: Props) => {
   return (
     // @ts-expect-error TS(2746) FIXME: This JSX tag's 'children' prop expects a single ch... Remove this comment to see the full error message
     <List>
-      {variant.rsids && ncbiReference(variant.rsids)}
+      {variant.rsids && NcbiReference(variant.rsids)}
       {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
       <ListItem>
         {/* @ts-expect-error TS(2786) FIXME: 'ExternalLink' cannot be used as a JSX component. */}
@@ -53,7 +53,7 @@ const MitochondrialVariantReferenceList = ({ variant }: Props) => {
           </ExternalLink>
         </ListItem>
       )}
-      {variant.clinvar && clinvarReference(variant.clinvar.clinvar_variation_id)}
+      {variant.clinvar && ClinvarReference(variant.clinvar.clinvar_variation_id)}
     </List>
   )
 }

--- a/browser/src/VariantPage/ReferenceList.spec.tsx
+++ b/browser/src/VariantPage/ReferenceList.spec.tsx
@@ -1,17 +1,17 @@
 import { describe, expect, test } from '@jest/globals'
 import 'jest-styled-components'
 
-import { ncbiReference, clinvarReference } from './ReferenceList'
+import { NcbiReference, ClinvarReference } from './ReferenceList'
 
 describe('ReferenceLists NCBI external link', () => {
   test('is formatted as single hyperlink if the given array only contains 1 rsid', () =>
-    expect(ncbiReference(['rs12345'])).toMatchSnapshot())
+    expect(NcbiReference(['rs12345'])).toMatchSnapshot())
 
   test('is formatted as multiple comma seperated hyperlinks if the given array contains more than 1 rsid', () =>
-    expect(ncbiReference(['rs12345', 'rs23456', 'rs34567'])).toMatchSnapshot())
+    expect(NcbiReference(['rs12345', 'rs23456', 'rs34567'])).toMatchSnapshot())
 })
 
 describe('ReferenceLists ClinVar external link', () => {
   test('is formatted as single hyperlink with the given clinvar id', () =>
-    expect(clinvarReference('12345')).toMatchSnapshot())
+    expect(ClinvarReference('12345')).toMatchSnapshot())
 })

--- a/browser/src/VariantPage/ReferenceList.spec.tsx
+++ b/browser/src/VariantPage/ReferenceList.spec.tsx
@@ -1,0 +1,17 @@
+import { describe, expect, test } from '@jest/globals'
+import 'jest-styled-components'
+
+import { ncbiReference, clinvarReference } from './ReferenceList'
+
+describe('ReferenceLists NCBI external link', () => {
+  test('is formatted as single hyperlink if the given array only contains 1 rsid', () =>
+    expect(ncbiReference(['rs12345'])).toMatchSnapshot())
+
+  test('is formatted as multiple comma seperated hyperlinks if the given array contains more than 1 rsid', () =>
+    expect(ncbiReference(['rs12345', 'rs23456', 'rs34567'])).toMatchSnapshot())
+})
+
+describe('ReferenceLists ClinVar external link', () => {
+  test('is formatted as single hyperlink with the given clinvar id', () =>
+    expect(clinvarReference('12345')).toMatchSnapshot())
+})

--- a/browser/src/VariantPage/ReferenceList.tsx
+++ b/browser/src/VariantPage/ReferenceList.tsx
@@ -17,6 +17,52 @@ type Props = {
   }
 }
 
+export const ncbiReference = (variantRsids: string[]) => {
+  return (
+    <>
+      {variantRsids.length === 1 && (
+        // @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message
+        <ListItem>
+          {/* @ts-expect-error TS(2769) FIXME: No overload matches this call. */}
+          <ExternalLink href={`http://www.ncbi.nlm.nih.gov/snp/${variantRsids[0]}`}>
+            dbSNP ({variantRsids[0]})
+          </ExternalLink>
+        </ListItem>
+      )}
+      {variantRsids.length > 1 && (
+        // @ts-expect-error TS(2746) FIXME: This JSX tag's 'children' prop expects a single ch... Remove this comment to see the full error message
+        <ListItem>
+          dbSNP ({' '}
+          {(variantRsids
+            .map((rsid) => (
+              // @ts-expect-error TS(2786) FIXME: 'ExternalLink' cannot be used as a JSX component.
+              <ExternalLink key={rsid} href={`https://www.ncbi.nlm.nih.gov/snp/${rsid}`}>
+                {rsid}
+              </ExternalLink>
+            ))
+            // @ts-expect-error TS(2769) FIXME: No overload matches this call.
+            .reduce((acc, el) => [...acc, ', ', el], []) as any).slice(1)}
+          )
+        </ListItem>
+      )}
+    </>
+  )
+}
+
+export const clinvarReference = (variantClinvarVariationId: string) => {
+  return (
+    // @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message
+    <ListItem>
+      {/* @ts-expect-error TS(2769) FIXME: No overload matches this call. */}
+      <ExternalLink
+        href={`https://www.ncbi.nlm.nih.gov/clinvar/variation/${variantClinvarVariationId}/`}
+      >
+        ClinVar ({variantClinvarVariationId})
+      </ExternalLink>
+    </ListItem>
+  )
+}
+
 export const ReferenceList = ({ variant }: Props) => {
   const ucscReferenceGenomeId = variant.reference_genome === 'GRCh37' ? 'hg19' : 'hg38'
   const { chrom, pos, ref } = variant
@@ -27,57 +73,16 @@ export const ReferenceList = ({ variant }: Props) => {
   return (
     // @ts-expect-error TS(2746) FIXME: This JSX tag's 'children' prop expects a single ch... Remove this comment to see the full error message
     <List>
-      {(variant.rsids || []).length === 1 && (
-        // @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message
-        <ListItem>
-          {/* @ts-expect-error TS(2769) FIXME: No overload matches this call. */}
-          <ExternalLink
-            // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
-            href={`https://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=${variant.rsids[0]}`}
-          >
-            {/* @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'. */}
-            dbSNP ({variant.rsids[0]})
-          </ExternalLink>
-        </ListItem>
-      )}
-      {(variant.rsids || []).length > 1 && (
-        // @ts-expect-error TS(2746) FIXME: This JSX tag's 'children' prop expects a single ch... Remove this comment to see the full error message
-        <ListItem>
-          dbSNP ({' '}
-          {
-            // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
-            (variant.rsids
-              .map((rsid) => (
-                // @ts-expect-error TS(2786) FIXME: 'ExternalLink' cannot be used as a JSX component.
-                <ExternalLink
-                  key={rsid}
-                  href={`https://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=${rsid}`}
-                >
-                  {rsid}
-                </ExternalLink>
-              ))
-              // @ts-expect-error TS(2769) FIXME: No overload matches this call.
-              .reduce((acc, el) => [...acc, ', ', el], []) as any).slice(1)
-          }
-          )
-        </ListItem>
-      )}
+      {variant.rsids && ncbiReference(variant.rsids)}
+
       {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
       <ListItem>
         {/* @ts-expect-error TS(2786) FIXME: 'ExternalLink' cannot be used as a JSX component. */}
         <ExternalLink href={ucscURL}>UCSC</ExternalLink>
       </ListItem>
-      {variant.clinvar && (
-        // @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message
-        <ListItem>
-          {/* @ts-expect-error TS(2769) FIXME: No overload matches this call. */}
-          <ExternalLink
-            href={`https://www.ncbi.nlm.nih.gov/clinvar/variation/${variant.clinvar.clinvar_variation_id}/`}
-          >
-            ClinVar ({variant.clinvar.clinvar_variation_id})
-          </ExternalLink>
-        </ListItem>
-      )}
+
+      {variant.clinvar && clinvarReference(variant.clinvar.clinvar_variation_id)}
+
       {variant.caid && (
         // @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message
         <ListItem>

--- a/browser/src/VariantPage/ReferenceList.tsx
+++ b/browser/src/VariantPage/ReferenceList.tsx
@@ -17,7 +17,7 @@ type Props = {
   }
 }
 
-export const ncbiReference = (variantRsids: string[]) => {
+export const NcbiReference = (variantRsids: string[]) => {
   return (
     <>
       {variantRsids.length === 1 && (
@@ -49,7 +49,7 @@ export const ncbiReference = (variantRsids: string[]) => {
   )
 }
 
-export const clinvarReference = (variantClinvarVariationId: string) => {
+export const ClinvarReference = (variantClinvarVariationId: string) => {
   return (
     // @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message
     <ListItem>
@@ -73,7 +73,7 @@ export const ReferenceList = ({ variant }: Props) => {
   return (
     // @ts-expect-error TS(2746) FIXME: This JSX tag's 'children' prop expects a single ch... Remove this comment to see the full error message
     <List>
-      {variant.rsids && ncbiReference(variant.rsids)}
+      {variant.rsids && NcbiReference(variant.rsids)}
 
       {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
       <ListItem>
@@ -81,7 +81,7 @@ export const ReferenceList = ({ variant }: Props) => {
         <ExternalLink href={ucscURL}>UCSC</ExternalLink>
       </ListItem>
 
-      {variant.clinvar && clinvarReference(variant.clinvar.clinvar_variation_id)}
+      {variant.clinvar && ClinvarReference(variant.clinvar.clinvar_variation_id)}
 
       {variant.caid && (
         // @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message

--- a/browser/src/VariantPage/__snapshots__/ReferenceList.spec.tsx.snap
+++ b/browser/src/VariantPage/__snapshots__/ReferenceList.spec.tsx.snap
@@ -1,0 +1,54 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ReferenceLists ClinVar external link is formatted as single hyperlink with the given clinvar id 1`] = `
+<List__ListItem>
+  <Link__ExternalLink
+    href="https://www.ncbi.nlm.nih.gov/clinvar/variation/12345/"
+  >
+    ClinVar (
+    12345
+    )
+  </Link__ExternalLink>
+</List__ListItem>
+`;
+
+exports[`ReferenceLists NCBI external link is formatted as multiple comma seperated hyperlinks if the given array contains more than 1 rsid 1`] = `
+<React.Fragment>
+  <List__ListItem>
+    dbSNP (
+     
+    <Link__ExternalLink
+      href="https://www.ncbi.nlm.nih.gov/snp/rs12345"
+    >
+      rs12345
+    </Link__ExternalLink>
+    , 
+    <Link__ExternalLink
+      href="https://www.ncbi.nlm.nih.gov/snp/rs23456"
+    >
+      rs23456
+    </Link__ExternalLink>
+    , 
+    <Link__ExternalLink
+      href="https://www.ncbi.nlm.nih.gov/snp/rs34567"
+    >
+      rs34567
+    </Link__ExternalLink>
+    )
+  </List__ListItem>
+</React.Fragment>
+`;
+
+exports[`ReferenceLists NCBI external link is formatted as single hyperlink if the given array only contains 1 rsid 1`] = `
+<React.Fragment>
+  <List__ListItem>
+    <Link__ExternalLink
+      href="http://www.ncbi.nlm.nih.gov/snp/rs12345"
+    >
+      dbSNP (
+      rs12345
+      )
+    </Link__ExternalLink>
+  </List__ListItem>
+</React.Fragment>
+`;


### PR DESCRIPTION
Resolves #1032 

At some point, the url convention for ncbi's dbSNP changed, causing gnomAD's links to dbSNP's variants by rsID to be broken links. This is a straightforward PR the changes instances in which this resource is linked to (`ReferenceList` and `MitochondrialVariantReferenceList`) to use the correct URL.

It also DRYs up the links a bit, and adds very small scoped unit tests. 

Localhost links for convenience:
* [This variant page](http://localhost:8008/variant/1-55505552-A-ACTGCTGCTG) has both a dbSNP and ClinVar link
* [This mitochondrial variant page](http://localhost:8008/variant/M-8602-T-C?dataset=gnomad_r3) has both a dbSNP and ClinVar link

---

Unrelated - in looking at all these components that use `<Link>` and `<ExternalLink>` that have related `ts` errors, I will likely make an issue to take a look at those (they're part of `gnomad-browser-toolkit`) to fix those errors so we can remove a whole slew of `ts-expects`. Looks like there are quiiiite a few `ts-expects` hanging around the codebase that could be resolved by taking some time to look at static typing errors that arise from the interaction of `gnomad-browser` and `gnomad-browser-toolkit` at some point.