### PR TITLE
Fix clinvar pipeline bug

### DIFF
--- a/data-pipeline/src/data_pipeline/datasets/clinvar.py
+++ b/data-pipeline/src/data_pipeline/datasets/clinvar.py
@@ -112,7 +112,7 @@ def _parse_variant(variant_element):
                 variant["locations"] = {}
                 allele_element = variant_element.findall("./InterpretedRecord/SimpleAllele")
                 print(
-                    f'Skipping variant with Allele ID: {allele_element.attrib["AlleleID"]} due to anomalous Chromosome value of "Un"'
+                    f' Skipping variant with Allele ID: {allele_element[0].attrib["AlleleID"]} due to anomalous Chromosome value of "Un"'
                 )
                 break
             variant["locations"][element.attrib["Assembly"]] = {


### PR DESCRIPTION
Resolves #1046 

Quick one line that fixes the output on the ClinVar pipeline to allow it to parse the xml without errors. I tested running the pipeline on a dataproc cluster, and it once again successfully parses the xml.

---

**Context / Opinion Question**

A release at some point introduced variants with a chromosome called '`Un`'. 

Additional logic was added to skip these and let the pipeline run. Later, a couple lines were added to give additional information to the runner of the pipeline when it skipped a variant, output currently looks like:

```
| [1 files][  2.0 GiB/  2.0 GiB]      0.0 B/s
Parsing XML file
  1%|          | 12990/1100000 [00:13<19:28, 930.40it/s] Skipping variant with Allele ID: 161065 due to anomalous Chromosome value of "Un"
 44%|████▍     | 484551/1100000 [05:52<07:45, 1321.52it/s] Skipping variant with Allele ID: 1676726 due to anomalous Chromosome value of "Un"
 83%|████████▎ | 913219/1100000 [11:42<02:00, 1549.61it/s]
```

This gives more information to the user, but also causes the progress bar to behave differently - it leaves behind lines of output when it skips a chromosome and notifies the user.

This PR fixes the output so that the pipeline can be run without error, but I'm curious as to opinions on if the output should be removed altogether - so that the pipeline just skips these variants quietly, and causes the progress bar to not leave behind afterimages.

Previously, it wouldn't leave behind afterimages:

```
| [1 files][  2.0 GiB/  2.0 GiB]      0.0 B/s
Parsing XML file
 83%|████████▎ | 913219/1100000 [11:42<02:00, 1549.61it/s]
```

Output - yay or nay?