### PR TITLE
Add test helpers to test datasets based on name matching regex

### DIFF
--- a/tests/__helpers__/datasets.tsx
+++ b/tests/__helpers__/datasets.tsx
@@ -8,6 +8,27 @@ export const forAllDatasets = (
   describe.each(allDatasetIds)(contextDescription, tests)
 }
 
+export const forDatasetsMatching = (
+  inclusionPattern: RegExp,
+  contextDescription: string,
+  tests: (datasetId: DatasetId) => void
+) => {
+  const matchingDatasets: DatasetId[] = allDatasetIds.filter((datasetId) =>
+    inclusionPattern.test(datasetId)
+  )
+  describe.each(matchingDatasets)(contextDescription, tests)
+}
+export const forDatasetsNotMatching = (
+  exclusionPattern: RegExp,
+  contextDescription: string,
+  tests: (datasetId: DatasetId) => void
+) => {
+  const matchingDatasets: DatasetId[] = allDatasetIds.filter(
+    (datasetId) => !exclusionPattern.test(datasetId)
+  )
+  describe.each(matchingDatasets)(contextDescription, tests)
+}
+
 export const forAllDatasetsExcept = (
   datasetIdsToExclude: DatasetId[],
   contextDescription: string,


### PR DESCRIPTION
This adds two more wrappers for `describe` that streamline running a set of tests over all datasets whose names do/don't match a given regex.