### PR TITLE
Add back to gene button on variant page

### DIFF
--- a/browser/src/VariantPage/VariantPageTitle.tsx
+++ b/browser/src/VariantPage/VariantPageTitle.tsx
@@ -59,7 +59,7 @@ const VariantPageTitle = ({ datasetId, variantId }: Props) => {
 
   let variantDescription = 'Variant'
   if (ref.length === 1 && alt.length === 1) {
-    variantDescription = 'Single nucleotide variant'
+    variantDescription = 'SNV'
   }
   if (ref.length < alt.length) {
     const insertionLength = alt.length - ref.length
@@ -72,7 +72,15 @@ const VariantPageTitle = ({ datasetId, variantId }: Props) => {
 
   return (
     <TitleWrapper>
-      <span>{variantDescription}</span>
+      {variantDescription === 'SNV' ? (
+        // @ts-expect-error TS(2322) -- error from gnomad-browser-toolkit component
+        <TooltipAnchor tooltip={'Single nucleotide variant'}>
+          <span>{variantDescription}</span>
+        </TooltipAnchor>
+      ) : (
+        <span>{variantDescription}</span>
+      )}
+
       <Separator style={{ width: '1ch' }}>:</Separator>
       {/* @ts-expect-error TS(2322) FIXME: Type '{ children: Element; tooltip: string; }' is ... Remove this comment to see the full error message */}
       <TooltipAnchor tooltip={variantId}>

--- a/browser/src/VariantPage/VariantRelatedVariants.tsx
+++ b/browser/src/VariantPage/VariantRelatedVariants.tsx
@@ -41,6 +41,7 @@ const isVariantEligibleForCooccurrence = (variant: any, datasetId: any) => {
 
   return (
     exomeAC <= 0.05 &&
+    !!variant.transcript_consequences &&
     variant.transcript_consequences.some((csq: any) =>
       CODING_AND_UTR_VEP_CONSEQUENCES.has(csq.major_consequence)
     )

--- a/browser/src/VariantPage/__snapshots__/VariantPage.spec.tsx.snap
+++ b/browser/src/VariantPage/__snapshots__/VariantPage.spec.tsx.snap
@@ -16,8 +16,11 @@ exports[`VariantPage with dataset "gnomad_r3" has no unexpected changes 1`] = `
         <span
           className="VariantPageTitle__TitleWrapper-sc-16g6pnt-0 bAAXLa"
         >
-          <span>
-            Single nucleotide variant
+          <span
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+          >
+            SNV
           </span>
           <span
             className="VariantPageTitle__Separator-sc-16g6pnt-1 jsfCLA"
@@ -64,6 +67,22 @@ exports[`VariantPage with dataset "gnomad_r3" has no unexpected changes 1`] = `
           </span>
         </span>
       </h1>
+      <div
+        className="GnomadPageHeading__CenterPanel-sc-sgz3rr-2 kzqcqw"
+      >
+        <button
+          className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+          onClick={[Function]}
+          style={
+            {
+              "margin": "0 1em 0 -0.33em",
+            }
+          }
+          type="button"
+        >
+          Gene page
+        </button>
+      </div>
     </div>
     <div
       className="GnomadPageHeading__PageControlsWrapper-sc-sgz3rr-4 liqJpb"
@@ -857,14 +876,13 @@ exports[`VariantPage with dataset "gnomad_r3" has no unexpected changes 1`] = `
       <div>
         <p>
           This variant falls on 
-          0
+          2
            transcript
           s
            in 
-          0
+          1
            
           gene
-          s
           .
         </p>
         <p>
@@ -877,7 +895,166 @@ exports[`VariantPage with dataset "gnomad_r3" has no unexpected changes 1`] = `
         </p>
         <ol
           className="TranscriptConsequenceList__ConsequenceListWrapper-sc-qi0gmz-1 cXJgYo"
-        />
+        >
+          <li
+            className="TranscriptConsequenceList__ConsequenceListItem-sc-qi0gmz-2 BzXEE"
+          >
+            <h3>
+              
+            </h3>
+            <ol
+              className="List__OrderedList-sc-4j87st-2 gKjCRF"
+            >
+              <li
+                className="List__ListItem-sc-4j87st-1 gGPLUe"
+              >
+                <h4>
+                  <a
+                    className="Link-sc-14lgydv-0-Link jBvaYQ"
+                    href="/gene/ENSG012345"
+                    onClick={[Function]}
+                  >
+                    ABC1
+                  </a>
+                </h4>
+                <ol
+                  className="List__OrderedList-sc-4j87st-2 gKjCRF"
+                >
+                  <li
+                    className="List__ListItem-sc-4j87st-1 gGPLUe"
+                  >
+                    <a
+                      className="Link-sc-14lgydv-0-Link jBvaYQ"
+                      href="/transcript/ENST123456"
+                      onClick={[Function]}
+                    >
+                      ENST123456
+                      .
+                      1
+                    </a>
+                    <div
+                      className="TranscriptConsequenceList__TranscriptInfoWrapper-sc-qi0gmz-0 cXgLUx"
+                    >
+                      Ensembl canonical transcript for 
+                      ABC1
+                    </div>
+                    <dl
+                      className="TranscriptConsequence__AttributeList-sc-1aaizap-2 bCFpVu"
+                    >
+                      <div
+                        style={
+                          {
+                            "marginTop": "0.25em",
+                          }
+                        }
+                      >
+                        <dt
+                          className="TranscriptConsequence__AttributeName-sc-1aaizap-0 hhgcrX"
+                        >
+                          HGVSc
+                        </dt>
+                        <dd
+                          className="TranscriptConsequence__AttributeValue-sc-1aaizap-1 cHxeFf"
+                        >
+                          
+                        </dd>
+                      </div>
+                      <div
+                        style={
+                          {
+                            "marginTop": "0.25em",
+                          }
+                        }
+                      >
+                        <dt
+                          className="TranscriptConsequence__AttributeName-sc-1aaizap-0 hhgcrX"
+                        >
+                          Domains
+                        </dt>
+                        <dd
+                          className="TranscriptConsequence__AttributeValue-sc-1aaizap-1 cHxeFf"
+                        >
+                          <ul
+                            className="InlineList__InlineListWrapper-sc-1wq0e6g-0 chCfJr"
+                          >
+                            <li>
+                              undefined (aaa)
+                            </li>
+                            <li>
+                              undefined (bbb)
+                            </li>
+                          </ul>
+                        </dd>
+                      </div>
+                    </dl>
+                  </li>
+                  <li
+                    className="List__ListItem-sc-4j87st-1 gGPLUe"
+                  >
+                    <a
+                      className="Link-sc-14lgydv-0-Link jBvaYQ"
+                      href="/transcript/ENST012345"
+                      onClick={[Function]}
+                    >
+                      ENST012345
+                      .
+                      1
+                    </a>
+                    <dl
+                      className="TranscriptConsequence__AttributeList-sc-1aaizap-2 bCFpVu"
+                    >
+                      <div
+                        style={
+                          {
+                            "marginTop": "0.25em",
+                          }
+                        }
+                      >
+                        <dt
+                          className="TranscriptConsequence__AttributeName-sc-1aaizap-0 hhgcrX"
+                        >
+                          HGVSc
+                        </dt>
+                        <dd
+                          className="TranscriptConsequence__AttributeValue-sc-1aaizap-1 cHxeFf"
+                        >
+                          
+                        </dd>
+                      </div>
+                      <div
+                        style={
+                          {
+                            "marginTop": "0.25em",
+                          }
+                        }
+                      >
+                        <dt
+                          className="TranscriptConsequence__AttributeName-sc-1aaizap-0 hhgcrX"
+                        >
+                          Domains
+                        </dt>
+                        <dd
+                          className="TranscriptConsequence__AttributeValue-sc-1aaizap-1 cHxeFf"
+                        >
+                          <ul
+                            className="InlineList__InlineListWrapper-sc-1wq0e6g-0 chCfJr"
+                          >
+                            <li>
+                              undefined (aaa)
+                            </li>
+                            <li>
+                              undefined (bbb)
+                            </li>
+                          </ul>
+                        </dd>
+                      </div>
+                    </dl>
+                  </li>
+                </ol>
+              </li>
+            </ol>
+          </li>
+        </ol>
       </div>
     </section>
     <div
@@ -2255,8 +2432,11 @@ exports[`VariantPage with dataset "gnomad_r3_controls_and_biobanks" has no unexp
         <span
           className="VariantPageTitle__TitleWrapper-sc-16g6pnt-0 bAAXLa"
         >
-          <span>
-            Single nucleotide variant
+          <span
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+          >
+            SNV
           </span>
           <span
             className="VariantPageTitle__Separator-sc-16g6pnt-1 jsfCLA"
@@ -2303,6 +2483,22 @@ exports[`VariantPage with dataset "gnomad_r3_controls_and_biobanks" has no unexp
           </span>
         </span>
       </h1>
+      <div
+        className="GnomadPageHeading__CenterPanel-sc-sgz3rr-2 kzqcqw"
+      >
+        <button
+          className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+          onClick={[Function]}
+          style={
+            {
+              "margin": "0 1em 0 -0.33em",
+            }
+          }
+          type="button"
+        >
+          Gene page
+        </button>
+      </div>
     </div>
     <div
       className="GnomadPageHeading__PageControlsWrapper-sc-sgz3rr-4 liqJpb"
@@ -3096,14 +3292,13 @@ exports[`VariantPage with dataset "gnomad_r3_controls_and_biobanks" has no unexp
       <div>
         <p>
           This variant falls on 
-          0
+          2
            transcript
           s
            in 
-          0
+          1
            
           gene
-          s
           .
         </p>
         <p>
@@ -3116,7 +3311,166 @@ exports[`VariantPage with dataset "gnomad_r3_controls_and_biobanks" has no unexp
         </p>
         <ol
           className="TranscriptConsequenceList__ConsequenceListWrapper-sc-qi0gmz-1 cXJgYo"
-        />
+        >
+          <li
+            className="TranscriptConsequenceList__ConsequenceListItem-sc-qi0gmz-2 BzXEE"
+          >
+            <h3>
+              
+            </h3>
+            <ol
+              className="List__OrderedList-sc-4j87st-2 gKjCRF"
+            >
+              <li
+                className="List__ListItem-sc-4j87st-1 gGPLUe"
+              >
+                <h4>
+                  <a
+                    className="Link-sc-14lgydv-0-Link jBvaYQ"
+                    href="/gene/ENSG012345"
+                    onClick={[Function]}
+                  >
+                    ABC1
+                  </a>
+                </h4>
+                <ol
+                  className="List__OrderedList-sc-4j87st-2 gKjCRF"
+                >
+                  <li
+                    className="List__ListItem-sc-4j87st-1 gGPLUe"
+                  >
+                    <a
+                      className="Link-sc-14lgydv-0-Link jBvaYQ"
+                      href="/transcript/ENST123456"
+                      onClick={[Function]}
+                    >
+                      ENST123456
+                      .
+                      1
+                    </a>
+                    <div
+                      className="TranscriptConsequenceList__TranscriptInfoWrapper-sc-qi0gmz-0 cXgLUx"
+                    >
+                      Ensembl canonical transcript for 
+                      ABC1
+                    </div>
+                    <dl
+                      className="TranscriptConsequence__AttributeList-sc-1aaizap-2 bCFpVu"
+                    >
+                      <div
+                        style={
+                          {
+                            "marginTop": "0.25em",
+                          }
+                        }
+                      >
+                        <dt
+                          className="TranscriptConsequence__AttributeName-sc-1aaizap-0 hhgcrX"
+                        >
+                          HGVSc
+                        </dt>
+                        <dd
+                          className="TranscriptConsequence__AttributeValue-sc-1aaizap-1 cHxeFf"
+                        >
+                          
+                        </dd>
+                      </div>
+                      <div
+                        style={
+                          {
+                            "marginTop": "0.25em",
+                          }
+                        }
+                      >
+                        <dt
+                          className="TranscriptConsequence__AttributeName-sc-1aaizap-0 hhgcrX"
+                        >
+                          Domains
+                        </dt>
+                        <dd
+                          className="TranscriptConsequence__AttributeValue-sc-1aaizap-1 cHxeFf"
+                        >
+                          <ul
+                            className="InlineList__InlineListWrapper-sc-1wq0e6g-0 chCfJr"
+                          >
+                            <li>
+                              undefined (aaa)
+                            </li>
+                            <li>
+                              undefined (bbb)
+                            </li>
+                          </ul>
+                        </dd>
+                      </div>
+                    </dl>
+                  </li>
+                  <li
+                    className="List__ListItem-sc-4j87st-1 gGPLUe"
+                  >
+                    <a
+                      className="Link-sc-14lgydv-0-Link jBvaYQ"
+                      href="/transcript/ENST012345"
+                      onClick={[Function]}
+                    >
+                      ENST012345
+                      .
+                      1
+                    </a>
+                    <dl
+                      className="TranscriptConsequence__AttributeList-sc-1aaizap-2 bCFpVu"
+                    >
+                      <div
+                        style={
+                          {
+                            "marginTop": "0.25em",
+                          }
+                        }
+                      >
+                        <dt
+                          className="TranscriptConsequence__AttributeName-sc-1aaizap-0 hhgcrX"
+                        >
+                          HGVSc
+                        </dt>
+                        <dd
+                          className="TranscriptConsequence__AttributeValue-sc-1aaizap-1 cHxeFf"
+                        >
+                          
+                        </dd>
+                      </div>
+                      <div
+                        style={
+                          {
+                            "marginTop": "0.25em",
+                          }
+                        }
+                      >
+                        <dt
+                          className="TranscriptConsequence__AttributeName-sc-1aaizap-0 hhgcrX"
+                        >
+                          Domains
+                        </dt>
+                        <dd
+                          className="TranscriptConsequence__AttributeValue-sc-1aaizap-1 cHxeFf"
+                        >
+                          <ul
+                            className="InlineList__InlineListWrapper-sc-1wq0e6g-0 chCfJr"
+                          >
+                            <li>
+                              undefined (aaa)
+                            </li>
+                            <li>
+                              undefined (bbb)
+                            </li>
+                          </ul>
+                        </dd>
+                      </div>
+                    </dl>
+                  </li>
+                </ol>
+              </li>
+            </ol>
+          </li>
+        </ol>
       </div>
     </section>
     <div
@@ -4497,8 +4851,11 @@ exports[`VariantPage with dataset "gnomad_r3_non_cancer" has no unexpected chang
         <span
           className="VariantPageTitle__TitleWrapper-sc-16g6pnt-0 bAAXLa"
         >
-          <span>
-            Single nucleotide variant
+          <span
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+          >
+            SNV
           </span>
           <span
             className="VariantPageTitle__Separator-sc-16g6pnt-1 jsfCLA"
@@ -4545,6 +4902,22 @@ exports[`VariantPage with dataset "gnomad_r3_non_cancer" has no unexpected chang
           </span>
         </span>
       </h1>
+      <div
+        className="GnomadPageHeading__CenterPanel-sc-sgz3rr-2 kzqcqw"
+      >
+        <button
+          className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+          onClick={[Function]}
+          style={
+            {
+              "margin": "0 1em 0 -0.33em",
+            }
+          }
+          type="button"
+        >
+          Gene page
+        </button>
+      </div>
     </div>
     <div
       className="GnomadPageHeading__PageControlsWrapper-sc-sgz3rr-4 liqJpb"
@@ -5338,14 +5711,13 @@ exports[`VariantPage with dataset "gnomad_r3_non_cancer" has no unexpected chang
       <div>
         <p>
           This variant falls on 
-          0
+          2
            transcript
           s
            in 
-          0
+          1
            
           gene
-          s
           .
         </p>
         <p>
@@ -5358,7 +5730,166 @@ exports[`VariantPage with dataset "gnomad_r3_non_cancer" has no unexpected chang
         </p>
         <ol
           className="TranscriptConsequenceList__ConsequenceListWrapper-sc-qi0gmz-1 cXJgYo"
-        />
+        >
+          <li
+            className="TranscriptConsequenceList__ConsequenceListItem-sc-qi0gmz-2 BzXEE"
+          >
+            <h3>
+              
+            </h3>
+            <ol
+              className="List__OrderedList-sc-4j87st-2 gKjCRF"
+            >
+              <li
+                className="List__ListItem-sc-4j87st-1 gGPLUe"
+              >
+                <h4>
+                  <a
+                    className="Link-sc-14lgydv-0-Link jBvaYQ"
+                    href="/gene/ENSG012345"
+                    onClick={[Function]}
+                  >
+                    ABC1
+                  </a>
+                </h4>
+                <ol
+                  className="List__OrderedList-sc-4j87st-2 gKjCRF"
+                >
+                  <li
+                    className="List__ListItem-sc-4j87st-1 gGPLUe"
+                  >
+                    <a
+                      className="Link-sc-14lgydv-0-Link jBvaYQ"
+                      href="/transcript/ENST123456"
+                      onClick={[Function]}
+                    >
+                      ENST123456
+                      .
+                      1
+                    </a>
+                    <div
+                      className="TranscriptConsequenceList__TranscriptInfoWrapper-sc-qi0gmz-0 cXgLUx"
+                    >
+                      Ensembl canonical transcript for 
+                      ABC1
+                    </div>
+                    <dl
+                      className="TranscriptConsequence__AttributeList-sc-1aaizap-2 bCFpVu"
+                    >
+                      <div
+                        style={
+                          {
+                            "marginTop": "0.25em",
+                          }
+                        }
+                      >
+                        <dt
+                          className="TranscriptConsequence__AttributeName-sc-1aaizap-0 hhgcrX"
+                        >
+                          HGVSc
+                        </dt>
+                        <dd
+                          className="TranscriptConsequence__AttributeValue-sc-1aaizap-1 cHxeFf"
+                        >
+                          
+                        </dd>
+                      </div>
+                      <div
+                        style={
+                          {
+                            "marginTop": "0.25em",
+                          }
+                        }
+                      >
+                        <dt
+                          className="TranscriptConsequence__AttributeName-sc-1aaizap-0 hhgcrX"
+                        >
+                          Domains
+                        </dt>
+                        <dd
+                          className="TranscriptConsequence__AttributeValue-sc-1aaizap-1 cHxeFf"
+                        >
+                          <ul
+                            className="InlineList__InlineListWrapper-sc-1wq0e6g-0 chCfJr"
+                          >
+                            <li>
+                              undefined (aaa)
+                            </li>
+                            <li>
+                              undefined (bbb)
+                            </li>
+                          </ul>
+                        </dd>
+                      </div>
+                    </dl>
+                  </li>
+                  <li
+                    className="List__ListItem-sc-4j87st-1 gGPLUe"
+                  >
+                    <a
+                      className="Link-sc-14lgydv-0-Link jBvaYQ"
+                      href="/transcript/ENST012345"
+                      onClick={[Function]}
+                    >
+                      ENST012345
+                      .
+                      1
+                    </a>
+                    <dl
+                      className="TranscriptConsequence__AttributeList-sc-1aaizap-2 bCFpVu"
+                    >
+                      <div
+                        style={
+                          {
+                            "marginTop": "0.25em",
+                          }
+                        }
+                      >
+                        <dt
+                          className="TranscriptConsequence__AttributeName-sc-1aaizap-0 hhgcrX"
+                        >
+                          HGVSc
+                        </dt>
+                        <dd
+                          className="TranscriptConsequence__AttributeValue-sc-1aaizap-1 cHxeFf"
+                        >
+                          
+                        </dd>
+                      </div>
+                      <div
+                        style={
+                          {
+                            "marginTop": "0.25em",
+                          }
+                        }
+                      >
+                        <dt
+                          className="TranscriptConsequence__AttributeName-sc-1aaizap-0 hhgcrX"
+                        >
+                          Domains
+                        </dt>
+                        <dd
+                          className="TranscriptConsequence__AttributeValue-sc-1aaizap-1 cHxeFf"
+                        >
+                          <ul
+                            className="InlineList__InlineListWrapper-sc-1wq0e6g-0 chCfJr"
+                          >
+                            <li>
+                              undefined (aaa)
+                            </li>
+                            <li>
+                              undefined (bbb)
+                            </li>
+                          </ul>
+                        </dd>
+                      </div>
+                    </dl>
+                  </li>
+                </ol>
+              </li>
+            </ol>
+          </li>
+        </ol>
       </div>
     </section>
     <div
@@ -6739,8 +7270,11 @@ exports[`VariantPage with dataset "gnomad_r3_non_neuro" has no unexpected change
         <span
           className="VariantPageTitle__TitleWrapper-sc-16g6pnt-0 bAAXLa"
         >
-          <span>
-            Single nucleotide variant
+          <span
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+          >
+            SNV
           </span>
           <span
             className="VariantPageTitle__Separator-sc-16g6pnt-1 jsfCLA"
@@ -6787,6 +7321,22 @@ exports[`VariantPage with dataset "gnomad_r3_non_neuro" has no unexpected change
           </span>
         </span>
       </h1>
+      <div
+        className="GnomadPageHeading__CenterPanel-sc-sgz3rr-2 kzqcqw"
+      >
+        <button
+          className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+          onClick={[Function]}
+          style={
+            {
+              "margin": "0 1em 0 -0.33em",
+            }
+          }
+          type="button"
+        >
+          Gene page
+        </button>
+      </div>
     </div>
     <div
       className="GnomadPageHeading__PageControlsWrapper-sc-sgz3rr-4 liqJpb"
@@ -7580,14 +8130,13 @@ exports[`VariantPage with dataset "gnomad_r3_non_neuro" has no unexpected change
       <div>
         <p>
           This variant falls on 
-          0
+          2
            transcript
           s
            in 
-          0
+          1
            
           gene
-          s
           .
         </p>
         <p>
@@ -7600,7 +8149,166 @@ exports[`VariantPage with dataset "gnomad_r3_non_neuro" has no unexpected change
         </p>
         <ol
           className="TranscriptConsequenceList__ConsequenceListWrapper-sc-qi0gmz-1 cXJgYo"
-        />
+        >
+          <li
+            className="TranscriptConsequenceList__ConsequenceListItem-sc-qi0gmz-2 BzXEE"
+          >
+            <h3>
+              
+            </h3>
+            <ol
+              className="List__OrderedList-sc-4j87st-2 gKjCRF"
+            >
+              <li
+                className="List__ListItem-sc-4j87st-1 gGPLUe"
+              >
+                <h4>
+                  <a
+                    className="Link-sc-14lgydv-0-Link jBvaYQ"
+                    href="/gene/ENSG012345"
+                    onClick={[Function]}
+                  >
+                    ABC1
+                  </a>
+                </h4>
+                <ol
+                  className="List__OrderedList-sc-4j87st-2 gKjCRF"
+                >
+                  <li
+                    className="List__ListItem-sc-4j87st-1 gGPLUe"
+                  >
+                    <a
+                      className="Link-sc-14lgydv-0-Link jBvaYQ"
+                      href="/transcript/ENST123456"
+                      onClick={[Function]}
+                    >
+                      ENST123456
+                      .
+                      1
+                    </a>
+                    <div
+                      className="TranscriptConsequenceList__TranscriptInfoWrapper-sc-qi0gmz-0 cXgLUx"
+                    >
+                      Ensembl canonical transcript for 
+                      ABC1
+                    </div>
+                    <dl
+                      className="TranscriptConsequence__AttributeList-sc-1aaizap-2 bCFpVu"
+                    >
+                      <div
+                        style={
+                          {
+                            "marginTop": "0.25em",
+                          }
+                        }
+                      >
+                        <dt
+                          className="TranscriptConsequence__AttributeName-sc-1aaizap-0 hhgcrX"
+                        >
+                          HGVSc
+                        </dt>
+                        <dd
+                          className="TranscriptConsequence__AttributeValue-sc-1aaizap-1 cHxeFf"
+                        >
+                          
+                        </dd>
+                      </div>
+                      <div
+                        style={
+                          {
+                            "marginTop": "0.25em",
+                          }
+                        }
+                      >
+                        <dt
+                          className="TranscriptConsequence__AttributeName-sc-1aaizap-0 hhgcrX"
+                        >
+                          Domains
+                        </dt>
+                        <dd
+                          className="TranscriptConsequence__AttributeValue-sc-1aaizap-1 cHxeFf"
+                        >
+                          <ul
+                            className="InlineList__InlineListWrapper-sc-1wq0e6g-0 chCfJr"
+                          >
+                            <li>
+                              undefined (aaa)
+                            </li>
+                            <li>
+                              undefined (bbb)
+                            </li>
+                          </ul>
+                        </dd>
+                      </div>
+                    </dl>
+                  </li>
+                  <li
+                    className="List__ListItem-sc-4j87st-1 gGPLUe"
+                  >
+                    <a
+                      className="Link-sc-14lgydv-0-Link jBvaYQ"
+                      href="/transcript/ENST012345"
+                      onClick={[Function]}
+                    >
+                      ENST012345
+                      .
+                      1
+                    </a>
+                    <dl
+                      className="TranscriptConsequence__AttributeList-sc-1aaizap-2 bCFpVu"
+                    >
+                      <div
+                        style={
+                          {
+                            "marginTop": "0.25em",
+                          }
+                        }
+                      >
+                        <dt
+                          className="TranscriptConsequence__AttributeName-sc-1aaizap-0 hhgcrX"
+                        >
+                          HGVSc
+                        </dt>
+                        <dd
+                          className="TranscriptConsequence__AttributeValue-sc-1aaizap-1 cHxeFf"
+                        >
+                          
+                        </dd>
+                      </div>
+                      <div
+                        style={
+                          {
+                            "marginTop": "0.25em",
+                          }
+                        }
+                      >
+                        <dt
+                          className="TranscriptConsequence__AttributeName-sc-1aaizap-0 hhgcrX"
+                        >
+                          Domains
+                        </dt>
+                        <dd
+                          className="TranscriptConsequence__AttributeValue-sc-1aaizap-1 cHxeFf"
+                        >
+                          <ul
+                            className="InlineList__InlineListWrapper-sc-1wq0e6g-0 chCfJr"
+                          >
+                            <li>
+                              undefined (aaa)
+                            </li>
+                            <li>
+                              undefined (bbb)
+                            </li>
+                          </ul>
+                        </dd>
+                      </div>
+                    </dl>
+                  </li>
+                </ol>
+              </li>
+            </ol>
+          </li>
+        </ol>
       </div>
     </section>
     <div
@@ -8981,8 +9689,11 @@ exports[`VariantPage with dataset "gnomad_r3_non_topmed" has no unexpected chang
         <span
           className="VariantPageTitle__TitleWrapper-sc-16g6pnt-0 bAAXLa"
         >
-          <span>
-            Single nucleotide variant
+          <span
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+          >
+            SNV
           </span>
           <span
             className="VariantPageTitle__Separator-sc-16g6pnt-1 jsfCLA"
@@ -9029,6 +9740,22 @@ exports[`VariantPage with dataset "gnomad_r3_non_topmed" has no unexpected chang
           </span>
         </span>
       </h1>
+      <div
+        className="GnomadPageHeading__CenterPanel-sc-sgz3rr-2 kzqcqw"
+      >
+        <button
+          className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+          onClick={[Function]}
+          style={
+            {
+              "margin": "0 1em 0 -0.33em",
+            }
+          }
+          type="button"
+        >
+          Gene page
+        </button>
+      </div>
     </div>
     <div
       className="GnomadPageHeading__PageControlsWrapper-sc-sgz3rr-4 liqJpb"
@@ -9822,14 +10549,13 @@ exports[`VariantPage with dataset "gnomad_r3_non_topmed" has no unexpected chang
       <div>
         <p>
           This variant falls on 
-          0
+          2
            transcript
           s
            in 
-          0
+          1
            
           gene
-          s
           .
         </p>
         <p>
@@ -9842,7 +10568,166 @@ exports[`VariantPage with dataset "gnomad_r3_non_topmed" has no unexpected chang
         </p>
         <ol
           className="TranscriptConsequenceList__ConsequenceListWrapper-sc-qi0gmz-1 cXJgYo"
-        />
+        >
+          <li
+            className="TranscriptConsequenceList__ConsequenceListItem-sc-qi0gmz-2 BzXEE"
+          >
+            <h3>
+              
+            </h3>
+            <ol
+              className="List__OrderedList-sc-4j87st-2 gKjCRF"
+            >
+              <li
+                className="List__ListItem-sc-4j87st-1 gGPLUe"
+              >
+                <h4>
+                  <a
+                    className="Link-sc-14lgydv-0-Link jBvaYQ"
+                    href="/gene/ENSG012345"
+                    onClick={[Function]}
+                  >
+                    ABC1
+                  </a>
+                </h4>
+                <ol
+                  className="List__OrderedList-sc-4j87st-2 gKjCRF"
+                >
+                  <li
+                    className="List__ListItem-sc-4j87st-1 gGPLUe"
+                  >
+                    <a
+                      className="Link-sc-14lgydv-0-Link jBvaYQ"
+                      href="/transcript/ENST123456"
+                      onClick={[Function]}
+                    >
+                      ENST123456
+                      .
+                      1
+                    </a>
+                    <div
+                      className="TranscriptConsequenceList__TranscriptInfoWrapper-sc-qi0gmz-0 cXgLUx"
+                    >
+                      Ensembl canonical transcript for 
+                      ABC1
+                    </div>
+                    <dl
+                      className="TranscriptConsequence__AttributeList-sc-1aaizap-2 bCFpVu"
+                    >
+                      <div
+                        style={
+                          {
+                            "marginTop": "0.25em",
+                          }
+                        }
+                      >
+                        <dt
+                          className="TranscriptConsequence__AttributeName-sc-1aaizap-0 hhgcrX"
+                        >
+                          HGVSc
+                        </dt>
+                        <dd
+                          className="TranscriptConsequence__AttributeValue-sc-1aaizap-1 cHxeFf"
+                        >
+                          
+                        </dd>
+                      </div>
+                      <div
+                        style={
+                          {
+                            "marginTop": "0.25em",
+                          }
+                        }
+                      >
+                        <dt
+                          className="TranscriptConsequence__AttributeName-sc-1aaizap-0 hhgcrX"
+                        >
+                          Domains
+                        </dt>
+                        <dd
+                          className="TranscriptConsequence__AttributeValue-sc-1aaizap-1 cHxeFf"
+                        >
+                          <ul
+                            className="InlineList__InlineListWrapper-sc-1wq0e6g-0 chCfJr"
+                          >
+                            <li>
+                              undefined (aaa)
+                            </li>
+                            <li>
+                              undefined (bbb)
+                            </li>
+                          </ul>
+                        </dd>
+                      </div>
+                    </dl>
+                  </li>
+                  <li
+                    className="List__ListItem-sc-4j87st-1 gGPLUe"
+                  >
+                    <a
+                      className="Link-sc-14lgydv-0-Link jBvaYQ"
+                      href="/transcript/ENST012345"
+                      onClick={[Function]}
+                    >
+                      ENST012345
+                      .
+                      1
+                    </a>
+                    <dl
+                      className="TranscriptConsequence__AttributeList-sc-1aaizap-2 bCFpVu"
+                    >
+                      <div
+                        style={
+                          {
+                            "marginTop": "0.25em",
+                          }
+                        }
+                      >
+                        <dt
+                          className="TranscriptConsequence__AttributeName-sc-1aaizap-0 hhgcrX"
+                        >
+                          HGVSc
+                        </dt>
+                        <dd
+                          className="TranscriptConsequence__AttributeValue-sc-1aaizap-1 cHxeFf"
+                        >
+                          
+                        </dd>
+                      </div>
+                      <div
+                        style={
+                          {
+                            "marginTop": "0.25em",
+                          }
+                        }
+                      >
+                        <dt
+                          className="TranscriptConsequence__AttributeName-sc-1aaizap-0 hhgcrX"
+                        >
+                          Domains
+                        </dt>
+                        <dd
+                          className="TranscriptConsequence__AttributeValue-sc-1aaizap-1 cHxeFf"
+                        >
+                          <ul
+                            className="InlineList__InlineListWrapper-sc-1wq0e6g-0 chCfJr"
+                          >
+                            <li>
+                              undefined (aaa)
+                            </li>
+                            <li>
+                              undefined (bbb)
+                            </li>
+                          </ul>
+                        </dd>
+                      </div>
+                    </dl>
+                  </li>
+                </ol>
+              </li>
+            </ol>
+          </li>
+        </ol>
       </div>
     </section>
     <div
@@ -11223,8 +12108,11 @@ exports[`VariantPage with dataset "gnomad_r3_non_v2" has no unexpected changes 1
         <span
           className="VariantPageTitle__TitleWrapper-sc-16g6pnt-0 bAAXLa"
         >
-          <span>
-            Single nucleotide variant
+          <span
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+          >
+            SNV
           </span>
           <span
             className="VariantPageTitle__Separator-sc-16g6pnt-1 jsfCLA"
@@ -11271,6 +12159,22 @@ exports[`VariantPage with dataset "gnomad_r3_non_v2" has no unexpected changes 1
           </span>
         </span>
       </h1>
+      <div
+        className="GnomadPageHeading__CenterPanel-sc-sgz3rr-2 kzqcqw"
+      >
+        <button
+          className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+          onClick={[Function]}
+          style={
+            {
+              "margin": "0 1em 0 -0.33em",
+            }
+          }
+          type="button"
+        >
+          Gene page
+        </button>
+      </div>
     </div>
     <div
       className="GnomadPageHeading__PageControlsWrapper-sc-sgz3rr-4 liqJpb"
@@ -12064,14 +12968,13 @@ exports[`VariantPage with dataset "gnomad_r3_non_v2" has no unexpected changes 1
       <div>
         <p>
           This variant falls on 
-          0
+          2
            transcript
           s
            in 
-          0
+          1
            
           gene
-          s
           .
         </p>
         <p>
@@ -12084,7 +12987,166 @@ exports[`VariantPage with dataset "gnomad_r3_non_v2" has no unexpected changes 1
         </p>
         <ol
           className="TranscriptConsequenceList__ConsequenceListWrapper-sc-qi0gmz-1 cXJgYo"
-        />
+        >
+          <li
+            className="TranscriptConsequenceList__ConsequenceListItem-sc-qi0gmz-2 BzXEE"
+          >
+            <h3>
+              
+            </h3>
+            <ol
+              className="List__OrderedList-sc-4j87st-2 gKjCRF"
+            >
+              <li
+                className="List__ListItem-sc-4j87st-1 gGPLUe"
+              >
+                <h4>
+                  <a
+                    className="Link-sc-14lgydv-0-Link jBvaYQ"
+                    href="/gene/ENSG012345"
+                    onClick={[Function]}
+                  >
+                    ABC1
+                  </a>
+                </h4>
+                <ol
+                  className="List__OrderedList-sc-4j87st-2 gKjCRF"
+                >
+                  <li
+                    className="List__ListItem-sc-4j87st-1 gGPLUe"
+                  >
+                    <a
+                      className="Link-sc-14lgydv-0-Link jBvaYQ"
+                      href="/transcript/ENST123456"
+                      onClick={[Function]}
+                    >
+                      ENST123456
+                      .
+                      1
+                    </a>
+                    <div
+                      className="TranscriptConsequenceList__TranscriptInfoWrapper-sc-qi0gmz-0 cXgLUx"
+                    >
+                      Ensembl canonical transcript for 
+                      ABC1
+                    </div>
+                    <dl
+                      className="TranscriptConsequence__AttributeList-sc-1aaizap-2 bCFpVu"
+                    >
+                      <div
+                        style={
+                          {
+                            "marginTop": "0.25em",
+                          }
+                        }
+                      >
+                        <dt
+                          className="TranscriptConsequence__AttributeName-sc-1aaizap-0 hhgcrX"
+                        >
+                          HGVSc
+                        </dt>
+                        <dd
+                          className="TranscriptConsequence__AttributeValue-sc-1aaizap-1 cHxeFf"
+                        >
+                          
+                        </dd>
+                      </div>
+                      <div
+                        style={
+                          {
+                            "marginTop": "0.25em",
+                          }
+                        }
+                      >
+                        <dt
+                          className="TranscriptConsequence__AttributeName-sc-1aaizap-0 hhgcrX"
+                        >
+                          Domains
+                        </dt>
+                        <dd
+                          className="TranscriptConsequence__AttributeValue-sc-1aaizap-1 cHxeFf"
+                        >
+                          <ul
+                            className="InlineList__InlineListWrapper-sc-1wq0e6g-0 chCfJr"
+                          >
+                            <li>
+                              undefined (aaa)
+                            </li>
+                            <li>
+                              undefined (bbb)
+                            </li>
+                          </ul>
+                        </dd>
+                      </div>
+                    </dl>
+                  </li>
+                  <li
+                    className="List__ListItem-sc-4j87st-1 gGPLUe"
+                  >
+                    <a
+                      className="Link-sc-14lgydv-0-Link jBvaYQ"
+                      href="/transcript/ENST012345"
+                      onClick={[Function]}
+                    >
+                      ENST012345
+                      .
+                      1
+                    </a>
+                    <dl
+                      className="TranscriptConsequence__AttributeList-sc-1aaizap-2 bCFpVu"
+                    >
+                      <div
+                        style={
+                          {
+                            "marginTop": "0.25em",
+                          }
+                        }
+                      >
+                        <dt
+                          className="TranscriptConsequence__AttributeName-sc-1aaizap-0 hhgcrX"
+                        >
+                          HGVSc
+                        </dt>
+                        <dd
+                          className="TranscriptConsequence__AttributeValue-sc-1aaizap-1 cHxeFf"
+                        >
+                          
+                        </dd>
+                      </div>
+                      <div
+                        style={
+                          {
+                            "marginTop": "0.25em",
+                          }
+                        }
+                      >
+                        <dt
+                          className="TranscriptConsequence__AttributeName-sc-1aaizap-0 hhgcrX"
+                        >
+                          Domains
+                        </dt>
+                        <dd
+                          className="TranscriptConsequence__AttributeValue-sc-1aaizap-1 cHxeFf"
+                        >
+                          <ul
+                            className="InlineList__InlineListWrapper-sc-1wq0e6g-0 chCfJr"
+                          >
+                            <li>
+                              undefined (aaa)
+                            </li>
+                            <li>
+                              undefined (bbb)
+                            </li>
+                          </ul>
+                        </dd>
+                      </div>
+                    </dl>
+                  </li>
+                </ol>
+              </li>
+            </ol>
+          </li>
+        </ol>
       </div>
     </section>
     <div
@@ -13465,8 +14527,11 @@ exports[`VariantPage with dataset exac has no unexpected changes 1`] = `
         <span
           className="VariantPageTitle__TitleWrapper-sc-16g6pnt-0 bAAXLa"
         >
-          <span>
-            Single nucleotide variant
+          <span
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+          >
+            SNV
           </span>
           <span
             className="VariantPageTitle__Separator-sc-16g6pnt-1 jsfCLA"
@@ -13513,6 +14578,22 @@ exports[`VariantPage with dataset exac has no unexpected changes 1`] = `
           </span>
         </span>
       </h1>
+      <div
+        className="GnomadPageHeading__CenterPanel-sc-sgz3rr-2 kzqcqw"
+      >
+        <button
+          className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+          onClick={[Function]}
+          style={
+            {
+              "margin": "0 1em 0 -0.33em",
+            }
+          }
+          type="button"
+        >
+          Gene page
+        </button>
+      </div>
     </div>
     <div
       className="GnomadPageHeading__PageControlsWrapper-sc-sgz3rr-4 liqJpb"
@@ -14114,14 +15195,13 @@ exports[`VariantPage with dataset exac has no unexpected changes 1`] = `
       <div>
         <p>
           This variant falls on 
-          0
+          2
            transcript
           s
            in 
-          0
+          1
            
           gene
-          s
           .
         </p>
         <p>
@@ -14134,7 +15214,166 @@ exports[`VariantPage with dataset exac has no unexpected changes 1`] = `
         </p>
         <ol
           className="TranscriptConsequenceList__ConsequenceListWrapper-sc-qi0gmz-1 cXJgYo"
-        />
+        >
+          <li
+            className="TranscriptConsequenceList__ConsequenceListItem-sc-qi0gmz-2 BzXEE"
+          >
+            <h3>
+              
+            </h3>
+            <ol
+              className="List__OrderedList-sc-4j87st-2 gKjCRF"
+            >
+              <li
+                className="List__ListItem-sc-4j87st-1 gGPLUe"
+              >
+                <h4>
+                  <a
+                    className="Link-sc-14lgydv-0-Link jBvaYQ"
+                    href="/gene/ENSG012345"
+                    onClick={[Function]}
+                  >
+                    ABC1
+                  </a>
+                </h4>
+                <ol
+                  className="List__OrderedList-sc-4j87st-2 gKjCRF"
+                >
+                  <li
+                    className="List__ListItem-sc-4j87st-1 gGPLUe"
+                  >
+                    <a
+                      className="Link-sc-14lgydv-0-Link jBvaYQ"
+                      href="/transcript/ENST123456"
+                      onClick={[Function]}
+                    >
+                      ENST123456
+                      .
+                      1
+                    </a>
+                    <div
+                      className="TranscriptConsequenceList__TranscriptInfoWrapper-sc-qi0gmz-0 cXgLUx"
+                    >
+                      Ensembl canonical transcript for 
+                      ABC1
+                    </div>
+                    <dl
+                      className="TranscriptConsequence__AttributeList-sc-1aaizap-2 bCFpVu"
+                    >
+                      <div
+                        style={
+                          {
+                            "marginTop": "0.25em",
+                          }
+                        }
+                      >
+                        <dt
+                          className="TranscriptConsequence__AttributeName-sc-1aaizap-0 hhgcrX"
+                        >
+                          HGVSc
+                        </dt>
+                        <dd
+                          className="TranscriptConsequence__AttributeValue-sc-1aaizap-1 cHxeFf"
+                        >
+                          
+                        </dd>
+                      </div>
+                      <div
+                        style={
+                          {
+                            "marginTop": "0.25em",
+                          }
+                        }
+                      >
+                        <dt
+                          className="TranscriptConsequence__AttributeName-sc-1aaizap-0 hhgcrX"
+                        >
+                          Domains
+                        </dt>
+                        <dd
+                          className="TranscriptConsequence__AttributeValue-sc-1aaizap-1 cHxeFf"
+                        >
+                          <ul
+                            className="InlineList__InlineListWrapper-sc-1wq0e6g-0 chCfJr"
+                          >
+                            <li>
+                              undefined (aaa)
+                            </li>
+                            <li>
+                              undefined (bbb)
+                            </li>
+                          </ul>
+                        </dd>
+                      </div>
+                    </dl>
+                  </li>
+                  <li
+                    className="List__ListItem-sc-4j87st-1 gGPLUe"
+                  >
+                    <a
+                      className="Link-sc-14lgydv-0-Link jBvaYQ"
+                      href="/transcript/ENST012345"
+                      onClick={[Function]}
+                    >
+                      ENST012345
+                      .
+                      1
+                    </a>
+                    <dl
+                      className="TranscriptConsequence__AttributeList-sc-1aaizap-2 bCFpVu"
+                    >
+                      <div
+                        style={
+                          {
+                            "marginTop": "0.25em",
+                          }
+                        }
+                      >
+                        <dt
+                          className="TranscriptConsequence__AttributeName-sc-1aaizap-0 hhgcrX"
+                        >
+                          HGVSc
+                        </dt>
+                        <dd
+                          className="TranscriptConsequence__AttributeValue-sc-1aaizap-1 cHxeFf"
+                        >
+                          
+                        </dd>
+                      </div>
+                      <div
+                        style={
+                          {
+                            "marginTop": "0.25em",
+                          }
+                        }
+                      >
+                        <dt
+                          className="TranscriptConsequence__AttributeName-sc-1aaizap-0 hhgcrX"
+                        >
+                          Domains
+                        </dt>
+                        <dd
+                          className="TranscriptConsequence__AttributeValue-sc-1aaizap-1 cHxeFf"
+                        >
+                          <ul
+                            className="InlineList__InlineListWrapper-sc-1wq0e6g-0 chCfJr"
+                          >
+                            <li>
+                              undefined (aaa)
+                            </li>
+                            <li>
+                              undefined (bbb)
+                            </li>
+                          </ul>
+                        </dd>
+                      </div>
+                    </dl>
+                  </li>
+                </ol>
+              </li>
+            </ol>
+          </li>
+        </ol>
       </div>
     </section>
     <div
@@ -15307,8 +16546,11 @@ exports[`VariantPage with dataset gnomad_r2_1 has no unexpected changes 1`] = `
         <span
           className="VariantPageTitle__TitleWrapper-sc-16g6pnt-0 bAAXLa"
         >
-          <span>
-            Single nucleotide variant
+          <span
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+          >
+            SNV
           </span>
           <span
             className="VariantPageTitle__Separator-sc-16g6pnt-1 jsfCLA"
@@ -15355,6 +16597,22 @@ exports[`VariantPage with dataset gnomad_r2_1 has no unexpected changes 1`] = `
           </span>
         </span>
       </h1>
+      <div
+        className="GnomadPageHeading__CenterPanel-sc-sgz3rr-2 kzqcqw"
+      >
+        <button
+          className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+          onClick={[Function]}
+          style={
+            {
+              "margin": "0 1em 0 -0.33em",
+            }
+          }
+          type="button"
+        >
+          Gene page
+        </button>
+      </div>
     </div>
     <div
       className="GnomadPageHeading__PageControlsWrapper-sc-sgz3rr-4 liqJpb"
@@ -16048,14 +17306,13 @@ exports[`VariantPage with dataset gnomad_r2_1 has no unexpected changes 1`] = `
       <div>
         <p>
           This variant falls on 
-          0
+          2
            transcript
           s
            in 
-          0
+          1
            
           gene
-          s
           .
         </p>
         <p>
@@ -16068,7 +17325,166 @@ exports[`VariantPage with dataset gnomad_r2_1 has no unexpected changes 1`] = `
         </p>
         <ol
           className="TranscriptConsequenceList__ConsequenceListWrapper-sc-qi0gmz-1 cXJgYo"
-        />
+        >
+          <li
+            className="TranscriptConsequenceList__ConsequenceListItem-sc-qi0gmz-2 BzXEE"
+          >
+            <h3>
+              
+            </h3>
+            <ol
+              className="List__OrderedList-sc-4j87st-2 gKjCRF"
+            >
+              <li
+                className="List__ListItem-sc-4j87st-1 gGPLUe"
+              >
+                <h4>
+                  <a
+                    className="Link-sc-14lgydv-0-Link jBvaYQ"
+                    href="/gene/ENSG012345"
+                    onClick={[Function]}
+                  >
+                    ABC1
+                  </a>
+                </h4>
+                <ol
+                  className="List__OrderedList-sc-4j87st-2 gKjCRF"
+                >
+                  <li
+                    className="List__ListItem-sc-4j87st-1 gGPLUe"
+                  >
+                    <a
+                      className="Link-sc-14lgydv-0-Link jBvaYQ"
+                      href="/transcript/ENST123456"
+                      onClick={[Function]}
+                    >
+                      ENST123456
+                      .
+                      1
+                    </a>
+                    <div
+                      className="TranscriptConsequenceList__TranscriptInfoWrapper-sc-qi0gmz-0 cXgLUx"
+                    >
+                      Ensembl canonical transcript for 
+                      ABC1
+                    </div>
+                    <dl
+                      className="TranscriptConsequence__AttributeList-sc-1aaizap-2 bCFpVu"
+                    >
+                      <div
+                        style={
+                          {
+                            "marginTop": "0.25em",
+                          }
+                        }
+                      >
+                        <dt
+                          className="TranscriptConsequence__AttributeName-sc-1aaizap-0 hhgcrX"
+                        >
+                          HGVSc
+                        </dt>
+                        <dd
+                          className="TranscriptConsequence__AttributeValue-sc-1aaizap-1 cHxeFf"
+                        >
+                          
+                        </dd>
+                      </div>
+                      <div
+                        style={
+                          {
+                            "marginTop": "0.25em",
+                          }
+                        }
+                      >
+                        <dt
+                          className="TranscriptConsequence__AttributeName-sc-1aaizap-0 hhgcrX"
+                        >
+                          Domains
+                        </dt>
+                        <dd
+                          className="TranscriptConsequence__AttributeValue-sc-1aaizap-1 cHxeFf"
+                        >
+                          <ul
+                            className="InlineList__InlineListWrapper-sc-1wq0e6g-0 chCfJr"
+                          >
+                            <li>
+                              undefined (aaa)
+                            </li>
+                            <li>
+                              undefined (bbb)
+                            </li>
+                          </ul>
+                        </dd>
+                      </div>
+                    </dl>
+                  </li>
+                  <li
+                    className="List__ListItem-sc-4j87st-1 gGPLUe"
+                  >
+                    <a
+                      className="Link-sc-14lgydv-0-Link jBvaYQ"
+                      href="/transcript/ENST012345"
+                      onClick={[Function]}
+                    >
+                      ENST012345
+                      .
+                      1
+                    </a>
+                    <dl
+                      className="TranscriptConsequence__AttributeList-sc-1aaizap-2 bCFpVu"
+                    >
+                      <div
+                        style={
+                          {
+                            "marginTop": "0.25em",
+                          }
+                        }
+                      >
+                        <dt
+                          className="TranscriptConsequence__AttributeName-sc-1aaizap-0 hhgcrX"
+                        >
+                          HGVSc
+                        </dt>
+                        <dd
+                          className="TranscriptConsequence__AttributeValue-sc-1aaizap-1 cHxeFf"
+                        >
+                          
+                        </dd>
+                      </div>
+                      <div
+                        style={
+                          {
+                            "marginTop": "0.25em",
+                          }
+                        }
+                      >
+                        <dt
+                          className="TranscriptConsequence__AttributeName-sc-1aaizap-0 hhgcrX"
+                        >
+                          Domains
+                        </dt>
+                        <dd
+                          className="TranscriptConsequence__AttributeValue-sc-1aaizap-1 cHxeFf"
+                        >
+                          <ul
+                            className="InlineList__InlineListWrapper-sc-1wq0e6g-0 chCfJr"
+                          >
+                            <li>
+                              undefined (aaa)
+                            </li>
+                            <li>
+                              undefined (bbb)
+                            </li>
+                          </ul>
+                        </dd>
+                      </div>
+                    </dl>
+                  </li>
+                </ol>
+              </li>
+            </ol>
+          </li>
+        </ol>
       </div>
     </section>
     <div
@@ -17499,8 +18915,11 @@ exports[`VariantPage with dataset gnomad_r2_1_controls has no unexpected changes
         <span
           className="VariantPageTitle__TitleWrapper-sc-16g6pnt-0 bAAXLa"
         >
-          <span>
-            Single nucleotide variant
+          <span
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+          >
+            SNV
           </span>
           <span
             className="VariantPageTitle__Separator-sc-16g6pnt-1 jsfCLA"
@@ -17547,6 +18966,22 @@ exports[`VariantPage with dataset gnomad_r2_1_controls has no unexpected changes
           </span>
         </span>
       </h1>
+      <div
+        className="GnomadPageHeading__CenterPanel-sc-sgz3rr-2 kzqcqw"
+      >
+        <button
+          className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+          onClick={[Function]}
+          style={
+            {
+              "margin": "0 1em 0 -0.33em",
+            }
+          }
+          type="button"
+        >
+          Gene page
+        </button>
+      </div>
     </div>
     <div
       className="GnomadPageHeading__PageControlsWrapper-sc-sgz3rr-4 liqJpb"
@@ -18240,14 +19675,13 @@ exports[`VariantPage with dataset gnomad_r2_1_controls has no unexpected changes
       <div>
         <p>
           This variant falls on 
-          0
+          2
            transcript
           s
            in 
-          0
+          1
            
           gene
-          s
           .
         </p>
         <p>
@@ -18260,7 +19694,166 @@ exports[`VariantPage with dataset gnomad_r2_1_controls has no unexpected changes
         </p>
         <ol
           className="TranscriptConsequenceList__ConsequenceListWrapper-sc-qi0gmz-1 cXJgYo"
-        />
+        >
+          <li
+            className="TranscriptConsequenceList__ConsequenceListItem-sc-qi0gmz-2 BzXEE"
+          >
+            <h3>
+              
+            </h3>
+            <ol
+              className="List__OrderedList-sc-4j87st-2 gKjCRF"
+            >
+              <li
+                className="List__ListItem-sc-4j87st-1 gGPLUe"
+              >
+                <h4>
+                  <a
+                    className="Link-sc-14lgydv-0-Link jBvaYQ"
+                    href="/gene/ENSG012345"
+                    onClick={[Function]}
+                  >
+                    ABC1
+                  </a>
+                </h4>
+                <ol
+                  className="List__OrderedList-sc-4j87st-2 gKjCRF"
+                >
+                  <li
+                    className="List__ListItem-sc-4j87st-1 gGPLUe"
+                  >
+                    <a
+                      className="Link-sc-14lgydv-0-Link jBvaYQ"
+                      href="/transcript/ENST123456"
+                      onClick={[Function]}
+                    >
+                      ENST123456
+                      .
+                      1
+                    </a>
+                    <div
+                      className="TranscriptConsequenceList__TranscriptInfoWrapper-sc-qi0gmz-0 cXgLUx"
+                    >
+                      Ensembl canonical transcript for 
+                      ABC1
+                    </div>
+                    <dl
+                      className="TranscriptConsequence__AttributeList-sc-1aaizap-2 bCFpVu"
+                    >
+                      <div
+                        style={
+                          {
+                            "marginTop": "0.25em",
+                          }
+                        }
+                      >
+                        <dt
+                          className="TranscriptConsequence__AttributeName-sc-1aaizap-0 hhgcrX"
+                        >
+                          HGVSc
+                        </dt>
+                        <dd
+                          className="TranscriptConsequence__AttributeValue-sc-1aaizap-1 cHxeFf"
+                        >
+                          
+                        </dd>
+                      </div>
+                      <div
+                        style={
+                          {
+                            "marginTop": "0.25em",
+                          }
+                        }
+                      >
+                        <dt
+                          className="TranscriptConsequence__AttributeName-sc-1aaizap-0 hhgcrX"
+                        >
+                          Domains
+                        </dt>
+                        <dd
+                          className="TranscriptConsequence__AttributeValue-sc-1aaizap-1 cHxeFf"
+                        >
+                          <ul
+                            className="InlineList__InlineListWrapper-sc-1wq0e6g-0 chCfJr"
+                          >
+                            <li>
+                              undefined (aaa)
+                            </li>
+                            <li>
+                              undefined (bbb)
+                            </li>
+                          </ul>
+                        </dd>
+                      </div>
+                    </dl>
+                  </li>
+                  <li
+                    className="List__ListItem-sc-4j87st-1 gGPLUe"
+                  >
+                    <a
+                      className="Link-sc-14lgydv-0-Link jBvaYQ"
+                      href="/transcript/ENST012345"
+                      onClick={[Function]}
+                    >
+                      ENST012345
+                      .
+                      1
+                    </a>
+                    <dl
+                      className="TranscriptConsequence__AttributeList-sc-1aaizap-2 bCFpVu"
+                    >
+                      <div
+                        style={
+                          {
+                            "marginTop": "0.25em",
+                          }
+                        }
+                      >
+                        <dt
+                          className="TranscriptConsequence__AttributeName-sc-1aaizap-0 hhgcrX"
+                        >
+                          HGVSc
+                        </dt>
+                        <dd
+                          className="TranscriptConsequence__AttributeValue-sc-1aaizap-1 cHxeFf"
+                        >
+                          
+                        </dd>
+                      </div>
+                      <div
+                        style={
+                          {
+                            "marginTop": "0.25em",
+                          }
+                        }
+                      >
+                        <dt
+                          className="TranscriptConsequence__AttributeName-sc-1aaizap-0 hhgcrX"
+                        >
+                          Domains
+                        </dt>
+                        <dd
+                          className="TranscriptConsequence__AttributeValue-sc-1aaizap-1 cHxeFf"
+                        >
+                          <ul
+                            className="InlineList__InlineListWrapper-sc-1wq0e6g-0 chCfJr"
+                          >
+                            <li>
+                              undefined (aaa)
+                            </li>
+                            <li>
+                              undefined (bbb)
+                            </li>
+                          </ul>
+                        </dd>
+                      </div>
+                    </dl>
+                  </li>
+                </ol>
+              </li>
+            </ol>
+          </li>
+        </ol>
       </div>
     </section>
     <div
@@ -19691,8 +21284,11 @@ exports[`VariantPage with dataset gnomad_r2_1_non_cancer has no unexpected chang
         <span
           className="VariantPageTitle__TitleWrapper-sc-16g6pnt-0 bAAXLa"
         >
-          <span>
-            Single nucleotide variant
+          <span
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+          >
+            SNV
           </span>
           <span
             className="VariantPageTitle__Separator-sc-16g6pnt-1 jsfCLA"
@@ -19739,6 +21335,22 @@ exports[`VariantPage with dataset gnomad_r2_1_non_cancer has no unexpected chang
           </span>
         </span>
       </h1>
+      <div
+        className="GnomadPageHeading__CenterPanel-sc-sgz3rr-2 kzqcqw"
+      >
+        <button
+          className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+          onClick={[Function]}
+          style={
+            {
+              "margin": "0 1em 0 -0.33em",
+            }
+          }
+          type="button"
+        >
+          Gene page
+        </button>
+      </div>
     </div>
     <div
       className="GnomadPageHeading__PageControlsWrapper-sc-sgz3rr-4 liqJpb"
@@ -20432,14 +22044,13 @@ exports[`VariantPage with dataset gnomad_r2_1_non_cancer has no unexpected chang
       <div>
         <p>
           This variant falls on 
-          0
+          2
            transcript
           s
            in 
-          0
+          1
            
           gene
-          s
           .
         </p>
         <p>
@@ -20452,7 +22063,166 @@ exports[`VariantPage with dataset gnomad_r2_1_non_cancer has no unexpected chang
         </p>
         <ol
           className="TranscriptConsequenceList__ConsequenceListWrapper-sc-qi0gmz-1 cXJgYo"
-        />
+        >
+          <li
+            className="TranscriptConsequenceList__ConsequenceListItem-sc-qi0gmz-2 BzXEE"
+          >
+            <h3>
+              
+            </h3>
+            <ol
+              className="List__OrderedList-sc-4j87st-2 gKjCRF"
+            >
+              <li
+                className="List__ListItem-sc-4j87st-1 gGPLUe"
+              >
+                <h4>
+                  <a
+                    className="Link-sc-14lgydv-0-Link jBvaYQ"
+                    href="/gene/ENSG012345"
+                    onClick={[Function]}
+                  >
+                    ABC1
+                  </a>
+                </h4>
+                <ol
+                  className="List__OrderedList-sc-4j87st-2 gKjCRF"
+                >
+                  <li
+                    className="List__ListItem-sc-4j87st-1 gGPLUe"
+                  >
+                    <a
+                      className="Link-sc-14lgydv-0-Link jBvaYQ"
+                      href="/transcript/ENST123456"
+                      onClick={[Function]}
+                    >
+                      ENST123456
+                      .
+                      1
+                    </a>
+                    <div
+                      className="TranscriptConsequenceList__TranscriptInfoWrapper-sc-qi0gmz-0 cXgLUx"
+                    >
+                      Ensembl canonical transcript for 
+                      ABC1
+                    </div>
+                    <dl
+                      className="TranscriptConsequence__AttributeList-sc-1aaizap-2 bCFpVu"
+                    >
+                      <div
+                        style={
+                          {
+                            "marginTop": "0.25em",
+                          }
+                        }
+                      >
+                        <dt
+                          className="TranscriptConsequence__AttributeName-sc-1aaizap-0 hhgcrX"
+                        >
+                          HGVSc
+                        </dt>
+                        <dd
+                          className="TranscriptConsequence__AttributeValue-sc-1aaizap-1 cHxeFf"
+                        >
+                          
+                        </dd>
+                      </div>
+                      <div
+                        style={
+                          {
+                            "marginTop": "0.25em",
+                          }
+                        }
+                      >
+                        <dt
+                          className="TranscriptConsequence__AttributeName-sc-1aaizap-0 hhgcrX"
+                        >
+                          Domains
+                        </dt>
+                        <dd
+                          className="TranscriptConsequence__AttributeValue-sc-1aaizap-1 cHxeFf"
+                        >
+                          <ul
+                            className="InlineList__InlineListWrapper-sc-1wq0e6g-0 chCfJr"
+                          >
+                            <li>
+                              undefined (aaa)
+                            </li>
+                            <li>
+                              undefined (bbb)
+                            </li>
+                          </ul>
+                        </dd>
+                      </div>
+                    </dl>
+                  </li>
+                  <li
+                    className="List__ListItem-sc-4j87st-1 gGPLUe"
+                  >
+                    <a
+                      className="Link-sc-14lgydv-0-Link jBvaYQ"
+                      href="/transcript/ENST012345"
+                      onClick={[Function]}
+                    >
+                      ENST012345
+                      .
+                      1
+                    </a>
+                    <dl
+                      className="TranscriptConsequence__AttributeList-sc-1aaizap-2 bCFpVu"
+                    >
+                      <div
+                        style={
+                          {
+                            "marginTop": "0.25em",
+                          }
+                        }
+                      >
+                        <dt
+                          className="TranscriptConsequence__AttributeName-sc-1aaizap-0 hhgcrX"
+                        >
+                          HGVSc
+                        </dt>
+                        <dd
+                          className="TranscriptConsequence__AttributeValue-sc-1aaizap-1 cHxeFf"
+                        >
+                          
+                        </dd>
+                      </div>
+                      <div
+                        style={
+                          {
+                            "marginTop": "0.25em",
+                          }
+                        }
+                      >
+                        <dt
+                          className="TranscriptConsequence__AttributeName-sc-1aaizap-0 hhgcrX"
+                        >
+                          Domains
+                        </dt>
+                        <dd
+                          className="TranscriptConsequence__AttributeValue-sc-1aaizap-1 cHxeFf"
+                        >
+                          <ul
+                            className="InlineList__InlineListWrapper-sc-1wq0e6g-0 chCfJr"
+                          >
+                            <li>
+                              undefined (aaa)
+                            </li>
+                            <li>
+                              undefined (bbb)
+                            </li>
+                          </ul>
+                        </dd>
+                      </div>
+                    </dl>
+                  </li>
+                </ol>
+              </li>
+            </ol>
+          </li>
+        </ol>
       </div>
     </section>
     <div
@@ -21883,8 +23653,11 @@ exports[`VariantPage with dataset gnomad_r2_1_non_neuro has no unexpected change
         <span
           className="VariantPageTitle__TitleWrapper-sc-16g6pnt-0 bAAXLa"
         >
-          <span>
-            Single nucleotide variant
+          <span
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+          >
+            SNV
           </span>
           <span
             className="VariantPageTitle__Separator-sc-16g6pnt-1 jsfCLA"
@@ -21931,6 +23704,22 @@ exports[`VariantPage with dataset gnomad_r2_1_non_neuro has no unexpected change
           </span>
         </span>
       </h1>
+      <div
+        className="GnomadPageHeading__CenterPanel-sc-sgz3rr-2 kzqcqw"
+      >
+        <button
+          className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+          onClick={[Function]}
+          style={
+            {
+              "margin": "0 1em 0 -0.33em",
+            }
+          }
+          type="button"
+        >
+          Gene page
+        </button>
+      </div>
     </div>
     <div
       className="GnomadPageHeading__PageControlsWrapper-sc-sgz3rr-4 liqJpb"
@@ -22624,14 +24413,13 @@ exports[`VariantPage with dataset gnomad_r2_1_non_neuro has no unexpected change
       <div>
         <p>
           This variant falls on 
-          0
+          2
            transcript
           s
            in 
-          0
+          1
            
           gene
-          s
           .
         </p>
         <p>
@@ -22644,7 +24432,166 @@ exports[`VariantPage with dataset gnomad_r2_1_non_neuro has no unexpected change
         </p>
         <ol
           className="TranscriptConsequenceList__ConsequenceListWrapper-sc-qi0gmz-1 cXJgYo"
-        />
+        >
+          <li
+            className="TranscriptConsequenceList__ConsequenceListItem-sc-qi0gmz-2 BzXEE"
+          >
+            <h3>
+              
+            </h3>
+            <ol
+              className="List__OrderedList-sc-4j87st-2 gKjCRF"
+            >
+              <li
+                className="List__ListItem-sc-4j87st-1 gGPLUe"
+              >
+                <h4>
+                  <a
+                    className="Link-sc-14lgydv-0-Link jBvaYQ"
+                    href="/gene/ENSG012345"
+                    onClick={[Function]}
+                  >
+                    ABC1
+                  </a>
+                </h4>
+                <ol
+                  className="List__OrderedList-sc-4j87st-2 gKjCRF"
+                >
+                  <li
+                    className="List__ListItem-sc-4j87st-1 gGPLUe"
+                  >
+                    <a
+                      className="Link-sc-14lgydv-0-Link jBvaYQ"
+                      href="/transcript/ENST123456"
+                      onClick={[Function]}
+                    >
+                      ENST123456
+                      .
+                      1
+                    </a>
+                    <div
+                      className="TranscriptConsequenceList__TranscriptInfoWrapper-sc-qi0gmz-0 cXgLUx"
+                    >
+                      Ensembl canonical transcript for 
+                      ABC1
+                    </div>
+                    <dl
+                      className="TranscriptConsequence__AttributeList-sc-1aaizap-2 bCFpVu"
+                    >
+                      <div
+                        style={
+                          {
+                            "marginTop": "0.25em",
+                          }
+                        }
+                      >
+                        <dt
+                          className="TranscriptConsequence__AttributeName-sc-1aaizap-0 hhgcrX"
+                        >
+                          HGVSc
+                        </dt>
+                        <dd
+                          className="TranscriptConsequence__AttributeValue-sc-1aaizap-1 cHxeFf"
+                        >
+                          
+                        </dd>
+                      </div>
+                      <div
+                        style={
+                          {
+                            "marginTop": "0.25em",
+                          }
+                        }
+                      >
+                        <dt
+                          className="TranscriptConsequence__AttributeName-sc-1aaizap-0 hhgcrX"
+                        >
+                          Domains
+                        </dt>
+                        <dd
+                          className="TranscriptConsequence__AttributeValue-sc-1aaizap-1 cHxeFf"
+                        >
+                          <ul
+                            className="InlineList__InlineListWrapper-sc-1wq0e6g-0 chCfJr"
+                          >
+                            <li>
+                              undefined (aaa)
+                            </li>
+                            <li>
+                              undefined (bbb)
+                            </li>
+                          </ul>
+                        </dd>
+                      </div>
+                    </dl>
+                  </li>
+                  <li
+                    className="List__ListItem-sc-4j87st-1 gGPLUe"
+                  >
+                    <a
+                      className="Link-sc-14lgydv-0-Link jBvaYQ"
+                      href="/transcript/ENST012345"
+                      onClick={[Function]}
+                    >
+                      ENST012345
+                      .
+                      1
+                    </a>
+                    <dl
+                      className="TranscriptConsequence__AttributeList-sc-1aaizap-2 bCFpVu"
+                    >
+                      <div
+                        style={
+                          {
+                            "marginTop": "0.25em",
+                          }
+                        }
+                      >
+                        <dt
+                          className="TranscriptConsequence__AttributeName-sc-1aaizap-0 hhgcrX"
+                        >
+                          HGVSc
+                        </dt>
+                        <dd
+                          className="TranscriptConsequence__AttributeValue-sc-1aaizap-1 cHxeFf"
+                        >
+                          
+                        </dd>
+                      </div>
+                      <div
+                        style={
+                          {
+                            "marginTop": "0.25em",
+                          }
+                        }
+                      >
+                        <dt
+                          className="TranscriptConsequence__AttributeName-sc-1aaizap-0 hhgcrX"
+                        >
+                          Domains
+                        </dt>
+                        <dd
+                          className="TranscriptConsequence__AttributeValue-sc-1aaizap-1 cHxeFf"
+                        >
+                          <ul
+                            className="InlineList__InlineListWrapper-sc-1wq0e6g-0 chCfJr"
+                          >
+                            <li>
+                              undefined (aaa)
+                            </li>
+                            <li>
+                              undefined (bbb)
+                            </li>
+                          </ul>
+                        </dd>
+                      </div>
+                    </dl>
+                  </li>
+                </ol>
+              </li>
+            </ol>
+          </li>
+        </ol>
       </div>
     </section>
     <div
@@ -24075,8 +26022,11 @@ exports[`VariantPage with dataset gnomad_r2_1_non_topmed has no unexpected chang
         <span
           className="VariantPageTitle__TitleWrapper-sc-16g6pnt-0 bAAXLa"
         >
-          <span>
-            Single nucleotide variant
+          <span
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+          >
+            SNV
           </span>
           <span
             className="VariantPageTitle__Separator-sc-16g6pnt-1 jsfCLA"
@@ -24123,6 +26073,22 @@ exports[`VariantPage with dataset gnomad_r2_1_non_topmed has no unexpected chang
           </span>
         </span>
       </h1>
+      <div
+        className="GnomadPageHeading__CenterPanel-sc-sgz3rr-2 kzqcqw"
+      >
+        <button
+          className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+          onClick={[Function]}
+          style={
+            {
+              "margin": "0 1em 0 -0.33em",
+            }
+          }
+          type="button"
+        >
+          Gene page
+        </button>
+      </div>
     </div>
     <div
       className="GnomadPageHeading__PageControlsWrapper-sc-sgz3rr-4 liqJpb"
@@ -24816,14 +26782,13 @@ exports[`VariantPage with dataset gnomad_r2_1_non_topmed has no unexpected chang
       <div>
         <p>
           This variant falls on 
-          0
+          2
            transcript
           s
            in 
-          0
+          1
            
           gene
-          s
           .
         </p>
         <p>
@@ -24836,7 +26801,166 @@ exports[`VariantPage with dataset gnomad_r2_1_non_topmed has no unexpected chang
         </p>
         <ol
           className="TranscriptConsequenceList__ConsequenceListWrapper-sc-qi0gmz-1 cXJgYo"
-        />
+        >
+          <li
+            className="TranscriptConsequenceList__ConsequenceListItem-sc-qi0gmz-2 BzXEE"
+          >
+            <h3>
+              
+            </h3>
+            <ol
+              className="List__OrderedList-sc-4j87st-2 gKjCRF"
+            >
+              <li
+                className="List__ListItem-sc-4j87st-1 gGPLUe"
+              >
+                <h4>
+                  <a
+                    className="Link-sc-14lgydv-0-Link jBvaYQ"
+                    href="/gene/ENSG012345"
+                    onClick={[Function]}
+                  >
+                    ABC1
+                  </a>
+                </h4>
+                <ol
+                  className="List__OrderedList-sc-4j87st-2 gKjCRF"
+                >
+                  <li
+                    className="List__ListItem-sc-4j87st-1 gGPLUe"
+                  >
+                    <a
+                      className="Link-sc-14lgydv-0-Link jBvaYQ"
+                      href="/transcript/ENST123456"
+                      onClick={[Function]}
+                    >
+                      ENST123456
+                      .
+                      1
+                    </a>
+                    <div
+                      className="TranscriptConsequenceList__TranscriptInfoWrapper-sc-qi0gmz-0 cXgLUx"
+                    >
+                      Ensembl canonical transcript for 
+                      ABC1
+                    </div>
+                    <dl
+                      className="TranscriptConsequence__AttributeList-sc-1aaizap-2 bCFpVu"
+                    >
+                      <div
+                        style={
+                          {
+                            "marginTop": "0.25em",
+                          }
+                        }
+                      >
+                        <dt
+                          className="TranscriptConsequence__AttributeName-sc-1aaizap-0 hhgcrX"
+                        >
+                          HGVSc
+                        </dt>
+                        <dd
+                          className="TranscriptConsequence__AttributeValue-sc-1aaizap-1 cHxeFf"
+                        >
+                          
+                        </dd>
+                      </div>
+                      <div
+                        style={
+                          {
+                            "marginTop": "0.25em",
+                          }
+                        }
+                      >
+                        <dt
+                          className="TranscriptConsequence__AttributeName-sc-1aaizap-0 hhgcrX"
+                        >
+                          Domains
+                        </dt>
+                        <dd
+                          className="TranscriptConsequence__AttributeValue-sc-1aaizap-1 cHxeFf"
+                        >
+                          <ul
+                            className="InlineList__InlineListWrapper-sc-1wq0e6g-0 chCfJr"
+                          >
+                            <li>
+                              undefined (aaa)
+                            </li>
+                            <li>
+                              undefined (bbb)
+                            </li>
+                          </ul>
+                        </dd>
+                      </div>
+                    </dl>
+                  </li>
+                  <li
+                    className="List__ListItem-sc-4j87st-1 gGPLUe"
+                  >
+                    <a
+                      className="Link-sc-14lgydv-0-Link jBvaYQ"
+                      href="/transcript/ENST012345"
+                      onClick={[Function]}
+                    >
+                      ENST012345
+                      .
+                      1
+                    </a>
+                    <dl
+                      className="TranscriptConsequence__AttributeList-sc-1aaizap-2 bCFpVu"
+                    >
+                      <div
+                        style={
+                          {
+                            "marginTop": "0.25em",
+                          }
+                        }
+                      >
+                        <dt
+                          className="TranscriptConsequence__AttributeName-sc-1aaizap-0 hhgcrX"
+                        >
+                          HGVSc
+                        </dt>
+                        <dd
+                          className="TranscriptConsequence__AttributeValue-sc-1aaizap-1 cHxeFf"
+                        >
+                          
+                        </dd>
+                      </div>
+                      <div
+                        style={
+                          {
+                            "marginTop": "0.25em",
+                          }
+                        }
+                      >
+                        <dt
+                          className="TranscriptConsequence__AttributeName-sc-1aaizap-0 hhgcrX"
+                        >
+                          Domains
+                        </dt>
+                        <dd
+                          className="TranscriptConsequence__AttributeValue-sc-1aaizap-1 cHxeFf"
+                        >
+                          <ul
+                            className="InlineList__InlineListWrapper-sc-1wq0e6g-0 chCfJr"
+                          >
+                            <li>
+                              undefined (aaa)
+                            </li>
+                            <li>
+                              undefined (bbb)
+                            </li>
+                          </ul>
+                        </dd>
+                      </div>
+                    </dl>
+                  </li>
+                </ol>
+              </li>
+            </ol>
+          </li>
+        </ol>
       </div>
     </section>
     <div

--- a/browser/src/__factories__/Variant.ts
+++ b/browser/src/__factories__/Variant.ts
@@ -1,5 +1,5 @@
 import { Factory } from 'fishery'
-import { Variant, SequencingType } from '../VariantPage/VariantPage'
+import { Variant, SequencingType, TranscriptConsequence } from '../VariantPage/VariantPage'
 
 const defaultHistogram = {
   bin_edges: [0.5],
@@ -7,6 +7,59 @@ const defaultHistogram = {
   n_larger: 0,
   n_smaller: 0,
 }
+
+const transcriptConsequenceFactory = Factory.define<TranscriptConsequence>(({ params }) => {
+  const {
+    consequence_terms = ['lof', 'plof'],
+    domains = ['aaa', 'bbb'],
+    gene_id = 'ENSG012345',
+    gene_version = '1',
+    gene_symbol = 'ABC1',
+    hgvs = '',
+    hgvsc = '',
+    hgvsp = '',
+    is_canonical = false,
+    is_mane_select = false,
+    is_mane_select_version = false,
+    lof = '',
+    lof_flags = '',
+    lof_filter = '',
+    major_consequence = '',
+    polyphen_prediction = '',
+    refseq_id = '',
+    refseq_version = '',
+    sift_prediction = '',
+    transcript_id = 'ENST012345',
+    transcript_version = '1',
+
+    canonical = false,
+  } = params
+
+  return {
+    consequence_terms,
+    domains,
+    gene_id,
+    gene_version,
+    gene_symbol,
+    hgvs,
+    hgvsc,
+    hgvsp,
+    is_canonical,
+    is_mane_select,
+    is_mane_select_version,
+    lof,
+    lof_flags,
+    lof_filter,
+    major_consequence,
+    polyphen_prediction,
+    refseq_id,
+    refseq_version,
+    sift_prediction,
+    transcript_id,
+    transcript_version,
+    canonical,
+  }
+})
 
 const variantFactory = Factory.define<Variant>(({ params, associations }) => {
   const {
@@ -22,7 +75,6 @@ const variantFactory = Factory.define<Variant>(({ params, associations }) => {
     in_silico_predictors = null,
     rsids = null,
     colocated_variants = [],
-    transcript_consequences = [],
     liftover = null,
     liftover_sources = null,
   } = params
@@ -33,6 +85,7 @@ const variantFactory = Factory.define<Variant>(({ params, associations }) => {
     non_coding_constraint = null,
     clinvar = null,
     coverage = { exome: null, genome: null },
+    transcript_consequences = [],
   } = associations
   return {
     reference_genome,
@@ -147,10 +200,24 @@ export const v3SequencingFactory = sequencingFactory.associations({
   },
 })
 
-export const v2VariantFactory = variantFactory
-  .params({ reference_genome: 'GRCh37' })
-  .associations({ exome: v2SequencingFactory.build(), genome: null })
+export const v2VariantFactory = variantFactory.params({ reference_genome: 'GRCh37' }).associations({
+  exome: v2SequencingFactory.build(),
+  genome: null,
+  transcript_consequences: [
+    transcriptConsequenceFactory
+      .params({ is_canonical: true, transcript_id: 'ENST123456' })
+      .build(),
+    transcriptConsequenceFactory.build(),
+  ],
+})
 
-export const v3VariantFactory = variantFactory
-  .params({ reference_genome: 'GRCh38' })
-  .associations({ exome: null, genome: v3SequencingFactory.build() })
+export const v3VariantFactory = variantFactory.params({ reference_genome: 'GRCh38' }).associations({
+  exome: null,
+  genome: v3SequencingFactory.build(),
+  transcript_consequences: [
+    transcriptConsequenceFactory
+      .params({ is_canonical: true, transcript_id: 'ENST123456' })
+      .build(),
+    transcriptConsequenceFactory.build(),
+  ],
+})


### PR DESCRIPTION
Resolves #1025 

Edit: Updated screenshot and description in initial text here for clarity:

Adds a "to gene" button on a variant page.

Checks to see if in the transcript consequences there's a MANE select transcript, if so, it links to that gene. If there's no MANE select transcript, it checks for a single canonical transcript, if there are multiple canonical transcripts (multiple genes) and no MANE select, it will not display a "Gene page" button.

- [Link to](http://localhost:8008/variant/1-55051215-G-GA?dataset=gnomad_r3) a Variant with a MANE select transcript ("Gene page" button links to Gene associated with MANE select transcript, here, PCSK9)
  - ![Screenshot 2023-04-05 at 12 25 59](https://user-images.githubusercontent.com/59549713/230157978-b6e9a6d4-be1e-4ead-850c-f0f30192765d.jpg)

- [Link to](http://localhost:8008/variant/9-38577187-G-A?dataset=gnomad_r2_1) a Variant with multiple canonical transcripts, and no MANE select transcript (no "Gene page" button)
  - ![Screenshot 2023-04-05 at 12 26 10](https://user-images.githubusercontent.com/59549713/230157646-71157a6e-a113-4983-9220-b433889ebd95.jpg)


If there are multiple 








---

## Outdated, kept for context (originally Dec 01, 2023):

Adds a more prominent link to the Gene page from the Variant page.

Localhost [link here](http://localhost:8008/variant/1-55051215-G-GA?dataset=gnomad_r3).

![Screen Shot 2022-12-01 at 10 11 45](https://user-images.githubusercontent.com/59549713/205088697-4e6d865a-3be2-4d40-b247-e3cd5871eee7.jpg)

Uses the ENSG ID from the canonical transcript for a given gene.