### PR TITLE
Remove `requester-pays-allow-buckets` parameter from Dataproc cluster creation

### DIFF
--- a/deploy/deployctl/subcommands/dataproc_cluster.py
+++ b/deploy/deployctl/subcommands/dataproc_cluster.py
@@ -39,7 +39,6 @@ def start_cluster(name: str, cluster_args: typing.List[str]) -> None:
             "--tags=dataproc-node",
             "--max-idle=1h",
             f"--packages={','.join(requirements)}",
-            "--requester-pays-allow-buckets=gnomad-public-requester-pays",
             f"--service-account=gnomad-data-pipeline@{config.project}.iam.gserviceaccount.com",
             # Required to access Secret Manager
             # https://cloud.google.com/secret-manager/docs/accessing-the-api#enabling_api_access


### PR DESCRIPTION
I couldn't find the `gnomad-public-requester-pays` bucket being mentioned anywhere else in the code, so I'm hoping the setting isn't necessary?

Removing this would provide some peace of mind when running the pipelines with workers outside the US :).