### PR TITLE
Elasticsearch 7 Compatibility

### DIFF
--- a/data-pipeline/requirements.txt
+++ b/data-pipeline/requirements.txt
@@ -1,3 +1,3 @@
-elasticsearch~=6.8
+elasticsearch~=7.17
 hail
 tqdm

--- a/data-pipeline/src/data_pipeline/helpers/elasticsearch_export.py
+++ b/data-pipeline/src/data_pipeline/helpers/elasticsearch_export.py
@@ -128,7 +128,7 @@ def export_table_to_elasticsearch(
 
     # https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html#index-modules-settings
     request_body = {
-        "mappings": {type_name: mapping},
+        "mappings": mapping,
         "settings": {
             "index.codec": "best_compression",
             "index.mapping.total_fields.limit": 10000,

--- a/deploy/deployctl/subcommands/blog_deployment.py
+++ b/deploy/deployctl/subcommands/blog_deployment.py
@@ -10,7 +10,7 @@ from deployctl.shell import kubectl, get_most_recent_tag, image_exists
 KUSTOMIZATION_TEMPLATE = """---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
+resources:
   - ../base
 images:
   - name: gnomad-blog

--- a/deploy/deployctl/subcommands/browser_deployments.py
+++ b/deploy/deployctl/subcommands/browser_deployments.py
@@ -13,7 +13,7 @@ from deployctl.shell import kubectl, get_most_recent_tag, image_exists, get_k8s_
 KUSTOMIZATION_TEMPLATE = """---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
+resources:
   - ../../base
 commonLabels:
   deployment: '{deployment_name}'

--- a/deploy/deployctl/subcommands/dataproc_cluster.py
+++ b/deploy/deployctl/subcommands/dataproc_cluster.py
@@ -39,7 +39,7 @@ def start_cluster(name: str, cluster_args: typing.List[str]) -> None:
             "--tags=dataproc-node",
             "--max-idle=1h",
             f"--packages={','.join(requirements)}",
-            f"--service-account=gnomad-data-pipeline@{config.project}.iam.gserviceaccount.com",
+            # f"--service-account=gnomad-data-pipeline@{config.project}.iam.gserviceaccount.com",
             # Required to access Secret Manager
             # https://cloud.google.com/secret-manager/docs/accessing-the-api#enabling_api_access
             "--scopes=cloud-platform",

--- a/deploy/deployctl/subcommands/dataproc_cluster.py
+++ b/deploy/deployctl/subcommands/dataproc_cluster.py
@@ -39,7 +39,7 @@ def start_cluster(name: str, cluster_args: typing.List[str]) -> None:
             "--tags=dataproc-node",
             "--max-idle=1h",
             f"--packages={','.join(requirements)}",
-            # f"--service-account=gnomad-data-pipeline@{config.project}.iam.gserviceaccount.com",
+            f"--service-account=gnomad-data-pipeline@{config.project}.iam.gserviceaccount.com",
             # Required to access Secret Manager
             # https://cloud.google.com/secret-manager/docs/accessing-the-api#enabling_api_access
             "--scopes=cloud-platform",

--- a/deploy/deployctl/subcommands/elasticsearch.py
+++ b/deploy/deployctl/subcommands/elasticsearch.py
@@ -45,7 +45,13 @@ def get_elasticsearch_password(cluster_name: str) -> None:
 def load_datasets(cluster_name: str, dataproc_cluster: str, secret: str, datasets: str):
     # Matches service name in deploy/manifests/elasticsearch.load-balancer.yaml.jinja2
     elasticsearch_load_balancer_ip = kubectl(
-        ["get", "service", f"{cluster_name}-elasticsearch-lb", "--output=jsonpath={.status.loadBalancer.ingress[0].ip}"]
+        [
+            "-n=elasticsearch",
+            "get",
+            "service",
+            f"{cluster_name}-elasticsearch-lb",
+            "--output=jsonpath={.status.loadBalancer.ingress[0].ip}",
+        ]
     )
 
     subprocess.check_call(

--- a/deploy/deployctl/subcommands/elasticsearch.py
+++ b/deploy/deployctl/subcommands/elasticsearch.py
@@ -46,7 +46,6 @@ def load_datasets(cluster_name: str, dataproc_cluster: str, secret: str, dataset
     # Matches service name in deploy/manifests/elasticsearch.load-balancer.yaml.jinja2
     elasticsearch_load_balancer_ip = kubectl(
         [
-            "-n=elasticsearch",
             "get",
             "service",
             f"{cluster_name}-elasticsearch-lb",

--- a/deploy/deployctl/subcommands/elasticsearch.py
+++ b/deploy/deployctl/subcommands/elasticsearch.py
@@ -76,6 +76,7 @@ def main(argv: typing.List[str]) -> None:
     apply_parser.set_defaults(action=apply_elasticsearch)
     apply_parser.add_argument("--cluster-name", default="gnomad")
     apply_parser.add_argument("--n-ingest-pods", type=int, default=0)
+    apply_parser.add_argument("--namespace", default="default")
 
     get_parser = subparsers.add_parser("get")
     get_parser.set_defaults(action=get_elasticsearch_cluster)

--- a/deploy/deployctl/subcommands/reads_deployments.py
+++ b/deploy/deployctl/subcommands/reads_deployments.py
@@ -13,7 +13,7 @@ from deployctl.shell import kubectl, get_most_recent_tag, image_exists, get_k8s_
 KUSTOMIZATION_TEMPLATE = """---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
+resources:
   - ../../base
 commonLabels:
   deployment: '{deployment_name}'

--- a/deploy/docs/ElasticsearchSnapshots.md
+++ b/deploy/docs/ElasticsearchSnapshots.md
@@ -9,7 +9,7 @@ Follow the steps in [ElasticsearchConnection.md](./ElasticsearchConnection.md) f
 
 ### Register a snapshot repository
 
-`deployctl setup` configures Elasticsearch with credentials to access a GCS bucket. That bucket should be used here.
+`deployctl setup` (or the terraform module) configures Elasticsearch with credentials to access a GCS bucket. That bucket should be used here.
 
 ```
 curl -u "elastic:$ELASTICSEARCH_PASSWORD" -XPUT http://localhost:9200/_snapshot/backups --header "Content-Type: application/json" --data @- <<EOF
@@ -23,6 +23,10 @@ curl -u "elastic:$ELASTICSEARCH_PASSWORD" -XPUT http://localhost:9200/_snapshot/
 }
 EOF
 ```
+
+If you'd like to configure readonly access to a snapshot bucket (e.g. if you're restoring a testing cluster from prod snaps), you can add a readonly flag to the register command above:
+
+`    "readonly": true`
 
 ### Create a snapshot
 
@@ -52,9 +56,50 @@ curl -u "elastic:$ELASTICSEARCH_PASSWORD" http://localhost:9200/_snapshot/backup
 
 ### Restore a snapshot
 
+#### Restoring all indices
+
+If you're restoring an entire cluster, you may want to set a few flags to improve recovery speed:
+
 ```
-curl -u "elastic:$ELASTICSEARCH_PASSWORD" -XPOST http://localhost:9200/_snapshot/backups/<snapshot-name>/_restore
+curl -u "elastic:$ELASTICSEARCH_PASSWORD" -XPUT "localhost:9200/_cluster/settings" -H 'Content-Type: application/json' -d '{
+"persistent" : {
+  "cluster.routing.allocation.node_concurrent_recoveries" : "2",
+  "indices.recovery.max_bytes_per_sec": "400mb"
+  }
+}'
 ```
+
+When restoring all indices, use the `_restore` API with a wildcard indices parameter:
+
+```
+curl -u "elastic:$ELASTICSEARCH_PASSWORD" -X POST "localhost:9200/_snapshot/backups/<snapshot-name>/_restore" -H 'Content-Type: application/json' -d '{
+  "indices": "*",
+  "index_settings": {
+    "index.number_of_replicas": 0
+  }
+}'
+```
+
+#### Restoring specific indices
+
+When you only want to restore a specific index or indices, specify those in the indices field with a comma separator. For large restores, you may want to omit the `wait_for_completion=true` parameter:
+
+```
+curl -u "elastic:$ELASTICSEARCH_PASSWORD" -X POST "localhost:9200/_snapshot/backups/<snapshot-name>/_restore?wait_for_completion=true&pretty" -H 'Content-Type: application/json' -d'
+{
+  "indices": "index-name-2023-01-01--00-00,index-name2-2023-01-01--00-00",
+  "index_settings": {
+    "index.number_of_replicas": 0
+  },
+  "include_global_state": false,
+  "rename_pattern": "(.+)",
+  "rename_replacement": "restored-$1",
+  "include_aliases": false
+}
+'
+```
+
+This will restore the index with a "restored-" prefixed to the name. When ready, you can update your index alias to point to the restored index, if desired. See [Elasticsearch Index Aliases](./ElasticsearchIndexAliases.md) for instructions.
 
 ### Delete a snapshot
 

--- a/deploy/docs/NewDeployment.md
+++ b/deploy/docs/NewDeployment.md
@@ -22,7 +22,11 @@ The setup step installs the [Elastic Cloud on Kubernetes (ECK)](https://www.elas
 
 To check if the operator is ready, run `kubectl -n elastic-system get statefulset.apps/elastic-operator`.
 
-To create an Elasticsearch cluster, run `./deployctl elasticsearch apply`.
+Create an elasticsearch namespace, run `kubectl create namespace elasticsearch`
+
+Create a kubernetes service account to use for elasticsearch snapshotting, run: `kubectl -n elasticsearch create serviceaccount es-snaps`
+
+To create an Elasticsearch cluster, run `./deployctl elasticsearch apply --namespace elasticsearch`.
 
 After creating the cluster, store the password in a secret so that Dataproc jobs can access it.
 

--- a/deploy/docs/NewDeployment.md
+++ b/deploy/docs/NewDeployment.md
@@ -22,11 +22,15 @@ The setup step installs the [Elastic Cloud on Kubernetes (ECK)](https://www.elas
 
 To check if the operator is ready, run `kubectl -n elastic-system get statefulset.apps/elastic-operator`.
 
-Create an elasticsearch namespace, run `kubectl create namespace elasticsearch`
+Create a kubernetes service account to use for elasticsearch snapshotting, run: `kubectl create serviceaccount es-snaps`
 
-Create a kubernetes service account to use for elasticsearch snapshotting, run: `kubectl -n elasticsearch create serviceaccount es-snaps`
+Annotate that service account to associate it with the GCP Service Account that can write to your snapthot storage:
 
-To create an Elasticsearch cluster, run `./deployctl elasticsearch apply --namespace elasticsearch`.
+```
+  kubectl annotate sa es-snaps iam.gke.io/gcp-service-account=your-service-acct@your-project.iam.gserviceaccount.com
+```
+
+To create an Elasticsearch cluster, run `./deployctl elasticsearch apply`.
 
 After creating the cluster, store the password in a secret so that Dataproc jobs can access it.
 

--- a/deploy/manifests/blog/base/blog.deployment.yaml
+++ b/deploy/manifests/blog/base/blog.deployment.yaml
@@ -56,4 +56,4 @@ spec:
               cpu: 100m
               memory: 25Mi
       nodeSelector:
-        cloud.google.com/gke-nodepool: 'default-pool'
+        cloud.google.com/gke-nodepool: 'main-pool'

--- a/deploy/manifests/browser/base/api.deployment.yaml
+++ b/deploy/manifests/browser/base/api.deployment.yaml
@@ -22,13 +22,13 @@ spec:
             - name: PORT
               value: '8000'
             - name: ELASTICSEARCH_URL
-              value: http://gnomad-es-http:9200  # FIXME: This depends on using "gnomad" as the ES cluster name
+              value: http://gnomad-es-http:9200 # FIXME: This depends on using "gnomad" as the ES cluster name
             - name: ELASTICSEARCH_USERNAME
               value: elastic
             - name: ELASTICSEARCH_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: gnomad-es-elastic-user  # FIXME: This depends on using "gnomad" as the ES cluster name
+                  name: gnomad-es-elastic-user # FIXME: This depends on using "gnomad" as the ES cluster name
                   key: elastic
             - name: CACHE_REDIS_URL
               value: redis://redis:6379/1
@@ -68,4 +68,4 @@ spec:
             initialDelaySeconds: 3
             periodSeconds: 10
       nodeSelector:
-        cloud.google.com/gke-nodepool: 'default-pool'
+        cloud.google.com/gke-nodepool: 'main-pool'

--- a/deploy/manifests/browser/base/browser.deployment.yaml
+++ b/deploy/manifests/browser/base/browser.deployment.yaml
@@ -31,11 +31,11 @@ spec:
               containerPort: 80
           resources:
             requests:
-              cpu: '100m'
-              memory: '256Mi'
+              cpu: "100m"
+              memory: "256Mi"
             limits:
-              cpu: '250m'
-              memory: '512Mi'
+              cpu: "250m"
+              memory: "512Mi"
           readinessProbe:
             httpGet:
               path: /health/ready
@@ -43,4 +43,4 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 30
       nodeSelector:
-        cloud.google.com/gke-nodepool: 'default-pool'
+        cloud.google.com/gke-nodepool: "main-pool"

--- a/deploy/manifests/elasticsearch/elasticsearch.load-balancer.yaml.jinja2
+++ b/deploy/manifests/elasticsearch/elasticsearch.load-balancer.yaml.jinja2
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ cluster_name }}-elasticsearch-lb
-  namespace: elasticsearch
   annotations:
     cloud.google.com/load-balancer-type: 'Internal'
 spec:

--- a/deploy/manifests/elasticsearch/elasticsearch.load-balancer.yaml.jinja2
+++ b/deploy/manifests/elasticsearch/elasticsearch.load-balancer.yaml.jinja2
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ cluster_name }}-elasticsearch-lb
+  namespace: elasticsearch
   annotations:
     cloud.google.com/load-balancer-type: 'Internal'
 spec:

--- a/deploy/manifests/elasticsearch/elasticsearch.yaml.jinja2
+++ b/deploy/manifests/elasticsearch/elasticsearch.yaml.jinja2
@@ -9,7 +9,6 @@ spec:
     tls:
       selfSignedCertificate:
         disabled: true
-  podDisruptionBudget: {}
   nodeSets:
     - name: master
       count: 3

--- a/deploy/manifests/elasticsearch/elasticsearch.yaml.jinja2
+++ b/deploy/manifests/elasticsearch/elasticsearch.yaml.jinja2
@@ -93,7 +93,7 @@ spec:
             - name: install-plugins
               command: ['sh', '-c', 'bin/elasticsearch-plugin install --batch repository-gcs']
     - name: data-green
-      count: 3
+      count: 2
       config:  # https://www.elastic.co/guide/en/elasticsearch/reference/current/settings.html
         node.roles: ["data"]
         cluster.routing.allocation.disk.watermark.low: '100gb'

--- a/deploy/manifests/elasticsearch/elasticsearch.yaml.jinja2
+++ b/deploy/manifests/elasticsearch/elasticsearch.yaml.jinja2
@@ -2,7 +2,6 @@ apiVersion: elasticsearch.k8s.elastic.co/v1
 kind: Elasticsearch
 metadata:
   name: {{ cluster_name }}
-  namespace: elasticsearch
 spec:
   version: 7.17.8
   http:
@@ -35,9 +34,9 @@ spec:
                 nodeSelectorTerms:
                   - matchExpressions:
                       - key: cloud.google.com/gke-nodepool
-                        operator: NotIn
+                        operator: In
                         values:
-                          - es-data
+                          - main-pool
           initContainers:
             - name: sysctl
               securityContext:
@@ -89,9 +88,9 @@ spec:
                 nodeSelectorTerms:
                   - matchExpressions:
                       - key: cloud.google.com/gke-nodepool
-                        operator: NotIn
+                        operator: In
                         values:
-                          - es-data
+                          - main-pool
           initContainers:
             - name: sysctl
               securityContext:

--- a/deploy/manifests/elasticsearch/elasticsearch.yaml.jinja2
+++ b/deploy/manifests/elasticsearch/elasticsearch.yaml.jinja2
@@ -2,14 +2,14 @@ apiVersion: elasticsearch.k8s.elastic.co/v1
 kind: Elasticsearch
 metadata:
   name: {{ cluster_name }}
+  namespace: elasticsearch
 spec:
-  version: 6.8.22
+  version: 7.17.8
   http:
     tls:
       selfSignedCertificate:
         disabled: true
-  secureSettings:
-    - secretName: es-snapshots-gcs-credentials
+  podDisruptionBudget: {}
   nodeSets:
     - name: master
       count: 3
@@ -18,11 +18,17 @@ spec:
         node.data: false
         node.ingest: false
         node.ml: false
+        cluster.routing.allocation.disk.watermark.low: '50gb'
+        cluster.routing.allocation.disk.watermark.high: '25gb'
+        cluster.routing.allocation.disk.watermark.flood_stage: '10gb'
+        ingest.geoip.downloader.enabled: false
       podTemplate:
         metadata:
           labels:
             role: master
         spec:
+          automountServiceAccountToken: true
+          serviceAccountName: es-snaps
           affinity:
             nodeAffinity:
               requiredDuringSchedulingIgnoredDuringExecution:
@@ -56,6 +62,10 @@ spec:
         node.data: false
         node.ingest: false
         node.ml: false
+        cluster.routing.allocation.disk.watermark.low: '50gb'
+        cluster.routing.allocation.disk.watermark.high: '25gb'
+        cluster.routing.allocation.disk.watermark.flood_stage: '10gb'
+        ingest.geoip.downloader.enabled: false
       volumeClaimTemplates:
       - metadata:
           name: elasticsearch-data
@@ -71,6 +81,8 @@ spec:
           labels:
             role: coordinating
         spec:
+          automountServiceAccountToken: true
+          serviceAccountName: es-snaps
           affinity:
             nodeAffinity:
               requiredDuringSchedulingIgnoredDuringExecution:
@@ -88,20 +100,23 @@ spec:
             - name: install-plugins
               command: ['sh', '-c', 'bin/elasticsearch-plugin install --batch repository-gcs']
     - name: data-green
-      count: 2
+      count: 3
       config:  # https://www.elastic.co/guide/en/elasticsearch/reference/current/settings.html
         node.master: false
         node.data: true
         node.ingest: false
         node.ml: false
-        cluster.routing.allocation.disk.watermark.low: '100gb'
-        cluster.routing.allocation.disk.watermark.high: '50gb'
+        cluster.routing.allocation.disk.watermark.low: '50gb'
+        cluster.routing.allocation.disk.watermark.high: '25gb'
         cluster.routing.allocation.disk.watermark.flood_stage: '10gb'
+        ingest.geoip.downloader.enabled: false
       podTemplate:
         metadata:
           labels:
             role: data
         spec:
+          automountServiceAccountToken: true
+          serviceAccountName: es-snaps
           affinity:
             nodeAffinity:
               requiredDuringSchedulingIgnoredDuringExecution:
@@ -148,11 +163,17 @@ spec:
         node.data: true
         node.ingest: true
         node.ml: false
+        cluster.routing.allocation.disk.watermark.low: '50gb'
+        cluster.routing.allocation.disk.watermark.high: '25gb'
+        cluster.routing.allocation.disk.watermark.flood_stage: '10gb'
+        ingest.geoip.downloader.enabled: false
       podTemplate:
         metadata:
           labels:
             role: ingest
         spec:
+          automountServiceAccountToken: true
+          serviceAccountName: es-snaps
           affinity:
             nodeAffinity:
               requiredDuringSchedulingIgnoredDuringExecution:

--- a/deploy/manifests/elasticsearch/elasticsearch.yaml.jinja2
+++ b/deploy/manifests/elasticsearch/elasticsearch.yaml.jinja2
@@ -13,12 +13,9 @@ spec:
     - name: master
       count: 3
       config:  # https://www.elastic.co/guide/en/elasticsearch/reference/current/settings.html
-        node.master: true
-        node.data: false
-        node.ingest: false
-        node.ml: false
-        cluster.routing.allocation.disk.watermark.low: '50gb'
-        cluster.routing.allocation.disk.watermark.high: '25gb'
+        node.roles: ["master"]
+        cluster.routing.allocation.disk.watermark.low: '100gb'
+        cluster.routing.allocation.disk.watermark.high: '50gb'
         cluster.routing.allocation.disk.watermark.flood_stage: '10gb'
         ingest.geoip.downloader.enabled: false
       podTemplate:
@@ -57,12 +54,9 @@ spec:
     - name: coordinating-nodes
       count: 3
       config:  # https://www.elastic.co/guide/en/elasticsearch/reference/current/settings.html
-        node.master: false
-        node.data: false
-        node.ingest: false
-        node.ml: false
-        cluster.routing.allocation.disk.watermark.low: '50gb'
-        cluster.routing.allocation.disk.watermark.high: '25gb'
+        node.roles: []
+        cluster.routing.allocation.disk.watermark.low: '100gb'
+        cluster.routing.allocation.disk.watermark.high: '50gb'
         cluster.routing.allocation.disk.watermark.flood_stage: '10gb'
         ingest.geoip.downloader.enabled: false
       volumeClaimTemplates:
@@ -101,12 +95,9 @@ spec:
     - name: data-green
       count: 3
       config:  # https://www.elastic.co/guide/en/elasticsearch/reference/current/settings.html
-        node.master: false
-        node.data: true
-        node.ingest: false
-        node.ml: false
-        cluster.routing.allocation.disk.watermark.low: '50gb'
-        cluster.routing.allocation.disk.watermark.high: '25gb'
+        node.roles: ["data"]
+        cluster.routing.allocation.disk.watermark.low: '100gb'
+        cluster.routing.allocation.disk.watermark.high: '50gb'
         cluster.routing.allocation.disk.watermark.flood_stage: '10gb'
         ingest.geoip.downloader.enabled: false
       podTemplate:
@@ -158,12 +149,9 @@ spec:
     - name: ingest
       count: {{ n_ingest_pods }}
       config:  # https://www.elastic.co/guide/en/elasticsearch/reference/current/settings.html
-        node.master: false
-        node.data: true
-        node.ingest: true
-        node.ml: false
-        cluster.routing.allocation.disk.watermark.low: '50gb'
-        cluster.routing.allocation.disk.watermark.high: '25gb'
+        node.roles: ["data", "ingest"]
+        cluster.routing.allocation.disk.watermark.low: '100gb'
+        cluster.routing.allocation.disk.watermark.high: '50gb'
         cluster.routing.allocation.disk.watermark.flood_stage: '10gb'
         ingest.geoip.downloader.enabled: false
       podTemplate:

--- a/deploy/manifests/elasticsearch/elasticsearch.yaml.jinja2
+++ b/deploy/manifests/elasticsearch/elasticsearch.yaml.jinja2
@@ -4,7 +4,7 @@ metadata:
   name: {{ cluster_name }}
   namespace: {{ namespace }}
 spec:
-  version: 7.17.8
+  version: 7.17.10
   http:
     tls:
       selfSignedCertificate:

--- a/deploy/manifests/elasticsearch/elasticsearch.yaml.jinja2
+++ b/deploy/manifests/elasticsearch/elasticsearch.yaml.jinja2
@@ -2,6 +2,7 @@ apiVersion: elasticsearch.k8s.elastic.co/v1
 kind: Elasticsearch
 metadata:
   name: {{ cluster_name }}
+  namespace: {{ namespace }}
 spec:
   version: 7.17.8
   http:

--- a/deploy/manifests/ingress/gnomad.ingress.yaml
+++ b/deploy/manifests/ingress/gnomad.ingress.yaml
@@ -5,59 +5,59 @@ metadata:
   labels:
     tier: production
   annotations:
-    kubernetes.io/ingress.global-static-ip-name: exac-gnomad-prod
+    kubernetes.io/ingress.global-static-ip-name: gnomad-prod-global-ip
     ingress.gcp.kubernetes.io/pre-shared-cert: gnomad-browser-cert
-    networking.gke.io/v1beta1.FrontendConfig: "gnomad-frontend-config"
+    networking.gke.io/v1beta1.FrontendConfig: 'gnomad-frontend-config'
 spec:
   rules:
-  - host: gnomad.broadinstitute.org
-    http:
-      paths:
-      - backend:
-          service:
-            name: gnomad-reads
-            port:
-              number: 80
-        path: /reads
-        pathType: ImplementationSpecific
-      - backend:
-          service:
-            name: gnomad-reads
-            port:
-              number: 80
-        path: /reads/*
-        pathType: ImplementationSpecific
-      - backend:
-          service:
-            name: gnomad-blog
-            port:
-              number: 80
-        path: /blog
-        pathType: ImplementationSpecific
-      - backend:
-          service:
-            name: gnomad-blog
-            port:
-              number: 80
-        path: /blog/*
-        pathType: ImplementationSpecific
-      - backend:
-          service:
-            name: gnomad-blog
-            port:
-              number: 80
-        path: /news
-        pathType: ImplementationSpecific
-      - backend:
-          service:
-            name: gnomad-blog
-            port:
-              number: 80
-        path: /news/*
-        pathType: ImplementationSpecific
-      - backend:
-          service:
-            name: gnomad-browser
-            port:
-              number: 80
-        pathType: ImplementationSpecific
+    - host: gnomad.broadinstitute.org
+      http:
+        paths:
+          - backend:
+              service:
+                name: gnomad-reads
+                port:
+                  number: 80
+            path: /reads
+            pathType: ImplementationSpecific
+          - backend:
+              service:
+                name: gnomad-reads
+                port:
+                  number: 80
+            path: /reads/*
+            pathType: ImplementationSpecific
+          - backend:
+              service:
+                name: gnomad-blog
+                port:
+                  number: 80
+            path: /blog
+            pathType: ImplementationSpecific
+          - backend:
+              service:
+                name: gnomad-blog
+                port:
+                  number: 80
+            path: /blog/*
+            pathType: ImplementationSpecific
+          - backend:
+              service:
+                name: gnomad-blog
+                port:
+                  number: 80
+            path: /news
+            pathType: ImplementationSpecific
+          - backend:
+              service:
+                name: gnomad-blog
+                port:
+                  number: 80
+            path: /news/*
+            pathType: ImplementationSpecific
+          - backend:
+              service:
+                name: gnomad-browser
+                port:
+                  number: 80
+            pathType: ImplementationSpecific

--- a/deploy/manifests/reads/base/reads.deployment.yaml
+++ b/deploy/manifests/reads/base/reads.deployment.yaml
@@ -30,11 +30,11 @@ spec:
               containerPort: 80
           resources:
             requests:
-              cpu: "50m"
-              memory: "4Gi"
+              cpu: '50m'
+              memory: '4Gi'
             limits:
-              cpu: "100m"
-              memory: "4Gi"
+              cpu: '100m'
+              memory: '4Gi'
           readinessProbe:
             httpGet:
               path: /health/ready
@@ -48,7 +48,7 @@ spec:
           image: gnomad-reads-api
           env:
             - name: PORT
-              value: "8000"
+              value: '8000'
             - name: TRUST_PROXY
               valueFrom:
                 configMapKeyRef:
@@ -59,11 +59,11 @@ spec:
               containerPort: 8000
           resources:
             requests:
-              cpu: "50m"
-              memory: "128Mi"
+              cpu: '50m'
+              memory: '128Mi'
             limits:
-              cpu: "100m"
-              memory: "256Mi"
+              cpu: '100m'
+              memory: '256Mi'
           readinessProbe:
             httpGet:
               path: /health/ready
@@ -74,10 +74,10 @@ spec:
             - name: readviz
               mountPath: /readviz
       nodeSelector:
-        cloud.google.com/gke-nodepool: "main-pool"
+        cloud.google.com/gke-nodepool: 'main-pool'
       volumes:
         - name: readviz
           gcePersistentDisk:
             fsType: ext4
-            pdName: readviz-data-2022-01-20
+            pdName: readviz-data-2022-01-20-new
             readOnly: true

--- a/deploy/manifests/reads/base/reads.deployment.yaml
+++ b/deploy/manifests/reads/base/reads.deployment.yaml
@@ -30,11 +30,11 @@ spec:
               containerPort: 80
           resources:
             requests:
-              cpu: '50m'
-              memory: '4Gi'
+              cpu: "50m"
+              memory: "4Gi"
             limits:
-              cpu: '100m'
-              memory: '4Gi'
+              cpu: "100m"
+              memory: "4Gi"
           readinessProbe:
             httpGet:
               path: /health/ready
@@ -48,7 +48,7 @@ spec:
           image: gnomad-reads-api
           env:
             - name: PORT
-              value: '8000'
+              value: "8000"
             - name: TRUST_PROXY
               valueFrom:
                 configMapKeyRef:
@@ -59,11 +59,11 @@ spec:
               containerPort: 8000
           resources:
             requests:
-              cpu: '50m'
-              memory: '128Mi'
+              cpu: "50m"
+              memory: "128Mi"
             limits:
-              cpu: '100m'
-              memory: '256Mi'
+              cpu: "100m"
+              memory: "256Mi"
           readinessProbe:
             httpGet:
               path: /health/ready
@@ -74,7 +74,7 @@ spec:
             - name: readviz
               mountPath: /readviz
       nodeSelector:
-        cloud.google.com/gke-nodepool: 'default-pool'
+        cloud.google.com/gke-nodepool: "main-pool"
       volumes:
         - name: readviz
           gcePersistentDisk:

--- a/development/api.docker-compose.yaml
+++ b/development/api.docker-compose.yaml
@@ -4,7 +4,7 @@ services:
     command:
       - sh
       - -c
-      - gcloud container clusters get-credentials gnomad --zone=$$ZONE && kubectl port-forward --address=$$(awk 'END { print $$1 }' /etc/hosts) service/gnomad-es-http 9200
+      - gcloud container clusters get-credentials gnomad-prod --zone=$$ZONE && kubectl port-forward --address=$$(awk 'END { print $$1 }' /etc/hosts) service/gnomad-es-http 9200
     environment:
       - PROJECT
       - ZONE

--- a/development/browser.docker-compose.yaml
+++ b/development/browser.docker-compose.yaml
@@ -7,7 +7,7 @@ services:
     command:
       - sh
       - -c
-      - ./browser/build/buildHelp.ts && yarn workspace '@gnomad/browser' run webpack serve --host '0.0.0.0'
+      - yarn run ts-node ./browser/build/buildHelp.ts && yarn workspace '@gnomad/browser' run webpack serve --host '0.0.0.0'
     environment:
       - NODE_ENV=development
       - GNOMAD_API_URL

--- a/graphql-api/src/queries/clinvar-variant-queries.ts
+++ b/graphql-api/src/queries/clinvar-variant-queries.ts
@@ -91,7 +91,7 @@ export const fetchClinvarVariantById = async (
     size: 1,
   })
 
-  if (response.body.hits.total === 0) {
+  if (response.body.hits.total.value === 0) {
     return null
   }
 

--- a/graphql-api/src/queries/gene-queries.ts
+++ b/graphql-api/src/queries/gene-queries.ts
@@ -48,7 +48,7 @@ export const fetchGeneBySymbol = async (esClient: any, geneSymbol: any, referenc
     size: 1,
   })
 
-  if (response.body.hits.total === 0) {
+  if (response.body.hits.total.value === 0) {
     return null
   }
 
@@ -134,7 +134,7 @@ export const fetchGenesMatchingText = async (esClient: any, query: any, referenc
     size: 5,
   })
 
-  if (response.body.hits.total === 0) {
+  if (response.body.hits.total.value === 0) {
     return []
   }
 

--- a/graphql-api/src/queries/helpers/elasticsearch-helpers.ts
+++ b/graphql-api/src/queries/helpers/elasticsearch-helpers.ts
@@ -24,7 +24,7 @@ export const fetchAllSearchResults = async (client: any, searchParams: any) => {
     const response = responseQueue.shift()
     allResults = allResults.concat(response.body.hits.hits)
 
-    if (allResults.length === response.body.hits.total) {
+    if (allResults.length === response.body.hits.total.value) {
       // eslint-disable-next-line no-await-in-loop
       await client.clearScroll({
         scrollId: response.body._scroll_id, // eslint-disable-line no-underscore-dangle
@@ -48,10 +48,9 @@ export const fetchAllSearchResults = async (client: any, searchParams: any) => {
 export const fetchIndexMetadata = async (esClient: any, index: any) => {
   const response = await esClient.indices.getMapping({
     index,
-    type: '_doc',
   })
 
   // @ts-expect-error TS(2571) FIXME: Object is of type 'unknown'.
   // eslint-disable-next-line no-underscore-dangle
-  return Object.values(response.body)[0].mappings._doc._meta
+  return Object.values(response.body)[0].mappings._meta
 }

--- a/graphql-api/src/queries/local-ancestry-queries.ts
+++ b/graphql-api/src/queries/local-ancestry-queries.ts
@@ -30,7 +30,7 @@ export const fetchLocalAncestryPopulationsByVariant = async (
     size: 1,
   })
 
-  if (response.body.hits.total === 0) {
+  if (response.body.hits.total.value === 0) {
     return { exome: [], genome: [] }
   }
 

--- a/graphql-api/src/queries/lof-curation-result-queries.ts
+++ b/graphql-api/src/queries/lof-curation-result-queries.ts
@@ -16,7 +16,7 @@ export const fetchLofCurationResultsByVariant = async (esClient: any, variantId:
     size: 1,
   })
 
-  if (response.body.hits.total === 0) {
+  if (response.body.hits.total.value === 0) {
     return null
   }
 

--- a/graphql-api/src/queries/mitochondrial-variant-datasets/gnomad-v3-mitochondrial-variant-queries.ts
+++ b/graphql-api/src/queries/mitochondrial-variant-datasets/gnomad-v3-mitochondrial-variant-queries.ts
@@ -26,7 +26,7 @@ const fetchMitochondrialVariantById = async (esClient: any, variantIdOrRsid: any
     size: 1,
   })
 
-  if (response.body.hits.total === 0) {
+  if (response.body.hits.total.value === 0) {
     return null
   }
 

--- a/graphql-api/src/queries/structural-variant-datasets/gnomad-sv-v2-queries.ts
+++ b/graphql-api/src/queries/structural-variant-datasets/gnomad-sv-v2-queries.ts
@@ -21,7 +21,7 @@ const fetchStructuralVariantById = async (esClient: any, variantId: any, subset:
     size: 1,
   })
 
-  if (response.body.hits.total === 0) {
+  if (response.body.hits.total.value === 0) {
     return null
   }
 

--- a/graphql-api/src/queries/variant-datasets/exac-variant-queries.ts
+++ b/graphql-api/src/queries/variant-datasets/exac-variant-queries.ts
@@ -64,12 +64,12 @@ export const fetchVariantById = async (esClient: any, variantIdOrRsid: any) => {
     size: 1,
   })
 
-  if (response.body.hits.total === 0) {
+  if (response.body.hits.total.value === 0) {
     throw new UserVisibleError('Variant not found')
   }
 
   // An rsID may match multiple variants
-  if (response.body.hits.total > 1) {
+  if (response.body.hits.total.value > 1) {
     throw new UserVisibleError('Multiple variants found, query using variant ID to select one.')
   }
 

--- a/graphql-api/src/queries/variant-datasets/gnomad-v2-variant-queries.ts
+++ b/graphql-api/src/queries/variant-datasets/gnomad-v2-variant-queries.ts
@@ -89,12 +89,12 @@ const fetchVariantById = async (esClient: any, variantIdOrRsid: any, subset: any
     size: 1,
   })
 
-  if (response.body.hits.total === 0) {
+  if (response.body.hits.total.value === 0) {
     throw new UserVisibleError('Variant not found')
   }
 
   // An rsID may match multiple variants
-  if (response.body.hits.total > 1) {
+  if (response.body.hits.total.value > 1) {
     throw new UserVisibleError('Multiple variants found, query using variant ID to select one.')
   }
 

--- a/graphql-api/src/queries/variant-datasets/gnomad-v3-variant-queries.ts
+++ b/graphql-api/src/queries/variant-datasets/gnomad-v3-variant-queries.ts
@@ -63,12 +63,12 @@ const fetchVariantById = async (esClient: any, variantIdOrRsid: any, subset: any
     size: 1,
   })
 
-  if (response.body.hits.total === 0) {
+  if (response.body.hits.total.value === 0) {
     throw new UserVisibleError('Variant not found')
   }
 
   // An rsID may match multiple variants
-  if (response.body.hits.total > 1) {
+  if (response.body.hits.total.value > 1) {
     throw new UserVisibleError('Multiple variants found, query using variant ID to select one.')
   }
 


### PR DESCRIPTION
This includes changes to the elasticsearch deployment, data-pipeline, and graphQL API (thanks @rileyhgrant ) to support elasticsearch 7. The big issue that this fixes is that due to [elastic's deprecation of index document types](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/removal-of-types.html), our elasticsearch_export and api queries no longer needed to nest their idea of the document structure within a type. I've also updated the `node.roles` config here to match the [most recent config syntax](https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-node-configuration.html), since the one we were using previously was deprecated starting with ES7.

There's a few other changes here that aren't strictly related to the v7 upgrade, but I've included them here, since they'll matter for when we move our prod deployment over to an upgraded cluster:

- The disk watermark settings are now applied to all nodeSets. For whatever reason, only specifying the watermarks on the master nodeset wasn't having any effect.
- Various deployments that were pinned to a 'default-pool' GKE pool are now pinned to 'main-pool', since that will be the name in the new deployment
- The non-data elasticsearch pods are now pinned to 'main-pool' instead of only being told _not_ to deploy onto the 'es-data' pool. This will prevent the ES master and coordinating pods from deploying onto the redis pool.
- Disabled the geoip downloader service in elasticsearch. I don't think we were using the geoip database, and it was creating an unneeded index
- Added a service account association to the elasticsearch nodeSets. This will associate them with the service account that has access to write ES snapshots in the new deployment.
- Various formatting fixes applied by the YAML formatter in my text editor