### PR TITLE
Update location of genomic constraint raw data

### DIFF
--- a/browser/src/DownloadsPage/GnomadV3Downloads.tsx
+++ b/browser/src/DownloadsPage/GnomadV3Downloads.tsx
@@ -359,40 +359,28 @@ const GnomadV3Downloads = () => (
         <ListItem>
           <GenericDownloadLinks
             label="README"
-            gcsBucket="gnomad-nc-constraint-v31-paper"
-            path="/download_files/nc_constraint_gnomad_v31_README.docx"
-            includeAWS={false}
-            includeAzure={false}
+            path="/release/3.1/secondary_analyses/genomic_constraint/nc_constraint_gnomad_v31_README.docx"
           />
         </ListItem>
         {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
         <ListItem>
           <GenericDownloadLinks
             label="Raw genomic constraint by 1kb regions"
-            gcsBucket="gnomad-nc-constraint-v31-paper"
-            path="/download_files/constraint_z_genome_1kb.raw.download.txt.gz"
-            includeAWS={false}
-            includeAzure={false}
+            path="/release/3.1/secondary_analyses/genomic_constraint/constraint_z_genome_1kb.raw.download.txt.gz"
           />
         </ListItem>
         {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
         <ListItem>
           <GenericDownloadLinks
             label="QCed genomic constraint by 1kb regions"
-            gcsBucket="gnomad-nc-constraint-v31-paper"
-            path="/download_files/constraint_z_genome_1kb.qc.download.txt.gz"
-            includeAWS={false}
-            includeAzure={false}
+            path="/release/3.1/secondary_analyses/genomic_constraint/constraint_z_genome_1kb.qc.download.txt.gz"
           />
         </ListItem>
         {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
         <ListItem>
           <GenericDownloadLinks
             label="Non-coding constraint for gene tissue enhancers"
-            gcsBucket="gnomad-nc-constraint-v31-paper"
-            path="/download_files/constraint_z_enh_gene_roadmaplinks.all.download.txt.gz"
-            includeAWS={false}
-            includeAzure={false}
+            path="/release/3.1/secondary_analyses/genomic_constraint/constraint_z_enh_gene_roadmaplinks.all.download.txt.gz"
           />
         </ListItem>
       </FileList>

--- a/browser/src/DownloadsPage/__snapshots__/DownloadsPage.spec.tsx.snap
+++ b/browser/src/DownloadsPage/__snapshots__/DownloadsPage.spec.tsx.snap
@@ -17398,11 +17398,31 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             <a
               aria-label="Download README from Google"
               className="c10"
-              href="https://storage.googleapis.com/gnomad-nc-constraint-v31-paper/download_files/nc_constraint_gnomad_v31_README.docx"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/secondary_analyses/genomic_constraint/nc_constraint_gnomad_v31_README.docx"
               rel="noopener noreferrer"
               target="_blank"
             >
               Google
+            </a>
+             / 
+            <a
+              aria-label="Download README from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/secondary_analyses/genomic_constraint/nc_constraint_gnomad_v31_README.docx"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download README from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/secondary_analyses/genomic_constraint/nc_constraint_gnomad_v31_README.docx"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
             </a>
           </span>
         </li>
@@ -17419,11 +17439,31 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             <a
               aria-label="Download Raw genomic constraint by 1kb regions from Google"
               className="c10"
-              href="https://storage.googleapis.com/gnomad-nc-constraint-v31-paper/download_files/constraint_z_genome_1kb.raw.download.txt.gz"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/secondary_analyses/genomic_constraint/constraint_z_genome_1kb.raw.download.txt.gz"
               rel="noopener noreferrer"
               target="_blank"
             >
               Google
+            </a>
+             / 
+            <a
+              aria-label="Download Raw genomic constraint by 1kb regions from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/secondary_analyses/genomic_constraint/constraint_z_genome_1kb.raw.download.txt.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download Raw genomic constraint by 1kb regions from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/secondary_analyses/genomic_constraint/constraint_z_genome_1kb.raw.download.txt.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
             </a>
           </span>
         </li>
@@ -17440,11 +17480,31 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             <a
               aria-label="Download QCed genomic constraint by 1kb regions from Google"
               className="c10"
-              href="https://storage.googleapis.com/gnomad-nc-constraint-v31-paper/download_files/constraint_z_genome_1kb.qc.download.txt.gz"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/secondary_analyses/genomic_constraint/constraint_z_genome_1kb.qc.download.txt.gz"
               rel="noopener noreferrer"
               target="_blank"
             >
               Google
+            </a>
+             / 
+            <a
+              aria-label="Download QCed genomic constraint by 1kb regions from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/secondary_analyses/genomic_constraint/constraint_z_genome_1kb.qc.download.txt.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download QCed genomic constraint by 1kb regions from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/secondary_analyses/genomic_constraint/constraint_z_genome_1kb.qc.download.txt.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
             </a>
           </span>
         </li>
@@ -17461,11 +17521,31 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             <a
               aria-label="Download Non-coding constraint for gene tissue enhancers from Google"
               className="c10"
-              href="https://storage.googleapis.com/gnomad-nc-constraint-v31-paper/download_files/constraint_z_enh_gene_roadmaplinks.all.download.txt.gz"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/secondary_analyses/genomic_constraint/constraint_z_enh_gene_roadmaplinks.all.download.txt.gz"
               rel="noopener noreferrer"
               target="_blank"
             >
               Google
+            </a>
+             / 
+            <a
+              aria-label="Download Non-coding constraint for gene tissue enhancers from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/secondary_analyses/genomic_constraint/constraint_z_enh_gene_roadmaplinks.all.download.txt.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download Non-coding constraint for gene tissue enhancers from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/secondary_analyses/genomic_constraint/constraint_z_enh_gene_roadmaplinks.all.download.txt.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
             </a>
           </span>
         </li>

--- a/data-pipeline/src/data_pipeline/datasets/gnomad_v3/gnomad_v3_genomic_constraint_regions.py
+++ b/data-pipeline/src/data_pipeline/datasets/gnomad_v3/gnomad_v3_genomic_constraint_regions.py
@@ -16,7 +16,6 @@ def prepare_gnomad_v3_genomic_constraint_regions(genomic_constraint_region_table
         expected=hl.float(ds.expected),
         oe=hl.float(ds.oe),
         z=hl.float(ds.z),
-        coding_prop=hl.float(ds.coding_prop),
     )
 
     ds = ds.key_by("element_id")

--- a/data-pipeline/src/data_pipeline/pipelines/gnomad_v3_genomic_constraint_regions.py
+++ b/data-pipeline/src/data_pipeline/pipelines/gnomad_v3_genomic_constraint_regions.py
@@ -11,7 +11,7 @@ pipeline.add_task(
     prepare_gnomad_v3_genomic_constraint_regions,
     "/constraint/gnomad_v3_genomic_constraint_regions.ht",
     {
-        "genomic_constraint_region_table_path": "gs://gnomad-browser-data-pipeline/output/2022-10-14-ncc/constraint_z_genome_1kb_filtered.browser.txt"
+        "genomic_constraint_region_table_path": "gs://gcp-public-data--gnomad/release/3.1/secondary_analyses/genomic_constraint/constraint_z_genome_1kb.qc.download.txt.gz"
     },
 )
 

--- a/graphql-api/src/graphql/types/variant.graphql
+++ b/graphql-api/src/graphql/types/variant.graphql
@@ -126,7 +126,6 @@ type NonCodingConstraintRegion {
   expected: Float!
   oe: Float!
   z: Float!
-  coding_prop: Float!
 }
 
 type Variant {


### PR DESCRIPTION
Updates the location of Siwei's Genomic Constraint Data to `gs://gcp-public-data--gnomad`, where it is now permanently stored.

Previously, this input data was stored in a bucket owned by Siwei. This data was then copied into a bucket in `exac-gnomad` to ensure that the browser would always have access to this data. 

Now, after the discussion with the Production team regarding the Core Dataset / Secondary Analyses dichotomy, the production team is copying Secondary Analyses data into the `gs://gcp-public-data--gnomad/`, where all the Core Dataset files are already stored. 

This PR changes that location on the downloads page, and in the data pipeline. It also removes one field that was previously included in the Genomic Constraint data release. The pipeline was run successfully locally with the new location, and a dev environment was used to confirm that since the frontend never requests the removed field (`coding_prop`), removing this from the API and the pipeline is safe to do.