### PR TITLE
Fix both LC OS flags displaying on the Variant tables

### DIFF
--- a/browser/src/VariantList/VariantFlag.tsx
+++ b/browser/src/VariantList/VariantFlag.tsx
@@ -35,7 +35,7 @@ export const FLAGS_CONFIG: Record<string, Flag> = {
     label: 'OS pLoF',
     level: 'info',
     formatTooltip: () =>
-      'Variant predicted to create or disrupt a splice site outside the canonical splice site (beta)',
+      'Other Splice Predicted Loss-of-Function: this variant is predicted to create or disrupt a splice site outside the canonical splice site (beta)',
   },
   mnv: {
     label: 'MNV',

--- a/graphql-api/src/queries/variant-datasets/shared/flags.js
+++ b/graphql-api/src/queries/variant-datasets/shared/flags.js
@@ -22,7 +22,11 @@ const getFlagsForGeneContext = (variant, geneId) => {
     // than a non-coding transcript with a pLoF VEP annotation. LOFTEE does not annotate
     // non-coding transcripts. Check for mostSevereConsequenceInGene.lof to avoid showing an
     // LC pLoF flag next to a non-pLoF VEP consequence.
-    if (!lofConsequencesInGene.some((csq) => csq.lof === 'HC') && mostSevereConsequenceInGene.lof) {
+    if (
+      !lofConsequencesInGene.some((csq) => csq.lof === 'HC') &&
+      mostSevereConsequenceInGene.lof &&
+      mostSevereConsequenceInGene.lof !== 'OS'
+    ) {
       flags.push('lc_lof')
     }
 
@@ -56,7 +60,11 @@ const getFlagsForRegionContext = (variant) => {
     // than a non-coding transcript with a pLoF VEP annotation. LOFTEE does not annotate
     // non-coding transcripts. Check for mostSevereConsequence.lof to avoid showing an
     // LC pLoF flag next to a non-pLoF VEP consequence.
-    if (!lofConsequences.some((csq) => csq.lof === 'HC') && mostSevereConsequence.lof) {
+    if (
+      !lofConsequences.some((csq) => csq.lof === 'HC') &&
+      mostSevereConsequence.lof &&
+      mostSevereConsequence.lof !== 'OS'
+    ) {
       flags.push('lc_lof')
     }
 

--- a/graphql-api/src/queries/variant-datasets/shared/flags.spec.ts
+++ b/graphql-api/src/queries/variant-datasets/shared/flags.spec.ts
@@ -20,6 +20,11 @@ describe('LOFTEE', () => {
           // does not annotate a transcript that VEP marks as pLoF
           { gene_id: 'G7', lof: '' },
           { gene_id: 'G7', lof: 'LC' },
+          // This should not flag OS as lc_lof because it's rare enough that there
+          //   is effectively no confidence
+          { gene_id: 'G8', lof: 'OS' },
+          { gene_id: 'G8', lof: 'OS' },
+          { gene_id: 'G8', lof: '' },
         ],
       }
 
@@ -33,7 +38,7 @@ describe('LOFTEE', () => {
         ['G7', false],
         ['G8', false],
       ])(
-        'should be included only if there are LOFTEE annotated consequences in the specified gene, none of them are annotated HC, and the highest ranked transcript is LOFTEE annotated',
+        'should be included only if there are LOFTEE annotated consequences in the specified gene, none of them are annotated HC, the highest ranked transcript is LOFTEE annotated, and the highest ranked transcript is not OS',
         (geneId, expected) => {
           expect(getFlagsForContext({ type: 'gene', geneId })(variant).includes('lc_lof')).toBe(
             expected
@@ -87,8 +92,20 @@ describe('LOFTEE', () => {
           },
           false,
         ],
+        [
+          {
+            transcript_consequences: [
+              // This should not flag OS as lc_lof because it's rare enough that there
+              //   is effectively no confidence
+              { lof: 'OS' },
+              { lof: 'OS' },
+              { lof: '' },
+            ],
+          },
+          false,
+        ],
       ])(
-        'should be included only if there are LOFTEE annotated consequences, none of them are annotated HC, and the highest ranked transcript is LOFTEE annotated',
+        'should be included only if there are LOFTEE annotated consequences, none of them are annotated HC, the highest ranked transcript is LOFTEE annotated, and the highest ranked transcript is not OS',
         (variant, expected) => {
           expect(getFlagsForContext({ type: 'region' })(variant).includes('lc_lof')).toBe(expected)
         }


### PR DESCRIPTION
Resolves #1070 

Adds an additional branch of to the flag display logic to correctly show only the `OS pLoF` on the Variant table of the Gene or Region page when the variant's most severe consequence is `OS pLoF`.

Screenshot:
![Screenshot 2023-01-31 at 11 24 10](https://user-images.githubusercontent.com/59549713/215819806-8f4a891f-c2f9-45e1-9924-75dc052f33f1.jpg)


Localhost link to Region that shows the change: http://localhost:8008/region/1-63868015-63868025
(The fix is in the API, so to confirm locally you should modify `Query.tsx` to point to localhost for the API, and start a local API)
