### PR TITLE
Fix md5 checksum on v3 mtDNA chrM vcf

### DIFF
--- a/browser/src/DownloadsPage/GnomadV3Downloads.tsx
+++ b/browser/src/DownloadsPage/GnomadV3Downloads.tsx
@@ -266,7 +266,7 @@ export default () => (
             label="chrM sites VCF"
             path="/release/3.1/vcf/genomes/gnomad.genomes.v3.1.sites.chrM.vcf.bgz"
             size="4.77 MiB"
-            md5="fbdf6807628c13b5379b359f12a39c61"
+            md5="d0ef2bd882ae44236897d743cb5528cf"
           />
         </ListItem>
         {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}

--- a/browser/src/DownloadsPage/__snapshots__/DownloadsPage.spec.tsx.snap
+++ b/browser/src/DownloadsPage/__snapshots__/DownloadsPage.spec.tsx.snap
@@ -16814,7 +16814,7 @@ exports[`Downloads page with location '#exac-' indicated in url  1`] = `
               <span>
                 4.77 MiB
                 , MD5: 
-                fbdf6807628c13b5379b359f12a39c61
+                d0ef2bd882ae44236897d743cb5528cf
               </span>
               <br />
               <span>
@@ -35989,7 +35989,7 @@ exports[`Downloads page with location '#research-' indicated in url  1`] = `
               <span>
                 4.77 MiB
                 , MD5: 
-                fbdf6807628c13b5379b359f12a39c61
+                d0ef2bd882ae44236897d743cb5528cf
               </span>
               <br />
               <span>
@@ -55160,7 +55160,7 @@ exports[`Downloads page with location '#v2-' indicated in url  1`] = `
               <span>
                 4.77 MiB
                 , MD5: 
-                fbdf6807628c13b5379b359f12a39c61
+                d0ef2bd882ae44236897d743cb5528cf
               </span>
               <br />
               <span>
@@ -74335,7 +74335,7 @@ exports[`Downloads page with location '#v2-liftover-' indicated in url  1`] = `
               <span>
                 4.77 MiB
                 , MD5: 
-                fbdf6807628c13b5379b359f12a39c61
+                d0ef2bd882ae44236897d743cb5528cf
               </span>
               <br />
               <span>
@@ -93510,7 +93510,7 @@ exports[`Downloads page with location '#v3-' indicated in url  1`] = `
               <span>
                 4.77 MiB
                 , MD5: 
-                fbdf6807628c13b5379b359f12a39c61
+                d0ef2bd882ae44236897d743cb5528cf
               </span>
               <br />
               <span>


### PR DESCRIPTION
Resolves #1067

Fix md5 checksum to be the checksum of the more recent download file. These are not automatically kept in sync. This one changing is discussed in [this slack thread](https://atgu.slack.com/archives/CNL7NA6H2/p1673278771740909).