### PR TITLE
Fuller type checking

### DIFF
--- a/.github/workflows/browser-ci.yml
+++ b/.github/workflows/browser-ci.yml
@@ -35,6 +35,8 @@ jobs:
         run: yarn run eslint .
       - name: Run stylelint
         run: yarn run stylelint './**/*.(js|jsx|ts|tsx)'
+      - name: Type check
+        run: yarn run ts-node ./browser/build/buildHelp.ts && yarn run typecheck
       - name: Verify clean build
         run: cd browser && yarn build
       - name: Run Jest tests

--- a/browser/src/ConstraintTable/ConstraintTable.tsx
+++ b/browser/src/ConstraintTable/ConstraintTable.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { Gene } from '../GenePage/GenePage'
+import { Transcript } from '../TranscriptPage/TranscriptPage'
 
 import Link from '../Link'
 
@@ -62,8 +63,9 @@ const ConstraintTable = ({ datasetId, geneOrTranscript }: Props) => {
     return <p>Constraint not yet available for gnomAD v3.</p>
   }
 
-  const { transcriptId, transcriptVersion, transcriptDescription } =
-    transcriptDetails(geneOrTranscript)
+  const { transcriptId, transcriptVersion, transcriptDescription } = transcriptDetails(
+    geneOrTranscript
+  )
 
   const gnomadConstraint = geneOrTranscript.gnomad_constraint
   const exacConstraint = geneOrTranscript.exac_constraint

--- a/browser/src/GenePage/GenePageContainer.tsx
+++ b/browser/src/GenePage/GenePageContainer.tsx
@@ -230,7 +230,6 @@ const GenePageContainer = ({ datasetId, geneIdOrSymbol }: Props) => {
   }
 
   return (
-    // @ts-expect-error TS(2769) FIXME: No overload matches this call.
     <BaseQuery operationName={operationName} query={query} variables={variables}>
       {({ data, error, graphQLErrors, loading }: any) => {
         if (loading) {

--- a/browser/src/MNVPage/MNVDetailsQuery.tsx
+++ b/browser/src/MNVPage/MNVDetailsQuery.tsx
@@ -66,7 +66,6 @@ type Props = {
 }
 
 const MNVDetailsQuery = ({ children, datasetId, variantId }: Props) => (
-  // @ts-expect-error TS(2769) FIXME: No overload matches this call.
   <BaseQuery operationName={operationName} query={query} variables={{ datasetId, variantId }}>
     {children}
   </BaseQuery>

--- a/browser/src/Query.tsx
+++ b/browser/src/Query.tsx
@@ -37,16 +37,15 @@ const cancelable = (promise: any) => {
   }
 }
 
-type OwnBaseQueryProps = {
-  operationName: string | null
-  query: string
-  url?: string
-  variables?: any
-}
-
 type BaseQueryState = any
 
-type BaseQueryProps = OwnBaseQueryProps & typeof BaseQuery.defaultProps
+type BaseQueryProps = {
+  operationName: string | null
+  query: string
+  url: string
+  variables?: any
+  children: (state: BaseQueryState) => JSX.Element
+}
 
 export class BaseQuery extends Component<BaseQueryProps, BaseQueryState> {
   static defaultProps = {
@@ -71,7 +70,7 @@ export class BaseQuery extends Component<BaseQueryProps, BaseQueryState> {
   }
 
   componentDidUpdate(prevProps: BaseQueryProps) {
-    const { operationName, query, variables } = this.props
+    const { query, variables } = this.props
     if (query !== prevProps.query || !areVariablesEqual(variables, prevProps.variables)) {
       this.loadData()
     }
@@ -134,7 +133,6 @@ export class BaseQuery extends Component<BaseQueryProps, BaseQueryState> {
   }
 
   render() {
-    // @ts-expect-error TS(2339) FIXME: Property 'children' does not exist on type 'Readon... Remove this comment to see the full error message
     const { children } = this.props
     return children(this.state)
   }
@@ -148,7 +146,7 @@ type OwnQueryProps = {
   operationName: string | null
   query: string
   success?: (...args: any[]) => any
-  url?: string
+  url: string
   variables?: any
 }
 
@@ -168,7 +166,6 @@ const Query = ({
   variables,
 }: QueryProps) => {
   return (
-    // @ts-expect-error TS(2769) FIXME: No overload matches this call.
     <BaseQuery operationName={operationName} query={query} url={url} variables={variables}>
       {({ data, error, graphQLErrors, loading }: any) => {
         if (loading) {

--- a/browser/src/ReadData/ReadData.tsx
+++ b/browser/src/ReadData/ReadData.tsx
@@ -461,7 +461,6 @@ const ReadDataContainer = ({ datasetId, variantIds }: ReadDataContainerProps) =>
   `
 
   return (
-    // @ts-expect-error TS(2769) FIXME: No overload matches this call.
     <BaseQuery query={query} url="/reads/">
       {({ data, error, graphQLErrors, loading }: any) => {
         if (loading) {

--- a/browser/src/VariantPage/VariantPage.tsx
+++ b/browser/src/VariantPage/VariantPage.tsx
@@ -513,7 +513,6 @@ const VariantPage = ({ datasetId, variantId }: VariantPageProps) => {
       <DocumentTitle title={`${variantId} | ${labelForDataset(datasetId)}`} />
       <BaseQuery
         key={datasetId}
-        // @ts-expect-error TS(2769) FIXME: No overload matches this call.
         operationName={operationName}
         query={variantQuery}
         variables={{

--- a/browser/src/queryHelperExample.spec.tsx
+++ b/browser/src/queryHelperExample.spec.tsx
@@ -6,7 +6,7 @@ import React from 'react'
 import renderer from 'react-test-renderer'
 
 // These next imports must appear in this order
-import { jest } from '@jest/globals'
+import { jest, expect } from '@jest/globals'
 import { mockQueries } from '../../tests/__helpers__/queries'
 import Query, { BaseQuery } from './Query'
 
@@ -29,7 +29,6 @@ const {
   resetMockApiResponses,
   simulateApiResponse,
   setMockApiResponses,
-  mockApiCalls,
 } = mockQueries()
 
 // You can do this on a test-by-test basis too, rather than beforeEach.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "test:jest": "jest",
     "test:jest:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",
     "test:cypress:headless": "cd browser && cypress run",
-    "test:full": "yarn test:jest && yarn test:cypress:headless"
+    "test:full": "yarn test:jest && yarn test:cypress:headless",
+    "typecheck": "yarn run tsc --noEmit",
+    "typecheck:watch": "yarn run tsc -w --noEmit"
   },
   "engines": {
     "node": ">=14.15.2 <15.0.0"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -99,5 +99,6 @@
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true /* Skip type checking all .d.ts files. */
-  }
+  },
+  "exclude": ["browser/dist/**/*"]
 }


### PR DESCRIPTION
It turns out that even with full Typescript support turned on, build tools such as `babel` silently discard TS type errors, and there's no way to get those tools to do otherwise (I can't explain why they do this: it seems like that immediately takes away most of the value of supporting TS in the first place). The recommendation, if you really want to make sure your types are checked in full, is to run a separate pass with `tsc` to explicitly do so.

Here we add some scripts to allow a dev to run those checks easily, and a corresponding CI step. We also fix a handful of type errors that this process turned up: there might have been more of them, but there are several other junctures in our dev workflow where types are checked to some partial extent, so many possible errors were indeed caught at some point.