### PR TITLE
Add a backend config to associate browser service with cloudarmor policy

### DIFF
--- a/deploy/deployctl/subcommands/ingress_production.py
+++ b/deploy/deployctl/subcommands/ingress_production.py
@@ -14,6 +14,8 @@ metadata:
   name: gnomad-browser
   labels:
     tier: production
+  annotations:
+    cloud.google.com/backend-config: '{"ports": {"80":"gnomad-backend-config"}}'
 spec:
   type: NodePort
   selector:

--- a/deploy/manifests/ingress/gnomad.backendconfig.yaml
+++ b/deploy/manifests/ingress/gnomad.backendconfig.yaml
@@ -1,0 +1,7 @@
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: gnomad-backend-config
+spec:
+  securityPolicy:
+    name: 'deny-problematic-requests'


### PR DESCRIPTION
I'm not yet sure if this is the best way to do this for now -- but the following config changes should be the way to associate the gnomad-browser service with our cloudarmor policy: https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-configuration#cloud_armor

Might need some work here to make this more optional, in the case of non-production or external gnomad deployments.

part of: #1006 