### PR TITLE
Allow Gene pipeline to output a smaller dataset

### DIFF
--- a/data-pipeline/src/data_pipeline/data_types/canonical_transcript.py
+++ b/data-pipeline/src/data_pipeline/data_types/canonical_transcript.py
@@ -1,10 +1,9 @@
 import hail as hl
 import pandas as pd
 
-# "." is required for importing when running pipeline 
-# from .seeds 
-import seeds   # this is temp for running locally as a standalone script
-
+# "." is required for importing when running pipeline
+# from .seeds
+import seeds  # this is temp for running locally as a standalone script
 
 
 def get_canonical_transcripts(create_test_datasets=False, **sites_table_paths):
@@ -51,7 +50,7 @@ def get_canonical_transcripts(create_test_datasets=False, **sites_table_paths):
 # TODO:FIXME: (rgrant): DELETE ME LATER
 #   literally just run this locally right here to see if it works
 
-g37exomes  = "gs://gcp-public-data--gnomad/release/2.1.1/ht/exomes/gnomad.exomes.r2.1.1.sites.ht"
+g37exomes = "gs://gcp-public-data--gnomad/release/2.1.1/ht/exomes/gnomad.exomes.r2.1.1.sites.ht"
 g37genomes = "gs://gcp-public-data--gnomad/release/2.1.1/ht/genomes/gnomad.genomes.r2.1.1.sites.ht"
 g38genomes = "gs://gcp-public-data--gnomad/release/3.1.1/ht/genomes/gnomad.genomes.v3.1.1.sites.ht"
 

--- a/data-pipeline/src/data_pipeline/data_types/canonical_transcript.py
+++ b/data-pipeline/src/data_pipeline/data_types/canonical_transcript.py
@@ -3,6 +3,9 @@ import pandas as pd
 
 # "." is required for importing when running pipeline
 # from .seeds
+
+
+# pylint: disable=import-error
 import seeds  # this is temp for running locally as a standalone script
 
 

--- a/data-pipeline/src/data_pipeline/data_types/canonical_transcript.py
+++ b/data-pipeline/src/data_pipeline/data_types/canonical_transcript.py
@@ -1,12 +1,7 @@
 import hail as hl
 import pandas as pd
 
-# "." is required for importing when running pipeline
-# from .seeds
-
-
-# pylint: disable=import-error
-import seeds  # this is temp for running locally as a standalone script
+from .seeds import SUBSAMPLE_FRACTION, INTEGER
 
 
 def get_canonical_transcripts(create_test_datasets=False, **sites_table_paths):
@@ -24,7 +19,7 @@ def get_canonical_transcripts(create_test_datasets=False, **sites_table_paths):
         if create_test_datasets:
             print(f"\nReceived create test datasets, downsampling table: {path}")
             print(f"\nTable count pre: {sites_table.count()}")
-            sites_table = sites_table.sample(seeds.SUBSAMPLE_FRACTION, seed=seeds.INTEGER)
+            sites_table = sites_table.sample(SUBSAMPLE_FRACTION, seed=INTEGER)
             print(f"\nTable count post: {sites_table.count()}")
 
         table_canonical_transcripts = sites_table.aggregate(
@@ -53,15 +48,15 @@ def get_canonical_transcripts(create_test_datasets=False, **sites_table_paths):
 # TODO:FIXME: (rgrant): DELETE ME LATER
 #   literally just run this locally right here to see if it works
 
-g37exomes = "gs://gcp-public-data--gnomad/release/2.1.1/ht/exomes/gnomad.exomes.r2.1.1.sites.ht"
-g37genomes = "gs://gcp-public-data--gnomad/release/2.1.1/ht/genomes/gnomad.genomes.r2.1.1.sites.ht"
-g38genomes = "gs://gcp-public-data--gnomad/release/3.1.1/ht/genomes/gnomad.genomes.v3.1.1.sites.ht"
+# g37exomes = "gs://gcp-public-data--gnomad/release/2.1.1/ht/exomes/gnomad.exomes.r2.1.1.sites.ht"
+# g37genomes = "gs://gcp-public-data--gnomad/release/2.1.1/ht/genomes/gnomad.genomes.r2.1.1.sites.ht"
+# g38genomes = "gs://gcp-public-data--gnomad/release/3.1.1/ht/genomes/gnomad.genomes.v3.1.1.sites.ht"
 
-result = get_canonical_transcripts(create_test_datasets=True, exomes=g37exomes, genomes=g37genomes)
+# result = get_canonical_transcripts(create_test_datasets=True, exomes=g37exomes, genomes=g37genomes)
 # result = get_canonical_transcripts(create_test_datasets=True, genomes=g38genomes)
-print(f"\n\nCount: {result.count()}\n")
-print(result.show(5))
-result.describe()
+# print(f"\n\nCount: {result.count()}\n")
+# print(result.show(5))
+# result.describe()
 
 # TODO:FIXME: (rgrant) DEBUG:
 # print("testing")

--- a/data-pipeline/src/data_pipeline/data_types/canonical_transcript.py
+++ b/data-pipeline/src/data_pipeline/data_types/canonical_transcript.py
@@ -1,11 +1,30 @@
 import hail as hl
 import pandas as pd
 
+# "." is required for importing when running pipeline 
+# from .seeds 
+import seeds   # this is temp for running locally as a standalone script
 
-def get_canonical_transcripts(**sites_table_paths):
+
+
+def get_canonical_transcripts(create_test_datasets=False, **sites_table_paths):
+
+    print(f"\n\nGot 'create-test-dataset's?: {create_test_datasets}\n")
+
     canonical_transcripts = set()
     for path in sites_table_paths.values():
         sites_table = hl.read_table(path)
+
+        # TODO:FIXME:(rgrant) Does this work? Need to keep which gene ID transcripts are kept
+        #   in sync. So a simple sample won't work. Maybe run sample a single time on the genes
+        #   then transcribe those ENSG-IDs into a single list that all the steps in the Genes
+        #   pipeline can filter down to
+        if create_test_datasets:
+            print(f"\nReceived create test datasets, downsampling table: {path}")
+            print(f"\nTable count pre: {sites_table.count()}")
+            sites_table = sites_table.sample(seeds.SUBSAMPLE_FRACTION, seed=seeds.INTEGER)
+            print(f"\nTable count post: {sites_table.count()}")
+
         table_canonical_transcripts = sites_table.aggregate(
             hl.agg.explode(
                 lambda csq: hl.agg.collect_as_set((csq.gene_id, csq.transcript_id)),
@@ -25,3 +44,22 @@ def get_canonical_transcripts(**sites_table_paths):
     canonical_transcripts = canonical_transcripts.repartition(32, shuffle=True)
 
     return canonical_transcripts
+
+
+# ======================================================
+
+# TODO:FIXME: (rgrant): DELETE ME LATER
+#   literally just run this locally right here to see if it works
+
+g37exomes  = "gs://gcp-public-data--gnomad/release/2.1.1/ht/exomes/gnomad.exomes.r2.1.1.sites.ht"
+g37genomes = "gs://gcp-public-data--gnomad/release/2.1.1/ht/genomes/gnomad.genomes.r2.1.1.sites.ht"
+g38genomes = "gs://gcp-public-data--gnomad/release/3.1.1/ht/genomes/gnomad.genomes.v3.1.1.sites.ht"
+
+result = get_canonical_transcripts(create_test_datasets=True, exomes=g37exomes, genomes=g37genomes)
+# result = get_canonical_transcripts(create_test_datasets=True, genomes=g38genomes)
+print(f"\n\nCount: {result.count()}\n")
+print(result.show(5))
+result.describe()
+
+# TODO:FIXME: (rgrant) DEBUG:
+# print("testing")

--- a/data-pipeline/src/data_pipeline/data_types/gene.py
+++ b/data-pipeline/src/data_pipeline/data_types/gene.py
@@ -1,6 +1,6 @@
 import hail as hl
 
-# TODO:FIXME: (rgrant) - ORIGINAL this "." is required to work in the pipeline 
+# TODO:FIXME: (rgrant) - ORIGINAL this "." is required to work in the pipeline
 # from .locus import normalized_contig, x_position
 
 # TESTING - without the "." you can run this as a standalone
@@ -233,7 +233,6 @@ def prepare_genes(gencode_path, hgnc_path, reference_genome, create_test_dataset
     # hmmm
     genes = genes.sample(0.01, seed=seeds.INTEGER)
 
-
     hgnc = import_hgnc(hgnc_path)
     hgnc = hgnc.filter(hl.is_defined(hgnc.ensembl_id)).key_by("ensembl_id")
     genes = genes.annotate(**hgnc[genes.gene_id])
@@ -261,14 +260,13 @@ def prepare_genes(gencode_path, hgnc_path, reference_genome, create_test_dataset
     )
 
     if create_test_datasets:
-        print(f'received create test datasets')
+        print(f"received create test datasets")
         downsampled_genes = genes.sample(0.01, seed=seeds.INTEGER)
         handselected_genes = genes.filter(hl.set(seeds.GENES_SET).contains(genes.gene_id))
         seeded_genes = downsampled_genes.union(handselected_genes).distinct()
         return seeded_genes
 
     return genes
-
 
 
 # ======================================================

--- a/data-pipeline/src/data_pipeline/data_types/gene.py
+++ b/data-pipeline/src/data_pipeline/data_types/gene.py
@@ -6,6 +6,7 @@ import hail as hl
 # TESTING - without the "." you can run this as a standalone
 # pylint: disable=import-error
 from locus import normalized_contig, x_position
+
 # pylint: disable=import-error
 import seeds
 

--- a/data-pipeline/src/data_pipeline/data_types/gene.py
+++ b/data-pipeline/src/data_pipeline/data_types/gene.py
@@ -1,14 +1,7 @@
 import hail as hl
 
-# TODO:FIXME: (rgrant) - ORIGINAL this "." is required to work in the pipeline
-# from .locus import normalized_contig, x_position
-
-# TESTING - without the "." you can run this as a standalone
-# pylint: disable=import-error
-from locus import normalized_contig, x_position
-
-# pylint: disable=import-error
-import seeds
+from .locus import normalized_contig, x_position
+from .seeds import INTEGER, GENES_SET
 
 
 def merge_overlapping_exons(regions):
@@ -233,8 +226,7 @@ def prepare_genes(gencode_path, hgnc_path, reference_genome, create_test_dataset
 
     genes = import_gencode(gencode_path, reference_genome)
 
-    # hmmm
-    genes = genes.sample(0.01, seed=seeds.INTEGER)
+    genes = genes.sample(0.01, seed=INTEGER)
 
     hgnc = import_hgnc(hgnc_path)
     hgnc = hgnc.filter(hl.is_defined(hgnc.ensembl_id)).key_by("ensembl_id")
@@ -264,8 +256,8 @@ def prepare_genes(gencode_path, hgnc_path, reference_genome, create_test_dataset
 
     if create_test_datasets:
         print("received create test datasets")
-        downsampled_genes = genes.sample(0.01, seed=seeds.INTEGER)
-        handselected_genes = genes.filter(hl.set(seeds.GENES_SET).contains(genes.gene_id))
+        downsampled_genes = genes.sample(0.01, seed=INTEGER)
+        handselected_genes = genes.filter(hl.set(GENES_SET).contains(genes.gene_id))
         seeded_genes = downsampled_genes.union(handselected_genes).distinct()
         return seeded_genes
 
@@ -277,8 +269,8 @@ def prepare_genes(gencode_path, hgnc_path, reference_genome, create_test_dataset
 # TODO:FIXME: (rgrant): DELETE ME LATER
 #   literally just run this locally right here to see if it works
 
-gencode_path_var = "/Users/rgrant/Downloads/output_external_sources_gencode.v19.annotation.gtf.gz"
-hgnc_path_var = "/Users/rgrant/Downloads/output_external_sources_hgnc.tsv"
+# gencode_path_var = "/Users/rgrant/Downloads/output_external_sources_gencode.v19.annotation.gtf.gz"
+# hgnc_path_var = "/Users/rgrant/Downloads/output_external_sources_hgnc.tsv"
 
 
 # print("\ntable 1")
@@ -289,12 +281,12 @@ hgnc_path_var = "/Users/rgrant/Downloads/output_external_sources_hgnc.tsv"
 
 # print(f"\nRandom seed is: {seeds.INTEGER}")
 
-print("\ntable 2 - subsetted")
-result2 = prepare_genes(gencode_path_var, hgnc_path_var, "GRCh37", True)
-print(f"\n\nCount: {result2.count()}\n")
+# print("\ntable 2 - subsetted")
+# result2 = prepare_genes(gencode_path_var, hgnc_path_var, "GRCh37", True)
+# print(f"\n\nCount: {result2.count()}\n")
 # result2.summarize()
-print(result2.show(5))
-result2.describe()
+# print(result2.show(5))
+# result2.describe()
 
 
 # TODO:FIXME: (rgrant) DEBUG:

--- a/data-pipeline/src/data_pipeline/data_types/gene.py
+++ b/data-pipeline/src/data_pipeline/data_types/gene.py
@@ -4,7 +4,9 @@ import hail as hl
 # from .locus import normalized_contig, x_position
 
 # TESTING - without the "." you can run this as a standalone
+# pylint: disable=import-error
 from locus import normalized_contig, x_position
+# pylint: disable=import-error
 import seeds
 
 
@@ -260,7 +262,7 @@ def prepare_genes(gencode_path, hgnc_path, reference_genome, create_test_dataset
     )
 
     if create_test_datasets:
-        print(f"received create test datasets")
+        print("received create test datasets")
         downsampled_genes = genes.sample(0.01, seed=seeds.INTEGER)
         handselected_genes = genes.filter(hl.set(seeds.GENES_SET).contains(genes.gene_id))
         seeded_genes = downsampled_genes.union(handselected_genes).distinct()
@@ -274,8 +276,8 @@ def prepare_genes(gencode_path, hgnc_path, reference_genome, create_test_dataset
 # TODO:FIXME: (rgrant): DELETE ME LATER
 #   literally just run this locally right here to see if it works
 
-gencode_path = "/Users/rgrant/Downloads/output_external_sources_gencode.v19.annotation.gtf.gz"
-hgnc_path = "/Users/rgrant/Downloads/output_external_sources_hgnc.tsv"
+gencode_path_var = "/Users/rgrant/Downloads/output_external_sources_gencode.v19.annotation.gtf.gz"
+hgnc_path_var = "/Users/rgrant/Downloads/output_external_sources_hgnc.tsv"
 
 
 # print("\ntable 1")
@@ -287,7 +289,7 @@ hgnc_path = "/Users/rgrant/Downloads/output_external_sources_hgnc.tsv"
 # print(f"\nRandom seed is: {seeds.INTEGER}")
 
 print("\ntable 2 - subsetted")
-result2 = prepare_genes(gencode_path, hgnc_path, "GRCh37", True)
+result2 = prepare_genes(gencode_path_var, hgnc_path_var, "GRCh37", True)
 print(f"\n\nCount: {result2.count()}\n")
 # result2.summarize()
 print(result2.show(5))

--- a/data-pipeline/src/data_pipeline/data_types/pext.py
+++ b/data-pipeline/src/data_pipeline/data_types/pext.py
@@ -6,7 +6,14 @@ from collections import namedtuple
 import hail as hl
 from tqdm import tqdm
 
+
+# import .seeds
+
+# FIXME: temp (rgrant) import this way to be imported after setting python path in local
+#   testing
+# pylint: disable=import-error
 import seeds
+
 
 
 TISSUE_NAME_MAP = {
@@ -91,7 +98,7 @@ def prepare_base_level_pext(base_level_pext_path, create_test_datasets=False):
     ds = hl.read_table(base_level_pext_path)
 
     if create_test_datasets:
-        print(f"\nGot create test datasets")
+        print("\nGot create test datasets")
         print(f"\nSize pre: {ds.count()}")
         ds = ds.sample(seeds.SUBSAMPLE_FRACTION, seed=seeds.INTEGER)
         print(f"\nSize post: {ds.count()}")

--- a/data-pipeline/src/data_pipeline/data_types/pext.py
+++ b/data-pipeline/src/data_pipeline/data_types/pext.py
@@ -107,7 +107,7 @@ def prepare_base_level_pext(base_level_pext_path, create_test_datasets=False):
         **{
             renamed: hl.if_else(hl.is_missing(ds[original]) | hl.is_nan(ds[original]), hl.float(0), ds[original])
             for original, renamed in TISSUE_NAME_MAP.items()
-        }
+        },
     )
 
     ds = ds.order_by(ds.gene_id, hl.asc(ds.pos)).drop("locus")

--- a/data-pipeline/src/data_pipeline/data_types/pext.py
+++ b/data-pipeline/src/data_pipeline/data_types/pext.py
@@ -15,7 +15,6 @@ from tqdm import tqdm
 import seeds
 
 
-
 TISSUE_NAME_MAP = {
     "Adipose_Subcutaneous": "adipose_subcutaneous",
     "Adipose_Visceral_Omentum_": "adipose_visceral_omentum",

--- a/data-pipeline/src/data_pipeline/data_types/pext.py
+++ b/data-pipeline/src/data_pipeline/data_types/pext.py
@@ -12,7 +12,8 @@ from tqdm import tqdm
 # FIXME: temp (rgrant) import this way to be imported after setting python path in local
 #   testing
 # pylint: disable=import-error
-import seeds
+# import seeds
+from .seeds import SUBSAMPLE_FRACTION, INTEGER
 
 
 TISSUE_NAME_MAP = {
@@ -88,6 +89,7 @@ def read_bases_tsv(filename):
             yield Row(gene=row[0], chrom=row[1], pos=int(row[2]), tissues=tissues)
 
 
+# TODO: this step is no longer being subset - remove all logic from this before merging
 def prepare_base_level_pext(base_level_pext_path, create_test_datasets=False):
     tmp_dir = os.path.expanduser("~")
 
@@ -99,7 +101,7 @@ def prepare_base_level_pext(base_level_pext_path, create_test_datasets=False):
     if create_test_datasets:
         print("\nGot create test datasets")
         print(f"\nSize pre: {ds.count()}")
-        ds = ds.sample(seeds.SUBSAMPLE_FRACTION, seed=seeds.INTEGER)
+        ds = ds.sample(SUBSAMPLE_FRACTION, seed=INTEGER)
         print(f"\nSize post: {ds.count()}")
 
     ds = ds.select(

--- a/data-pipeline/src/data_pipeline/data_types/seeds.py
+++ b/data-pipeline/src/data_pipeline/data_types/seeds.py
@@ -8,6 +8,6 @@ INTEGER = 1337
 #             PCSK9,             BRCA2,             DMD,               TTN
 GENES_SET = {"ENSG00000169174", "ENSG00000139618", "ENSG00000198947", "ENSG00000155657"}
 
-#TODO: There could be some sort of manual, and large (100+) set of genes such that
+# TODO: There could be some sort of manual, and large (100+) set of genes such that
 #   you never have to rely on ht.sample(n, m) - sample results in a random set of genes
 #   and you need to have annotations in the tables for the same set of genes across everything

--- a/data-pipeline/src/data_pipeline/data_types/seeds.py
+++ b/data-pipeline/src/data_pipeline/data_types/seeds.py
@@ -1,0 +1,13 @@
+# This file consists of shared variables to be used by various pipeline
+#   functions if given the '--create-test-datasets' flag.
+
+SUBSAMPLE_FRACTION = 0.01
+INTEGER = 1337
+
+# The list of genes that should be included overall
+#             PCSK9,             BRCA2,             DMD,               TTN
+GENES_SET = {"ENSG00000169174", "ENSG00000139618", "ENSG00000198947", "ENSG00000155657"}
+
+#TODO: There could be some sort of manual, and large (100+) set of genes such that
+#   you never have to rely on ht.sample(n, m) - sample results in a random set of genes
+#   and you need to have annotations in the tables for the same set of genes across everything

--- a/data-pipeline/src/data_pipeline/pipeline.py
+++ b/data-pipeline/src/data_pipeline/pipeline.py
@@ -74,6 +74,7 @@ class DownloadTask:
         return (False, None)
 
     def run(self, force=False, create_test_datasets=False):
+        # pylint: disable=unused-argument
         output_path = self.get_output_path()
         should_run, reason = (True, "Forced") if force else self.should_run()
         if should_run:

--- a/data-pipeline/src/data_pipeline/pipeline.py
+++ b/data-pipeline/src/data_pipeline/pipeline.py
@@ -140,7 +140,6 @@ class Task:
             #   so i can just hand off the value onto the `_work` method?
             #   and the `_work` is actually a given pipeline
 
-            
             if self.is_subsettable():
                 print("I am subsettable!")
                 # only pass this additional positional argument if the task itself supports subsetting
@@ -148,7 +147,6 @@ class Task:
                 result = self._work(**self.get_inputs(), **self._params, create_test_datasets=create_test_datasets)
             else:
                 result = self._work(**self.get_inputs(), **self._params)
-
 
             result.write(output_path, overwrite=True)  # pylint: disable=unexpected-keyword-arg
             stop = time.perf_counter()
@@ -192,7 +190,7 @@ class Pipeline:
             # if task.canBeSubsetted():
             task.run(force=force_tasks and task_name in force_tasks, create_test_datasets=create_test_datasets)
             # else:
-                # task.run(force=force_tasks and task_name in force_tasks)
+            # task.run(force=force_tasks and task_name in force_tasks)
 
     # TODO:FIXME: (rgrant) - OLD UNTOUCHED ONE
     # def run(self, force_tasks=None):

--- a/data-pipeline/src/data_pipeline/pipelines/genes.py
+++ b/data-pipeline/src/data_pipeline/pipelines/genes.py
@@ -158,15 +158,25 @@ pipeline.add_task(
 #     {"tmp_path": "/tmp"},
 # )
 
-pipeline.add_task(
-    "prepare_pext",
-    prepare_pext_data,
-    "/pext_grch37.ht",
-    {
-        "base_level_pext_path": "gs://gcp-public-data--gnomad/papers/2019-tx-annotation/gnomad_browser/all.baselevel.021620.ht",
-        "low_max_pext_genes_path": "gs://gcp-public-data--gnomad/papers/2019-tx-annotation/data/GRCH37_hg19/max_pext_low_genes.021520.tsv",
-    },
-)
+# ====================================================================================
+# Commented out pext steps February 07, 2023.
+# Per similar reasons as to issue 914 (above)
+#
+# The current workaround is to keep using the resultant hailtable from before this
+#   step started failing, as the files have not changed. A newer hail version caused
+#   this step to start failing, and that known bug will likely not be fixed. Pext,
+#   similarly to gtex, is unlikely to change.
+# ====================================================================================
+
+# pipeline.add_task(
+#     "prepare_pext",
+#     prepare_pext_data,
+#     "/pext_grch37.ht",
+#     {
+#         "base_level_pext_path": "gs://gcp-public-data--gnomad/papers/2019-tx-annotation/gnomad_browser/all.baselevel.021620.ht",
+#         "low_max_pext_genes_path": "gs://gcp-public-data--gnomad/papers/2019-tx-annotation/data/GRCH37_hg19/max_pext_low_genes.021520.tsv",
+#     },
+# )
 
 ###############################################
 # Constraint
@@ -206,7 +216,12 @@ pipeline.add_task(
     {
         "table_path": pipeline.get_task("prepare_grch37_genes"),
         "canonical_transcript": pipeline.get_task("get_grch37_canonical_transcripts"),
-        "pext": pipeline.get_task("prepare_pext"),
+        # Direct link to previous resultant pext hailtable as a workaround
+        #    todo: (rgrant) when no one is actively developing anything with pipelines
+        #      I'd love to move the pext hailtable into a pext/ directory, similar
+        #      to gtex. That way we could make a backup of the final pext table in the
+        #      directory just in case.
+        "pext": "gs://gnomad-browser-data-pipeline/output/pext_grch37.ht",
     },
 )
 

--- a/data-pipeline/src/data_pipeline/pipelines/genes.py
+++ b/data-pipeline/src/data_pipeline/pipelines/genes.py
@@ -22,7 +22,7 @@ from data_pipeline.datasets.exac.exac_constraint import prepare_exac_constraint
 from data_pipeline.datasets.exac.exac_regional_missense_constraint import prepare_exac_regional_missense_constraint
 from data_pipeline.datasets.gnomad_v2.gnomad_v2_constraint import prepare_gnomad_v2_constraint
 
-
+# TODO:FIXME: (rgrant) - original one! Uncomment later
 pipeline = Pipeline()
 
 ###############################################
@@ -65,6 +65,10 @@ pipeline.add_task(
     "/genes/genes_grch37_base.ht",
     {"gencode_path": pipeline.get_task("download_gencode_v19_gtf"), "hgnc_path": pipeline.get_task("download_hgnc")},
     {"reference_genome": "GRCh37"},
+    # TODO:FIXME:
+    # 6th positional argument is subsettable
+    subsettable=True,
+    # True,
 )
 
 pipeline.add_task(
@@ -73,6 +77,10 @@ pipeline.add_task(
     "/genes/genes_grch38_base.ht",
     {"gencode_path": pipeline.get_task("download_gencode_v35_gtf"), "hgnc_path": pipeline.get_task("download_hgnc")},
     {"reference_genome": "GRCh38"},
+    # TODO:FIXME:
+    # 6th positional argument is subsettable
+    subsettable=True,
+    # True,
 )
 
 ###############################################
@@ -111,6 +119,7 @@ pipeline.add_task(
         "exomes": "gs://gcp-public-data--gnomad/release/2.1.1/ht/exomes/gnomad.exomes.r2.1.1.sites.ht",
         "genomes": "gs://gcp-public-data--gnomad/release/2.1.1/ht/genomes/gnomad.genomes.r2.1.1.sites.ht",
     },
+    subsettable=True,
 )
 
 pipeline.add_task(
@@ -118,6 +127,7 @@ pipeline.add_task(
     get_canonical_transcripts,
     "/genes/canonical_transcripts_grch38.ht",
     {"genomes": "gs://gcp-public-data--gnomad/release/3.1.1/ht/genomes/gnomad.genomes.v3.1.1.sites.ht"},
+    subsettable=True,
 )
 
 ###############################################

--- a/data-pipeline/src/data_pipeline/pipelines/genes.py
+++ b/data-pipeline/src/data_pipeline/pipelines/genes.py
@@ -15,7 +15,8 @@ from data_pipeline.data_types.transcript import (
 
 # Removed Jan 19, 2023. Using the result hailtable of an older successful gtex task as a workaround
 # from data_pipeline.data_types.gtex_tissue_expression import prepare_gtex_expression_data
-from data_pipeline.data_types.pext import prepare_pext_data
+# Removed Feb 07, 2023. Using the result hailtable of an older successful pext task as a workaround
+# from data_pipeline.data_types.pext import prepare_pext_data
 
 from data_pipeline.datasets.exac.exac_constraint import prepare_exac_constraint
 from data_pipeline.datasets.exac.exac_regional_missense_constraint import prepare_exac_regional_missense_constraint

--- a/data-pipeline/src/data_pipeline/pipelines/genes.py
+++ b/data-pipeline/src/data_pipeline/pipelines/genes.py
@@ -12,7 +12,9 @@ from data_pipeline.data_types.transcript import (
     annotate_gene_transcripts_with_refseq_id,
     extract_transcripts,
 )
-from data_pipeline.data_types.gtex_tissue_expression import prepare_gtex_expression_data
+
+# Removed Jan 19, 2023. Using the result hailtable of an older successful gtex task as a workaround
+# from data_pipeline.data_types.gtex_tissue_expression import prepare_gtex_expression_data
 from data_pipeline.data_types.pext import prepare_pext_data
 
 from data_pipeline.datasets.exac.exac_constraint import prepare_exac_constraint
@@ -121,28 +123,40 @@ pipeline.add_task(
 # Tissue expression
 ###############################################
 
-pipeline.add_download_task(
-    "download_gtex_v7_tpm_data",
-    "https://storage.googleapis.com/gtex_analysis_v7/rna_seq_data/GTEx_Analysis_2016-01-15_v7_RSEMv1.2.22_transcript_tpm.txt.gz",
-    "/external_sources/gtex/v7/GTEx_Analysis_2016-01-15_v7_RSEMv1.2.22_transcript_tpm.txt.gz",
-)
+# ====================================================================================
+# Commented out gtex steps January 19, 2023.
+# Per issue 914 (https://github.com/broadinstitute/gnomad-browser/issues/914)
+#
+# The current workaround is to keep using the resultant hailtable from before this
+#   step started failing, as the files have not changed. A newer hail version caused
+#   this step to start failing, and that known bug will likely not be fixed. Newer
+#   versions of gtex may be in a different format. For now this is the workaround as
+#   gtex hasn't changed in quite a while (Oct 2021), if a newer version of gtex comes
+#   out this can be revisited.
+# ====================================================================================
 
-pipeline.add_download_task(
-    "download_gtex_v7_sample_attributes",
-    "https://storage.googleapis.com/gtex_analysis_v7/annotations/GTEx_v7_Annotations_SampleAttributesDS.txt",
-    "/external_sources/gtex/v7/GTEx_v7_Annotations_SampleAttributesDS.txt",
-)
+# pipeline.add_download_task(
+#     "download_gtex_v7_tpm_data",
+#     "https://storage.googleapis.com/gtex_analysis_v7/rna_seq_data/GTEx_Analysis_2016-01-15_v7_RSEMv1.2.22_transcript_tpm.txt.gz",
+#     "/external_sources/gtex/v7/GTEx_Analysis_2016-01-15_v7_RSEMv1.2.22_transcript_tpm.txt.gz",
+# )
 
-pipeline.add_task(
-    "prepare_gtex_v7_expression_data",
-    prepare_gtex_expression_data,
-    "/gtex/gtex_v7_tissue_expression.ht",
-    {
-        "transcript_tpms_path": pipeline.get_task("download_gtex_v7_tpm_data"),
-        "sample_annotations_path": pipeline.get_task("download_gtex_v7_sample_attributes"),
-    },
-    {"tmp_path": "/tmp"},
-)
+# pipeline.add_download_task(
+#     "download_gtex_v7_sample_attributes",
+#     "https://storage.googleapis.com/gtex_analysis_v7/annotations/GTEx_v7_Annotations_SampleAttributesDS.txt",
+#     "/external_sources/gtex/v7/GTEx_v7_Annotations_SampleAttributesDS.txt",
+# )
+
+# pipeline.add_task(
+#     "prepare_gtex_v7_expression_data",
+#     prepare_gtex_expression_data,
+#     "/gtex/gtex_v7_tissue_expression.ht",
+#     {
+#         "transcript_tpms_path": pipeline.get_task("download_gtex_v7_tpm_data"),
+#         "sample_annotations_path": pipeline.get_task("download_gtex_v7_sample_attributes"),
+#     },
+#     {"tmp_path": "/tmp"},
+# )
 
 pipeline.add_task(
     "prepare_pext",
@@ -202,7 +216,8 @@ pipeline.add_task(
     "/genes/genes_grch37_annotated_2.ht",
     {
         "table_path": pipeline.get_task("annotate_grch37_genes_step_1"),
-        "gtex_tissue_expression_path": pipeline.get_task("prepare_gtex_v7_expression_data"),
+        # Direct link to previous resultant gtex hailtable as a workaround
+        "gtex_tissue_expression_path": "gs://gnomad-browser-data-pipeline/output/gtex/2023-01-19-backup/gtex_v7_tissue_expression.ht",
     },
 )
 

--- a/data-pipeline/src/data_pipeline/pipelines/rg_test_pipeline.py
+++ b/data-pipeline/src/data_pipeline/pipelines/rg_test_pipeline.py
@@ -1,3 +1,5 @@
+# pylint: skip-file
+
 import hail as hl
 
 from pipeline import Pipeline, Task, run_pipeline

--- a/data-pipeline/src/data_pipeline/pipelines/rg_test_pipeline.py
+++ b/data-pipeline/src/data_pipeline/pipelines/rg_test_pipeline.py
@@ -2,34 +2,37 @@ import hail as hl
 
 from pipeline import Pipeline, Task, run_pipeline
 
+
 def test1(path, random_thing, create_test_datasets=False):
-	print(f"\ntest1: running as subset? - {create_test_datasets}\n")
-	test1ds = hl.import_table('/Users/rgrant/Downloads/test2/data.tsv', types={'Height': hl.tfloat64, 'Age': hl.tint32})
-	return test1ds
+    print(f"\ntest1: running as subset? - {create_test_datasets}\n")
+    test1ds = hl.import_table("/Users/rgrant/Downloads/test2/data.tsv", types={"Height": hl.tfloat64, "Age": hl.tint32})
+    return test1ds
+
 
 def test2(path, random_thing):
-	print(f"\ntest2: not possible to run as subset\n")
-	test2ds = hl.import_table('/Users/rgrant/Downloads/test2/data.tsv', types={'Height': hl.tfloat64, 'Age': hl.tint32})
-	return test2ds
+    print(f"\ntest2: not possible to run as subset\n")
+    test2ds = hl.import_table("/Users/rgrant/Downloads/test2/data.tsv", types={"Height": hl.tfloat64, "Age": hl.tint32})
+    return test2ds
+
 
 pipeline = Pipeline()
 
 pipeline.add_task(
-	"test1",
-	test1,
-	"random/path/1",
-	{"path": "random/path/2"},
-	{"random_thing": "any_value"},
-	subsettable=True,
+    "test1",
+    test1,
+    "random/path/1",
+    {"path": "random/path/2"},
+    {"random_thing": "any_value"},
+    subsettable=True,
 )
 
 pipeline.add_task(
-	"test2",
-	test2,
-	"random/path/3",
-	{"path": "random/path/4"},
-	{"random_thing": "any_value"},
-	# subsettable=True,
+    "test2",
+    test2,
+    "random/path/3",
+    {"path": "random/path/4"},
+    {"random_thing": "any_value"},
+    # subsettable=True,
 )
 
 print("\nTask 1\n=====")
@@ -41,10 +44,10 @@ task2 = pipeline.get_task("test2")
 print(f"Is subsettable?: {task2.is_subsettable()}\n\n")
 
 pipeline.set_outputs(
-	{
-		"test1_output": "test1",
-		"test2_output": "test2",	
-	}
+    {
+        "test1_output": "test1",
+        "test2_output": "test2",
+    }
 )
 
 run_pipeline(pipeline)
@@ -53,5 +56,5 @@ run_pipeline(pipeline)
 # ---
 # Seems to be a success - can be run as a pipeline given the --create-test-datasets arg, and the only the
 # tasks that are defined as being possible to subset will recieve the arg
-# this way, you don't have to add the possible parameter to every single defined task 
+# this way, you don't have to add the possible parameter to every single defined task
 # - just the ones that should be able to support small datasets.

--- a/data-pipeline/src/data_pipeline/pipelines/rg_test_pipeline.py
+++ b/data-pipeline/src/data_pipeline/pipelines/rg_test_pipeline.py
@@ -1,0 +1,57 @@
+import hail as hl
+
+from pipeline import Pipeline, Task, run_pipeline
+
+def test1(path, random_thing, create_test_datasets=False):
+	print(f"\ntest1: running as subset? - {create_test_datasets}\n")
+	test1ds = hl.import_table('/Users/rgrant/Downloads/test2/data.tsv', types={'Height': hl.tfloat64, 'Age': hl.tint32})
+	return test1ds
+
+def test2(path, random_thing):
+	print(f"\ntest2: not possible to run as subset\n")
+	test2ds = hl.import_table('/Users/rgrant/Downloads/test2/data.tsv', types={'Height': hl.tfloat64, 'Age': hl.tint32})
+	return test2ds
+
+pipeline = Pipeline()
+
+pipeline.add_task(
+	"test1",
+	test1,
+	"random/path/1",
+	{"path": "random/path/2"},
+	{"random_thing": "any_value"},
+	subsettable=True,
+)
+
+pipeline.add_task(
+	"test2",
+	test2,
+	"random/path/3",
+	{"path": "random/path/4"},
+	{"random_thing": "any_value"},
+	# subsettable=True,
+)
+
+print("\nTask 1\n=====")
+task1 = pipeline.get_task("test1")
+print(f"Is subsettable?: {task1.is_subsettable()}")
+
+print("\nTask 2\n=====")
+task2 = pipeline.get_task("test2")
+print(f"Is subsettable?: {task2.is_subsettable()}\n\n")
+
+pipeline.set_outputs(
+	{
+		"test1_output": "test1",
+		"test2_output": "test2",	
+	}
+)
+
+run_pipeline(pipeline)
+
+# RG - note to self
+# ---
+# Seems to be a success - can be run as a pipeline given the --create-test-datasets arg, and the only the
+# tasks that are defined as being possible to subset will recieve the arg
+# this way, you don't have to add the possible parameter to every single defined task 
+# - just the ones that should be able to support small datasets.

--- a/deploy/deployctl/subcommands/data_pipeline.py
+++ b/deploy/deployctl/subcommands/data_pipeline.py
@@ -15,7 +15,7 @@ DATA_PIPELINE_DIRECTORY = os.path.abspath(
 
 
 def run_pipeline(
-    pipeline: str, cluster: str, dry_run: bool, other_args: typing.Optional[typing.List[str]] = None
+    pipeline: str, cluster: str, dry_run: bool, create_test_datasets: bool, other_args: typing.Optional[typing.List[str]] = None
 ) -> None:
     if not config.project:
         raise RuntimeError("project configuration is required")
@@ -51,6 +51,10 @@ def run_pipeline(
             f"--output-root={config.data_pipeline_output}",
         ]
 
+        # TODO:FIXME: (rgrant) added to get the plumbing to work!
+        if create_test_datasets:
+            command.extend(["--create-test-datasets"])
+
         if other_args:
             command.extend(other_args)
 
@@ -70,6 +74,14 @@ def main(argv: typing.List[str]) -> None:
     run_parser.add_argument("--cluster", required=True, help="Dataproc cluster to run the pipeline on")
     run_parser.add_argument("--dry-run", action="store_true", help="Print pipeline command without running it")
 
+    # TODO:FIXME: (rgrant) this is added to work towards allowing subset of data
+    #   added as a first class argument, seems to make sense? idk
+    run_parser.add_argument(
+        "--create-test-datasets",
+        action="store_true",
+        help="Run pipeline with smaller resulting datasets for development",
+    )
+
     if "--" in argv:
         divider_index = argv.index("--")
         other_args = argv[divider_index + 1 :]
@@ -87,5 +99,8 @@ def main(argv: typing.List[str]) -> None:
     try:
         action(**vars(args))
     except Exception as err:  # pylint: disable=broad-except
+        # TODO:FIXME: (rgrant) error in here? only errors when I do the --create-test-datasets as part of
+        #   other args
+        print("in here")
         print(f"Error: {err}", file=sys.stderr)
         sys.exit(1)

--- a/deploy/deployctl/subcommands/data_pipeline.py
+++ b/deploy/deployctl/subcommands/data_pipeline.py
@@ -15,7 +15,11 @@ DATA_PIPELINE_DIRECTORY = os.path.abspath(
 
 
 def run_pipeline(
-    pipeline: str, cluster: str, dry_run: bool, create_test_datasets: bool, other_args: typing.Optional[typing.List[str]] = None
+    pipeline: str,
+    cluster: str,
+    dry_run: bool,
+    create_test_datasets: bool,
+    other_args: typing.Optional[typing.List[str]] = None,
 ) -> None:
     if not config.project:
         raise RuntimeError("project configuration is required")
@@ -99,8 +103,6 @@ def main(argv: typing.List[str]) -> None:
     try:
         action(**vars(args))
     except Exception as err:  # pylint: disable=broad-except
-        # TODO:FIXME: (rgrant) error in here? only errors when I do the --create-test-datasets as part of
-        #   other args
         print("in here")
         print(f"Error: {err}", file=sys.stderr)
         sys.exit(1)

--- a/deploy/deployctl/subcommands/dataproc_cluster.py
+++ b/deploy/deployctl/subcommands/dataproc_cluster.py
@@ -35,7 +35,10 @@ def start_cluster(name: str, cluster_args: typing.List[str]) -> None:
             f"--project={config.project}",
             f"--region={config.region}",
             f"--zone={config.zone}",
-            f"--subnet={config.network_name}-dataproc",
+            # TODO: hacky fix
+            # f"--subnet={config.network_name}-dataproc",
+            # TODO:FIXME: added here manually to have it conect to the right place
+            f"--subnet=rgrant-dev-dataproc-subnet",
             "--tags=dataproc-node",
             "--max-idle=1h",
             f"--packages={','.join(requirements)}",

--- a/deploy/deployctl/subcommands/dataproc_cluster.py
+++ b/deploy/deployctl/subcommands/dataproc_cluster.py
@@ -38,7 +38,7 @@ def start_cluster(name: str, cluster_args: typing.List[str]) -> None:
             # TODO: hacky fix
             # f"--subnet={config.network_name}-dataproc",
             # TODO:FIXME: added here manually to have it conect to the right place
-            f"--subnet=rgrant-dev-dataproc-subnet",
+            "--subnet=rgrant-dev-dataproc-subnet",
             "--tags=dataproc-node",
             "--max-idle=1h",
             f"--packages={','.join(requirements)}",

--- a/deploy/deployctl/subcommands/elasticsearch.py
+++ b/deploy/deployctl/subcommands/elasticsearch.py
@@ -84,7 +84,8 @@ def main(argv: typing.List[str]) -> None:
     load_parser.set_defaults(action=load_datasets)
     load_parser.add_argument("--cluster-name", default="gnomad")
     load_parser.add_argument("--dataproc-cluster", required=True)
-    load_parser.add_argument("--secret", default="gnomad-elasticsearch-password")
+    # TODO:FIXME: added a hacky fix here so that it uses your new password
+    load_parser.add_argument("--secret", default="gnomad-elasticsearch-password-rgrant")
     load_parser.add_argument("datasets")
 
     args = parser.parse_args(argv)

--- a/deploy/manifests/elasticsearch/elasticsearch.yaml.jinja2
+++ b/deploy/manifests/elasticsearch/elasticsearch.yaml.jinja2
@@ -122,14 +122,14 @@ spec:
             - name: elasticsearch
               env:
                 - name: ES_JAVA_OPTS
-                  value: '-Xms26g -Xmx26g'
+                  value: '-Xms10g -Xmx10g'
               resources:
                 requests:
-                  cpu: 6
-                  memory: 52Gi
+                  cpu: 3
+                  memory: 20Gi
                 limits:
-                  cpu: 7
-                  memory: 52Gi
+                  cpu: 4
+                  memory: 20Gi
       volumeClaimTemplates:
         - metadata:
             name: elasticsearch-data
@@ -139,7 +139,7 @@ spec:
             storageClassName: standard
             resources:
               requests:
-                storage: 1750Gi
+                storage: 400Gi
 {% if n_ingest_pods > 0 %}
     - name: ingest
       count: {{ n_ingest_pods }}


### PR DESCRIPTION
Will eventually resolve #1064 

This is very in progress, it is not yet functional. I think.

---

Extends the Pipeline to allow it to receive an additional flag per Matt's suggestion. If given this flag, any task that is flagged as subset-able (happy to change terminology) will be passed a boolean value that changes the Tasks resultant data.

Modified the Genes pipeline and tasks within the Genes pipeline to create a smaller dataset.

WIP. Need to have all annotation and steps that start from their own tables (Genes, Canonical Transcripts, Pext, etc) trim down to the same smaller set of data. 