### PR TITLE
Add monoallelic variant flag

### DIFF
--- a/browser/src/MitochondrialVariantList/ExportMitochondrialVariantsButton.tsx
+++ b/browser/src/MitochondrialVariantList/ExportMitochondrialVariantsButton.tsx
@@ -36,8 +36,7 @@ const BASE_COLUMNS = [
   {
     label: 'Flags',
     getValue: (variant: any) =>
-      // @ts-expect-error TS(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-      variant.flags.map((flag: any) => FLAGS_CONFIG[flag].label).join(';'),
+      variant.flags.map((flag: string) => FLAGS_CONFIG[flag].label).join(';'),
   },
   {
     label: 'Allele Number',

--- a/browser/src/VariantList/VariantFlag.spec.tsx
+++ b/browser/src/VariantList/VariantFlag.spec.tsx
@@ -1,0 +1,25 @@
+import { describe, expect, test } from '@jest/globals'
+import 'jest-styled-components'
+
+import React from 'react'
+import renderer from 'react-test-renderer'
+
+import VariantFlag, { FLAGS_CONFIG } from './VariantFlag'
+
+describe('Variant flag', () => {
+  const realFlags = Object.keys(FLAGS_CONFIG)
+
+  realFlags.forEach((flag) => {
+    test(`correctly formats with key of '${flag}'`, () => {
+      const tree = renderer.create(<VariantFlag key={flag} type={flag} variant={{}} />)
+      expect(tree).toMatchSnapshot()
+    })
+  })
+
+  test('correctly formats as nothing when given a non-existent variant flag', () => {
+    const tree = renderer.create(
+      <VariantFlag key="not-a-real-flag" type="not-a-real-flag" variant={{}} />
+    )
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/browser/src/VariantList/VariantFlag.tsx
+++ b/browser/src/VariantList/VariantFlag.tsx
@@ -2,7 +2,13 @@ import React from 'react'
 
 import { Badge } from '@gnomad/ui'
 
-export const FLAGS_CONFIG = {
+type Flag = {
+  label: string
+  level: 'info' | 'warning' | 'error' | 'success' | undefined
+  formatTooltip: (input: any) => string
+}
+
+export const FLAGS_CONFIG: Record<string, Flag> = {
   lcr: {
     label: 'LCR',
     level: 'info',
@@ -37,6 +43,11 @@ export const FLAGS_CONFIG = {
     formatTooltip: () =>
       'Multi-nucleotide variant: this variant is found in phase with another variant in some individuals, altering the amino acid sequence\nVariant annotation dubious',
   },
+  monoallelic: {
+    label: 'Monoallelic',
+    level: 'info',
+    formatTooltip: () => 'All samples are homozygous alternate for the variant',
+  },
   // Mitochondrial variants
   common_low_heteroplasmy: {
     label: 'Common Low Heteroplasmy',
@@ -47,18 +58,21 @@ export const FLAGS_CONFIG = {
 }
 
 type Props = {
-  type: any // TODO: PropTypes.oneOf(Object.keys(FLAGS_CONFIG))
+  type: string
   variant: any
 }
 
 const VariantFlag = ({ type, variant }: Props) => {
-  // @ts-expect-error TS(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-  const { label, level, formatTooltip } = FLAGS_CONFIG[type]
-  return (
-    <Badge level={level} tooltip={formatTooltip(variant)}>
-      {label}
-    </Badge>
-  )
+  if (type in FLAGS_CONFIG) {
+    const { label, level, formatTooltip } = FLAGS_CONFIG[type as keyof typeof FLAGS_CONFIG]
+    return (
+      <Badge level={level} tooltip={formatTooltip(variant)}>
+        {label}
+      </Badge>
+    )
+  }
+
+  return null
 }
 
 export default VariantFlag

--- a/browser/src/VariantList/__snapshots__/VariantFlag.spec.tsx.snap
+++ b/browser/src/VariantList/__snapshots__/VariantFlag.spec.tsx.snap
@@ -1,0 +1,195 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Variant flag correctly formats as nothing when given a non-existent variant flag 1`] = `null`;
+
+exports[`Variant flag correctly formats with key of 'common_low_heteroplasmy' 1`] = `
+.c0 {
+  position: relative;
+  top: -0.1em;
+  display: inline-block;
+  padding: 0.25em 0.4em 0.2em;
+  border: 1px solid #000;
+  border-radius: 0.3em;
+  background: orange;
+  color: #000;
+  font-size: 0.75em;
+  font-weight: bold;
+  line-height: 1;
+}
+
+<span
+  className="c0"
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+>
+  Common Low Heteroplasmy
+</span>
+`;
+
+exports[`Variant flag correctly formats with key of 'lc_lof' 1`] = `
+.c0 {
+  position: relative;
+  top: -0.1em;
+  display: inline-block;
+  padding: 0.25em 0.4em 0.2em;
+  border: 1px solid #000;
+  border-radius: 0.3em;
+  background: #DD2C00;
+  color: #fff;
+  font-size: 0.75em;
+  font-weight: bold;
+  line-height: 1;
+}
+
+<span
+  className="c0"
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+>
+  LC pLoF
+</span>
+`;
+
+exports[`Variant flag correctly formats with key of 'lcr' 1`] = `
+.c0 {
+  position: relative;
+  top: -0.1em;
+  display: inline-block;
+  padding: 0.25em 0.4em 0.2em;
+  border: 1px solid #000;
+  border-radius: 0.3em;
+  background: #424242;
+  color: #fff;
+  font-size: 0.75em;
+  font-weight: bold;
+  line-height: 1;
+}
+
+<span
+  className="c0"
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+>
+  LCR
+</span>
+`;
+
+exports[`Variant flag correctly formats with key of 'lof_flag' 1`] = `
+.c0 {
+  position: relative;
+  top: -0.1em;
+  display: inline-block;
+  padding: 0.25em 0.4em 0.2em;
+  border: 1px solid #000;
+  border-radius: 0.3em;
+  background: orange;
+  color: #000;
+  font-size: 0.75em;
+  font-weight: bold;
+  line-height: 1;
+}
+
+<span
+  className="c0"
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+>
+  pLoF flag
+</span>
+`;
+
+exports[`Variant flag correctly formats with key of 'mnv' 1`] = `
+.c0 {
+  position: relative;
+  top: -0.1em;
+  display: inline-block;
+  padding: 0.25em 0.4em 0.2em;
+  border: 1px solid #000;
+  border-radius: 0.3em;
+  background: #DD2C00;
+  color: #fff;
+  font-size: 0.75em;
+  font-weight: bold;
+  line-height: 1;
+}
+
+<span
+  className="c0"
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+>
+  MNV
+</span>
+`;
+
+exports[`Variant flag correctly formats with key of 'monoallelic' 1`] = `
+.c0 {
+  position: relative;
+  top: -0.1em;
+  display: inline-block;
+  padding: 0.25em 0.4em 0.2em;
+  border: 1px solid #000;
+  border-radius: 0.3em;
+  background: #424242;
+  color: #fff;
+  font-size: 0.75em;
+  font-weight: bold;
+  line-height: 1;
+}
+
+<span
+  className="c0"
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+>
+  Monoallelic
+</span>
+`;
+
+exports[`Variant flag correctly formats with key of 'nc_transcript' 1`] = `
+.c0 {
+  position: relative;
+  top: -0.1em;
+  display: inline-block;
+  padding: 0.25em 0.4em 0.2em;
+  border: 1px solid #000;
+  border-radius: 0.3em;
+  background: #DD2C00;
+  color: #fff;
+  font-size: 0.75em;
+  font-weight: bold;
+  line-height: 1;
+}
+
+<span
+  className="c0"
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+>
+  NC Transcript
+</span>
+`;
+
+exports[`Variant flag correctly formats with key of 'os_lof' 1`] = `
+.c0 {
+  position: relative;
+  top: -0.1em;
+  display: inline-block;
+  padding: 0.25em 0.4em 0.2em;
+  border: 1px solid #000;
+  border-radius: 0.3em;
+  background: #424242;
+  color: #fff;
+  font-size: 0.75em;
+  font-weight: bold;
+  line-height: 1;
+}
+
+<span
+  className="c0"
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+>
+  OS pLoF
+</span>
+`;


### PR DESCRIPTION
Resolves #990, and by transitive property also resolves #989

Related blog (changelog) PR: https://github.com/broadinstitute/gnomad-blog/pull/99

Adds an additional Variant Flag to fix the crashing of pages that contain a variant table in which one or more of the Variants contains the `monoallelic` flag.

Also adds functionality to prevent crashes if any further unexpected flags are trying to display in the table.

For convenience, here is a localhost link to a page that is [currently `Error`'ing in prod](https://gnomad.broadinstitute.org/region/17-8002615-8020342?dataset=gnomad_r3) 
- http://localhost:8008/region/17-8002615-8020342?dataset=gnomad_r3

If you scroll a bit down the variant list, the `Monoallelic` flag can be seen.

![Screen Shot 2022-11-29 at 11 56 49](https://user-images.githubusercontent.com/59549713/204606052-98cf7083-59f4-4983-8aab-a7a1aa1b61f3.jpg)

Adds typing for flags, and scoped Jest tests for the `VariantFlag` component