### PR TITLE
Centralized metadata on Variant page

### DIFF
--- a/browser/src/GenePage/GenePage.spec.tsx
+++ b/browser/src/GenePage/GenePage.spec.tsx
@@ -33,13 +33,13 @@ const {
 
 beforeEach(() => {
   Query.mockImplementation(
-    jest.fn(({ children, operationName, variables }) =>
-      simulateApiResponse('Query', children, operationName, variables)
+    jest.fn(({ children, operationName, variables, query }) =>
+      simulateApiResponse('Query', query, children, operationName, variables)
     )
   )
   ;(BaseQuery as any).mockImplementation(
-    jest.fn(({ children, operationName, variables }) =>
-      simulateApiResponse('BaseQuery', children, operationName, variables)
+    jest.fn(({ children, operationName, variables, query }) =>
+      simulateApiResponse('BaseQuery', query, children, operationName, variables)
     )
   )
 })

--- a/browser/src/ReadData/ReadData.tsx
+++ b/browser/src/ReadData/ReadData.tsx
@@ -435,7 +435,7 @@ const ReadDataContainer = ({ datasetId, variantIds }: ReadDataContainerProps) =>
   }
 
   const query = `
-    {
+    query ReadData {
       ${variantIds
         .map(
           (
@@ -461,7 +461,7 @@ const ReadDataContainer = ({ datasetId, variantIds }: ReadDataContainerProps) =>
   `
 
   return (
-    <BaseQuery query={query} url="/reads/">
+    <BaseQuery operationName="ReadData" query={query} url="/reads/">
       {({ data, error, graphQLErrors, loading }: any) => {
         if (loading) {
           return <StatusMessage>Loading reads...</StatusMessage>

--- a/browser/src/VariantPage/GnomadAgeDistribution.tsx
+++ b/browser/src/VariantPage/GnomadAgeDistribution.tsx
@@ -7,6 +7,12 @@ import { Checkbox, Select } from '@gnomad/ui'
 
 import gnomadV2AgeDistribution from '@gnomad/dataset-metadata/datasets/gnomad-v2/ageDistribution.json'
 import gnomadV3AgeDistribution from '@gnomad/dataset-metadata/datasets/gnomad-v3/ageDistribution.json'
+import {
+  DatasetId,
+  isV2,
+  isV3,
+  showAllIndividualsInAgeDistributionByDefault,
+} from '@gnomad/dataset-metadata/metadata'
 
 import Legend, { StripedSwatch } from '../Legend'
 import StackedHistogram from '../StackedHistogram'
@@ -75,9 +81,9 @@ const prepareVariantData = ({
 
 const prepareOverallData = ({ datasetId, includeExomes, includeGenomes }: any) => {
   let overallAgeDistribution = null
-  if (datasetId.startsWith('gnomad_r3')) {
+  if (isV3(datasetId)) {
     overallAgeDistribution = gnomadV3AgeDistribution
-  } else if (datasetId.startsWith('gnomad_r2')) {
+  } else if (isV2(datasetId)) {
     overallAgeDistribution = gnomadV2AgeDistribution
   }
 
@@ -118,7 +124,7 @@ const getDefaultSelectedSequencingType = (variant: any) => {
 }
 
 type GnomadAgeDistributionProps = {
-  datasetId: string
+  datasetId: DatasetId
   variant: Variant
 }
 
@@ -131,7 +137,9 @@ const GnomadAgeDistribution = ({ datasetId, variant }: GnomadAgeDistributionProp
   const [includeHomozygotes, setIncludeHomozygotes] = useState(true)
 
   const showVariantCarriers = includeHeterozygotes || includeHomozygotes
-  const [showAllIndividuals, setShowAllIndividuals] = useState(datasetId !== 'exac')
+  const [showAllIndividuals, setShowAllIndividuals] = useState(
+    showAllIndividualsInAgeDistributionByDefault(datasetId)
+  )
 
   // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   const binEdges = (variant.exome || variant.genome).age_distribution.het.bin_edges

--- a/browser/src/VariantPage/GnomadAgeDistribution.tsx
+++ b/browser/src/VariantPage/GnomadAgeDistribution.tsx
@@ -11,6 +11,7 @@ import gnomadV3AgeDistribution from '@gnomad/dataset-metadata/datasets/gnomad-v3
 import Legend, { StripedSwatch } from '../Legend'
 import StackedHistogram from '../StackedHistogram'
 import ControlSection from './ControlSection'
+import { Variant } from './VariantPage'
 
 const LegendWrapper = styled.div`
   display: flex;
@@ -118,15 +119,7 @@ const getDefaultSelectedSequencingType = (variant: any) => {
 
 type GnomadAgeDistributionProps = {
   datasetId: string
-  variant: {
-    chrom: string
-    exome?: {
-      age_distribution: AgeDistributionPropType
-    }
-    genome?: {
-      age_distribution: AgeDistributionPropType
-    }
-  }
+  variant: Variant
 }
 
 const GnomadAgeDistribution = ({ datasetId, variant }: GnomadAgeDistributionProps) => {

--- a/browser/src/VariantPage/GnomadPopulationsTable.tsx
+++ b/browser/src/VariantPage/GnomadPopulationsTable.tsx
@@ -6,6 +6,7 @@ import { Checkbox } from '@gnomad/ui'
 import { GNOMAD_POPULATION_NAMES } from '@gnomad/dataset-metadata/gnomadPopulations'
 
 import { PopulationsTable } from './PopulationsTable'
+import { Population } from './VariantPage'
 
 const ControlSection = styled.div`
   margin-top: 1em;
@@ -102,20 +103,8 @@ const nestPopulations = (populations: any) => {
 
 type OwnGnomadPopulationsTableProps = {
   datasetId: string
-  exomePopulations: {
-    id: string
-    ac: number
-    an: number
-    ac_hemi?: number
-    ac_hom: number
-  }[]
-  genomePopulations: {
-    id: string
-    ac: number
-    an: number
-    ac_hemi?: number
-    ac_hom: number
-  }[]
+  exomePopulations: Population[]
+  genomePopulations: Population[]
   showHemizygotes?: boolean
   showHomozygotes?: boolean
 }
@@ -144,13 +133,8 @@ export class GnomadPopulationsTable extends Component<
   }
 
   render() {
-    const {
-      datasetId,
-      exomePopulations,
-      genomePopulations,
-      showHemizygotes,
-      showHomozygotes,
-    } = this.props
+    const { datasetId, exomePopulations, genomePopulations, showHemizygotes, showHomozygotes } =
+      this.props
     const { includeExomes, includeGenomes } = this.state
 
     let includedPopulations: any = []

--- a/browser/src/VariantPage/GnomadPopulationsTable.tsx
+++ b/browser/src/VariantPage/GnomadPopulationsTable.tsx
@@ -4,9 +4,9 @@ import styled from 'styled-components'
 import { Checkbox } from '@gnomad/ui'
 
 import { GNOMAD_POPULATION_NAMES } from '@gnomad/dataset-metadata/gnomadPopulations'
-
 import { PopulationsTable } from './PopulationsTable'
 import { Population } from './VariantPage'
+import { DatasetId, hasGenome } from '@gnomad/dataset-metadata/metadata'
 
 const ControlSection = styled.div`
   margin-top: 1em;
@@ -102,7 +102,7 @@ const nestPopulations = (populations: any) => {
 }
 
 type OwnGnomadPopulationsTableProps = {
-  datasetId: string
+  datasetId: DatasetId
   exomePopulations: Population[]
   genomePopulations: Population[]
   showHemizygotes?: boolean
@@ -146,7 +146,7 @@ export class GnomadPopulationsTable extends Component<
     }
 
     let populations = nestPopulations(addPopulationNames(mergePopulations(includedPopulations)))
-    if (datasetId.startsWith('gnomad_r2_1') && includeGenomes) {
+    if (hasGenome(datasetId) && includeGenomes) {
       populations = populations.map((pop) => {
         if (pop.id === 'eas') {
           // If the variant is only present in genomes, sub-continental populations won't be present at all.
@@ -181,7 +181,7 @@ export class GnomadPopulationsTable extends Component<
           showHemizygotes={showHemizygotes}
           showHomozygotes={showHomozygotes}
         />
-        {datasetId.startsWith('gnomad_r2_1') && includeGenomes && (
+        {hasGenome(datasetId) && includeGenomes && (
           <p>
             * Allele frequencies for some sub-continental populations were not computed for genome
             samples.

--- a/browser/src/VariantPage/VariantClinvarInfo.tsx
+++ b/browser/src/VariantPage/VariantClinvarInfo.tsx
@@ -4,6 +4,7 @@ import { ExternalLink, List, ListItem, Modal, TextButton } from '@gnomad/ui'
 
 import AttributeList from '../AttributeList'
 import formatClinvarDate from '../ClinvarVariantsTrack/formatClinvarDate'
+import { ClinvarVariant } from './VariantPage'
 
 type SubmissionsListProps = {
   submissions: {
@@ -64,32 +65,13 @@ const SubmissionsList = ({ submissions }: SubmissionsListProps) => (
 )
 
 type VariantClinvarInfoProps = {
-  variant: {
-    clinvar: {
-      clinical_significance: string
-      clinvar_variation_id: string
-      gold_stars: number
-      last_evaluated?: string
-      release_date: string
-      review_status: string
-      submissions: {
-        clinical_significance: string
-        conditions?: {
-          medgen_id?: string
-          name: string
-        }[]
-        last_evaluated?: string
-        review_status: string
-        submitter_name: string
-      }[]
-    }
-  }
+  clinvar: ClinvarVariant
 }
 
-const VariantClinvarInfo = ({ variant }: VariantClinvarInfoProps) => {
+const VariantClinvarInfo = ({ clinvar }: VariantClinvarInfoProps) => {
   const [isSubmissionsModalOpen, setIsSubmissionsModalOpen] = useState(false)
 
-  const conditions = variant.clinvar.submissions
+  const conditions = clinvar.submissions
     .flatMap((submission: any) => submission.conditions)
     .reduce(
       (acc, condition) => ({
@@ -104,7 +86,7 @@ const VariantClinvarInfo = ({ variant }: VariantClinvarInfoProps) => {
       <AttributeList>
         {/* @ts-expect-error TS(2604) FIXME: JSX element type 'AttributeList.Item' does not hav... Remove this comment to see the full error message */}
         <AttributeList.Item label="ClinVar Variation ID">
-          {variant.clinvar.clinvar_variation_id}
+          {clinvar.clinvar_variation_id}
         </AttributeList.Item>
         {/* @ts-expect-error TS(2604) FIXME: JSX element type 'AttributeList.Item' does not hav... Remove this comment to see the full error message */}
         <AttributeList.Item label="Conditions">
@@ -129,16 +111,16 @@ const VariantClinvarInfo = ({ variant }: VariantClinvarInfoProps) => {
         </AttributeList.Item>
         {/* @ts-expect-error TS(2604) FIXME: JSX element type 'AttributeList.Item' does not hav... Remove this comment to see the full error message */}
         <AttributeList.Item label="Clinical significance">
-          {variant.clinvar.clinical_significance}
+          {clinvar.clinical_significance}
         </AttributeList.Item>
         {/* @ts-expect-error TS(2604) FIXME: JSX element type 'AttributeList.Item' does not hav... Remove this comment to see the full error message */}
         <AttributeList.Item label="Review status">
-          {variant.clinvar.review_status} ({variant.clinvar.gold_stars}{' '}
-          {variant.clinvar.gold_stars === 1 ? 'star' : 'stars'})
+          {clinvar.review_status} ({clinvar.gold_stars}{' '}
+          {clinvar.gold_stars === 1 ? 'star' : 'stars'})
         </AttributeList.Item>
         {/* @ts-expect-error TS(2604) FIXME: JSX element type 'AttributeList.Item' does not hav... Remove this comment to see the full error message */}
         <AttributeList.Item label="Last evaluated">
-          {variant.clinvar.last_evaluated ? formatClinvarDate(variant.clinvar.last_evaluated) : '–'}
+          {clinvar.last_evaluated ? formatClinvarDate(clinvar.last_evaluated) : '–'}
         </AttributeList.Item>
       </AttributeList>
 
@@ -149,19 +131,19 @@ const VariantClinvarInfo = ({ variant }: VariantClinvarInfoProps) => {
           }}
         >
           See{' '}
-          {variant.clinvar.submissions.length === 1
+          {clinvar.submissions.length === 1
             ? 'submission'
-            : `all ${variant.clinvar.submissions.length} submissions`}
+            : `all ${clinvar.submissions.length} submissions`}
         </TextButton>{' '}
         or find more information on the{' '}
         {/* @ts-expect-error TS(2786) FIXME: 'ExternalLink' cannot be used as a JSX component. */}
         <ExternalLink
-          href={`https://www.ncbi.nlm.nih.gov/clinvar/variation/${variant.clinvar.clinvar_variation_id}/`}
+          href={`https://www.ncbi.nlm.nih.gov/clinvar/variation/${clinvar.clinvar_variation_id}/`}
         >
           ClinVar website
         </ExternalLink>
-        . Data displayed here is from ClinVar&apos;s{' '}
-        {formatClinvarDate(variant.clinvar.release_date)} release.
+        . Data displayed here is from ClinVar&apos;s {formatClinvarDate(clinvar.release_date)}{' '}
+        release.
       </p>
 
       {isSubmissionsModalOpen && (
@@ -172,7 +154,7 @@ const VariantClinvarInfo = ({ variant }: VariantClinvarInfoProps) => {
             setIsSubmissionsModalOpen(false)
           }}
         >
-          <SubmissionsList submissions={variant.clinvar.submissions} />
+          <SubmissionsList submissions={clinvar.submissions} />
         </Modal>
       )}
     </>

--- a/browser/src/VariantPage/VariantGenotypeQualityMetrics.tsx
+++ b/browser/src/VariantPage/VariantGenotypeQualityMetrics.tsx
@@ -8,6 +8,7 @@ import { Checkbox, Select, Tabs } from '@gnomad/ui'
 import Legend, { StripedSwatch } from '../Legend'
 import StackedHistogram from '../StackedHistogram'
 import ControlSection from './ControlSection'
+import { Variant } from './VariantPage'
 
 const LegendWrapper = styled.div`
   display: flex;
@@ -61,14 +62,7 @@ const getDefaultSelectedSequencingType = (variant: any) => {
 
 type VariantGenotypeQualityMetricsProps = {
   datasetId: string
-  variant: {
-    exome?: {
-      quality_metrics: GenotypeQualityMetricPropType
-    }
-    genome?: {
-      quality_metrics: GenotypeQualityMetricPropType
-    }
-  }
+  variant: Variant
 }
 
 const VariantGenotypeQualityMetrics = ({

--- a/browser/src/VariantPage/VariantGenotypeQualityMetrics.tsx
+++ b/browser/src/VariantPage/VariantGenotypeQualityMetrics.tsx
@@ -10,6 +10,12 @@ import StackedHistogram from '../StackedHistogram'
 import ControlSection from './ControlSection'
 import { Variant } from './VariantPage'
 
+import {
+  DatasetId,
+  metricsIncludeLowQualityGenotypes,
+  hasAlleleBalance,
+} from '@gnomad/dataset-metadata/metadata'
+
 const LegendWrapper = styled.div`
   display: flex;
   justify-content: space-between;
@@ -61,7 +67,7 @@ const getDefaultSelectedSequencingType = (variant: any) => {
 }
 
 type VariantGenotypeQualityMetricsProps = {
-  datasetId: string
+  datasetId: DatasetId
   variant: Variant
 }
 
@@ -244,7 +250,7 @@ const VariantGenotypeQualityMetrics = ({
     },
   ]
 
-  if (datasetId !== 'exac') {
+  if (hasAlleleBalance(datasetId)) {
     tabs.push({
       id: 'allele_balance',
       label: 'Allele balance for heterozygotes',
@@ -316,7 +322,7 @@ const VariantGenotypeQualityMetrics = ({
         </label>
       </ControlSection>
 
-      {(datasetId.startsWith('gnomad_r2') || datasetId === 'exac') && (
+      {metricsIncludeLowQualityGenotypes(datasetId) && (
         <p>
           Note: This plot may include low-quality genotypes that were excluded from allele counts in
           the tables above.

--- a/browser/src/VariantPage/VariantPage.spec.tsx
+++ b/browser/src/VariantPage/VariantPage.spec.tsx
@@ -6,7 +6,7 @@ import renderer from 'react-test-renderer'
 import { forDatasetsMatching, forDatasetsNotMatching } from '../../../tests/__helpers__/datasets'
 import { withDummyRouter } from '../../../tests/__helpers__/router'
 import VariantPage from './VariantPage'
-import { v3VariantFactory } from '../__factories__/Variant'
+import { v2VariantFactory, v3VariantFactory } from '../__factories__/Variant'
 
 jest.mock('../Query', () => {
   const originalModule = jest.requireActual('../Query')
@@ -65,6 +65,23 @@ forDatasetsMatching(/gnomad_r3/, 'VariantPage with dataset "%s"', (datasetId) =>
   })
 })
 
-forDatasetsNotMatching(/gnomad_r3/, 'VariantPage with dataset %s', () => {
+forDatasetsMatching(/gnomad_r2/, 'VariantPage with dataset %s', (datasetId) => {
+  test('has no unexpected changes', () => {
+    const variant = v2VariantFactory.build()
+
+    setMockApiResponses({
+      GnomadVariant: () => ({ variant }),
+      ReadData: () => ({
+        variant_0: { exome: null, genome: [] },
+      }),
+    })
+    const tree = renderer.create(
+      withDummyRouter(<VariantPage datasetId={datasetId} variantId={variant.variant_id} />)
+    )
+    expect(tree).toMatchSnapshot()
+  })
+})
+
+forDatasetsNotMatching(/gnomad_r[23]/, 'VariantPage with dataset %s', () => {
   test.todo('be correct')
 })

--- a/browser/src/VariantPage/VariantPage.spec.tsx
+++ b/browser/src/VariantPage/VariantPage.spec.tsx
@@ -82,6 +82,19 @@ forDatasetsMatching(/gnomad_r2/, 'VariantPage with dataset %s', (datasetId) => {
   })
 })
 
-forDatasetsNotMatching(/gnomad_r[23]/, 'VariantPage with dataset %s', () => {
-  test.todo('be correct')
+describe('VariantPage with dataset exac', () => {
+  test('has no unexpected changes', () => {
+    const variant = v2VariantFactory.build()
+
+    setMockApiResponses({
+      GnomadVariant: () => ({ variant }),
+      ReadData: () => ({
+        variant_0: { exome: null, genome: [] },
+      }),
+    })
+    const tree = renderer.create(
+      withDummyRouter(<VariantPage datasetId="exac" variantId={variant.variant_id} />)
+    )
+    expect(tree).toMatchSnapshot()
+  })
 })

--- a/browser/src/VariantPage/VariantPage.spec.tsx
+++ b/browser/src/VariantPage/VariantPage.spec.tsx
@@ -1,0 +1,70 @@
+import React from 'react'
+import { jest, expect, test } from '@jest/globals'
+import { mockQueries } from '../../../tests/__helpers__/queries'
+import Query, { BaseQuery } from '../Query'
+import renderer from 'react-test-renderer'
+import { forDatasetsMatching, forDatasetsNotMatching } from '../../../tests/__helpers__/datasets'
+import { withDummyRouter } from '../../../tests/__helpers__/router'
+import VariantPage from './VariantPage'
+import { v3VariantFactory } from '../__factories__/Variant'
+
+jest.mock('../Query', () => {
+  const originalModule = jest.requireActual('../Query')
+
+  return {
+    __esModule: true,
+    ...(originalModule as Object),
+    default: jest.fn(),
+    BaseQuery: jest.fn(),
+  }
+})
+
+const {
+  resetMockApiCalls,
+  resetMockApiResponses,
+  simulateApiResponse,
+  setMockApiResponses,
+} = mockQueries()
+
+beforeEach(() => {
+  Query.mockImplementation(
+    jest.fn(({ query, children, operationName, variables }) =>
+      simulateApiResponse('Query', query, children, operationName, variables)
+    )
+  )
+  // The semicolon is due to a quirk of JS/TS parsing--try taking it out and
+  // you'll see what happens.
+  // Also, it's not clear why we have to cast BaseQuery here but not Query
+  // above.
+  ;(BaseQuery as any).mockImplementation(
+    jest.fn(({ query, children, operationName, variables }) =>
+      simulateApiResponse('BaseQuery', query, children, operationName, variables)
+    )
+  )
+})
+
+afterEach(() => {
+  resetMockApiCalls()
+  resetMockApiResponses()
+})
+
+forDatasetsMatching(/gnomad_r3/, 'VariantPage with dataset "%s"', (datasetId) => {
+  test('has no unexpected changes', () => {
+    const variant = v3VariantFactory.build()
+
+    setMockApiResponses({
+      GnomadVariant: () => ({ variant }),
+      ReadData: () => ({
+        variant_0: { exome: null, genome: [] },
+      }),
+    })
+    const tree = renderer.create(
+      withDummyRouter(<VariantPage datasetId={datasetId} variantId={variant.variant_id} />)
+    )
+    expect(tree).toMatchSnapshot()
+  })
+})
+
+forDatasetsNotMatching(/gnomad_r3/, 'VariantPage with dataset %s', () => {
+  test.todo('be correct')
+})

--- a/browser/src/VariantPage/VariantPage.tsx
+++ b/browser/src/VariantPage/VariantPage.tsx
@@ -253,7 +253,7 @@ type VariantPageContentProps = {
   variant: Variant
 }
 
-const VariantPageContent = ({ datasetId, variant }: VariantPageContentProps) => {
+export const VariantPageContent = ({ datasetId, variant }: VariantPageContentProps) => {
   return (
     <FlexWrapper>
       <ResponsiveSection>

--- a/browser/src/VariantPage/VariantPopulationFrequencies.tsx
+++ b/browser/src/VariantPage/VariantPopulationFrequencies.tsx
@@ -7,20 +7,11 @@ import { GnomadPopulationsTable } from './GnomadPopulationsTable'
 import LocalAncestryPopulationsTable from './LocalAncestryPopulationsTable'
 import HGDPPopulationsTable from './HGDPPopulationsTable'
 import TGPPopulationsTable from './TGPPopulationsTable'
+import { Variant } from './VariantPage'
 
 type Props = {
   datasetId: string
-  variant: {
-    chrom: string
-    exome?: {
-      populations: any[]
-      local_ancestry_populations?: any[]
-    }
-    genome?: {
-      populations: any[]
-      local_ancestry_populations?: any[]
-    }
-  }
+  variant: Variant
 }
 
 const VariantPopulationFrequencies = ({ datasetId, variant }: Props) => {
@@ -115,7 +106,6 @@ const VariantPopulationFrequencies = ({ datasetId, variant }: Props) => {
                 return <p>Local ancestry is not available for subsets of gnomAD v3.</p>
               }
 
-              // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
               if (localAncestryPopulations.length === 0) {
                 return (
                   <p>
@@ -128,7 +118,6 @@ const VariantPopulationFrequencies = ({ datasetId, variant }: Props) => {
 
               return (
                 <TableWrapper>
-                  {/* @ts-expect-error TS(2322) FIXME: Type 'any[] | undefined' is not assignable to type... Remove this comment to see the full error message */}
                   <LocalAncestryPopulationsTable populations={localAncestryPopulations} />
                 </TableWrapper>
               )

--- a/browser/src/VariantPage/VariantPopulationFrequencies.tsx
+++ b/browser/src/VariantPage/VariantPopulationFrequencies.tsx
@@ -8,29 +8,32 @@ import LocalAncestryPopulationsTable from './LocalAncestryPopulationsTable'
 import HGDPPopulationsTable from './HGDPPopulationsTable'
 import TGPPopulationsTable from './TGPPopulationsTable'
 import { Variant } from './VariantPage'
+import {
+  DatasetId,
+  hasLocalAncestryPopulations,
+  isSubset,
+  has1000GenomesPopulationFrequencies,
+} from '@gnomad/dataset-metadata/metadata'
 
 type Props = {
-  datasetId: string
+  datasetId: DatasetId
   variant: Variant
 }
 
 const VariantPopulationFrequencies = ({ datasetId, variant }: Props) => {
-  if (datasetId.startsWith('gnomad_r3')) {
-    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
-    const gnomadPopulations = variant.genome.populations.filter(
+  if (hasLocalAncestryPopulations(datasetId)) {
+    const genome = variant.genome!
+    const gnomadPopulations = genome.populations.filter(
       (pop) => !(pop.id.startsWith('hgdp:') || pop.id.startsWith('1kg:'))
     )
-    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
-    const hgdpPopulations = variant.genome.populations
+    const hgdpPopulations = genome.populations
       .filter((pop) => pop.id.startsWith('hgdp:'))
       .map((pop) => ({ ...pop, id: pop.id.slice(5) })) // Remove hgdp: prefix
-    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
-    const tgpPopulations = variant.genome.populations
+    const tgpPopulations = genome.populations
       .filter((pop) => pop.id.startsWith('1kg:'))
       .map((pop) => ({ ...pop, id: pop.id.slice(4) })) // Remove 1kg: prefix
 
-    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
-    const localAncestryPopulations = variant.genome.local_ancestry_populations
+    const localAncestryPopulations = genome.local_ancestry_populations
 
     return (
       // @ts-expect-error TS(2741) FIXME: Property 'onChange' is missing in type '{ tabs: { ... Remove this comment to see the full error message
@@ -80,7 +83,7 @@ const VariantPopulationFrequencies = ({ datasetId, variant }: Props) => {
                 )
               }
 
-              if (datasetId === 'gnomad_r3_non_v2') {
+              if (has1000GenomesPopulationFrequencies(datasetId)) {
                 return (
                   <p>
                     1000 Genomes Project population frequencies are not available for this subset.
@@ -102,7 +105,7 @@ const VariantPopulationFrequencies = ({ datasetId, variant }: Props) => {
             id: 'local-ancestry',
             label: 'Local Ancestry',
             render: () => {
-              if (datasetId !== 'gnomad_r3') {
+              if (isSubset(datasetId)) {
                 return <p>Local ancestry is not available for subsets of gnomAD v3.</p>
               }
 

--- a/browser/src/VariantPage/VariantRelatedVariants.tsx
+++ b/browser/src/VariantPage/VariantRelatedVariants.tsx
@@ -5,6 +5,7 @@ import Link from '../Link'
 import MNVSummaryList from '../MNVPage/MNVSummaryList'
 import VariantLiftover from './VariantLiftover'
 import { Variant } from './VariantPage'
+import { hasRelatedVariants } from '@gnomad/dataset-metadata/metadata'
 
 const CODING_AND_UTR_VEP_CONSEQUENCES = new Set([
   'transcript_ablation',
@@ -32,7 +33,7 @@ const CODING_AND_UTR_VEP_CONSEQUENCES = new Set([
 ])
 
 const isVariantEligibleForCooccurrence = (variant: any, datasetId: any) => {
-  if (datasetId !== 'gnomad_r2_1') {
+  if (hasRelatedVariants(datasetId)) {
     return false
   }
 

--- a/browser/src/VariantPage/VariantRelatedVariants.tsx
+++ b/browser/src/VariantPage/VariantRelatedVariants.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components'
 import Link from '../Link'
 import MNVSummaryList from '../MNVPage/MNVSummaryList'
 import VariantLiftover from './VariantLiftover'
+import { Variant } from './VariantPage'
 
 const CODING_AND_UTR_VEP_CONSEQUENCES = new Set([
   'transcript_ablation',
@@ -70,16 +71,7 @@ const getLocusWindow = ({ chrom, pos }: any, range = 20) => {
 
 type VariantRelatedVariantsProps = {
   datasetId: string
-  variant: {
-    variant_id: string
-    colocated_variants?: string[]
-    liftover?: any[]
-    liftover_sources?: any[]
-    multi_nucleotide_variants?: any[]
-    exome?: any
-    genome?: any
-    transcript_consequences?: any[]
-  }
+  variant: Variant
 }
 
 const VariantRelatedVariants = ({ datasetId, variant }: VariantRelatedVariantsProps) => {

--- a/browser/src/VariantPage/VariantSiteQualityMetrics.tsx
+++ b/browser/src/VariantPage/VariantSiteQualityMetrics.tsx
@@ -14,6 +14,7 @@ import gnomadV3SiteQualityMetricDistributions from '@gnomad/dataset-metadata/dat
 import Legend from '../Legend'
 import ControlSection from './ControlSection'
 import { Variant, SequencingType } from './VariantPage'
+import { DatasetId, isV2, isV3, isExac } from '@gnomad/dataset-metadata/metadata'
 
 // ================================================================================================
 // Metric descriptions
@@ -45,7 +46,7 @@ const qualityMetricDescriptions = {
 }
 
 const getSiteQualityMetricDescription = (datasetId: any) => {
-  return datasetId.startsWith('gnomad_r2') || datasetId === 'exac'
+  return isV2(datasetId) || isExac(datasetId)
     ? 'Phred-scaled quality score for the assertion made in ALT. i.e. −10log10 prob(no variant). High Phred-scaled quality scores indicate high confidence calls.'
     : 'Sum of PL[0] values; used to approximate the Phred-scaled quality score for the assertion made in ALT. i.e. −10log10 prob(no variant). High Phred-scaled quality scores indicate high confidence calls.'
 }
@@ -343,19 +344,19 @@ const prepareData = ({
   metric,
   variant,
 }: {
-  datasetId: string
+  datasetId: DatasetId
   metric: string
   variant: Variant
 }) => {
-  if (datasetId.startsWith('gnomad_r3')) {
+  if (isV3(datasetId)) {
     return prepareDataGnomadV3({ metric, genome: variant.genome! })
   }
 
-  if (datasetId.startsWith('gnomad_r2')) {
+  if (isV2(datasetId)) {
     return prepareDataGnomadV2({ metric, variant })
   }
 
-  if (datasetId === 'exac') {
+  if (isExac(datasetId)) {
     return prepareDataExac({ metric, variant })
   }
 
@@ -363,7 +364,7 @@ const prepareData = ({
 }
 
 const getAvailableMetrics = (datasetId: any) => {
-  if (datasetId.startsWith('gnomad_r3')) {
+  if (isV3(datasetId)) {
     return [
       'SiteQuality',
       'InbreedingCoeff',
@@ -380,7 +381,7 @@ const getAvailableMetrics = (datasetId: any) => {
     ]
   }
 
-  if (datasetId.startsWith('gnomad_r2')) {
+  if (isV2(datasetId)) {
     return [
       'BaseQRankSum',
       'ClippingRankSum',
@@ -399,7 +400,7 @@ const getAvailableMetrics = (datasetId: any) => {
     ]
   }
 
-  if (datasetId === 'exac') {
+  if (isExac(datasetId)) {
     return [
       'BaseQRankSum',
       'ClippingRankSum',
@@ -817,17 +818,17 @@ const AutosizedSiteQualityMetricsHistogram = withSize()(({ size, ...props }) => 
 ))
 
 type VariantSiteQualityMetricsDistributionProps = {
-  datasetId: string
+  datasetId: DatasetId
   variant: Variant
 }
 
 type VariantSiteQualityMetricsTableProps = {
-  datasetId: string
+  datasetId: DatasetId
   variant: Variant
 }
 
 type VariantSiteQualityMetricsProps = {
-  datasetId: string
+  datasetId: DatasetId
   variant: Variant
 }
 
@@ -965,7 +966,7 @@ const VariantSiteQualityMetricsDistribution = ({
 
       {selectedMetric === 'SiteQuality' && <p>{description}</p>}
 
-      {!datasetId.startsWith('gnomad_r3') && (
+      {!isV3(datasetId) && (
         <p>
           Note: These are site-level quality metrics, they may be unpredictable for multi-allelic
           sites.

--- a/browser/src/VariantPage/VariantSiteQualityMetrics.tsx
+++ b/browser/src/VariantPage/VariantSiteQualityMetrics.tsx
@@ -13,6 +13,7 @@ import gnomadV3SiteQualityMetricDistributions from '@gnomad/dataset-metadata/dat
 
 import Legend from '../Legend'
 import ControlSection from './ControlSection'
+import { Variant } from './VariantPage'
 
 // ================================================================================================
 // Metric descriptions
@@ -808,68 +809,17 @@ const AutosizedSiteQualityMetricsHistogram = withSize()(({ size, ...props }) => 
 
 type VariantSiteQualityMetricsDistributionProps = {
   datasetId: string
-  variant: {
-    exome?: {
-      quality_metrics: {
-        site_quality_metrics: {
-          metric: string
-          value?: number
-        }[]
-      }
-    }
-    genome?: {
-      quality_metrics: {
-        site_quality_metrics: {
-          metric: string
-          value?: number
-        }[]
-      }
-    }
-  }
+  variant: Variant
 }
 
 type VariantSiteQualityMetricsTableProps = {
   datasetId: string
-  variant: {
-    exome?: {
-      quality_metrics: {
-        site_quality_metrics: {
-          metric: string
-          value?: number
-        }[]
-      }
-    }
-    genome?: {
-      quality_metrics: {
-        site_quality_metrics: {
-          metric: string
-          value?: number
-        }[]
-      }
-    }
-  }
+  variant: Variant
 }
 
 type VariantSiteQualityMetricsProps = {
   datasetId: string
-  variant: {
-    exome?: {
-      quality_metrics: {
-        site_quality_metrics: {
-          metric: string
-          value?: number
-        }[]
-      }
-    }
-    genome?: {
-      quality_metrics: {
-        site_quality_metrics: {
-          metric: string
-          value?: number
-        }[]
-      }
-    }
-  }
+  variant: Variant
 }
 
 const LegendWrapper = styled.div`
@@ -1058,7 +1008,7 @@ const VariantSiteQualityMetricsTable = ({
   const isVariantInExomes = Boolean(variant.exome)
   const isVariantInGenomes = Boolean(variant.genome)
 
-  const exomeMetricValues = variant.exome
+  const exomeMetricValues: Record<string, number> | null = variant.exome
     ? variant.exome.quality_metrics.site_quality_metrics.reduce(
         (acc, m) => ({
           ...acc,
@@ -1067,7 +1017,7 @@ const VariantSiteQualityMetricsTable = ({
         {}
       )
     : null
-  const genomeMetricValues = variant.genome
+  const genomeMetricValues: Record<string, number> | null = variant.genome
     ? variant.genome.quality_metrics.site_quality_metrics.reduce(
         (acc, m) => ({
           ...acc,
@@ -1095,19 +1045,15 @@ const VariantSiteQualityMetricsTable = ({
             <th scope="row">{renderMetric(metric, datasetId)}</th>
             {isVariantInExomes && (
               <td>
-                {/* @ts-expect-error TS(2531) FIXME: Object is possibly 'null'. */}
-                {exomeMetricValues[metric] != null
-                  ? // @ts-expect-error TS(2531) FIXME: Object is possibly 'null'.
-                    formatMetricValue(exomeMetricValues[metric], metric)
+                {exomeMetricValues![metric] != null
+                  ? formatMetricValue(exomeMetricValues![metric], metric)
                   : '–'}
               </td>
             )}
             {isVariantInGenomes && (
               <td>
-                {/* @ts-expect-error TS(2531) FIXME: Object is possibly 'null'. */}
-                {genomeMetricValues[metric] != null
-                  ? // @ts-expect-error TS(2531) FIXME: Object is possibly 'null'.
-                    formatMetricValue(genomeMetricValues[metric], metric)
+                {genomeMetricValues![metric] != null
+                  ? formatMetricValue(genomeMetricValues![metric], metric)
                   : '–'}
               </td>
             )}

--- a/browser/src/VariantPage/__snapshots__/VariantPage.spec.tsx.snap
+++ b/browser/src/VariantPage/__snapshots__/VariantPage.spec.tsx.snap
@@ -13449,6 +13449,1848 @@ exports[`VariantPage with dataset "gnomad_r3_non_v2" has no unexpected changes 1
 </div>
 `;
 
+exports[`VariantPage with dataset exac has no unexpected changes 1`] = `
+<div
+  className="Page-w7h773-0 dRYfBS"
+>
+  <div
+    className="GnomadPageHeading__PageHeadingWrapper-sc-sgz3rr-0 gcOcdP"
+  >
+    <div
+      className="GnomadPageHeading__PageHeadingInnerWrapper-sc-sgz3rr-1 dLZzAa"
+    >
+      <h1
+        className="GnomadPageHeading__PageHeadingText-sc-sgz3rr-3 edXBqX"
+      >
+        <span
+          className="VariantPageTitle__TitleWrapper-sc-16g6pnt-0 bAAXLa"
+        >
+          <span>
+            Single nucleotide variant
+          </span>
+          <span
+            className="VariantPageTitle__Separator-sc-16g6pnt-1 jsfCLA"
+            style={
+              {
+                "width": "1ch",
+              }
+            }
+          >
+            :
+          </span>
+          <span
+            className="VariantPageTitle__VariantIdWrapper-sc-16g6pnt-2 jxIjmG"
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+          >
+            <span>
+              13
+              -
+              123
+            </span>
+            <span
+              className="VariantPageTitle__VariantIdSeparator-sc-16g6pnt-3 gwKaru"
+            >
+              -
+            </span>
+            <span
+              className="VariantPageTitle__TitleAlleles-sc-16g6pnt-4 dgrTjT"
+            >
+              A
+              -
+              C
+            </span>
+          </span>
+          <span
+            className="VariantPageTitle__Separator-sc-16g6pnt-1 jsfCLA"
+          >
+             
+          </span>
+          <span>
+            (
+            GRCh37
+            )
+          </span>
+        </span>
+      </h1>
+    </div>
+    <div
+      className="GnomadPageHeading__PageControlsWrapper-sc-sgz3rr-4 liqJpb"
+    >
+      <span
+        className="GnomadPageHeading__Label-sc-sgz3rr-5 dOhShJ"
+      >
+        Dataset
+      </span>
+      <ul
+        className="DatasetSelector__NavigationMenuWrapper-sc-1p2fxbn-0 ebZvwy"
+      >
+        <li
+          className="DatasetSelector__NavigationMenuItem-sc-1p2fxbn-2 ifirRc"
+        >
+          <a
+            className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
+            data-item="current_short_variant"
+            href="/?dataset=exac"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+          >
+            ExAC v1.0
+          </a>
+        </li>
+        <li
+          className="DatasetSelector__NavigationMenuItem-sc-1p2fxbn-2 ifirRc"
+        >
+          <a
+            aria-expanded={false}
+            aria-haspopup="true"
+            aria-label="More datasets"
+            className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
+            data-item="other_short_variant"
+            href="/"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="button"
+          >
+            <span
+              className="DatasetSelector__MoreIcon-sc-1p2fxbn-3 hTYFQu"
+            >
+              <img
+                alt=""
+                aria-hidden="true"
+                src="test-file-stub"
+              />
+            </span>
+          </a>
+          <ul
+            className="DatasetSelector__SubNavigationMenu-sc-1p2fxbn-4 epYyTQ"
+          >
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r2_1"
+                href="/?dataset=gnomad_r2_1"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v2.1.1
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  141,456 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r2_1_non_topmed"
+                href="/?dataset=gnomad_r2_1_non_topmed"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v2.1.1 (non-TOPMed)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  135,743 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r2_1_non_cancer"
+                href="/?dataset=gnomad_r2_1_non_cancer"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v2.1.1 (non-cancer)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  134,187 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r2_1_non_neuro"
+                href="/?dataset=gnomad_r2_1_non_neuro"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v2.1.1 (non-neuro)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  114,704 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r2_1_controls"
+                href="/?dataset=gnomad_r2_1_controls"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v2.1.1 (controls)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  60,146 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="exac"
+                href="/?dataset=exac"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                ExAC v1.0
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  60,706 samples
+                </div>
+              </a>
+            </li>
+          </ul>
+        </li>
+      </ul>
+      <span>
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+          >
+            More information
+          </span>
+        </button>
+      </span>
+    </div>
+  </div>
+  <div
+    className="VariantPage__FlexWrapper-sc-hd87ur-2 bjkoAa"
+  >
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+    >
+      <div
+        className="TableWrapper-sc-1ep26r3-0 edvjZa"
+      >
+        <div>
+          <table
+            className="ExacVariantOccurrenceTable__Table-sc-1i3jn4b-0 dvPJZS"
+          >
+            <tbody>
+              <tr>
+                <td />
+                <th
+                  scope="col"
+                >
+                  Exomes
+                </th>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Filters
+                  </span>
+                </th>
+                <td>
+                  <span
+                    className="Badge__BadgeWrapper-j4izdp-1 bhuqae"
+                  >
+                    Pass
+                  </span>
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Count
+                  </span>
+                </th>
+                <td>
+                  0
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Number
+                  </span>
+                </th>
+                <td>
+                  0
+                   *
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Frequency
+                  </span>
+                </th>
+                <td>
+                  0
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Number of homozygotes
+                  </span>
+                </th>
+                <td>
+                  0
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Mean depth of coverage
+                  </span>
+                </th>
+                <td>
+                  –
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <p>
+            <span
+              className="Badge__BadgeWrapper-j4izdp-1 dyHZPQ"
+            >
+              Warning
+            </span>
+             This variant is covered in fewer than 50% of individuals in ExAC. Allele frequency estimates may not be reliable.
+          </p>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+    >
+      <h2>
+        External Resources
+      </h2>
+      <ul
+        className="List-sc-4j87st-0 fQRmhM"
+      >
+        <li
+          className="List__ListItem-sc-4j87st-1 gGPLUe"
+        >
+          <a
+            className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+            href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&highlight=hg19.chr13%3A123-123&position=chr13%3A98-148"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            UCSC
+          </a>
+        </li>
+      </ul>
+      <h2>
+        Feedback
+      </h2>
+      <a
+        className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+        href="mailto:gnomad@broadinstitute.org"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        Report an issue with this variant
+      </a>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 CMQAN"
+    >
+      <h2>
+        Population Frequencies 
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
+      <div
+        className="TableWrapper-sc-1ep26r3-0 edvjZa"
+      >
+        <table
+          className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+        >
+          <thead>
+            <tr>
+              <th
+                aria-sort="none"
+                colSpan={2}
+                scope="col"
+              >
+                <button
+                  onClick={[Function]}
+                  type="button"
+                >
+                  Population
+                </button>
+              </th>
+              <th
+                aria-sort="none"
+                className="right-align"
+                scope="col"
+              >
+                <button
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Count
+                  </span>
+                </button>
+              </th>
+              <th
+                aria-sort="none"
+                className="right-align"
+                scope="col"
+              >
+                <button
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Number
+                  </span>
+                </button>
+              </th>
+              <th
+                aria-sort="none"
+                className="right-align"
+                scope="col"
+              >
+                <button
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Number of Homozygotes
+                  </span>
+                </button>
+              </th>
+              <th
+                aria-sort="descending"
+                scope="col"
+                style={
+                  {
+                    "paddingLeft": "25px",
+                  }
+                }
+              >
+                <button
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Frequency
+                  </span>
+                </button>
+              </th>
+            </tr>
+          </thead>
+          <tfoot>
+            <tr
+              className="border"
+            >
+              <th
+                colSpan={2}
+                scope="row"
+              >
+                Total
+              </th>
+              <td
+                className="right-align"
+              >
+                0
+              </td>
+              <td
+                className="right-align"
+              >
+                0
+              </td>
+              <td
+                className="right-align"
+              >
+                0
+              </td>
+              <td
+                style={
+                  {
+                    "paddingLeft": "25px",
+                  }
+                }
+              >
+                0.000
+              </td>
+            </tr>
+          </tfoot>
+        </table>
+        <div
+          className="GnomadPopulationsTable__ControlSection-sc-1ghxck9-0 bsALfR"
+        >
+          Include:
+          <label
+            className="Checkbox__Label-hrpa6b-0 gtTKXr"
+            htmlFor="includeExomePopulations"
+          >
+            <input
+              checked={false}
+              className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+              disabled={true}
+              id="includeExomePopulations"
+              onChange={[Function]}
+              type="checkbox"
+            />
+            Exomes
+          </label>
+          <label
+            className="Checkbox__Label-hrpa6b-0 gtTKXr"
+            htmlFor="includeGenomePopulations"
+          >
+            <input
+              checked={false}
+              className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+              disabled={true}
+              id="includeGenomePopulations"
+              onChange={[Function]}
+              type="checkbox"
+            />
+            Genomes
+          </label>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 CMQAN"
+    >
+      <h2>
+        Related Variants
+      </h2>
+      <div
+        className="VariantRelatedVariants__Wrapper-sc-y59fw8-0 bOggsA"
+      >
+        <div
+          className="VariantRelatedVariants__Item-sc-y59fw8-1 kqiRIK"
+        >
+          <h3>
+            Nearby Variants
+          </h3>
+          <p>
+            <a
+              className="Link-sc-14lgydv-0-Link jBvaYQ"
+              href="/region/13-103-143"
+              onClick={[Function]}
+            >
+              View variants located within 20 bases of this variant.
+            </a>
+          </p>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 CMQAN"
+    >
+      <h2>
+        Variant Effect Predictor
+      </h2>
+      <div>
+        <p>
+          This variant falls on 
+          0
+           transcript
+          s
+           in 
+          0
+           
+          gene
+          s
+          .
+        </p>
+        <p>
+          <span
+            className="Badge__BadgeWrapper-j4izdp-1 cJObdY"
+          >
+            Note
+          </span>
+           The gene symbols shown below are provided by VEP and may differ from the symbol shown on gene pages.
+        </p>
+        <ol
+          className="TranscriptConsequenceList__ConsequenceListWrapper-sc-qi0gmz-1 cXJgYo"
+        />
+      </div>
+    </section>
+    <div
+      className="VariantPage__FlexWrapper-sc-hd87ur-2 bjkoAa"
+    />
+    <div
+      className="VariantPage__FlexWrapper-sc-hd87ur-2 bjkoAa"
+    >
+      <section
+        className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+      >
+        <h2>
+          Age Distribution 
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
+        <div>
+          <div
+            className="GnomadAgeDistribution__LegendWrapper-sc-ty24oq-0 kOKZpq"
+          >
+            <ul
+              className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+            >
+              <li
+                className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+              >
+                <svg
+                  height={16}
+                  width={16}
+                >
+                  <rect
+                    fill="#428bca"
+                    height={16}
+                    stroke="#000"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                </svg>
+                <span
+                  style={
+                    {
+                      "marginLeft": "0.25em",
+                    }
+                  }
+                >
+                  Exome
+                </span>
+              </li>
+              <li
+                className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+              >
+                <svg
+                  height={16}
+                  width={16}
+                >
+                  <rect
+                    fill="#73ab3d"
+                    height={16}
+                    stroke="#000"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                </svg>
+                <span
+                  style={
+                    {
+                      "marginLeft": "0.25em",
+                    }
+                  }
+                >
+                  Genome
+                </span>
+              </li>
+            </ul>
+          </div>
+          <div
+            style={
+              {
+                "height": "100%",
+                "width": "100%",
+              }
+            }
+          />
+          <div
+            className="ControlSection__Wrapper-sc-rro5al-1 dSZUkP"
+          >
+            <span
+              className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+            >
+              <div
+                className="GnomadAgeDistribution__CheckboxWrapper-sc-ty24oq-1 fatvfk"
+              >
+                <label
+                  className="Checkbox__Label-hrpa6b-0 gtTKXr"
+                  htmlFor="age-distribution-include-heterozygotes"
+                >
+                  <input
+                    checked={true}
+                    className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                    disabled={false}
+                    id="age-distribution-include-heterozygotes"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Include heterozygous variant carriers
+                </label>
+                <label
+                  className="Checkbox__Label-hrpa6b-0 gtTKXr"
+                  htmlFor="age-distribution-include-homozygotes"
+                >
+                  <input
+                    checked={true}
+                    className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                    disabled={false}
+                    id="age-distribution-include-homozygotes"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Include homozygous variant carriers
+                </label>
+                <label
+                  className="Checkbox__Label-hrpa6b-0 gtTKXr"
+                  htmlFor="age-distribution-show-all-individuals"
+                >
+                  <input
+                    checked={false}
+                    className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                    disabled={true}
+                    id="age-distribution-show-all-individuals"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Compare to all individuals
+                </label>
+              </div>
+            </span>
+            <span
+              className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+            >
+              <label
+                htmlFor="age-distribution-sequencing-type"
+              >
+                Sequencing types: 
+                <select
+                  className="Select-sc-1lkyg9e-0 ivadCR"
+                  disabled={true}
+                  id="age-distribution-sequencing-type"
+                  onChange={[Function]}
+                  value="e"
+                >
+                  <option
+                    value="eg"
+                  >
+                    Exome and Genome
+                  </option>
+                  <option
+                    value="e"
+                  >
+                    Exome
+                  </option>
+                  <option
+                    value="g"
+                  >
+                    Genome
+                  </option>
+                </select>
+              </label>
+            </span>
+          </div>
+        </div>
+      </section>
+    </div>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+    >
+      <h2>
+        Genotype Quality Metrics
+      </h2>
+      <div>
+        <div>
+          <div
+            role="tablist"
+          >
+            <ul
+              className="Tabs__TabListWrapper-jzgyty-0 gUVxKq"
+            >
+              <li>
+                <div
+                  aria-controls="genotype_quality-panel"
+                  aria-selected={true}
+                  className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                  id="genotype_quality"
+                  onFocus={[Function]}
+                  role="tab"
+                  tabIndex={0}
+                >
+                  <div
+                    className="Tabs__TabLabel-jzgyty-2 dcUyBp"
+                  >
+                    Genotype quality
+                  </div>
+                </div>
+              </li>
+              <li>
+                <div
+                  aria-controls="genotype_depth-panel"
+                  aria-selected={false}
+                  className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                  id="genotype_depth"
+                  onFocus={[Function]}
+                  role="tab"
+                  tabIndex={-1}
+                >
+                  <div
+                    className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                  >
+                    Depth
+                  </div>
+                </div>
+              </li>
+            </ul>
+          </div>
+          <div>
+            <div
+              aria-describedby="genotype_quality"
+              aria-hidden={false}
+              className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+              id="genotype_quality-panel"
+              onKeyDown={[Function]}
+              role="tabpanel"
+              style={{}}
+            >
+              <div
+                className="VariantGenotypeQualityMetrics__LegendWrapper-sc-tgmwmq-0 ihxxGK"
+              >
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#428bca"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Exome
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#73ab3d"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Genome
+                    </span>
+                  </li>
+                </ul>
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#999"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Variant carriers
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <defs>
+                        <pattern
+                          height={4}
+                          id="genotype-quality-legend-swatch-stripes"
+                          patternTransform="rotate(45)"
+                          patternUnits="userSpaceOnUse"
+                          width={4}
+                        >
+                          <rect
+                            fill="#fff"
+                            height={4}
+                            transform="translate(0,0)"
+                            width={3}
+                          />
+                        </pattern>
+                        <mask
+                          id="genotype-quality-legend-swatch-mask"
+                        >
+                          <rect
+                            fill="url(#genotype-quality-legend-swatch-stripes)"
+                            height="100%"
+                            width="100%"
+                            x={0}
+                            y={0}
+                          />
+                        </mask>
+                      </defs>
+                      <rect
+                        fill="#999"
+                        height={16}
+                        mask="url(#genotype-quality-legend-swatch-mask)"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                      <rect
+                        fill="none"
+                        height={16}
+                        stroke="#333"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      All individuals
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                style={
+                  {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              />
+            </div>
+            <div
+              aria-describedby="genotype_depth"
+              aria-hidden={true}
+              className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+              id="genotype_depth-panel"
+              onKeyDown={[Function]}
+              role="tabpanel"
+              style={
+                {
+                  "display": "none",
+                }
+              }
+            >
+              <div
+                className="VariantGenotypeQualityMetrics__LegendWrapper-sc-tgmwmq-0 ihxxGK"
+                style={
+                  {
+                    "marginTop": "1em",
+                  }
+                }
+              >
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#428bca"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Exome
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#73ab3d"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Genome
+                    </span>
+                  </li>
+                </ul>
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#999"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Variant carriers
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <defs>
+                        <pattern
+                          height={4}
+                          id="depth-legend-swatch-stripes"
+                          patternTransform="rotate(45)"
+                          patternUnits="userSpaceOnUse"
+                          width={4}
+                        >
+                          <rect
+                            fill="#fff"
+                            height={4}
+                            transform="translate(0,0)"
+                            width={3}
+                          />
+                        </pattern>
+                        <mask
+                          id="depth-legend-swatch-mask"
+                        >
+                          <rect
+                            fill="url(#depth-legend-swatch-stripes)"
+                            height="100%"
+                            width="100%"
+                            x={0}
+                            y={0}
+                          />
+                        </mask>
+                      </defs>
+                      <rect
+                        fill="#999"
+                        height={16}
+                        mask="url(#depth-legend-swatch-mask)"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                      <rect
+                        fill="none"
+                        height={16}
+                        stroke="#333"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      All individuals
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                style={
+                  {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          className="ControlSection__Wrapper-sc-rro5al-1 dSZUkP"
+        >
+          <span
+            className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+          >
+            <label
+              className="Checkbox__Label-hrpa6b-0 gtTKXr"
+              htmlFor="genotype-quality-metrics-show-all-individuals"
+            >
+              <input
+                checked={true}
+                className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                disabled={false}
+                id="genotype-quality-metrics-show-all-individuals"
+                onChange={[Function]}
+                type="checkbox"
+              />
+              Compare to all individuals
+            </label>
+          </span>
+          <span
+            className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+          >
+            <label
+              htmlFor="genotype-quality-metrics-sequencing-type"
+            >
+              Sequencing types: 
+              <select
+                className="Select-sc-1lkyg9e-0 ivadCR"
+                disabled={true}
+                id="genotype-quality-metrics-sequencing-type"
+                onChange={[Function]}
+                value="e"
+              >
+                <option
+                  value="eg"
+                >
+                  Exome and Genome
+                </option>
+                <option
+                  value="e"
+                >
+                  Exome
+                </option>
+                <option
+                  value="g"
+                >
+                  Genome
+                </option>
+              </select>
+            </label>
+          </span>
+        </div>
+        <p>
+          Note: This plot may include low-quality genotypes that were excluded from allele counts in the tables above.
+        </p>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+    >
+      <h2>
+        Site Quality Metrics
+      </h2>
+      <div>
+        <div
+          role="tablist"
+        >
+          <ul
+            className="Tabs__TabListWrapper-jzgyty-0 gUVxKq"
+          >
+            <li>
+              <div
+                aria-controls="distribution-panel"
+                aria-selected={true}
+                className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                id="distribution"
+                onFocus={[Function]}
+                role="tab"
+                tabIndex={0}
+              >
+                <div
+                  className="Tabs__TabLabel-jzgyty-2 dcUyBp"
+                >
+                  Metric distribution
+                </div>
+              </div>
+            </li>
+            <li>
+              <div
+                aria-controls="values-panel"
+                aria-selected={false}
+                className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                id="values"
+                onFocus={[Function]}
+                role="tab"
+                tabIndex={-1}
+              >
+                <div
+                  className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                >
+                  All metric values
+                </div>
+              </div>
+            </li>
+          </ul>
+        </div>
+        <div>
+          <div
+            aria-describedby="distribution"
+            aria-hidden={false}
+            className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+            id="distribution-panel"
+            onKeyDown={[Function]}
+            role="tabpanel"
+            style={{}}
+          >
+            <div>
+              <div
+                className="VariantSiteQualityMetrics__LegendWrapper-sc-186wx2k-2 gDWfxF"
+              >
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#428bca"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Exome
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#73ab3d"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Genome
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                style={
+                  {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              />
+              <div
+                style={
+                  {
+                    "marginBottom": "0.5rem",
+                    "overflow": "hidden",
+                  }
+                }
+              />
+              <div
+                className="ControlSection__Wrapper-sc-rro5al-1 dSZUkP"
+              >
+                <span
+                  className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+                >
+                  <label
+                    htmlFor="site-quality-metrics-metric"
+                  >
+                    Metric: 
+                    <select
+                      className="Select-sc-1lkyg9e-0 ivadCR"
+                      id="site-quality-metrics-metric"
+                      onChange={[Function]}
+                      value="SiteQuality"
+                    >
+                      <option
+                        value="BaseQRankSum"
+                      >
+                        BaseQRankSum
+                      </option>
+                      <option
+                        value="ClippingRankSum"
+                      >
+                        ClippingRankSum
+                      </option>
+                      <option
+                        value="DP"
+                      >
+                        DP
+                      </option>
+                      <option
+                        value="FS"
+                      >
+                        FS
+                      </option>
+                      <option
+                        value="InbreedingCoeff"
+                      >
+                        InbreedingCoeff
+                      </option>
+                      <option
+                        value="MQ"
+                      >
+                        MQ
+                      </option>
+                      <option
+                        value="MQRankSum"
+                      >
+                        MQRankSum
+                      </option>
+                      <option
+                        value="QD"
+                      >
+                        QD
+                      </option>
+                      <option
+                        value="ReadPosRankSum"
+                      >
+                        ReadPosRankSum
+                      </option>
+                      <option
+                        value="SiteQuality"
+                      >
+                        SiteQuality
+                      </option>
+                      <option
+                        value="VQSLOD"
+                      >
+                        VQSLOD
+                      </option>
+                    </select>
+                  </label>
+                </span>
+                <span
+                  className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+                >
+                  <label
+                    htmlFor="site-quality-metrics-sequencing-type"
+                  >
+                    Sequencing types: 
+                    <select
+                      className="Select-sc-1lkyg9e-0 ivadCR"
+                      disabled={true}
+                      id="site-quality-metrics-sequencing-type"
+                      onChange={[Function]}
+                      value="e"
+                    >
+                      <option
+                        value="eg"
+                      >
+                        Exome and Genome
+                      </option>
+                      <option
+                        value="e"
+                      >
+                        Exome
+                      </option>
+                      <option
+                        value="g"
+                      >
+                        Genome
+                      </option>
+                    </select>
+                  </label>
+                </span>
+              </div>
+              <p>
+                Value: 
+                0 (exome samples)
+              </p>
+              <p>
+                This is the site quality distribution for all variants with 0 &lt;= AF &lt; 0.0001.
+              </p>
+              <p>
+                Note: These are site-level quality metrics, they may be unpredictable for multi-allelic sites.
+              </p>
+            </div>
+          </div>
+          <div
+            aria-describedby="values"
+            aria-hidden={true}
+            className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+            id="values-panel"
+            onKeyDown={[Function]}
+            role="tabpanel"
+            style={
+              {
+                "display": "none",
+              }
+            }
+          >
+            <table
+              className="Table__BaseTable-sc-7fgtt2-0 dIBzV"
+              style={
+                {
+                  "width": "100%",
+                }
+              }
+            >
+              <thead>
+                <tr>
+                  <th
+                    scope="col"
+                  >
+                    Metric
+                  </th>
+                  <th
+                    scope="col"
+                  >
+                    Exome samples
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      BaseQRankSum
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      ClippingRankSum
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      DP
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      FS
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      InbreedingCoeff
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      MQ
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      MQRankSum
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      QD
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      ReadPosRankSum
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      SiteQuality
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      VQSLOD
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 CMQAN"
+    >
+      <h2>
+        Read Data
+      </h2>
+      <div>
+        <p>
+          No read data available for this variant.
+        </p>
+        <p>
+          <span
+            className="Badge__BadgeWrapper-j4izdp-1 cJObdY"
+          >
+            Note
+          </span>
+           Read data for non-coding regions is not available in gnomAD v2.1.1 and ExAC.
+        </p>
+      </div>
+    </section>
+  </div>
+</div>
+`;
+
 exports[`VariantPage with dataset gnomad_r2_1 has no unexpected changes 1`] = `
 <div
   className="Page-w7h773-0 dRYfBS"

--- a/browser/src/VariantPage/__snapshots__/VariantPage.spec.tsx.snap
+++ b/browser/src/VariantPage/__snapshots__/VariantPage.spec.tsx.snap
@@ -1,0 +1,13450 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`VariantPage with dataset "gnomad_r3" has no unexpected changes 1`] = `
+<div
+  className="Page-w7h773-0 dRYfBS"
+>
+  <div
+    className="GnomadPageHeading__PageHeadingWrapper-sc-sgz3rr-0 gcOcdP"
+  >
+    <div
+      className="GnomadPageHeading__PageHeadingInnerWrapper-sc-sgz3rr-1 dLZzAa"
+    >
+      <h1
+        className="GnomadPageHeading__PageHeadingText-sc-sgz3rr-3 edXBqX"
+      >
+        <span
+          className="VariantPageTitle__TitleWrapper-sc-16g6pnt-0 bAAXLa"
+        >
+          <span>
+            Single nucleotide variant
+          </span>
+          <span
+            className="VariantPageTitle__Separator-sc-16g6pnt-1 jsfCLA"
+            style={
+              {
+                "width": "1ch",
+              }
+            }
+          >
+            :
+          </span>
+          <span
+            className="VariantPageTitle__VariantIdWrapper-sc-16g6pnt-2 jxIjmG"
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+          >
+            <span>
+              13
+              -
+              123
+            </span>
+            <span
+              className="VariantPageTitle__VariantIdSeparator-sc-16g6pnt-3 gwKaru"
+            >
+              -
+            </span>
+            <span
+              className="VariantPageTitle__TitleAlleles-sc-16g6pnt-4 dgrTjT"
+            >
+              A
+              -
+              C
+            </span>
+          </span>
+          <span
+            className="VariantPageTitle__Separator-sc-16g6pnt-1 jsfCLA"
+          >
+             
+          </span>
+          <span>
+            (
+            GRCh38
+            )
+          </span>
+        </span>
+      </h1>
+    </div>
+    <div
+      className="GnomadPageHeading__PageControlsWrapper-sc-sgz3rr-4 liqJpb"
+    >
+      <span
+        className="GnomadPageHeading__Label-sc-sgz3rr-5 dOhShJ"
+      >
+        Dataset
+      </span>
+      <ul
+        className="DatasetSelector__NavigationMenuWrapper-sc-1p2fxbn-0 ebZvwy"
+      >
+        <li
+          className="DatasetSelector__NavigationMenuItem-sc-1p2fxbn-2 ifirRc"
+        >
+          <a
+            className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
+            data-item="current_short_variant"
+            href="/?dataset=gnomad_r3"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+          >
+            gnomAD v3.1.2
+          </a>
+        </li>
+        <li
+          className="DatasetSelector__NavigationMenuItem-sc-1p2fxbn-2 ifirRc"
+        >
+          <a
+            aria-expanded={false}
+            aria-haspopup="true"
+            aria-label="More datasets"
+            className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
+            data-item="other_short_variant"
+            href="/"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="button"
+          >
+            <span
+              className="DatasetSelector__MoreIcon-sc-1p2fxbn-3 hTYFQu"
+            >
+              <img
+                alt=""
+                aria-hidden="true"
+                src="test-file-stub"
+              />
+            </span>
+          </a>
+          <ul
+            className="DatasetSelector__SubNavigationMenu-sc-1p2fxbn-4 epYyTQ"
+          >
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r3"
+                href="/?dataset=gnomad_r3"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v3.1.2
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  76,156 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r3_non_cancer"
+                href="/?dataset=gnomad_r3_non_cancer"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v3.1.2 (non-cancer)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  74,023 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r3_non_neuro"
+                href="/?dataset=gnomad_r3_non_neuro"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v3.1.2 (non-neuro)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  67,442 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r3_non_v2"
+                href="/?dataset=gnomad_r3_non_v2"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v3.1.2 (non-v2)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  57,344 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r3_non_topmed"
+                href="/?dataset=gnomad_r3_non_topmed"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v3.1.2 (non-TOPMed)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  40,433 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r3_controls_and_biobanks"
+                href="/?dataset=gnomad_r3_controls_and_biobanks"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v3.1.2 (controls/biobanks)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  16,465 samples
+                </div>
+              </a>
+            </li>
+          </ul>
+        </li>
+      </ul>
+      <span>
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+          >
+            More information
+          </span>
+        </button>
+      </span>
+    </div>
+  </div>
+  <div
+    className="VariantPage__FlexWrapper-sc-hd87ur-2 bjkoAa"
+  >
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+    >
+      <div
+        className="TableWrapper-sc-1ep26r3-0 edvjZa"
+      >
+        <div>
+          <table
+            className="VariantOccurrenceTable__Table-sc-8b13g7-0 iwAwP"
+          >
+            <tbody>
+              <tr>
+                <td />
+                <th
+                  scope="col"
+                >
+                  Genomes
+                </th>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Filters
+                  </span>
+                </th>
+                <td>
+                  <span
+                    className="Badge__BadgeWrapper-j4izdp-1 bhuqae"
+                  >
+                    Pass
+                  </span>
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Count
+                  </span>
+                </th>
+                <td>
+                  0
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Number
+                  </span>
+                </th>
+                <td>
+                  0
+                   *
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Frequency
+                  </span>
+                </th>
+                <td>
+                  0.000
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="VariantOccurrenceTable__NoWrap-sc-8b13g7-1 kmxNQ"
+                  >
+                    Popmax Filtering AF 
+                    <button
+                      className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <img
+                        alt=""
+                        aria-hidden="true"
+                        src="test-file-stub"
+                      />
+                      <span
+                        style={
+                          {
+                            "border": "0",
+                            "clip": "rect(0 0 0 0)",
+                            "height": "1px",
+                            "margin": "-1px",
+                            "overflow": "hidden",
+                            "padding": "0",
+                            "position": "absolute",
+                            "whiteSpace": "nowrap",
+                            "width": "1px",
+                          }
+                        }
+                      >
+                        More information
+                      </span>
+                    </button>
+                  </span>
+                  <br />
+                  (95% confidence)
+                </th>
+                <td>
+                  <span>
+                    0
+                  </span>
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Number of homozygotes
+                  </span>
+                </th>
+                <td>
+                  0
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Mean depth of coverage
+                  </span>
+                </th>
+                <td>
+                  –
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <p>
+            <span
+              className="Badge__BadgeWrapper-j4izdp-1 bbjxGL"
+            >
+              Warning
+            </span>
+             This variant is covered in fewer than 50% of individuals in 
+            gnomAD v3.1.2 genomes
+            .
+             
+            This may indicate a low-quality site
+            .
+          </p>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+    >
+      <h2>
+        External Resources
+      </h2>
+      <ul
+        className="List-sc-4j87st-0 fQRmhM"
+      >
+        <li
+          className="List__ListItem-sc-4j87st-1 gGPLUe"
+        >
+          <a
+            className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+            href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&highlight=hg38.chr13%3A123-123&position=chr13%3A98-148"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            UCSC
+          </a>
+        </li>
+      </ul>
+      <h2>
+        Feedback
+      </h2>
+      <a
+        className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+        href="mailto:gnomad@broadinstitute.org"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        Report an issue with this variant
+      </a>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 CMQAN"
+    >
+      <h2>
+        Population Frequencies 
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
+      <div>
+        <div
+          role="tablist"
+        >
+          <ul
+            className="Tabs__TabListWrapper-jzgyty-0 gUVxKq"
+          >
+            <li>
+              <div
+                aria-controls="gnomAD-panel"
+                aria-selected={true}
+                className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                id="gnomAD"
+                onFocus={[Function]}
+                role="tab"
+                tabIndex={0}
+              >
+                <div
+                  className="Tabs__TabLabel-jzgyty-2 dcUyBp"
+                >
+                  gnomAD
+                </div>
+              </div>
+            </li>
+            <li>
+              <div
+                aria-controls="HGDP-panel"
+                aria-selected={false}
+                className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                id="HGDP"
+                onFocus={[Function]}
+                role="tab"
+                tabIndex={-1}
+              >
+                <div
+                  className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                >
+                  HGDP
+                </div>
+              </div>
+            </li>
+            <li>
+              <div
+                aria-controls="1KG-panel"
+                aria-selected={false}
+                className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                id="1KG"
+                onFocus={[Function]}
+                role="tab"
+                tabIndex={-1}
+              >
+                <div
+                  className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                >
+                  1KG
+                </div>
+              </div>
+            </li>
+            <li>
+              <div
+                aria-controls="local-ancestry-panel"
+                aria-selected={false}
+                className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                id="local-ancestry"
+                onFocus={[Function]}
+                role="tab"
+                tabIndex={-1}
+              >
+                <div
+                  className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                >
+                  Local Ancestry
+                </div>
+              </div>
+            </li>
+          </ul>
+        </div>
+        <div>
+          <div
+            aria-describedby="gnomAD"
+            aria-hidden={false}
+            className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+            id="gnomAD-panel"
+            onKeyDown={[Function]}
+            role="tabpanel"
+            style={{}}
+          >
+            <div
+              className="TableWrapper-sc-1ep26r3-0 edvjZa"
+            >
+              <table
+                className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+              >
+                <thead>
+                  <tr>
+                    <th
+                      aria-sort="none"
+                      colSpan={2}
+                      scope="col"
+                    >
+                      <button
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        Population
+                      </button>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      className="right-align"
+                      scope="col"
+                    >
+                      <button
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <span
+                          className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                        >
+                          Allele Count
+                        </span>
+                      </button>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      className="right-align"
+                      scope="col"
+                    >
+                      <button
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <span
+                          className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                        >
+                          Allele Number
+                        </span>
+                      </button>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      className="right-align"
+                      scope="col"
+                    >
+                      <button
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <span
+                          className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                        >
+                          Number of Homozygotes
+                        </span>
+                      </button>
+                    </th>
+                    <th
+                      aria-sort="descending"
+                      scope="col"
+                      style={
+                        {
+                          "paddingLeft": "25px",
+                        }
+                      }
+                    >
+                      <button
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <span
+                          className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                        >
+                          Allele Frequency
+                        </span>
+                      </button>
+                    </th>
+                  </tr>
+                </thead>
+                <tfoot>
+                  <tr
+                    className="border"
+                  >
+                    <th
+                      colSpan={2}
+                      scope="row"
+                    >
+                      Total
+                    </th>
+                    <td
+                      className="right-align"
+                    >
+                      0
+                    </td>
+                    <td
+                      className="right-align"
+                    >
+                      0
+                    </td>
+                    <td
+                      className="right-align"
+                    >
+                      0
+                    </td>
+                    <td
+                      style={
+                        {
+                          "paddingLeft": "25px",
+                        }
+                      }
+                    >
+                      0.000
+                    </td>
+                  </tr>
+                </tfoot>
+              </table>
+              <div
+                className="GnomadPopulationsTable__ControlSection-sc-1ghxck9-0 bsALfR"
+              >
+                Include:
+                <label
+                  className="Checkbox__Label-hrpa6b-0 gtTKXr"
+                  htmlFor="includeExomePopulations"
+                >
+                  <input
+                    checked={false}
+                    className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                    disabled={true}
+                    id="includeExomePopulations"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Exomes
+                </label>
+                <label
+                  className="Checkbox__Label-hrpa6b-0 gtTKXr"
+                  htmlFor="includeGenomePopulations"
+                >
+                  <input
+                    checked={false}
+                    className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                    disabled={true}
+                    id="includeGenomePopulations"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Genomes
+                </label>
+              </div>
+            </div>
+          </div>
+          <div
+            aria-describedby="HGDP"
+            aria-hidden={true}
+            className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+            id="HGDP-panel"
+            onKeyDown={[Function]}
+            role="tabpanel"
+            style={
+              {
+                "display": "none",
+              }
+            }
+          >
+            <p>
+              HGDP population frequencies are not available for this variant.
+            </p>
+          </div>
+          <div
+            aria-describedby="1KG"
+            aria-hidden={true}
+            className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+            id="1KG-panel"
+            onKeyDown={[Function]}
+            role="tabpanel"
+            style={
+              {
+                "display": "none",
+              }
+            }
+          >
+            <p>
+              1000 Genomes Project population frequencies are not available for this variant.
+            </p>
+          </div>
+          <div
+            aria-describedby="local-ancestry"
+            aria-hidden={true}
+            className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+            id="local-ancestry-panel"
+            onKeyDown={[Function]}
+            role="tabpanel"
+            style={
+              {
+                "display": "none",
+              }
+            }
+          >
+            <p>
+              Local ancestry is not available for this variant. Local ancestry is only available for bi-allelic variants with high call rates and with an allele frequency &gt; 0.1% within the Latino/Admixed American gnomAD population.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 CMQAN"
+    >
+      <h2>
+        Related Variants
+      </h2>
+      <div
+        className="VariantRelatedVariants__Wrapper-sc-y59fw8-0 bOggsA"
+      >
+        <div
+          className="VariantRelatedVariants__Item-sc-y59fw8-1 kqiRIK"
+        >
+          <h3>
+            Nearby Variants
+          </h3>
+          <p>
+            <a
+              className="Link-sc-14lgydv-0-Link jBvaYQ"
+              href="/region/13-103-143"
+              onClick={[Function]}
+            >
+              View variants located within 20 bases of this variant.
+            </a>
+          </p>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 CMQAN"
+    >
+      <h2>
+        Variant Effect Predictor
+      </h2>
+      <div>
+        <p>
+          This variant falls on 
+          0
+           transcript
+          s
+           in 
+          0
+           
+          gene
+          s
+          .
+        </p>
+        <p>
+          <span
+            className="Badge__BadgeWrapper-j4izdp-1 cJObdY"
+          >
+            Note
+          </span>
+           The gene symbols shown below are provided by VEP and may differ from the symbol shown on gene pages.
+        </p>
+        <ol
+          className="TranscriptConsequenceList__ConsequenceListWrapper-sc-qi0gmz-1 cXJgYo"
+        />
+      </div>
+    </section>
+    <div
+      className="VariantPage__FlexWrapper-sc-hd87ur-2 bjkoAa"
+    >
+      <section
+        className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+      >
+        <h2>
+          Genomic Constraint of Surrounding 1kb Region
+        </h2>
+        This variant does not have non coding constraint data for the surrounding region.
+      </section>
+    </div>
+    <div
+      className="VariantPage__FlexWrapper-sc-hd87ur-2 bjkoAa"
+    >
+      <section
+        className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+      >
+        <h2>
+          Age Distribution 
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
+        <div>
+          <div
+            className="GnomadAgeDistribution__LegendWrapper-sc-ty24oq-0 kOKZpq"
+          >
+            <ul
+              className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+            >
+              <li
+                className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+              >
+                <svg
+                  height={16}
+                  width={16}
+                >
+                  <rect
+                    fill="#428bca"
+                    height={16}
+                    stroke="#000"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                </svg>
+                <span
+                  style={
+                    {
+                      "marginLeft": "0.25em",
+                    }
+                  }
+                >
+                  Exome
+                </span>
+              </li>
+              <li
+                className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+              >
+                <svg
+                  height={16}
+                  width={16}
+                >
+                  <rect
+                    fill="#73ab3d"
+                    height={16}
+                    stroke="#000"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                </svg>
+                <span
+                  style={
+                    {
+                      "marginLeft": "0.25em",
+                    }
+                  }
+                >
+                  Genome
+                </span>
+              </li>
+            </ul>
+            <ul
+              className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+            >
+              <li
+                className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+              >
+                <svg
+                  height={16}
+                  width={16}
+                >
+                  <rect
+                    fill="#999"
+                    height={16}
+                    stroke="#000"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                </svg>
+                <span
+                  style={
+                    {
+                      "marginLeft": "0.25em",
+                    }
+                  }
+                >
+                  Variant carriers
+                </span>
+              </li>
+              <li
+                className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+              >
+                <svg
+                  height={16}
+                  width={16}
+                >
+                  <defs>
+                    <pattern
+                      height={4}
+                      id="age-distribution-legend-swatch-stripes"
+                      patternTransform="rotate(45)"
+                      patternUnits="userSpaceOnUse"
+                      width={4}
+                    >
+                      <rect
+                        fill="#fff"
+                        height={4}
+                        transform="translate(0,0)"
+                        width={3}
+                      />
+                    </pattern>
+                    <mask
+                      id="age-distribution-legend-swatch-mask"
+                    >
+                      <rect
+                        fill="url(#age-distribution-legend-swatch-stripes)"
+                        height="100%"
+                        width="100%"
+                        x={0}
+                        y={0}
+                      />
+                    </mask>
+                  </defs>
+                  <rect
+                    fill="#999"
+                    height={16}
+                    mask="url(#age-distribution-legend-swatch-mask)"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                  <rect
+                    fill="none"
+                    height={16}
+                    stroke="#333"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                </svg>
+                <span
+                  style={
+                    {
+                      "marginLeft": "0.25em",
+                    }
+                  }
+                >
+                  All individuals
+                </span>
+              </li>
+            </ul>
+          </div>
+          <div
+            style={
+              {
+                "height": "100%",
+                "width": "100%",
+              }
+            }
+          />
+          <div
+            className="ControlSection__Wrapper-sc-rro5al-1 dSZUkP"
+          >
+            <span
+              className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+            >
+              <div
+                className="GnomadAgeDistribution__CheckboxWrapper-sc-ty24oq-1 fatvfk"
+              >
+                <label
+                  className="Checkbox__Label-hrpa6b-0 gtTKXr"
+                  htmlFor="age-distribution-include-heterozygotes"
+                >
+                  <input
+                    checked={true}
+                    className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                    disabled={false}
+                    id="age-distribution-include-heterozygotes"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Include heterozygous variant carriers
+                </label>
+                <label
+                  className="Checkbox__Label-hrpa6b-0 gtTKXr"
+                  htmlFor="age-distribution-include-homozygotes"
+                >
+                  <input
+                    checked={true}
+                    className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                    disabled={false}
+                    id="age-distribution-include-homozygotes"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Include homozygous variant carriers
+                </label>
+                <label
+                  className="Checkbox__Label-hrpa6b-0 gtTKXr"
+                  htmlFor="age-distribution-show-all-individuals"
+                >
+                  <input
+                    checked={true}
+                    className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                    disabled={false}
+                    id="age-distribution-show-all-individuals"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Compare to all individuals
+                </label>
+              </div>
+            </span>
+            <span
+              className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+            >
+              <label
+                htmlFor="age-distribution-sequencing-type"
+              >
+                Sequencing types: 
+                <select
+                  className="Select-sc-1lkyg9e-0 ivadCR"
+                  disabled={true}
+                  id="age-distribution-sequencing-type"
+                  onChange={[Function]}
+                  value="g"
+                >
+                  <option
+                    value="eg"
+                  >
+                    Exome and Genome
+                  </option>
+                  <option
+                    value="e"
+                  >
+                    Exome
+                  </option>
+                  <option
+                    value="g"
+                  >
+                    Genome
+                  </option>
+                </select>
+              </label>
+            </span>
+          </div>
+        </div>
+      </section>
+    </div>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+    >
+      <h2>
+        Genotype Quality Metrics
+      </h2>
+      <div>
+        <div>
+          <div
+            role="tablist"
+          >
+            <ul
+              className="Tabs__TabListWrapper-jzgyty-0 gUVxKq"
+            >
+              <li>
+                <div
+                  aria-controls="genotype_quality-panel"
+                  aria-selected={true}
+                  className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                  id="genotype_quality"
+                  onFocus={[Function]}
+                  role="tab"
+                  tabIndex={0}
+                >
+                  <div
+                    className="Tabs__TabLabel-jzgyty-2 dcUyBp"
+                  >
+                    Genotype quality
+                  </div>
+                </div>
+              </li>
+              <li>
+                <div
+                  aria-controls="genotype_depth-panel"
+                  aria-selected={false}
+                  className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                  id="genotype_depth"
+                  onFocus={[Function]}
+                  role="tab"
+                  tabIndex={-1}
+                >
+                  <div
+                    className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                  >
+                    Depth
+                  </div>
+                </div>
+              </li>
+              <li>
+                <div
+                  aria-controls="allele_balance-panel"
+                  aria-selected={false}
+                  className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                  id="allele_balance"
+                  onFocus={[Function]}
+                  role="tab"
+                  tabIndex={-1}
+                >
+                  <div
+                    className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                  >
+                    Allele balance for heterozygotes
+                  </div>
+                </div>
+              </li>
+            </ul>
+          </div>
+          <div>
+            <div
+              aria-describedby="genotype_quality"
+              aria-hidden={false}
+              className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+              id="genotype_quality-panel"
+              onKeyDown={[Function]}
+              role="tabpanel"
+              style={{}}
+            >
+              <div
+                className="VariantGenotypeQualityMetrics__LegendWrapper-sc-tgmwmq-0 ihxxGK"
+              >
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#428bca"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Exome
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#73ab3d"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Genome
+                    </span>
+                  </li>
+                </ul>
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#999"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Variant carriers
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <defs>
+                        <pattern
+                          height={4}
+                          id="genotype-quality-legend-swatch-stripes"
+                          patternTransform="rotate(45)"
+                          patternUnits="userSpaceOnUse"
+                          width={4}
+                        >
+                          <rect
+                            fill="#fff"
+                            height={4}
+                            transform="translate(0,0)"
+                            width={3}
+                          />
+                        </pattern>
+                        <mask
+                          id="genotype-quality-legend-swatch-mask"
+                        >
+                          <rect
+                            fill="url(#genotype-quality-legend-swatch-stripes)"
+                            height="100%"
+                            width="100%"
+                            x={0}
+                            y={0}
+                          />
+                        </mask>
+                      </defs>
+                      <rect
+                        fill="#999"
+                        height={16}
+                        mask="url(#genotype-quality-legend-swatch-mask)"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                      <rect
+                        fill="none"
+                        height={16}
+                        stroke="#333"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      All individuals
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                style={
+                  {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              />
+            </div>
+            <div
+              aria-describedby="genotype_depth"
+              aria-hidden={true}
+              className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+              id="genotype_depth-panel"
+              onKeyDown={[Function]}
+              role="tabpanel"
+              style={
+                {
+                  "display": "none",
+                }
+              }
+            >
+              <div
+                className="VariantGenotypeQualityMetrics__LegendWrapper-sc-tgmwmq-0 ihxxGK"
+                style={
+                  {
+                    "marginTop": "1em",
+                  }
+                }
+              >
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#428bca"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Exome
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#73ab3d"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Genome
+                    </span>
+                  </li>
+                </ul>
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#999"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Variant carriers
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <defs>
+                        <pattern
+                          height={4}
+                          id="depth-legend-swatch-stripes"
+                          patternTransform="rotate(45)"
+                          patternUnits="userSpaceOnUse"
+                          width={4}
+                        >
+                          <rect
+                            fill="#fff"
+                            height={4}
+                            transform="translate(0,0)"
+                            width={3}
+                          />
+                        </pattern>
+                        <mask
+                          id="depth-legend-swatch-mask"
+                        >
+                          <rect
+                            fill="url(#depth-legend-swatch-stripes)"
+                            height="100%"
+                            width="100%"
+                            x={0}
+                            y={0}
+                          />
+                        </mask>
+                      </defs>
+                      <rect
+                        fill="#999"
+                        height={16}
+                        mask="url(#depth-legend-swatch-mask)"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                      <rect
+                        fill="none"
+                        height={16}
+                        stroke="#333"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      All individuals
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                style={
+                  {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              />
+            </div>
+            <div
+              aria-describedby="allele_balance"
+              aria-hidden={true}
+              className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+              id="allele_balance-panel"
+              onKeyDown={[Function]}
+              role="tabpanel"
+              style={
+                {
+                  "display": "none",
+                }
+              }
+            >
+              <div
+                className="VariantGenotypeQualityMetrics__LegendWrapper-sc-tgmwmq-0 ihxxGK"
+                style={
+                  {
+                    "marginTop": "1em",
+                  }
+                }
+              >
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#428bca"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Exome
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#73ab3d"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Genome
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                style={
+                  {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          className="ControlSection__Wrapper-sc-rro5al-1 dSZUkP"
+        >
+          <span
+            className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+          >
+            <label
+              className="Checkbox__Label-hrpa6b-0 gtTKXr"
+              htmlFor="genotype-quality-metrics-show-all-individuals"
+            >
+              <input
+                checked={true}
+                className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                disabled={false}
+                id="genotype-quality-metrics-show-all-individuals"
+                onChange={[Function]}
+                type="checkbox"
+              />
+              Compare to all individuals
+            </label>
+          </span>
+          <span
+            className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+          >
+            <label
+              htmlFor="genotype-quality-metrics-sequencing-type"
+            >
+              Sequencing types: 
+              <select
+                className="Select-sc-1lkyg9e-0 ivadCR"
+                disabled={true}
+                id="genotype-quality-metrics-sequencing-type"
+                onChange={[Function]}
+                value="g"
+              >
+                <option
+                  value="eg"
+                >
+                  Exome and Genome
+                </option>
+                <option
+                  value="e"
+                >
+                  Exome
+                </option>
+                <option
+                  value="g"
+                >
+                  Genome
+                </option>
+              </select>
+            </label>
+          </span>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+    >
+      <h2>
+        Site Quality Metrics
+      </h2>
+      <div>
+        <div
+          role="tablist"
+        >
+          <ul
+            className="Tabs__TabListWrapper-jzgyty-0 gUVxKq"
+          >
+            <li>
+              <div
+                aria-controls="distribution-panel"
+                aria-selected={true}
+                className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                id="distribution"
+                onFocus={[Function]}
+                role="tab"
+                tabIndex={0}
+              >
+                <div
+                  className="Tabs__TabLabel-jzgyty-2 dcUyBp"
+                >
+                  Metric distribution
+                </div>
+              </div>
+            </li>
+            <li>
+              <div
+                aria-controls="values-panel"
+                aria-selected={false}
+                className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                id="values"
+                onFocus={[Function]}
+                role="tab"
+                tabIndex={-1}
+              >
+                <div
+                  className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                >
+                  All metric values
+                </div>
+              </div>
+            </li>
+          </ul>
+        </div>
+        <div>
+          <div
+            aria-describedby="distribution"
+            aria-hidden={false}
+            className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+            id="distribution-panel"
+            onKeyDown={[Function]}
+            role="tabpanel"
+            style={{}}
+          >
+            <div>
+              <div
+                className="VariantSiteQualityMetrics__LegendWrapper-sc-186wx2k-2 gDWfxF"
+              >
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#428bca"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Exome
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#73ab3d"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Genome
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                style={
+                  {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              />
+              <div
+                style={
+                  {
+                    "marginBottom": "0.5rem",
+                    "overflow": "hidden",
+                  }
+                }
+              />
+              <div
+                className="ControlSection__Wrapper-sc-rro5al-1 dSZUkP"
+              >
+                <span
+                  className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+                >
+                  <label
+                    htmlFor="site-quality-metrics-metric"
+                  >
+                    Metric: 
+                    <select
+                      className="Select-sc-1lkyg9e-0 ivadCR"
+                      id="site-quality-metrics-metric"
+                      onChange={[Function]}
+                      value="SiteQuality"
+                    >
+                      <option
+                        value="SiteQuality"
+                      >
+                        SiteQuality
+                      </option>
+                      <option
+                        value="InbreedingCoeff"
+                      >
+                        InbreedingCoeff
+                      </option>
+                      <option
+                        value="AS_FS"
+                      >
+                        AS_FS
+                      </option>
+                      <option
+                        value="AS_MQ"
+                      >
+                        AS_MQ
+                      </option>
+                      <option
+                        value="AS_MQRankSum"
+                      >
+                        AS_MQRankSum
+                      </option>
+                      <option
+                        value="AS_pab_max"
+                      >
+                        AS_pab_max
+                      </option>
+                      <option
+                        value="AS_QUALapprox"
+                      >
+                        AS_QUALapprox
+                      </option>
+                      <option
+                        value="AS_QD"
+                      >
+                        AS_QD
+                      </option>
+                      <option
+                        value="AS_ReadPosRankSum"
+                      >
+                        AS_ReadPosRankSum
+                      </option>
+                      <option
+                        value="AS_SOR"
+                      >
+                        AS_SOR
+                      </option>
+                      <option
+                        value="AS_VarDP"
+                      >
+                        AS_VarDP
+                      </option>
+                      <option
+                        value="AS_VQSLOD"
+                      >
+                        AS_VQSLOD
+                      </option>
+                    </select>
+                  </label>
+                </span>
+                <span
+                  className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+                >
+                  <label
+                    htmlFor="site-quality-metrics-sequencing-type"
+                  >
+                    Sequencing types: 
+                    <select
+                      className="Select-sc-1lkyg9e-0 ivadCR"
+                      disabled={true}
+                      id="site-quality-metrics-sequencing-type"
+                      onChange={[Function]}
+                      value="g"
+                    >
+                      <option
+                        value="eg"
+                      >
+                        Exome and Genome
+                      </option>
+                      <option
+                        value="e"
+                      >
+                        Exome
+                      </option>
+                      <option
+                        value="g"
+                      >
+                        Genome
+                      </option>
+                    </select>
+                  </label>
+                </span>
+              </div>
+              <p>
+                Value: 
+                0 (genome samples)
+              </p>
+              <p>
+                Site quality approximation for all variants with 0 &lt;= AF &lt; 0.00005.
+              </p>
+            </div>
+          </div>
+          <div
+            aria-describedby="values"
+            aria-hidden={true}
+            className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+            id="values-panel"
+            onKeyDown={[Function]}
+            role="tabpanel"
+            style={
+              {
+                "display": "none",
+              }
+            }
+          >
+            <table
+              className="Table__BaseTable-sc-7fgtt2-0 dIBzV"
+              style={
+                {
+                  "width": "100%",
+                }
+              }
+            >
+              <thead>
+                <tr>
+                  <th
+                    scope="col"
+                  >
+                    Metric
+                  </th>
+                  <th
+                    scope="col"
+                  >
+                    Genome samples
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      SiteQuality
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      InbreedingCoeff
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_FS
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_MQ
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_MQRankSum
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_pab_max
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    AS_QUALapprox
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_QD
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_ReadPosRankSum
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_SOR
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_VarDP
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_VQSLOD
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 CMQAN"
+    >
+      <h2>
+        Read Data
+      </h2>
+      <div>
+        <p>
+          No read data available for this variant.
+        </p>
+      </div>
+    </section>
+  </div>
+</div>
+`;
+
+exports[`VariantPage with dataset "gnomad_r3_controls_and_biobanks" has no unexpected changes 1`] = `
+<div
+  className="Page-w7h773-0 dRYfBS"
+>
+  <div
+    className="GnomadPageHeading__PageHeadingWrapper-sc-sgz3rr-0 gcOcdP"
+  >
+    <div
+      className="GnomadPageHeading__PageHeadingInnerWrapper-sc-sgz3rr-1 dLZzAa"
+    >
+      <h1
+        className="GnomadPageHeading__PageHeadingText-sc-sgz3rr-3 edXBqX"
+      >
+        <span
+          className="VariantPageTitle__TitleWrapper-sc-16g6pnt-0 bAAXLa"
+        >
+          <span>
+            Single nucleotide variant
+          </span>
+          <span
+            className="VariantPageTitle__Separator-sc-16g6pnt-1 jsfCLA"
+            style={
+              {
+                "width": "1ch",
+              }
+            }
+          >
+            :
+          </span>
+          <span
+            className="VariantPageTitle__VariantIdWrapper-sc-16g6pnt-2 jxIjmG"
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+          >
+            <span>
+              13
+              -
+              123
+            </span>
+            <span
+              className="VariantPageTitle__VariantIdSeparator-sc-16g6pnt-3 gwKaru"
+            >
+              -
+            </span>
+            <span
+              className="VariantPageTitle__TitleAlleles-sc-16g6pnt-4 dgrTjT"
+            >
+              A
+              -
+              C
+            </span>
+          </span>
+          <span
+            className="VariantPageTitle__Separator-sc-16g6pnt-1 jsfCLA"
+          >
+             
+          </span>
+          <span>
+            (
+            GRCh38
+            )
+          </span>
+        </span>
+      </h1>
+    </div>
+    <div
+      className="GnomadPageHeading__PageControlsWrapper-sc-sgz3rr-4 liqJpb"
+    >
+      <span
+        className="GnomadPageHeading__Label-sc-sgz3rr-5 dOhShJ"
+      >
+        Dataset
+      </span>
+      <ul
+        className="DatasetSelector__NavigationMenuWrapper-sc-1p2fxbn-0 ebZvwy"
+      >
+        <li
+          className="DatasetSelector__NavigationMenuItem-sc-1p2fxbn-2 ifirRc"
+        >
+          <a
+            className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
+            data-item="current_short_variant"
+            href="/?dataset=gnomad_r3_controls_and_biobanks"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+          >
+            gnomAD v3.1.2 (controls/biobanks)
+          </a>
+        </li>
+        <li
+          className="DatasetSelector__NavigationMenuItem-sc-1p2fxbn-2 ifirRc"
+        >
+          <a
+            aria-expanded={false}
+            aria-haspopup="true"
+            aria-label="More datasets"
+            className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
+            data-item="other_short_variant"
+            href="/"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="button"
+          >
+            <span
+              className="DatasetSelector__MoreIcon-sc-1p2fxbn-3 hTYFQu"
+            >
+              <img
+                alt=""
+                aria-hidden="true"
+                src="test-file-stub"
+              />
+            </span>
+          </a>
+          <ul
+            className="DatasetSelector__SubNavigationMenu-sc-1p2fxbn-4 epYyTQ"
+          >
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r3"
+                href="/?dataset=gnomad_r3"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v3.1.2
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  76,156 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r3_non_cancer"
+                href="/?dataset=gnomad_r3_non_cancer"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v3.1.2 (non-cancer)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  74,023 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r3_non_neuro"
+                href="/?dataset=gnomad_r3_non_neuro"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v3.1.2 (non-neuro)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  67,442 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r3_non_v2"
+                href="/?dataset=gnomad_r3_non_v2"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v3.1.2 (non-v2)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  57,344 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r3_non_topmed"
+                href="/?dataset=gnomad_r3_non_topmed"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v3.1.2 (non-TOPMed)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  40,433 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r3_controls_and_biobanks"
+                href="/?dataset=gnomad_r3_controls_and_biobanks"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v3.1.2 (controls/biobanks)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  16,465 samples
+                </div>
+              </a>
+            </li>
+          </ul>
+        </li>
+      </ul>
+      <span>
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+          >
+            More information
+          </span>
+        </button>
+      </span>
+    </div>
+  </div>
+  <div
+    className="VariantPage__FlexWrapper-sc-hd87ur-2 bjkoAa"
+  >
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+    >
+      <div
+        className="TableWrapper-sc-1ep26r3-0 edvjZa"
+      >
+        <div>
+          <table
+            className="VariantOccurrenceTable__Table-sc-8b13g7-0 iwAwP"
+          >
+            <tbody>
+              <tr>
+                <td />
+                <th
+                  scope="col"
+                >
+                  Genomes
+                </th>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Filters
+                  </span>
+                </th>
+                <td>
+                  <span
+                    className="Badge__BadgeWrapper-j4izdp-1 bhuqae"
+                  >
+                    Pass
+                  </span>
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Count
+                  </span>
+                </th>
+                <td>
+                  0
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Number
+                  </span>
+                </th>
+                <td>
+                  0
+                   *
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Frequency
+                  </span>
+                </th>
+                <td>
+                  0.000
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="VariantOccurrenceTable__NoWrap-sc-8b13g7-1 kmxNQ"
+                  >
+                    Popmax Filtering AF 
+                    <button
+                      className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <img
+                        alt=""
+                        aria-hidden="true"
+                        src="test-file-stub"
+                      />
+                      <span
+                        style={
+                          {
+                            "border": "0",
+                            "clip": "rect(0 0 0 0)",
+                            "height": "1px",
+                            "margin": "-1px",
+                            "overflow": "hidden",
+                            "padding": "0",
+                            "position": "absolute",
+                            "whiteSpace": "nowrap",
+                            "width": "1px",
+                          }
+                        }
+                      >
+                        More information
+                      </span>
+                    </button>
+                  </span>
+                  <br />
+                  (95% confidence)
+                </th>
+                <td>
+                  <span>
+                    0
+                  </span>
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Number of homozygotes
+                  </span>
+                </th>
+                <td>
+                  0
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Mean depth of coverage
+                  </span>
+                </th>
+                <td>
+                  –
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <p>
+            <span
+              className="Badge__BadgeWrapper-j4izdp-1 bbjxGL"
+            >
+              Warning
+            </span>
+             This variant is covered in fewer than 50% of individuals in 
+            gnomAD v3.1.2 (controls/biobanks) genomes
+            .
+             
+            This may indicate a low-quality site
+            .
+          </p>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+    >
+      <h2>
+        External Resources
+      </h2>
+      <ul
+        className="List-sc-4j87st-0 fQRmhM"
+      >
+        <li
+          className="List__ListItem-sc-4j87st-1 gGPLUe"
+        >
+          <a
+            className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+            href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&highlight=hg38.chr13%3A123-123&position=chr13%3A98-148"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            UCSC
+          </a>
+        </li>
+      </ul>
+      <h2>
+        Feedback
+      </h2>
+      <a
+        className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+        href="mailto:gnomad@broadinstitute.org"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        Report an issue with this variant
+      </a>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 CMQAN"
+    >
+      <h2>
+        Population Frequencies 
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
+      <div>
+        <div
+          role="tablist"
+        >
+          <ul
+            className="Tabs__TabListWrapper-jzgyty-0 gUVxKq"
+          >
+            <li>
+              <div
+                aria-controls="gnomAD-panel"
+                aria-selected={true}
+                className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                id="gnomAD"
+                onFocus={[Function]}
+                role="tab"
+                tabIndex={0}
+              >
+                <div
+                  className="Tabs__TabLabel-jzgyty-2 dcUyBp"
+                >
+                  gnomAD
+                </div>
+              </div>
+            </li>
+            <li>
+              <div
+                aria-controls="HGDP-panel"
+                aria-selected={false}
+                className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                id="HGDP"
+                onFocus={[Function]}
+                role="tab"
+                tabIndex={-1}
+              >
+                <div
+                  className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                >
+                  HGDP
+                </div>
+              </div>
+            </li>
+            <li>
+              <div
+                aria-controls="1KG-panel"
+                aria-selected={false}
+                className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                id="1KG"
+                onFocus={[Function]}
+                role="tab"
+                tabIndex={-1}
+              >
+                <div
+                  className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                >
+                  1KG
+                </div>
+              </div>
+            </li>
+            <li>
+              <div
+                aria-controls="local-ancestry-panel"
+                aria-selected={false}
+                className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                id="local-ancestry"
+                onFocus={[Function]}
+                role="tab"
+                tabIndex={-1}
+              >
+                <div
+                  className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                >
+                  Local Ancestry
+                </div>
+              </div>
+            </li>
+          </ul>
+        </div>
+        <div>
+          <div
+            aria-describedby="gnomAD"
+            aria-hidden={false}
+            className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+            id="gnomAD-panel"
+            onKeyDown={[Function]}
+            role="tabpanel"
+            style={{}}
+          >
+            <div
+              className="TableWrapper-sc-1ep26r3-0 edvjZa"
+            >
+              <table
+                className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+              >
+                <thead>
+                  <tr>
+                    <th
+                      aria-sort="none"
+                      colSpan={2}
+                      scope="col"
+                    >
+                      <button
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        Population
+                      </button>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      className="right-align"
+                      scope="col"
+                    >
+                      <button
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <span
+                          className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                        >
+                          Allele Count
+                        </span>
+                      </button>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      className="right-align"
+                      scope="col"
+                    >
+                      <button
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <span
+                          className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                        >
+                          Allele Number
+                        </span>
+                      </button>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      className="right-align"
+                      scope="col"
+                    >
+                      <button
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <span
+                          className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                        >
+                          Number of Homozygotes
+                        </span>
+                      </button>
+                    </th>
+                    <th
+                      aria-sort="descending"
+                      scope="col"
+                      style={
+                        {
+                          "paddingLeft": "25px",
+                        }
+                      }
+                    >
+                      <button
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <span
+                          className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                        >
+                          Allele Frequency
+                        </span>
+                      </button>
+                    </th>
+                  </tr>
+                </thead>
+                <tfoot>
+                  <tr
+                    className="border"
+                  >
+                    <th
+                      colSpan={2}
+                      scope="row"
+                    >
+                      Total
+                    </th>
+                    <td
+                      className="right-align"
+                    >
+                      0
+                    </td>
+                    <td
+                      className="right-align"
+                    >
+                      0
+                    </td>
+                    <td
+                      className="right-align"
+                    >
+                      0
+                    </td>
+                    <td
+                      style={
+                        {
+                          "paddingLeft": "25px",
+                        }
+                      }
+                    >
+                      0.000
+                    </td>
+                  </tr>
+                </tfoot>
+              </table>
+              <div
+                className="GnomadPopulationsTable__ControlSection-sc-1ghxck9-0 bsALfR"
+              >
+                Include:
+                <label
+                  className="Checkbox__Label-hrpa6b-0 gtTKXr"
+                  htmlFor="includeExomePopulations"
+                >
+                  <input
+                    checked={false}
+                    className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                    disabled={true}
+                    id="includeExomePopulations"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Exomes
+                </label>
+                <label
+                  className="Checkbox__Label-hrpa6b-0 gtTKXr"
+                  htmlFor="includeGenomePopulations"
+                >
+                  <input
+                    checked={false}
+                    className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                    disabled={true}
+                    id="includeGenomePopulations"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Genomes
+                </label>
+              </div>
+            </div>
+          </div>
+          <div
+            aria-describedby="HGDP"
+            aria-hidden={true}
+            className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+            id="HGDP-panel"
+            onKeyDown={[Function]}
+            role="tabpanel"
+            style={
+              {
+                "display": "none",
+              }
+            }
+          >
+            <p>
+              HGDP population frequencies are not available for this variant.
+            </p>
+          </div>
+          <div
+            aria-describedby="1KG"
+            aria-hidden={true}
+            className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+            id="1KG-panel"
+            onKeyDown={[Function]}
+            role="tabpanel"
+            style={
+              {
+                "display": "none",
+              }
+            }
+          >
+            <p>
+              1000 Genomes Project population frequencies are not available for this variant.
+            </p>
+          </div>
+          <div
+            aria-describedby="local-ancestry"
+            aria-hidden={true}
+            className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+            id="local-ancestry-panel"
+            onKeyDown={[Function]}
+            role="tabpanel"
+            style={
+              {
+                "display": "none",
+              }
+            }
+          >
+            <p>
+              Local ancestry is not available for subsets of gnomAD v3.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 CMQAN"
+    >
+      <h2>
+        Related Variants
+      </h2>
+      <div
+        className="VariantRelatedVariants__Wrapper-sc-y59fw8-0 bOggsA"
+      >
+        <div
+          className="VariantRelatedVariants__Item-sc-y59fw8-1 kqiRIK"
+        >
+          <h3>
+            Nearby Variants
+          </h3>
+          <p>
+            <a
+              className="Link-sc-14lgydv-0-Link jBvaYQ"
+              href="/region/13-103-143"
+              onClick={[Function]}
+            >
+              View variants located within 20 bases of this variant.
+            </a>
+          </p>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 CMQAN"
+    >
+      <h2>
+        Variant Effect Predictor
+      </h2>
+      <div>
+        <p>
+          This variant falls on 
+          0
+           transcript
+          s
+           in 
+          0
+           
+          gene
+          s
+          .
+        </p>
+        <p>
+          <span
+            className="Badge__BadgeWrapper-j4izdp-1 cJObdY"
+          >
+            Note
+          </span>
+           The gene symbols shown below are provided by VEP and may differ from the symbol shown on gene pages.
+        </p>
+        <ol
+          className="TranscriptConsequenceList__ConsequenceListWrapper-sc-qi0gmz-1 cXJgYo"
+        />
+      </div>
+    </section>
+    <div
+      className="VariantPage__FlexWrapper-sc-hd87ur-2 bjkoAa"
+    >
+      <section
+        className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+      >
+        <h2>
+          Genomic Constraint of Surrounding 1kb Region
+        </h2>
+        This variant does not have non coding constraint data for the surrounding region.
+      </section>
+    </div>
+    <div
+      className="VariantPage__FlexWrapper-sc-hd87ur-2 bjkoAa"
+    >
+      <section
+        className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+      >
+        <h2>
+          Age Distribution 
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
+        <p>
+          Age distribution is based on the full gnomAD dataset, not the selected subset.
+        </p>
+        <div>
+          <div
+            className="GnomadAgeDistribution__LegendWrapper-sc-ty24oq-0 kOKZpq"
+          >
+            <ul
+              className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+            >
+              <li
+                className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+              >
+                <svg
+                  height={16}
+                  width={16}
+                >
+                  <rect
+                    fill="#428bca"
+                    height={16}
+                    stroke="#000"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                </svg>
+                <span
+                  style={
+                    {
+                      "marginLeft": "0.25em",
+                    }
+                  }
+                >
+                  Exome
+                </span>
+              </li>
+              <li
+                className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+              >
+                <svg
+                  height={16}
+                  width={16}
+                >
+                  <rect
+                    fill="#73ab3d"
+                    height={16}
+                    stroke="#000"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                </svg>
+                <span
+                  style={
+                    {
+                      "marginLeft": "0.25em",
+                    }
+                  }
+                >
+                  Genome
+                </span>
+              </li>
+            </ul>
+            <ul
+              className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+            >
+              <li
+                className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+              >
+                <svg
+                  height={16}
+                  width={16}
+                >
+                  <rect
+                    fill="#999"
+                    height={16}
+                    stroke="#000"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                </svg>
+                <span
+                  style={
+                    {
+                      "marginLeft": "0.25em",
+                    }
+                  }
+                >
+                  Variant carriers
+                </span>
+              </li>
+              <li
+                className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+              >
+                <svg
+                  height={16}
+                  width={16}
+                >
+                  <defs>
+                    <pattern
+                      height={4}
+                      id="age-distribution-legend-swatch-stripes"
+                      patternTransform="rotate(45)"
+                      patternUnits="userSpaceOnUse"
+                      width={4}
+                    >
+                      <rect
+                        fill="#fff"
+                        height={4}
+                        transform="translate(0,0)"
+                        width={3}
+                      />
+                    </pattern>
+                    <mask
+                      id="age-distribution-legend-swatch-mask"
+                    >
+                      <rect
+                        fill="url(#age-distribution-legend-swatch-stripes)"
+                        height="100%"
+                        width="100%"
+                        x={0}
+                        y={0}
+                      />
+                    </mask>
+                  </defs>
+                  <rect
+                    fill="#999"
+                    height={16}
+                    mask="url(#age-distribution-legend-swatch-mask)"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                  <rect
+                    fill="none"
+                    height={16}
+                    stroke="#333"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                </svg>
+                <span
+                  style={
+                    {
+                      "marginLeft": "0.25em",
+                    }
+                  }
+                >
+                  All individuals
+                </span>
+              </li>
+            </ul>
+          </div>
+          <div
+            style={
+              {
+                "height": "100%",
+                "width": "100%",
+              }
+            }
+          />
+          <div
+            className="ControlSection__Wrapper-sc-rro5al-1 dSZUkP"
+          >
+            <span
+              className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+            >
+              <div
+                className="GnomadAgeDistribution__CheckboxWrapper-sc-ty24oq-1 fatvfk"
+              >
+                <label
+                  className="Checkbox__Label-hrpa6b-0 gtTKXr"
+                  htmlFor="age-distribution-include-heterozygotes"
+                >
+                  <input
+                    checked={true}
+                    className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                    disabled={false}
+                    id="age-distribution-include-heterozygotes"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Include heterozygous variant carriers
+                </label>
+                <label
+                  className="Checkbox__Label-hrpa6b-0 gtTKXr"
+                  htmlFor="age-distribution-include-homozygotes"
+                >
+                  <input
+                    checked={true}
+                    className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                    disabled={false}
+                    id="age-distribution-include-homozygotes"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Include homozygous variant carriers
+                </label>
+                <label
+                  className="Checkbox__Label-hrpa6b-0 gtTKXr"
+                  htmlFor="age-distribution-show-all-individuals"
+                >
+                  <input
+                    checked={true}
+                    className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                    disabled={false}
+                    id="age-distribution-show-all-individuals"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Compare to all individuals
+                </label>
+              </div>
+            </span>
+            <span
+              className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+            >
+              <label
+                htmlFor="age-distribution-sequencing-type"
+              >
+                Sequencing types: 
+                <select
+                  className="Select-sc-1lkyg9e-0 ivadCR"
+                  disabled={true}
+                  id="age-distribution-sequencing-type"
+                  onChange={[Function]}
+                  value="g"
+                >
+                  <option
+                    value="eg"
+                  >
+                    Exome and Genome
+                  </option>
+                  <option
+                    value="e"
+                  >
+                    Exome
+                  </option>
+                  <option
+                    value="g"
+                  >
+                    Genome
+                  </option>
+                </select>
+              </label>
+            </span>
+          </div>
+        </div>
+      </section>
+    </div>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+    >
+      <h2>
+        Genotype Quality Metrics
+      </h2>
+      <div>
+        <div>
+          <div
+            role="tablist"
+          >
+            <ul
+              className="Tabs__TabListWrapper-jzgyty-0 gUVxKq"
+            >
+              <li>
+                <div
+                  aria-controls="genotype_quality-panel"
+                  aria-selected={true}
+                  className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                  id="genotype_quality"
+                  onFocus={[Function]}
+                  role="tab"
+                  tabIndex={0}
+                >
+                  <div
+                    className="Tabs__TabLabel-jzgyty-2 dcUyBp"
+                  >
+                    Genotype quality
+                  </div>
+                </div>
+              </li>
+              <li>
+                <div
+                  aria-controls="genotype_depth-panel"
+                  aria-selected={false}
+                  className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                  id="genotype_depth"
+                  onFocus={[Function]}
+                  role="tab"
+                  tabIndex={-1}
+                >
+                  <div
+                    className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                  >
+                    Depth
+                  </div>
+                </div>
+              </li>
+              <li>
+                <div
+                  aria-controls="allele_balance-panel"
+                  aria-selected={false}
+                  className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                  id="allele_balance"
+                  onFocus={[Function]}
+                  role="tab"
+                  tabIndex={-1}
+                >
+                  <div
+                    className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                  >
+                    Allele balance for heterozygotes
+                  </div>
+                </div>
+              </li>
+            </ul>
+          </div>
+          <div>
+            <div
+              aria-describedby="genotype_quality"
+              aria-hidden={false}
+              className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+              id="genotype_quality-panel"
+              onKeyDown={[Function]}
+              role="tabpanel"
+              style={{}}
+            >
+              <div
+                className="VariantGenotypeQualityMetrics__LegendWrapper-sc-tgmwmq-0 ihxxGK"
+              >
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#428bca"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Exome
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#73ab3d"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Genome
+                    </span>
+                  </li>
+                </ul>
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#999"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Variant carriers
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <defs>
+                        <pattern
+                          height={4}
+                          id="genotype-quality-legend-swatch-stripes"
+                          patternTransform="rotate(45)"
+                          patternUnits="userSpaceOnUse"
+                          width={4}
+                        >
+                          <rect
+                            fill="#fff"
+                            height={4}
+                            transform="translate(0,0)"
+                            width={3}
+                          />
+                        </pattern>
+                        <mask
+                          id="genotype-quality-legend-swatch-mask"
+                        >
+                          <rect
+                            fill="url(#genotype-quality-legend-swatch-stripes)"
+                            height="100%"
+                            width="100%"
+                            x={0}
+                            y={0}
+                          />
+                        </mask>
+                      </defs>
+                      <rect
+                        fill="#999"
+                        height={16}
+                        mask="url(#genotype-quality-legend-swatch-mask)"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                      <rect
+                        fill="none"
+                        height={16}
+                        stroke="#333"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      All individuals
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                style={
+                  {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              />
+            </div>
+            <div
+              aria-describedby="genotype_depth"
+              aria-hidden={true}
+              className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+              id="genotype_depth-panel"
+              onKeyDown={[Function]}
+              role="tabpanel"
+              style={
+                {
+                  "display": "none",
+                }
+              }
+            >
+              <div
+                className="VariantGenotypeQualityMetrics__LegendWrapper-sc-tgmwmq-0 ihxxGK"
+                style={
+                  {
+                    "marginTop": "1em",
+                  }
+                }
+              >
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#428bca"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Exome
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#73ab3d"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Genome
+                    </span>
+                  </li>
+                </ul>
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#999"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Variant carriers
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <defs>
+                        <pattern
+                          height={4}
+                          id="depth-legend-swatch-stripes"
+                          patternTransform="rotate(45)"
+                          patternUnits="userSpaceOnUse"
+                          width={4}
+                        >
+                          <rect
+                            fill="#fff"
+                            height={4}
+                            transform="translate(0,0)"
+                            width={3}
+                          />
+                        </pattern>
+                        <mask
+                          id="depth-legend-swatch-mask"
+                        >
+                          <rect
+                            fill="url(#depth-legend-swatch-stripes)"
+                            height="100%"
+                            width="100%"
+                            x={0}
+                            y={0}
+                          />
+                        </mask>
+                      </defs>
+                      <rect
+                        fill="#999"
+                        height={16}
+                        mask="url(#depth-legend-swatch-mask)"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                      <rect
+                        fill="none"
+                        height={16}
+                        stroke="#333"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      All individuals
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                style={
+                  {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              />
+            </div>
+            <div
+              aria-describedby="allele_balance"
+              aria-hidden={true}
+              className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+              id="allele_balance-panel"
+              onKeyDown={[Function]}
+              role="tabpanel"
+              style={
+                {
+                  "display": "none",
+                }
+              }
+            >
+              <div
+                className="VariantGenotypeQualityMetrics__LegendWrapper-sc-tgmwmq-0 ihxxGK"
+                style={
+                  {
+                    "marginTop": "1em",
+                  }
+                }
+              >
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#428bca"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Exome
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#73ab3d"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Genome
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                style={
+                  {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          className="ControlSection__Wrapper-sc-rro5al-1 dSZUkP"
+        >
+          <span
+            className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+          >
+            <label
+              className="Checkbox__Label-hrpa6b-0 gtTKXr"
+              htmlFor="genotype-quality-metrics-show-all-individuals"
+            >
+              <input
+                checked={true}
+                className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                disabled={false}
+                id="genotype-quality-metrics-show-all-individuals"
+                onChange={[Function]}
+                type="checkbox"
+              />
+              Compare to all individuals
+            </label>
+          </span>
+          <span
+            className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+          >
+            <label
+              htmlFor="genotype-quality-metrics-sequencing-type"
+            >
+              Sequencing types: 
+              <select
+                className="Select-sc-1lkyg9e-0 ivadCR"
+                disabled={true}
+                id="genotype-quality-metrics-sequencing-type"
+                onChange={[Function]}
+                value="g"
+              >
+                <option
+                  value="eg"
+                >
+                  Exome and Genome
+                </option>
+                <option
+                  value="e"
+                >
+                  Exome
+                </option>
+                <option
+                  value="g"
+                >
+                  Genome
+                </option>
+              </select>
+            </label>
+          </span>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+    >
+      <h2>
+        Site Quality Metrics
+      </h2>
+      <div>
+        <div
+          role="tablist"
+        >
+          <ul
+            className="Tabs__TabListWrapper-jzgyty-0 gUVxKq"
+          >
+            <li>
+              <div
+                aria-controls="distribution-panel"
+                aria-selected={true}
+                className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                id="distribution"
+                onFocus={[Function]}
+                role="tab"
+                tabIndex={0}
+              >
+                <div
+                  className="Tabs__TabLabel-jzgyty-2 dcUyBp"
+                >
+                  Metric distribution
+                </div>
+              </div>
+            </li>
+            <li>
+              <div
+                aria-controls="values-panel"
+                aria-selected={false}
+                className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                id="values"
+                onFocus={[Function]}
+                role="tab"
+                tabIndex={-1}
+              >
+                <div
+                  className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                >
+                  All metric values
+                </div>
+              </div>
+            </li>
+          </ul>
+        </div>
+        <div>
+          <div
+            aria-describedby="distribution"
+            aria-hidden={false}
+            className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+            id="distribution-panel"
+            onKeyDown={[Function]}
+            role="tabpanel"
+            style={{}}
+          >
+            <div>
+              <div
+                className="VariantSiteQualityMetrics__LegendWrapper-sc-186wx2k-2 gDWfxF"
+              >
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#428bca"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Exome
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#73ab3d"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Genome
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                style={
+                  {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              />
+              <div
+                style={
+                  {
+                    "marginBottom": "0.5rem",
+                    "overflow": "hidden",
+                  }
+                }
+              />
+              <div
+                className="ControlSection__Wrapper-sc-rro5al-1 dSZUkP"
+              >
+                <span
+                  className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+                >
+                  <label
+                    htmlFor="site-quality-metrics-metric"
+                  >
+                    Metric: 
+                    <select
+                      className="Select-sc-1lkyg9e-0 ivadCR"
+                      id="site-quality-metrics-metric"
+                      onChange={[Function]}
+                      value="SiteQuality"
+                    >
+                      <option
+                        value="SiteQuality"
+                      >
+                        SiteQuality
+                      </option>
+                      <option
+                        value="InbreedingCoeff"
+                      >
+                        InbreedingCoeff
+                      </option>
+                      <option
+                        value="AS_FS"
+                      >
+                        AS_FS
+                      </option>
+                      <option
+                        value="AS_MQ"
+                      >
+                        AS_MQ
+                      </option>
+                      <option
+                        value="AS_MQRankSum"
+                      >
+                        AS_MQRankSum
+                      </option>
+                      <option
+                        value="AS_pab_max"
+                      >
+                        AS_pab_max
+                      </option>
+                      <option
+                        value="AS_QUALapprox"
+                      >
+                        AS_QUALapprox
+                      </option>
+                      <option
+                        value="AS_QD"
+                      >
+                        AS_QD
+                      </option>
+                      <option
+                        value="AS_ReadPosRankSum"
+                      >
+                        AS_ReadPosRankSum
+                      </option>
+                      <option
+                        value="AS_SOR"
+                      >
+                        AS_SOR
+                      </option>
+                      <option
+                        value="AS_VarDP"
+                      >
+                        AS_VarDP
+                      </option>
+                      <option
+                        value="AS_VQSLOD"
+                      >
+                        AS_VQSLOD
+                      </option>
+                    </select>
+                  </label>
+                </span>
+                <span
+                  className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+                >
+                  <label
+                    htmlFor="site-quality-metrics-sequencing-type"
+                  >
+                    Sequencing types: 
+                    <select
+                      className="Select-sc-1lkyg9e-0 ivadCR"
+                      disabled={true}
+                      id="site-quality-metrics-sequencing-type"
+                      onChange={[Function]}
+                      value="g"
+                    >
+                      <option
+                        value="eg"
+                      >
+                        Exome and Genome
+                      </option>
+                      <option
+                        value="e"
+                      >
+                        Exome
+                      </option>
+                      <option
+                        value="g"
+                      >
+                        Genome
+                      </option>
+                    </select>
+                  </label>
+                </span>
+              </div>
+              <p>
+                Value: 
+                0 (genome samples)
+              </p>
+              <p>
+                Site quality approximation for all variants with 0 &lt;= AF &lt; 0.00005.
+              </p>
+            </div>
+          </div>
+          <div
+            aria-describedby="values"
+            aria-hidden={true}
+            className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+            id="values-panel"
+            onKeyDown={[Function]}
+            role="tabpanel"
+            style={
+              {
+                "display": "none",
+              }
+            }
+          >
+            <table
+              className="Table__BaseTable-sc-7fgtt2-0 dIBzV"
+              style={
+                {
+                  "width": "100%",
+                }
+              }
+            >
+              <thead>
+                <tr>
+                  <th
+                    scope="col"
+                  >
+                    Metric
+                  </th>
+                  <th
+                    scope="col"
+                  >
+                    Genome samples
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      SiteQuality
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      InbreedingCoeff
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_FS
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_MQ
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_MQRankSum
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_pab_max
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    AS_QUALapprox
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_QD
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_ReadPosRankSum
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_SOR
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_VarDP
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_VQSLOD
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 CMQAN"
+    >
+      <h2>
+        Read Data
+      </h2>
+      <div>
+        <p>
+          No read data available for this variant.
+        </p>
+      </div>
+    </section>
+  </div>
+</div>
+`;
+
+exports[`VariantPage with dataset "gnomad_r3_non_cancer" has no unexpected changes 1`] = `
+<div
+  className="Page-w7h773-0 dRYfBS"
+>
+  <div
+    className="GnomadPageHeading__PageHeadingWrapper-sc-sgz3rr-0 gcOcdP"
+  >
+    <div
+      className="GnomadPageHeading__PageHeadingInnerWrapper-sc-sgz3rr-1 dLZzAa"
+    >
+      <h1
+        className="GnomadPageHeading__PageHeadingText-sc-sgz3rr-3 edXBqX"
+      >
+        <span
+          className="VariantPageTitle__TitleWrapper-sc-16g6pnt-0 bAAXLa"
+        >
+          <span>
+            Single nucleotide variant
+          </span>
+          <span
+            className="VariantPageTitle__Separator-sc-16g6pnt-1 jsfCLA"
+            style={
+              {
+                "width": "1ch",
+              }
+            }
+          >
+            :
+          </span>
+          <span
+            className="VariantPageTitle__VariantIdWrapper-sc-16g6pnt-2 jxIjmG"
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+          >
+            <span>
+              13
+              -
+              123
+            </span>
+            <span
+              className="VariantPageTitle__VariantIdSeparator-sc-16g6pnt-3 gwKaru"
+            >
+              -
+            </span>
+            <span
+              className="VariantPageTitle__TitleAlleles-sc-16g6pnt-4 dgrTjT"
+            >
+              A
+              -
+              C
+            </span>
+          </span>
+          <span
+            className="VariantPageTitle__Separator-sc-16g6pnt-1 jsfCLA"
+          >
+             
+          </span>
+          <span>
+            (
+            GRCh38
+            )
+          </span>
+        </span>
+      </h1>
+    </div>
+    <div
+      className="GnomadPageHeading__PageControlsWrapper-sc-sgz3rr-4 liqJpb"
+    >
+      <span
+        className="GnomadPageHeading__Label-sc-sgz3rr-5 dOhShJ"
+      >
+        Dataset
+      </span>
+      <ul
+        className="DatasetSelector__NavigationMenuWrapper-sc-1p2fxbn-0 ebZvwy"
+      >
+        <li
+          className="DatasetSelector__NavigationMenuItem-sc-1p2fxbn-2 ifirRc"
+        >
+          <a
+            className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
+            data-item="current_short_variant"
+            href="/?dataset=gnomad_r3_non_cancer"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+          >
+            gnomAD v3.1.2 (non-cancer)
+          </a>
+        </li>
+        <li
+          className="DatasetSelector__NavigationMenuItem-sc-1p2fxbn-2 ifirRc"
+        >
+          <a
+            aria-expanded={false}
+            aria-haspopup="true"
+            aria-label="More datasets"
+            className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
+            data-item="other_short_variant"
+            href="/"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="button"
+          >
+            <span
+              className="DatasetSelector__MoreIcon-sc-1p2fxbn-3 hTYFQu"
+            >
+              <img
+                alt=""
+                aria-hidden="true"
+                src="test-file-stub"
+              />
+            </span>
+          </a>
+          <ul
+            className="DatasetSelector__SubNavigationMenu-sc-1p2fxbn-4 epYyTQ"
+          >
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r3"
+                href="/?dataset=gnomad_r3"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v3.1.2
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  76,156 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r3_non_cancer"
+                href="/?dataset=gnomad_r3_non_cancer"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v3.1.2 (non-cancer)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  74,023 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r3_non_neuro"
+                href="/?dataset=gnomad_r3_non_neuro"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v3.1.2 (non-neuro)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  67,442 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r3_non_v2"
+                href="/?dataset=gnomad_r3_non_v2"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v3.1.2 (non-v2)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  57,344 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r3_non_topmed"
+                href="/?dataset=gnomad_r3_non_topmed"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v3.1.2 (non-TOPMed)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  40,433 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r3_controls_and_biobanks"
+                href="/?dataset=gnomad_r3_controls_and_biobanks"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v3.1.2 (controls/biobanks)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  16,465 samples
+                </div>
+              </a>
+            </li>
+          </ul>
+        </li>
+      </ul>
+      <span>
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+          >
+            More information
+          </span>
+        </button>
+      </span>
+    </div>
+  </div>
+  <div
+    className="VariantPage__FlexWrapper-sc-hd87ur-2 bjkoAa"
+  >
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+    >
+      <div
+        className="TableWrapper-sc-1ep26r3-0 edvjZa"
+      >
+        <div>
+          <table
+            className="VariantOccurrenceTable__Table-sc-8b13g7-0 iwAwP"
+          >
+            <tbody>
+              <tr>
+                <td />
+                <th
+                  scope="col"
+                >
+                  Genomes
+                </th>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Filters
+                  </span>
+                </th>
+                <td>
+                  <span
+                    className="Badge__BadgeWrapper-j4izdp-1 bhuqae"
+                  >
+                    Pass
+                  </span>
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Count
+                  </span>
+                </th>
+                <td>
+                  0
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Number
+                  </span>
+                </th>
+                <td>
+                  0
+                   *
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Frequency
+                  </span>
+                </th>
+                <td>
+                  0.000
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="VariantOccurrenceTable__NoWrap-sc-8b13g7-1 kmxNQ"
+                  >
+                    Popmax Filtering AF 
+                    <button
+                      className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <img
+                        alt=""
+                        aria-hidden="true"
+                        src="test-file-stub"
+                      />
+                      <span
+                        style={
+                          {
+                            "border": "0",
+                            "clip": "rect(0 0 0 0)",
+                            "height": "1px",
+                            "margin": "-1px",
+                            "overflow": "hidden",
+                            "padding": "0",
+                            "position": "absolute",
+                            "whiteSpace": "nowrap",
+                            "width": "1px",
+                          }
+                        }
+                      >
+                        More information
+                      </span>
+                    </button>
+                  </span>
+                  <br />
+                  (95% confidence)
+                </th>
+                <td>
+                  <span>
+                    0
+                  </span>
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Number of homozygotes
+                  </span>
+                </th>
+                <td>
+                  0
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Mean depth of coverage
+                  </span>
+                </th>
+                <td>
+                  –
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <p>
+            <span
+              className="Badge__BadgeWrapper-j4izdp-1 bbjxGL"
+            >
+              Warning
+            </span>
+             This variant is covered in fewer than 50% of individuals in 
+            gnomAD v3.1.2 (non-cancer) genomes
+            .
+             
+            This may indicate a low-quality site
+            .
+          </p>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+    >
+      <h2>
+        External Resources
+      </h2>
+      <ul
+        className="List-sc-4j87st-0 fQRmhM"
+      >
+        <li
+          className="List__ListItem-sc-4j87st-1 gGPLUe"
+        >
+          <a
+            className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+            href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&highlight=hg38.chr13%3A123-123&position=chr13%3A98-148"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            UCSC
+          </a>
+        </li>
+      </ul>
+      <h2>
+        Feedback
+      </h2>
+      <a
+        className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+        href="mailto:gnomad@broadinstitute.org"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        Report an issue with this variant
+      </a>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 CMQAN"
+    >
+      <h2>
+        Population Frequencies 
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
+      <div>
+        <div
+          role="tablist"
+        >
+          <ul
+            className="Tabs__TabListWrapper-jzgyty-0 gUVxKq"
+          >
+            <li>
+              <div
+                aria-controls="gnomAD-panel"
+                aria-selected={true}
+                className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                id="gnomAD"
+                onFocus={[Function]}
+                role="tab"
+                tabIndex={0}
+              >
+                <div
+                  className="Tabs__TabLabel-jzgyty-2 dcUyBp"
+                >
+                  gnomAD
+                </div>
+              </div>
+            </li>
+            <li>
+              <div
+                aria-controls="HGDP-panel"
+                aria-selected={false}
+                className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                id="HGDP"
+                onFocus={[Function]}
+                role="tab"
+                tabIndex={-1}
+              >
+                <div
+                  className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                >
+                  HGDP
+                </div>
+              </div>
+            </li>
+            <li>
+              <div
+                aria-controls="1KG-panel"
+                aria-selected={false}
+                className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                id="1KG"
+                onFocus={[Function]}
+                role="tab"
+                tabIndex={-1}
+              >
+                <div
+                  className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                >
+                  1KG
+                </div>
+              </div>
+            </li>
+            <li>
+              <div
+                aria-controls="local-ancestry-panel"
+                aria-selected={false}
+                className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                id="local-ancestry"
+                onFocus={[Function]}
+                role="tab"
+                tabIndex={-1}
+              >
+                <div
+                  className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                >
+                  Local Ancestry
+                </div>
+              </div>
+            </li>
+          </ul>
+        </div>
+        <div>
+          <div
+            aria-describedby="gnomAD"
+            aria-hidden={false}
+            className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+            id="gnomAD-panel"
+            onKeyDown={[Function]}
+            role="tabpanel"
+            style={{}}
+          >
+            <div
+              className="TableWrapper-sc-1ep26r3-0 edvjZa"
+            >
+              <table
+                className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+              >
+                <thead>
+                  <tr>
+                    <th
+                      aria-sort="none"
+                      colSpan={2}
+                      scope="col"
+                    >
+                      <button
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        Population
+                      </button>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      className="right-align"
+                      scope="col"
+                    >
+                      <button
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <span
+                          className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                        >
+                          Allele Count
+                        </span>
+                      </button>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      className="right-align"
+                      scope="col"
+                    >
+                      <button
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <span
+                          className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                        >
+                          Allele Number
+                        </span>
+                      </button>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      className="right-align"
+                      scope="col"
+                    >
+                      <button
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <span
+                          className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                        >
+                          Number of Homozygotes
+                        </span>
+                      </button>
+                    </th>
+                    <th
+                      aria-sort="descending"
+                      scope="col"
+                      style={
+                        {
+                          "paddingLeft": "25px",
+                        }
+                      }
+                    >
+                      <button
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <span
+                          className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                        >
+                          Allele Frequency
+                        </span>
+                      </button>
+                    </th>
+                  </tr>
+                </thead>
+                <tfoot>
+                  <tr
+                    className="border"
+                  >
+                    <th
+                      colSpan={2}
+                      scope="row"
+                    >
+                      Total
+                    </th>
+                    <td
+                      className="right-align"
+                    >
+                      0
+                    </td>
+                    <td
+                      className="right-align"
+                    >
+                      0
+                    </td>
+                    <td
+                      className="right-align"
+                    >
+                      0
+                    </td>
+                    <td
+                      style={
+                        {
+                          "paddingLeft": "25px",
+                        }
+                      }
+                    >
+                      0.000
+                    </td>
+                  </tr>
+                </tfoot>
+              </table>
+              <div
+                className="GnomadPopulationsTable__ControlSection-sc-1ghxck9-0 bsALfR"
+              >
+                Include:
+                <label
+                  className="Checkbox__Label-hrpa6b-0 gtTKXr"
+                  htmlFor="includeExomePopulations"
+                >
+                  <input
+                    checked={false}
+                    className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                    disabled={true}
+                    id="includeExomePopulations"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Exomes
+                </label>
+                <label
+                  className="Checkbox__Label-hrpa6b-0 gtTKXr"
+                  htmlFor="includeGenomePopulations"
+                >
+                  <input
+                    checked={false}
+                    className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                    disabled={true}
+                    id="includeGenomePopulations"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Genomes
+                </label>
+              </div>
+            </div>
+          </div>
+          <div
+            aria-describedby="HGDP"
+            aria-hidden={true}
+            className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+            id="HGDP-panel"
+            onKeyDown={[Function]}
+            role="tabpanel"
+            style={
+              {
+                "display": "none",
+              }
+            }
+          >
+            <p>
+              HGDP population frequencies are not available for this variant.
+            </p>
+          </div>
+          <div
+            aria-describedby="1KG"
+            aria-hidden={true}
+            className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+            id="1KG-panel"
+            onKeyDown={[Function]}
+            role="tabpanel"
+            style={
+              {
+                "display": "none",
+              }
+            }
+          >
+            <p>
+              1000 Genomes Project population frequencies are not available for this variant.
+            </p>
+          </div>
+          <div
+            aria-describedby="local-ancestry"
+            aria-hidden={true}
+            className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+            id="local-ancestry-panel"
+            onKeyDown={[Function]}
+            role="tabpanel"
+            style={
+              {
+                "display": "none",
+              }
+            }
+          >
+            <p>
+              Local ancestry is not available for subsets of gnomAD v3.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 CMQAN"
+    >
+      <h2>
+        Related Variants
+      </h2>
+      <div
+        className="VariantRelatedVariants__Wrapper-sc-y59fw8-0 bOggsA"
+      >
+        <div
+          className="VariantRelatedVariants__Item-sc-y59fw8-1 kqiRIK"
+        >
+          <h3>
+            Nearby Variants
+          </h3>
+          <p>
+            <a
+              className="Link-sc-14lgydv-0-Link jBvaYQ"
+              href="/region/13-103-143"
+              onClick={[Function]}
+            >
+              View variants located within 20 bases of this variant.
+            </a>
+          </p>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 CMQAN"
+    >
+      <h2>
+        Variant Effect Predictor
+      </h2>
+      <div>
+        <p>
+          This variant falls on 
+          0
+           transcript
+          s
+           in 
+          0
+           
+          gene
+          s
+          .
+        </p>
+        <p>
+          <span
+            className="Badge__BadgeWrapper-j4izdp-1 cJObdY"
+          >
+            Note
+          </span>
+           The gene symbols shown below are provided by VEP and may differ from the symbol shown on gene pages.
+        </p>
+        <ol
+          className="TranscriptConsequenceList__ConsequenceListWrapper-sc-qi0gmz-1 cXJgYo"
+        />
+      </div>
+    </section>
+    <div
+      className="VariantPage__FlexWrapper-sc-hd87ur-2 bjkoAa"
+    >
+      <section
+        className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+      >
+        <h2>
+          Genomic Constraint of Surrounding 1kb Region
+        </h2>
+        This variant does not have non coding constraint data for the surrounding region.
+      </section>
+    </div>
+    <div
+      className="VariantPage__FlexWrapper-sc-hd87ur-2 bjkoAa"
+    >
+      <section
+        className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+      >
+        <h2>
+          Age Distribution 
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
+        <p>
+          Age distribution is based on the full gnomAD dataset, not the selected subset.
+        </p>
+        <div>
+          <div
+            className="GnomadAgeDistribution__LegendWrapper-sc-ty24oq-0 kOKZpq"
+          >
+            <ul
+              className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+            >
+              <li
+                className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+              >
+                <svg
+                  height={16}
+                  width={16}
+                >
+                  <rect
+                    fill="#428bca"
+                    height={16}
+                    stroke="#000"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                </svg>
+                <span
+                  style={
+                    {
+                      "marginLeft": "0.25em",
+                    }
+                  }
+                >
+                  Exome
+                </span>
+              </li>
+              <li
+                className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+              >
+                <svg
+                  height={16}
+                  width={16}
+                >
+                  <rect
+                    fill="#73ab3d"
+                    height={16}
+                    stroke="#000"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                </svg>
+                <span
+                  style={
+                    {
+                      "marginLeft": "0.25em",
+                    }
+                  }
+                >
+                  Genome
+                </span>
+              </li>
+            </ul>
+            <ul
+              className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+            >
+              <li
+                className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+              >
+                <svg
+                  height={16}
+                  width={16}
+                >
+                  <rect
+                    fill="#999"
+                    height={16}
+                    stroke="#000"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                </svg>
+                <span
+                  style={
+                    {
+                      "marginLeft": "0.25em",
+                    }
+                  }
+                >
+                  Variant carriers
+                </span>
+              </li>
+              <li
+                className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+              >
+                <svg
+                  height={16}
+                  width={16}
+                >
+                  <defs>
+                    <pattern
+                      height={4}
+                      id="age-distribution-legend-swatch-stripes"
+                      patternTransform="rotate(45)"
+                      patternUnits="userSpaceOnUse"
+                      width={4}
+                    >
+                      <rect
+                        fill="#fff"
+                        height={4}
+                        transform="translate(0,0)"
+                        width={3}
+                      />
+                    </pattern>
+                    <mask
+                      id="age-distribution-legend-swatch-mask"
+                    >
+                      <rect
+                        fill="url(#age-distribution-legend-swatch-stripes)"
+                        height="100%"
+                        width="100%"
+                        x={0}
+                        y={0}
+                      />
+                    </mask>
+                  </defs>
+                  <rect
+                    fill="#999"
+                    height={16}
+                    mask="url(#age-distribution-legend-swatch-mask)"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                  <rect
+                    fill="none"
+                    height={16}
+                    stroke="#333"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                </svg>
+                <span
+                  style={
+                    {
+                      "marginLeft": "0.25em",
+                    }
+                  }
+                >
+                  All individuals
+                </span>
+              </li>
+            </ul>
+          </div>
+          <div
+            style={
+              {
+                "height": "100%",
+                "width": "100%",
+              }
+            }
+          />
+          <div
+            className="ControlSection__Wrapper-sc-rro5al-1 dSZUkP"
+          >
+            <span
+              className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+            >
+              <div
+                className="GnomadAgeDistribution__CheckboxWrapper-sc-ty24oq-1 fatvfk"
+              >
+                <label
+                  className="Checkbox__Label-hrpa6b-0 gtTKXr"
+                  htmlFor="age-distribution-include-heterozygotes"
+                >
+                  <input
+                    checked={true}
+                    className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                    disabled={false}
+                    id="age-distribution-include-heterozygotes"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Include heterozygous variant carriers
+                </label>
+                <label
+                  className="Checkbox__Label-hrpa6b-0 gtTKXr"
+                  htmlFor="age-distribution-include-homozygotes"
+                >
+                  <input
+                    checked={true}
+                    className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                    disabled={false}
+                    id="age-distribution-include-homozygotes"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Include homozygous variant carriers
+                </label>
+                <label
+                  className="Checkbox__Label-hrpa6b-0 gtTKXr"
+                  htmlFor="age-distribution-show-all-individuals"
+                >
+                  <input
+                    checked={true}
+                    className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                    disabled={false}
+                    id="age-distribution-show-all-individuals"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Compare to all individuals
+                </label>
+              </div>
+            </span>
+            <span
+              className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+            >
+              <label
+                htmlFor="age-distribution-sequencing-type"
+              >
+                Sequencing types: 
+                <select
+                  className="Select-sc-1lkyg9e-0 ivadCR"
+                  disabled={true}
+                  id="age-distribution-sequencing-type"
+                  onChange={[Function]}
+                  value="g"
+                >
+                  <option
+                    value="eg"
+                  >
+                    Exome and Genome
+                  </option>
+                  <option
+                    value="e"
+                  >
+                    Exome
+                  </option>
+                  <option
+                    value="g"
+                  >
+                    Genome
+                  </option>
+                </select>
+              </label>
+            </span>
+          </div>
+        </div>
+      </section>
+    </div>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+    >
+      <h2>
+        Genotype Quality Metrics
+      </h2>
+      <div>
+        <div>
+          <div
+            role="tablist"
+          >
+            <ul
+              className="Tabs__TabListWrapper-jzgyty-0 gUVxKq"
+            >
+              <li>
+                <div
+                  aria-controls="genotype_quality-panel"
+                  aria-selected={true}
+                  className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                  id="genotype_quality"
+                  onFocus={[Function]}
+                  role="tab"
+                  tabIndex={0}
+                >
+                  <div
+                    className="Tabs__TabLabel-jzgyty-2 dcUyBp"
+                  >
+                    Genotype quality
+                  </div>
+                </div>
+              </li>
+              <li>
+                <div
+                  aria-controls="genotype_depth-panel"
+                  aria-selected={false}
+                  className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                  id="genotype_depth"
+                  onFocus={[Function]}
+                  role="tab"
+                  tabIndex={-1}
+                >
+                  <div
+                    className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                  >
+                    Depth
+                  </div>
+                </div>
+              </li>
+              <li>
+                <div
+                  aria-controls="allele_balance-panel"
+                  aria-selected={false}
+                  className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                  id="allele_balance"
+                  onFocus={[Function]}
+                  role="tab"
+                  tabIndex={-1}
+                >
+                  <div
+                    className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                  >
+                    Allele balance for heterozygotes
+                  </div>
+                </div>
+              </li>
+            </ul>
+          </div>
+          <div>
+            <div
+              aria-describedby="genotype_quality"
+              aria-hidden={false}
+              className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+              id="genotype_quality-panel"
+              onKeyDown={[Function]}
+              role="tabpanel"
+              style={{}}
+            >
+              <div
+                className="VariantGenotypeQualityMetrics__LegendWrapper-sc-tgmwmq-0 ihxxGK"
+              >
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#428bca"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Exome
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#73ab3d"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Genome
+                    </span>
+                  </li>
+                </ul>
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#999"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Variant carriers
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <defs>
+                        <pattern
+                          height={4}
+                          id="genotype-quality-legend-swatch-stripes"
+                          patternTransform="rotate(45)"
+                          patternUnits="userSpaceOnUse"
+                          width={4}
+                        >
+                          <rect
+                            fill="#fff"
+                            height={4}
+                            transform="translate(0,0)"
+                            width={3}
+                          />
+                        </pattern>
+                        <mask
+                          id="genotype-quality-legend-swatch-mask"
+                        >
+                          <rect
+                            fill="url(#genotype-quality-legend-swatch-stripes)"
+                            height="100%"
+                            width="100%"
+                            x={0}
+                            y={0}
+                          />
+                        </mask>
+                      </defs>
+                      <rect
+                        fill="#999"
+                        height={16}
+                        mask="url(#genotype-quality-legend-swatch-mask)"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                      <rect
+                        fill="none"
+                        height={16}
+                        stroke="#333"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      All individuals
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                style={
+                  {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              />
+            </div>
+            <div
+              aria-describedby="genotype_depth"
+              aria-hidden={true}
+              className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+              id="genotype_depth-panel"
+              onKeyDown={[Function]}
+              role="tabpanel"
+              style={
+                {
+                  "display": "none",
+                }
+              }
+            >
+              <div
+                className="VariantGenotypeQualityMetrics__LegendWrapper-sc-tgmwmq-0 ihxxGK"
+                style={
+                  {
+                    "marginTop": "1em",
+                  }
+                }
+              >
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#428bca"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Exome
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#73ab3d"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Genome
+                    </span>
+                  </li>
+                </ul>
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#999"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Variant carriers
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <defs>
+                        <pattern
+                          height={4}
+                          id="depth-legend-swatch-stripes"
+                          patternTransform="rotate(45)"
+                          patternUnits="userSpaceOnUse"
+                          width={4}
+                        >
+                          <rect
+                            fill="#fff"
+                            height={4}
+                            transform="translate(0,0)"
+                            width={3}
+                          />
+                        </pattern>
+                        <mask
+                          id="depth-legend-swatch-mask"
+                        >
+                          <rect
+                            fill="url(#depth-legend-swatch-stripes)"
+                            height="100%"
+                            width="100%"
+                            x={0}
+                            y={0}
+                          />
+                        </mask>
+                      </defs>
+                      <rect
+                        fill="#999"
+                        height={16}
+                        mask="url(#depth-legend-swatch-mask)"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                      <rect
+                        fill="none"
+                        height={16}
+                        stroke="#333"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      All individuals
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                style={
+                  {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              />
+            </div>
+            <div
+              aria-describedby="allele_balance"
+              aria-hidden={true}
+              className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+              id="allele_balance-panel"
+              onKeyDown={[Function]}
+              role="tabpanel"
+              style={
+                {
+                  "display": "none",
+                }
+              }
+            >
+              <div
+                className="VariantGenotypeQualityMetrics__LegendWrapper-sc-tgmwmq-0 ihxxGK"
+                style={
+                  {
+                    "marginTop": "1em",
+                  }
+                }
+              >
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#428bca"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Exome
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#73ab3d"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Genome
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                style={
+                  {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          className="ControlSection__Wrapper-sc-rro5al-1 dSZUkP"
+        >
+          <span
+            className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+          >
+            <label
+              className="Checkbox__Label-hrpa6b-0 gtTKXr"
+              htmlFor="genotype-quality-metrics-show-all-individuals"
+            >
+              <input
+                checked={true}
+                className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                disabled={false}
+                id="genotype-quality-metrics-show-all-individuals"
+                onChange={[Function]}
+                type="checkbox"
+              />
+              Compare to all individuals
+            </label>
+          </span>
+          <span
+            className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+          >
+            <label
+              htmlFor="genotype-quality-metrics-sequencing-type"
+            >
+              Sequencing types: 
+              <select
+                className="Select-sc-1lkyg9e-0 ivadCR"
+                disabled={true}
+                id="genotype-quality-metrics-sequencing-type"
+                onChange={[Function]}
+                value="g"
+              >
+                <option
+                  value="eg"
+                >
+                  Exome and Genome
+                </option>
+                <option
+                  value="e"
+                >
+                  Exome
+                </option>
+                <option
+                  value="g"
+                >
+                  Genome
+                </option>
+              </select>
+            </label>
+          </span>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+    >
+      <h2>
+        Site Quality Metrics
+      </h2>
+      <div>
+        <div
+          role="tablist"
+        >
+          <ul
+            className="Tabs__TabListWrapper-jzgyty-0 gUVxKq"
+          >
+            <li>
+              <div
+                aria-controls="distribution-panel"
+                aria-selected={true}
+                className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                id="distribution"
+                onFocus={[Function]}
+                role="tab"
+                tabIndex={0}
+              >
+                <div
+                  className="Tabs__TabLabel-jzgyty-2 dcUyBp"
+                >
+                  Metric distribution
+                </div>
+              </div>
+            </li>
+            <li>
+              <div
+                aria-controls="values-panel"
+                aria-selected={false}
+                className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                id="values"
+                onFocus={[Function]}
+                role="tab"
+                tabIndex={-1}
+              >
+                <div
+                  className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                >
+                  All metric values
+                </div>
+              </div>
+            </li>
+          </ul>
+        </div>
+        <div>
+          <div
+            aria-describedby="distribution"
+            aria-hidden={false}
+            className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+            id="distribution-panel"
+            onKeyDown={[Function]}
+            role="tabpanel"
+            style={{}}
+          >
+            <div>
+              <div
+                className="VariantSiteQualityMetrics__LegendWrapper-sc-186wx2k-2 gDWfxF"
+              >
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#428bca"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Exome
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#73ab3d"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Genome
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                style={
+                  {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              />
+              <div
+                style={
+                  {
+                    "marginBottom": "0.5rem",
+                    "overflow": "hidden",
+                  }
+                }
+              />
+              <div
+                className="ControlSection__Wrapper-sc-rro5al-1 dSZUkP"
+              >
+                <span
+                  className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+                >
+                  <label
+                    htmlFor="site-quality-metrics-metric"
+                  >
+                    Metric: 
+                    <select
+                      className="Select-sc-1lkyg9e-0 ivadCR"
+                      id="site-quality-metrics-metric"
+                      onChange={[Function]}
+                      value="SiteQuality"
+                    >
+                      <option
+                        value="SiteQuality"
+                      >
+                        SiteQuality
+                      </option>
+                      <option
+                        value="InbreedingCoeff"
+                      >
+                        InbreedingCoeff
+                      </option>
+                      <option
+                        value="AS_FS"
+                      >
+                        AS_FS
+                      </option>
+                      <option
+                        value="AS_MQ"
+                      >
+                        AS_MQ
+                      </option>
+                      <option
+                        value="AS_MQRankSum"
+                      >
+                        AS_MQRankSum
+                      </option>
+                      <option
+                        value="AS_pab_max"
+                      >
+                        AS_pab_max
+                      </option>
+                      <option
+                        value="AS_QUALapprox"
+                      >
+                        AS_QUALapprox
+                      </option>
+                      <option
+                        value="AS_QD"
+                      >
+                        AS_QD
+                      </option>
+                      <option
+                        value="AS_ReadPosRankSum"
+                      >
+                        AS_ReadPosRankSum
+                      </option>
+                      <option
+                        value="AS_SOR"
+                      >
+                        AS_SOR
+                      </option>
+                      <option
+                        value="AS_VarDP"
+                      >
+                        AS_VarDP
+                      </option>
+                      <option
+                        value="AS_VQSLOD"
+                      >
+                        AS_VQSLOD
+                      </option>
+                    </select>
+                  </label>
+                </span>
+                <span
+                  className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+                >
+                  <label
+                    htmlFor="site-quality-metrics-sequencing-type"
+                  >
+                    Sequencing types: 
+                    <select
+                      className="Select-sc-1lkyg9e-0 ivadCR"
+                      disabled={true}
+                      id="site-quality-metrics-sequencing-type"
+                      onChange={[Function]}
+                      value="g"
+                    >
+                      <option
+                        value="eg"
+                      >
+                        Exome and Genome
+                      </option>
+                      <option
+                        value="e"
+                      >
+                        Exome
+                      </option>
+                      <option
+                        value="g"
+                      >
+                        Genome
+                      </option>
+                    </select>
+                  </label>
+                </span>
+              </div>
+              <p>
+                Value: 
+                0 (genome samples)
+              </p>
+              <p>
+                Site quality approximation for all variants with 0 &lt;= AF &lt; 0.00005.
+              </p>
+            </div>
+          </div>
+          <div
+            aria-describedby="values"
+            aria-hidden={true}
+            className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+            id="values-panel"
+            onKeyDown={[Function]}
+            role="tabpanel"
+            style={
+              {
+                "display": "none",
+              }
+            }
+          >
+            <table
+              className="Table__BaseTable-sc-7fgtt2-0 dIBzV"
+              style={
+                {
+                  "width": "100%",
+                }
+              }
+            >
+              <thead>
+                <tr>
+                  <th
+                    scope="col"
+                  >
+                    Metric
+                  </th>
+                  <th
+                    scope="col"
+                  >
+                    Genome samples
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      SiteQuality
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      InbreedingCoeff
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_FS
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_MQ
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_MQRankSum
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_pab_max
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    AS_QUALapprox
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_QD
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_ReadPosRankSum
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_SOR
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_VarDP
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_VQSLOD
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 CMQAN"
+    >
+      <h2>
+        Read Data
+      </h2>
+      <div>
+        <p>
+          No read data available for this variant.
+        </p>
+      </div>
+    </section>
+  </div>
+</div>
+`;
+
+exports[`VariantPage with dataset "gnomad_r3_non_neuro" has no unexpected changes 1`] = `
+<div
+  className="Page-w7h773-0 dRYfBS"
+>
+  <div
+    className="GnomadPageHeading__PageHeadingWrapper-sc-sgz3rr-0 gcOcdP"
+  >
+    <div
+      className="GnomadPageHeading__PageHeadingInnerWrapper-sc-sgz3rr-1 dLZzAa"
+    >
+      <h1
+        className="GnomadPageHeading__PageHeadingText-sc-sgz3rr-3 edXBqX"
+      >
+        <span
+          className="VariantPageTitle__TitleWrapper-sc-16g6pnt-0 bAAXLa"
+        >
+          <span>
+            Single nucleotide variant
+          </span>
+          <span
+            className="VariantPageTitle__Separator-sc-16g6pnt-1 jsfCLA"
+            style={
+              {
+                "width": "1ch",
+              }
+            }
+          >
+            :
+          </span>
+          <span
+            className="VariantPageTitle__VariantIdWrapper-sc-16g6pnt-2 jxIjmG"
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+          >
+            <span>
+              13
+              -
+              123
+            </span>
+            <span
+              className="VariantPageTitle__VariantIdSeparator-sc-16g6pnt-3 gwKaru"
+            >
+              -
+            </span>
+            <span
+              className="VariantPageTitle__TitleAlleles-sc-16g6pnt-4 dgrTjT"
+            >
+              A
+              -
+              C
+            </span>
+          </span>
+          <span
+            className="VariantPageTitle__Separator-sc-16g6pnt-1 jsfCLA"
+          >
+             
+          </span>
+          <span>
+            (
+            GRCh38
+            )
+          </span>
+        </span>
+      </h1>
+    </div>
+    <div
+      className="GnomadPageHeading__PageControlsWrapper-sc-sgz3rr-4 liqJpb"
+    >
+      <span
+        className="GnomadPageHeading__Label-sc-sgz3rr-5 dOhShJ"
+      >
+        Dataset
+      </span>
+      <ul
+        className="DatasetSelector__NavigationMenuWrapper-sc-1p2fxbn-0 ebZvwy"
+      >
+        <li
+          className="DatasetSelector__NavigationMenuItem-sc-1p2fxbn-2 ifirRc"
+        >
+          <a
+            className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
+            data-item="current_short_variant"
+            href="/?dataset=gnomad_r3_non_neuro"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+          >
+            gnomAD v3.1.2 (non-neuro)
+          </a>
+        </li>
+        <li
+          className="DatasetSelector__NavigationMenuItem-sc-1p2fxbn-2 ifirRc"
+        >
+          <a
+            aria-expanded={false}
+            aria-haspopup="true"
+            aria-label="More datasets"
+            className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
+            data-item="other_short_variant"
+            href="/"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="button"
+          >
+            <span
+              className="DatasetSelector__MoreIcon-sc-1p2fxbn-3 hTYFQu"
+            >
+              <img
+                alt=""
+                aria-hidden="true"
+                src="test-file-stub"
+              />
+            </span>
+          </a>
+          <ul
+            className="DatasetSelector__SubNavigationMenu-sc-1p2fxbn-4 epYyTQ"
+          >
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r3"
+                href="/?dataset=gnomad_r3"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v3.1.2
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  76,156 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r3_non_cancer"
+                href="/?dataset=gnomad_r3_non_cancer"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v3.1.2 (non-cancer)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  74,023 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r3_non_neuro"
+                href="/?dataset=gnomad_r3_non_neuro"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v3.1.2 (non-neuro)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  67,442 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r3_non_v2"
+                href="/?dataset=gnomad_r3_non_v2"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v3.1.2 (non-v2)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  57,344 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r3_non_topmed"
+                href="/?dataset=gnomad_r3_non_topmed"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v3.1.2 (non-TOPMed)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  40,433 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r3_controls_and_biobanks"
+                href="/?dataset=gnomad_r3_controls_and_biobanks"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v3.1.2 (controls/biobanks)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  16,465 samples
+                </div>
+              </a>
+            </li>
+          </ul>
+        </li>
+      </ul>
+      <span>
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+          >
+            More information
+          </span>
+        </button>
+      </span>
+    </div>
+  </div>
+  <div
+    className="VariantPage__FlexWrapper-sc-hd87ur-2 bjkoAa"
+  >
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+    >
+      <div
+        className="TableWrapper-sc-1ep26r3-0 edvjZa"
+      >
+        <div>
+          <table
+            className="VariantOccurrenceTable__Table-sc-8b13g7-0 iwAwP"
+          >
+            <tbody>
+              <tr>
+                <td />
+                <th
+                  scope="col"
+                >
+                  Genomes
+                </th>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Filters
+                  </span>
+                </th>
+                <td>
+                  <span
+                    className="Badge__BadgeWrapper-j4izdp-1 bhuqae"
+                  >
+                    Pass
+                  </span>
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Count
+                  </span>
+                </th>
+                <td>
+                  0
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Number
+                  </span>
+                </th>
+                <td>
+                  0
+                   *
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Frequency
+                  </span>
+                </th>
+                <td>
+                  0.000
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="VariantOccurrenceTable__NoWrap-sc-8b13g7-1 kmxNQ"
+                  >
+                    Popmax Filtering AF 
+                    <button
+                      className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <img
+                        alt=""
+                        aria-hidden="true"
+                        src="test-file-stub"
+                      />
+                      <span
+                        style={
+                          {
+                            "border": "0",
+                            "clip": "rect(0 0 0 0)",
+                            "height": "1px",
+                            "margin": "-1px",
+                            "overflow": "hidden",
+                            "padding": "0",
+                            "position": "absolute",
+                            "whiteSpace": "nowrap",
+                            "width": "1px",
+                          }
+                        }
+                      >
+                        More information
+                      </span>
+                    </button>
+                  </span>
+                  <br />
+                  (95% confidence)
+                </th>
+                <td>
+                  <span>
+                    0
+                  </span>
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Number of homozygotes
+                  </span>
+                </th>
+                <td>
+                  0
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Mean depth of coverage
+                  </span>
+                </th>
+                <td>
+                  –
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <p>
+            <span
+              className="Badge__BadgeWrapper-j4izdp-1 bbjxGL"
+            >
+              Warning
+            </span>
+             This variant is covered in fewer than 50% of individuals in 
+            gnomAD v3.1.2 (non-neuro) genomes
+            .
+             
+            This may indicate a low-quality site
+            .
+          </p>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+    >
+      <h2>
+        External Resources
+      </h2>
+      <ul
+        className="List-sc-4j87st-0 fQRmhM"
+      >
+        <li
+          className="List__ListItem-sc-4j87st-1 gGPLUe"
+        >
+          <a
+            className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+            href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&highlight=hg38.chr13%3A123-123&position=chr13%3A98-148"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            UCSC
+          </a>
+        </li>
+      </ul>
+      <h2>
+        Feedback
+      </h2>
+      <a
+        className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+        href="mailto:gnomad@broadinstitute.org"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        Report an issue with this variant
+      </a>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 CMQAN"
+    >
+      <h2>
+        Population Frequencies 
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
+      <div>
+        <div
+          role="tablist"
+        >
+          <ul
+            className="Tabs__TabListWrapper-jzgyty-0 gUVxKq"
+          >
+            <li>
+              <div
+                aria-controls="gnomAD-panel"
+                aria-selected={true}
+                className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                id="gnomAD"
+                onFocus={[Function]}
+                role="tab"
+                tabIndex={0}
+              >
+                <div
+                  className="Tabs__TabLabel-jzgyty-2 dcUyBp"
+                >
+                  gnomAD
+                </div>
+              </div>
+            </li>
+            <li>
+              <div
+                aria-controls="HGDP-panel"
+                aria-selected={false}
+                className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                id="HGDP"
+                onFocus={[Function]}
+                role="tab"
+                tabIndex={-1}
+              >
+                <div
+                  className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                >
+                  HGDP
+                </div>
+              </div>
+            </li>
+            <li>
+              <div
+                aria-controls="1KG-panel"
+                aria-selected={false}
+                className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                id="1KG"
+                onFocus={[Function]}
+                role="tab"
+                tabIndex={-1}
+              >
+                <div
+                  className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                >
+                  1KG
+                </div>
+              </div>
+            </li>
+            <li>
+              <div
+                aria-controls="local-ancestry-panel"
+                aria-selected={false}
+                className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                id="local-ancestry"
+                onFocus={[Function]}
+                role="tab"
+                tabIndex={-1}
+              >
+                <div
+                  className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                >
+                  Local Ancestry
+                </div>
+              </div>
+            </li>
+          </ul>
+        </div>
+        <div>
+          <div
+            aria-describedby="gnomAD"
+            aria-hidden={false}
+            className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+            id="gnomAD-panel"
+            onKeyDown={[Function]}
+            role="tabpanel"
+            style={{}}
+          >
+            <div
+              className="TableWrapper-sc-1ep26r3-0 edvjZa"
+            >
+              <table
+                className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+              >
+                <thead>
+                  <tr>
+                    <th
+                      aria-sort="none"
+                      colSpan={2}
+                      scope="col"
+                    >
+                      <button
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        Population
+                      </button>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      className="right-align"
+                      scope="col"
+                    >
+                      <button
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <span
+                          className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                        >
+                          Allele Count
+                        </span>
+                      </button>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      className="right-align"
+                      scope="col"
+                    >
+                      <button
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <span
+                          className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                        >
+                          Allele Number
+                        </span>
+                      </button>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      className="right-align"
+                      scope="col"
+                    >
+                      <button
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <span
+                          className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                        >
+                          Number of Homozygotes
+                        </span>
+                      </button>
+                    </th>
+                    <th
+                      aria-sort="descending"
+                      scope="col"
+                      style={
+                        {
+                          "paddingLeft": "25px",
+                        }
+                      }
+                    >
+                      <button
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <span
+                          className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                        >
+                          Allele Frequency
+                        </span>
+                      </button>
+                    </th>
+                  </tr>
+                </thead>
+                <tfoot>
+                  <tr
+                    className="border"
+                  >
+                    <th
+                      colSpan={2}
+                      scope="row"
+                    >
+                      Total
+                    </th>
+                    <td
+                      className="right-align"
+                    >
+                      0
+                    </td>
+                    <td
+                      className="right-align"
+                    >
+                      0
+                    </td>
+                    <td
+                      className="right-align"
+                    >
+                      0
+                    </td>
+                    <td
+                      style={
+                        {
+                          "paddingLeft": "25px",
+                        }
+                      }
+                    >
+                      0.000
+                    </td>
+                  </tr>
+                </tfoot>
+              </table>
+              <div
+                className="GnomadPopulationsTable__ControlSection-sc-1ghxck9-0 bsALfR"
+              >
+                Include:
+                <label
+                  className="Checkbox__Label-hrpa6b-0 gtTKXr"
+                  htmlFor="includeExomePopulations"
+                >
+                  <input
+                    checked={false}
+                    className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                    disabled={true}
+                    id="includeExomePopulations"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Exomes
+                </label>
+                <label
+                  className="Checkbox__Label-hrpa6b-0 gtTKXr"
+                  htmlFor="includeGenomePopulations"
+                >
+                  <input
+                    checked={false}
+                    className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                    disabled={true}
+                    id="includeGenomePopulations"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Genomes
+                </label>
+              </div>
+            </div>
+          </div>
+          <div
+            aria-describedby="HGDP"
+            aria-hidden={true}
+            className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+            id="HGDP-panel"
+            onKeyDown={[Function]}
+            role="tabpanel"
+            style={
+              {
+                "display": "none",
+              }
+            }
+          >
+            <p>
+              HGDP population frequencies are not available for this variant.
+            </p>
+          </div>
+          <div
+            aria-describedby="1KG"
+            aria-hidden={true}
+            className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+            id="1KG-panel"
+            onKeyDown={[Function]}
+            role="tabpanel"
+            style={
+              {
+                "display": "none",
+              }
+            }
+          >
+            <p>
+              1000 Genomes Project population frequencies are not available for this variant.
+            </p>
+          </div>
+          <div
+            aria-describedby="local-ancestry"
+            aria-hidden={true}
+            className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+            id="local-ancestry-panel"
+            onKeyDown={[Function]}
+            role="tabpanel"
+            style={
+              {
+                "display": "none",
+              }
+            }
+          >
+            <p>
+              Local ancestry is not available for subsets of gnomAD v3.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 CMQAN"
+    >
+      <h2>
+        Related Variants
+      </h2>
+      <div
+        className="VariantRelatedVariants__Wrapper-sc-y59fw8-0 bOggsA"
+      >
+        <div
+          className="VariantRelatedVariants__Item-sc-y59fw8-1 kqiRIK"
+        >
+          <h3>
+            Nearby Variants
+          </h3>
+          <p>
+            <a
+              className="Link-sc-14lgydv-0-Link jBvaYQ"
+              href="/region/13-103-143"
+              onClick={[Function]}
+            >
+              View variants located within 20 bases of this variant.
+            </a>
+          </p>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 CMQAN"
+    >
+      <h2>
+        Variant Effect Predictor
+      </h2>
+      <div>
+        <p>
+          This variant falls on 
+          0
+           transcript
+          s
+           in 
+          0
+           
+          gene
+          s
+          .
+        </p>
+        <p>
+          <span
+            className="Badge__BadgeWrapper-j4izdp-1 cJObdY"
+          >
+            Note
+          </span>
+           The gene symbols shown below are provided by VEP and may differ from the symbol shown on gene pages.
+        </p>
+        <ol
+          className="TranscriptConsequenceList__ConsequenceListWrapper-sc-qi0gmz-1 cXJgYo"
+        />
+      </div>
+    </section>
+    <div
+      className="VariantPage__FlexWrapper-sc-hd87ur-2 bjkoAa"
+    >
+      <section
+        className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+      >
+        <h2>
+          Genomic Constraint of Surrounding 1kb Region
+        </h2>
+        This variant does not have non coding constraint data for the surrounding region.
+      </section>
+    </div>
+    <div
+      className="VariantPage__FlexWrapper-sc-hd87ur-2 bjkoAa"
+    >
+      <section
+        className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+      >
+        <h2>
+          Age Distribution 
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
+        <p>
+          Age distribution is based on the full gnomAD dataset, not the selected subset.
+        </p>
+        <div>
+          <div
+            className="GnomadAgeDistribution__LegendWrapper-sc-ty24oq-0 kOKZpq"
+          >
+            <ul
+              className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+            >
+              <li
+                className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+              >
+                <svg
+                  height={16}
+                  width={16}
+                >
+                  <rect
+                    fill="#428bca"
+                    height={16}
+                    stroke="#000"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                </svg>
+                <span
+                  style={
+                    {
+                      "marginLeft": "0.25em",
+                    }
+                  }
+                >
+                  Exome
+                </span>
+              </li>
+              <li
+                className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+              >
+                <svg
+                  height={16}
+                  width={16}
+                >
+                  <rect
+                    fill="#73ab3d"
+                    height={16}
+                    stroke="#000"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                </svg>
+                <span
+                  style={
+                    {
+                      "marginLeft": "0.25em",
+                    }
+                  }
+                >
+                  Genome
+                </span>
+              </li>
+            </ul>
+            <ul
+              className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+            >
+              <li
+                className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+              >
+                <svg
+                  height={16}
+                  width={16}
+                >
+                  <rect
+                    fill="#999"
+                    height={16}
+                    stroke="#000"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                </svg>
+                <span
+                  style={
+                    {
+                      "marginLeft": "0.25em",
+                    }
+                  }
+                >
+                  Variant carriers
+                </span>
+              </li>
+              <li
+                className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+              >
+                <svg
+                  height={16}
+                  width={16}
+                >
+                  <defs>
+                    <pattern
+                      height={4}
+                      id="age-distribution-legend-swatch-stripes"
+                      patternTransform="rotate(45)"
+                      patternUnits="userSpaceOnUse"
+                      width={4}
+                    >
+                      <rect
+                        fill="#fff"
+                        height={4}
+                        transform="translate(0,0)"
+                        width={3}
+                      />
+                    </pattern>
+                    <mask
+                      id="age-distribution-legend-swatch-mask"
+                    >
+                      <rect
+                        fill="url(#age-distribution-legend-swatch-stripes)"
+                        height="100%"
+                        width="100%"
+                        x={0}
+                        y={0}
+                      />
+                    </mask>
+                  </defs>
+                  <rect
+                    fill="#999"
+                    height={16}
+                    mask="url(#age-distribution-legend-swatch-mask)"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                  <rect
+                    fill="none"
+                    height={16}
+                    stroke="#333"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                </svg>
+                <span
+                  style={
+                    {
+                      "marginLeft": "0.25em",
+                    }
+                  }
+                >
+                  All individuals
+                </span>
+              </li>
+            </ul>
+          </div>
+          <div
+            style={
+              {
+                "height": "100%",
+                "width": "100%",
+              }
+            }
+          />
+          <div
+            className="ControlSection__Wrapper-sc-rro5al-1 dSZUkP"
+          >
+            <span
+              className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+            >
+              <div
+                className="GnomadAgeDistribution__CheckboxWrapper-sc-ty24oq-1 fatvfk"
+              >
+                <label
+                  className="Checkbox__Label-hrpa6b-0 gtTKXr"
+                  htmlFor="age-distribution-include-heterozygotes"
+                >
+                  <input
+                    checked={true}
+                    className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                    disabled={false}
+                    id="age-distribution-include-heterozygotes"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Include heterozygous variant carriers
+                </label>
+                <label
+                  className="Checkbox__Label-hrpa6b-0 gtTKXr"
+                  htmlFor="age-distribution-include-homozygotes"
+                >
+                  <input
+                    checked={true}
+                    className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                    disabled={false}
+                    id="age-distribution-include-homozygotes"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Include homozygous variant carriers
+                </label>
+                <label
+                  className="Checkbox__Label-hrpa6b-0 gtTKXr"
+                  htmlFor="age-distribution-show-all-individuals"
+                >
+                  <input
+                    checked={true}
+                    className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                    disabled={false}
+                    id="age-distribution-show-all-individuals"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Compare to all individuals
+                </label>
+              </div>
+            </span>
+            <span
+              className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+            >
+              <label
+                htmlFor="age-distribution-sequencing-type"
+              >
+                Sequencing types: 
+                <select
+                  className="Select-sc-1lkyg9e-0 ivadCR"
+                  disabled={true}
+                  id="age-distribution-sequencing-type"
+                  onChange={[Function]}
+                  value="g"
+                >
+                  <option
+                    value="eg"
+                  >
+                    Exome and Genome
+                  </option>
+                  <option
+                    value="e"
+                  >
+                    Exome
+                  </option>
+                  <option
+                    value="g"
+                  >
+                    Genome
+                  </option>
+                </select>
+              </label>
+            </span>
+          </div>
+        </div>
+      </section>
+    </div>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+    >
+      <h2>
+        Genotype Quality Metrics
+      </h2>
+      <div>
+        <div>
+          <div
+            role="tablist"
+          >
+            <ul
+              className="Tabs__TabListWrapper-jzgyty-0 gUVxKq"
+            >
+              <li>
+                <div
+                  aria-controls="genotype_quality-panel"
+                  aria-selected={true}
+                  className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                  id="genotype_quality"
+                  onFocus={[Function]}
+                  role="tab"
+                  tabIndex={0}
+                >
+                  <div
+                    className="Tabs__TabLabel-jzgyty-2 dcUyBp"
+                  >
+                    Genotype quality
+                  </div>
+                </div>
+              </li>
+              <li>
+                <div
+                  aria-controls="genotype_depth-panel"
+                  aria-selected={false}
+                  className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                  id="genotype_depth"
+                  onFocus={[Function]}
+                  role="tab"
+                  tabIndex={-1}
+                >
+                  <div
+                    className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                  >
+                    Depth
+                  </div>
+                </div>
+              </li>
+              <li>
+                <div
+                  aria-controls="allele_balance-panel"
+                  aria-selected={false}
+                  className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                  id="allele_balance"
+                  onFocus={[Function]}
+                  role="tab"
+                  tabIndex={-1}
+                >
+                  <div
+                    className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                  >
+                    Allele balance for heterozygotes
+                  </div>
+                </div>
+              </li>
+            </ul>
+          </div>
+          <div>
+            <div
+              aria-describedby="genotype_quality"
+              aria-hidden={false}
+              className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+              id="genotype_quality-panel"
+              onKeyDown={[Function]}
+              role="tabpanel"
+              style={{}}
+            >
+              <div
+                className="VariantGenotypeQualityMetrics__LegendWrapper-sc-tgmwmq-0 ihxxGK"
+              >
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#428bca"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Exome
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#73ab3d"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Genome
+                    </span>
+                  </li>
+                </ul>
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#999"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Variant carriers
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <defs>
+                        <pattern
+                          height={4}
+                          id="genotype-quality-legend-swatch-stripes"
+                          patternTransform="rotate(45)"
+                          patternUnits="userSpaceOnUse"
+                          width={4}
+                        >
+                          <rect
+                            fill="#fff"
+                            height={4}
+                            transform="translate(0,0)"
+                            width={3}
+                          />
+                        </pattern>
+                        <mask
+                          id="genotype-quality-legend-swatch-mask"
+                        >
+                          <rect
+                            fill="url(#genotype-quality-legend-swatch-stripes)"
+                            height="100%"
+                            width="100%"
+                            x={0}
+                            y={0}
+                          />
+                        </mask>
+                      </defs>
+                      <rect
+                        fill="#999"
+                        height={16}
+                        mask="url(#genotype-quality-legend-swatch-mask)"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                      <rect
+                        fill="none"
+                        height={16}
+                        stroke="#333"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      All individuals
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                style={
+                  {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              />
+            </div>
+            <div
+              aria-describedby="genotype_depth"
+              aria-hidden={true}
+              className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+              id="genotype_depth-panel"
+              onKeyDown={[Function]}
+              role="tabpanel"
+              style={
+                {
+                  "display": "none",
+                }
+              }
+            >
+              <div
+                className="VariantGenotypeQualityMetrics__LegendWrapper-sc-tgmwmq-0 ihxxGK"
+                style={
+                  {
+                    "marginTop": "1em",
+                  }
+                }
+              >
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#428bca"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Exome
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#73ab3d"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Genome
+                    </span>
+                  </li>
+                </ul>
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#999"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Variant carriers
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <defs>
+                        <pattern
+                          height={4}
+                          id="depth-legend-swatch-stripes"
+                          patternTransform="rotate(45)"
+                          patternUnits="userSpaceOnUse"
+                          width={4}
+                        >
+                          <rect
+                            fill="#fff"
+                            height={4}
+                            transform="translate(0,0)"
+                            width={3}
+                          />
+                        </pattern>
+                        <mask
+                          id="depth-legend-swatch-mask"
+                        >
+                          <rect
+                            fill="url(#depth-legend-swatch-stripes)"
+                            height="100%"
+                            width="100%"
+                            x={0}
+                            y={0}
+                          />
+                        </mask>
+                      </defs>
+                      <rect
+                        fill="#999"
+                        height={16}
+                        mask="url(#depth-legend-swatch-mask)"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                      <rect
+                        fill="none"
+                        height={16}
+                        stroke="#333"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      All individuals
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                style={
+                  {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              />
+            </div>
+            <div
+              aria-describedby="allele_balance"
+              aria-hidden={true}
+              className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+              id="allele_balance-panel"
+              onKeyDown={[Function]}
+              role="tabpanel"
+              style={
+                {
+                  "display": "none",
+                }
+              }
+            >
+              <div
+                className="VariantGenotypeQualityMetrics__LegendWrapper-sc-tgmwmq-0 ihxxGK"
+                style={
+                  {
+                    "marginTop": "1em",
+                  }
+                }
+              >
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#428bca"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Exome
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#73ab3d"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Genome
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                style={
+                  {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          className="ControlSection__Wrapper-sc-rro5al-1 dSZUkP"
+        >
+          <span
+            className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+          >
+            <label
+              className="Checkbox__Label-hrpa6b-0 gtTKXr"
+              htmlFor="genotype-quality-metrics-show-all-individuals"
+            >
+              <input
+                checked={true}
+                className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                disabled={false}
+                id="genotype-quality-metrics-show-all-individuals"
+                onChange={[Function]}
+                type="checkbox"
+              />
+              Compare to all individuals
+            </label>
+          </span>
+          <span
+            className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+          >
+            <label
+              htmlFor="genotype-quality-metrics-sequencing-type"
+            >
+              Sequencing types: 
+              <select
+                className="Select-sc-1lkyg9e-0 ivadCR"
+                disabled={true}
+                id="genotype-quality-metrics-sequencing-type"
+                onChange={[Function]}
+                value="g"
+              >
+                <option
+                  value="eg"
+                >
+                  Exome and Genome
+                </option>
+                <option
+                  value="e"
+                >
+                  Exome
+                </option>
+                <option
+                  value="g"
+                >
+                  Genome
+                </option>
+              </select>
+            </label>
+          </span>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+    >
+      <h2>
+        Site Quality Metrics
+      </h2>
+      <div>
+        <div
+          role="tablist"
+        >
+          <ul
+            className="Tabs__TabListWrapper-jzgyty-0 gUVxKq"
+          >
+            <li>
+              <div
+                aria-controls="distribution-panel"
+                aria-selected={true}
+                className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                id="distribution"
+                onFocus={[Function]}
+                role="tab"
+                tabIndex={0}
+              >
+                <div
+                  className="Tabs__TabLabel-jzgyty-2 dcUyBp"
+                >
+                  Metric distribution
+                </div>
+              </div>
+            </li>
+            <li>
+              <div
+                aria-controls="values-panel"
+                aria-selected={false}
+                className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                id="values"
+                onFocus={[Function]}
+                role="tab"
+                tabIndex={-1}
+              >
+                <div
+                  className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                >
+                  All metric values
+                </div>
+              </div>
+            </li>
+          </ul>
+        </div>
+        <div>
+          <div
+            aria-describedby="distribution"
+            aria-hidden={false}
+            className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+            id="distribution-panel"
+            onKeyDown={[Function]}
+            role="tabpanel"
+            style={{}}
+          >
+            <div>
+              <div
+                className="VariantSiteQualityMetrics__LegendWrapper-sc-186wx2k-2 gDWfxF"
+              >
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#428bca"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Exome
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#73ab3d"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Genome
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                style={
+                  {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              />
+              <div
+                style={
+                  {
+                    "marginBottom": "0.5rem",
+                    "overflow": "hidden",
+                  }
+                }
+              />
+              <div
+                className="ControlSection__Wrapper-sc-rro5al-1 dSZUkP"
+              >
+                <span
+                  className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+                >
+                  <label
+                    htmlFor="site-quality-metrics-metric"
+                  >
+                    Metric: 
+                    <select
+                      className="Select-sc-1lkyg9e-0 ivadCR"
+                      id="site-quality-metrics-metric"
+                      onChange={[Function]}
+                      value="SiteQuality"
+                    >
+                      <option
+                        value="SiteQuality"
+                      >
+                        SiteQuality
+                      </option>
+                      <option
+                        value="InbreedingCoeff"
+                      >
+                        InbreedingCoeff
+                      </option>
+                      <option
+                        value="AS_FS"
+                      >
+                        AS_FS
+                      </option>
+                      <option
+                        value="AS_MQ"
+                      >
+                        AS_MQ
+                      </option>
+                      <option
+                        value="AS_MQRankSum"
+                      >
+                        AS_MQRankSum
+                      </option>
+                      <option
+                        value="AS_pab_max"
+                      >
+                        AS_pab_max
+                      </option>
+                      <option
+                        value="AS_QUALapprox"
+                      >
+                        AS_QUALapprox
+                      </option>
+                      <option
+                        value="AS_QD"
+                      >
+                        AS_QD
+                      </option>
+                      <option
+                        value="AS_ReadPosRankSum"
+                      >
+                        AS_ReadPosRankSum
+                      </option>
+                      <option
+                        value="AS_SOR"
+                      >
+                        AS_SOR
+                      </option>
+                      <option
+                        value="AS_VarDP"
+                      >
+                        AS_VarDP
+                      </option>
+                      <option
+                        value="AS_VQSLOD"
+                      >
+                        AS_VQSLOD
+                      </option>
+                    </select>
+                  </label>
+                </span>
+                <span
+                  className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+                >
+                  <label
+                    htmlFor="site-quality-metrics-sequencing-type"
+                  >
+                    Sequencing types: 
+                    <select
+                      className="Select-sc-1lkyg9e-0 ivadCR"
+                      disabled={true}
+                      id="site-quality-metrics-sequencing-type"
+                      onChange={[Function]}
+                      value="g"
+                    >
+                      <option
+                        value="eg"
+                      >
+                        Exome and Genome
+                      </option>
+                      <option
+                        value="e"
+                      >
+                        Exome
+                      </option>
+                      <option
+                        value="g"
+                      >
+                        Genome
+                      </option>
+                    </select>
+                  </label>
+                </span>
+              </div>
+              <p>
+                Value: 
+                0 (genome samples)
+              </p>
+              <p>
+                Site quality approximation for all variants with 0 &lt;= AF &lt; 0.00005.
+              </p>
+            </div>
+          </div>
+          <div
+            aria-describedby="values"
+            aria-hidden={true}
+            className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+            id="values-panel"
+            onKeyDown={[Function]}
+            role="tabpanel"
+            style={
+              {
+                "display": "none",
+              }
+            }
+          >
+            <table
+              className="Table__BaseTable-sc-7fgtt2-0 dIBzV"
+              style={
+                {
+                  "width": "100%",
+                }
+              }
+            >
+              <thead>
+                <tr>
+                  <th
+                    scope="col"
+                  >
+                    Metric
+                  </th>
+                  <th
+                    scope="col"
+                  >
+                    Genome samples
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      SiteQuality
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      InbreedingCoeff
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_FS
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_MQ
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_MQRankSum
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_pab_max
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    AS_QUALapprox
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_QD
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_ReadPosRankSum
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_SOR
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_VarDP
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_VQSLOD
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 CMQAN"
+    >
+      <h2>
+        Read Data
+      </h2>
+      <div>
+        <p>
+          No read data available for this variant.
+        </p>
+      </div>
+    </section>
+  </div>
+</div>
+`;
+
+exports[`VariantPage with dataset "gnomad_r3_non_topmed" has no unexpected changes 1`] = `
+<div
+  className="Page-w7h773-0 dRYfBS"
+>
+  <div
+    className="GnomadPageHeading__PageHeadingWrapper-sc-sgz3rr-0 gcOcdP"
+  >
+    <div
+      className="GnomadPageHeading__PageHeadingInnerWrapper-sc-sgz3rr-1 dLZzAa"
+    >
+      <h1
+        className="GnomadPageHeading__PageHeadingText-sc-sgz3rr-3 edXBqX"
+      >
+        <span
+          className="VariantPageTitle__TitleWrapper-sc-16g6pnt-0 bAAXLa"
+        >
+          <span>
+            Single nucleotide variant
+          </span>
+          <span
+            className="VariantPageTitle__Separator-sc-16g6pnt-1 jsfCLA"
+            style={
+              {
+                "width": "1ch",
+              }
+            }
+          >
+            :
+          </span>
+          <span
+            className="VariantPageTitle__VariantIdWrapper-sc-16g6pnt-2 jxIjmG"
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+          >
+            <span>
+              13
+              -
+              123
+            </span>
+            <span
+              className="VariantPageTitle__VariantIdSeparator-sc-16g6pnt-3 gwKaru"
+            >
+              -
+            </span>
+            <span
+              className="VariantPageTitle__TitleAlleles-sc-16g6pnt-4 dgrTjT"
+            >
+              A
+              -
+              C
+            </span>
+          </span>
+          <span
+            className="VariantPageTitle__Separator-sc-16g6pnt-1 jsfCLA"
+          >
+             
+          </span>
+          <span>
+            (
+            GRCh38
+            )
+          </span>
+        </span>
+      </h1>
+    </div>
+    <div
+      className="GnomadPageHeading__PageControlsWrapper-sc-sgz3rr-4 liqJpb"
+    >
+      <span
+        className="GnomadPageHeading__Label-sc-sgz3rr-5 dOhShJ"
+      >
+        Dataset
+      </span>
+      <ul
+        className="DatasetSelector__NavigationMenuWrapper-sc-1p2fxbn-0 ebZvwy"
+      >
+        <li
+          className="DatasetSelector__NavigationMenuItem-sc-1p2fxbn-2 ifirRc"
+        >
+          <a
+            className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
+            data-item="current_short_variant"
+            href="/?dataset=gnomad_r3_non_topmed"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+          >
+            gnomAD v3.1.2 (non-TOPMed)
+          </a>
+        </li>
+        <li
+          className="DatasetSelector__NavigationMenuItem-sc-1p2fxbn-2 ifirRc"
+        >
+          <a
+            aria-expanded={false}
+            aria-haspopup="true"
+            aria-label="More datasets"
+            className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
+            data-item="other_short_variant"
+            href="/"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="button"
+          >
+            <span
+              className="DatasetSelector__MoreIcon-sc-1p2fxbn-3 hTYFQu"
+            >
+              <img
+                alt=""
+                aria-hidden="true"
+                src="test-file-stub"
+              />
+            </span>
+          </a>
+          <ul
+            className="DatasetSelector__SubNavigationMenu-sc-1p2fxbn-4 epYyTQ"
+          >
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r3"
+                href="/?dataset=gnomad_r3"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v3.1.2
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  76,156 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r3_non_cancer"
+                href="/?dataset=gnomad_r3_non_cancer"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v3.1.2 (non-cancer)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  74,023 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r3_non_neuro"
+                href="/?dataset=gnomad_r3_non_neuro"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v3.1.2 (non-neuro)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  67,442 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r3_non_v2"
+                href="/?dataset=gnomad_r3_non_v2"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v3.1.2 (non-v2)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  57,344 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r3_non_topmed"
+                href="/?dataset=gnomad_r3_non_topmed"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v3.1.2 (non-TOPMed)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  40,433 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r3_controls_and_biobanks"
+                href="/?dataset=gnomad_r3_controls_and_biobanks"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v3.1.2 (controls/biobanks)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  16,465 samples
+                </div>
+              </a>
+            </li>
+          </ul>
+        </li>
+      </ul>
+      <span>
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+          >
+            More information
+          </span>
+        </button>
+      </span>
+    </div>
+  </div>
+  <div
+    className="VariantPage__FlexWrapper-sc-hd87ur-2 bjkoAa"
+  >
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+    >
+      <div
+        className="TableWrapper-sc-1ep26r3-0 edvjZa"
+      >
+        <div>
+          <table
+            className="VariantOccurrenceTable__Table-sc-8b13g7-0 iwAwP"
+          >
+            <tbody>
+              <tr>
+                <td />
+                <th
+                  scope="col"
+                >
+                  Genomes
+                </th>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Filters
+                  </span>
+                </th>
+                <td>
+                  <span
+                    className="Badge__BadgeWrapper-j4izdp-1 bhuqae"
+                  >
+                    Pass
+                  </span>
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Count
+                  </span>
+                </th>
+                <td>
+                  0
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Number
+                  </span>
+                </th>
+                <td>
+                  0
+                   *
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Frequency
+                  </span>
+                </th>
+                <td>
+                  0.000
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="VariantOccurrenceTable__NoWrap-sc-8b13g7-1 kmxNQ"
+                  >
+                    Popmax Filtering AF 
+                    <button
+                      className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <img
+                        alt=""
+                        aria-hidden="true"
+                        src="test-file-stub"
+                      />
+                      <span
+                        style={
+                          {
+                            "border": "0",
+                            "clip": "rect(0 0 0 0)",
+                            "height": "1px",
+                            "margin": "-1px",
+                            "overflow": "hidden",
+                            "padding": "0",
+                            "position": "absolute",
+                            "whiteSpace": "nowrap",
+                            "width": "1px",
+                          }
+                        }
+                      >
+                        More information
+                      </span>
+                    </button>
+                  </span>
+                  <br />
+                  (95% confidence)
+                </th>
+                <td>
+                  <span>
+                    0
+                  </span>
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Number of homozygotes
+                  </span>
+                </th>
+                <td>
+                  0
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Mean depth of coverage
+                  </span>
+                </th>
+                <td>
+                  –
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <p>
+            <span
+              className="Badge__BadgeWrapper-j4izdp-1 bbjxGL"
+            >
+              Warning
+            </span>
+             This variant is covered in fewer than 50% of individuals in 
+            gnomAD v3.1.2 (non-TOPMed) genomes
+            .
+             
+            This may indicate a low-quality site
+            .
+          </p>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+    >
+      <h2>
+        External Resources
+      </h2>
+      <ul
+        className="List-sc-4j87st-0 fQRmhM"
+      >
+        <li
+          className="List__ListItem-sc-4j87st-1 gGPLUe"
+        >
+          <a
+            className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+            href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&highlight=hg38.chr13%3A123-123&position=chr13%3A98-148"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            UCSC
+          </a>
+        </li>
+      </ul>
+      <h2>
+        Feedback
+      </h2>
+      <a
+        className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+        href="mailto:gnomad@broadinstitute.org"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        Report an issue with this variant
+      </a>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 CMQAN"
+    >
+      <h2>
+        Population Frequencies 
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
+      <div>
+        <div
+          role="tablist"
+        >
+          <ul
+            className="Tabs__TabListWrapper-jzgyty-0 gUVxKq"
+          >
+            <li>
+              <div
+                aria-controls="gnomAD-panel"
+                aria-selected={true}
+                className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                id="gnomAD"
+                onFocus={[Function]}
+                role="tab"
+                tabIndex={0}
+              >
+                <div
+                  className="Tabs__TabLabel-jzgyty-2 dcUyBp"
+                >
+                  gnomAD
+                </div>
+              </div>
+            </li>
+            <li>
+              <div
+                aria-controls="HGDP-panel"
+                aria-selected={false}
+                className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                id="HGDP"
+                onFocus={[Function]}
+                role="tab"
+                tabIndex={-1}
+              >
+                <div
+                  className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                >
+                  HGDP
+                </div>
+              </div>
+            </li>
+            <li>
+              <div
+                aria-controls="1KG-panel"
+                aria-selected={false}
+                className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                id="1KG"
+                onFocus={[Function]}
+                role="tab"
+                tabIndex={-1}
+              >
+                <div
+                  className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                >
+                  1KG
+                </div>
+              </div>
+            </li>
+            <li>
+              <div
+                aria-controls="local-ancestry-panel"
+                aria-selected={false}
+                className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                id="local-ancestry"
+                onFocus={[Function]}
+                role="tab"
+                tabIndex={-1}
+              >
+                <div
+                  className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                >
+                  Local Ancestry
+                </div>
+              </div>
+            </li>
+          </ul>
+        </div>
+        <div>
+          <div
+            aria-describedby="gnomAD"
+            aria-hidden={false}
+            className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+            id="gnomAD-panel"
+            onKeyDown={[Function]}
+            role="tabpanel"
+            style={{}}
+          >
+            <div
+              className="TableWrapper-sc-1ep26r3-0 edvjZa"
+            >
+              <table
+                className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+              >
+                <thead>
+                  <tr>
+                    <th
+                      aria-sort="none"
+                      colSpan={2}
+                      scope="col"
+                    >
+                      <button
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        Population
+                      </button>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      className="right-align"
+                      scope="col"
+                    >
+                      <button
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <span
+                          className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                        >
+                          Allele Count
+                        </span>
+                      </button>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      className="right-align"
+                      scope="col"
+                    >
+                      <button
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <span
+                          className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                        >
+                          Allele Number
+                        </span>
+                      </button>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      className="right-align"
+                      scope="col"
+                    >
+                      <button
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <span
+                          className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                        >
+                          Number of Homozygotes
+                        </span>
+                      </button>
+                    </th>
+                    <th
+                      aria-sort="descending"
+                      scope="col"
+                      style={
+                        {
+                          "paddingLeft": "25px",
+                        }
+                      }
+                    >
+                      <button
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <span
+                          className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                        >
+                          Allele Frequency
+                        </span>
+                      </button>
+                    </th>
+                  </tr>
+                </thead>
+                <tfoot>
+                  <tr
+                    className="border"
+                  >
+                    <th
+                      colSpan={2}
+                      scope="row"
+                    >
+                      Total
+                    </th>
+                    <td
+                      className="right-align"
+                    >
+                      0
+                    </td>
+                    <td
+                      className="right-align"
+                    >
+                      0
+                    </td>
+                    <td
+                      className="right-align"
+                    >
+                      0
+                    </td>
+                    <td
+                      style={
+                        {
+                          "paddingLeft": "25px",
+                        }
+                      }
+                    >
+                      0.000
+                    </td>
+                  </tr>
+                </tfoot>
+              </table>
+              <div
+                className="GnomadPopulationsTable__ControlSection-sc-1ghxck9-0 bsALfR"
+              >
+                Include:
+                <label
+                  className="Checkbox__Label-hrpa6b-0 gtTKXr"
+                  htmlFor="includeExomePopulations"
+                >
+                  <input
+                    checked={false}
+                    className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                    disabled={true}
+                    id="includeExomePopulations"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Exomes
+                </label>
+                <label
+                  className="Checkbox__Label-hrpa6b-0 gtTKXr"
+                  htmlFor="includeGenomePopulations"
+                >
+                  <input
+                    checked={false}
+                    className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                    disabled={true}
+                    id="includeGenomePopulations"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Genomes
+                </label>
+              </div>
+            </div>
+          </div>
+          <div
+            aria-describedby="HGDP"
+            aria-hidden={true}
+            className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+            id="HGDP-panel"
+            onKeyDown={[Function]}
+            role="tabpanel"
+            style={
+              {
+                "display": "none",
+              }
+            }
+          >
+            <p>
+              HGDP population frequencies are not available for this variant.
+            </p>
+          </div>
+          <div
+            aria-describedby="1KG"
+            aria-hidden={true}
+            className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+            id="1KG-panel"
+            onKeyDown={[Function]}
+            role="tabpanel"
+            style={
+              {
+                "display": "none",
+              }
+            }
+          >
+            <p>
+              1000 Genomes Project population frequencies are not available for this variant.
+            </p>
+          </div>
+          <div
+            aria-describedby="local-ancestry"
+            aria-hidden={true}
+            className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+            id="local-ancestry-panel"
+            onKeyDown={[Function]}
+            role="tabpanel"
+            style={
+              {
+                "display": "none",
+              }
+            }
+          >
+            <p>
+              Local ancestry is not available for subsets of gnomAD v3.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 CMQAN"
+    >
+      <h2>
+        Related Variants
+      </h2>
+      <div
+        className="VariantRelatedVariants__Wrapper-sc-y59fw8-0 bOggsA"
+      >
+        <div
+          className="VariantRelatedVariants__Item-sc-y59fw8-1 kqiRIK"
+        >
+          <h3>
+            Nearby Variants
+          </h3>
+          <p>
+            <a
+              className="Link-sc-14lgydv-0-Link jBvaYQ"
+              href="/region/13-103-143"
+              onClick={[Function]}
+            >
+              View variants located within 20 bases of this variant.
+            </a>
+          </p>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 CMQAN"
+    >
+      <h2>
+        Variant Effect Predictor
+      </h2>
+      <div>
+        <p>
+          This variant falls on 
+          0
+           transcript
+          s
+           in 
+          0
+           
+          gene
+          s
+          .
+        </p>
+        <p>
+          <span
+            className="Badge__BadgeWrapper-j4izdp-1 cJObdY"
+          >
+            Note
+          </span>
+           The gene symbols shown below are provided by VEP and may differ from the symbol shown on gene pages.
+        </p>
+        <ol
+          className="TranscriptConsequenceList__ConsequenceListWrapper-sc-qi0gmz-1 cXJgYo"
+        />
+      </div>
+    </section>
+    <div
+      className="VariantPage__FlexWrapper-sc-hd87ur-2 bjkoAa"
+    >
+      <section
+        className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+      >
+        <h2>
+          Genomic Constraint of Surrounding 1kb Region
+        </h2>
+        This variant does not have non coding constraint data for the surrounding region.
+      </section>
+    </div>
+    <div
+      className="VariantPage__FlexWrapper-sc-hd87ur-2 bjkoAa"
+    >
+      <section
+        className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+      >
+        <h2>
+          Age Distribution 
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
+        <p>
+          Age distribution is based on the full gnomAD dataset, not the selected subset.
+        </p>
+        <div>
+          <div
+            className="GnomadAgeDistribution__LegendWrapper-sc-ty24oq-0 kOKZpq"
+          >
+            <ul
+              className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+            >
+              <li
+                className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+              >
+                <svg
+                  height={16}
+                  width={16}
+                >
+                  <rect
+                    fill="#428bca"
+                    height={16}
+                    stroke="#000"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                </svg>
+                <span
+                  style={
+                    {
+                      "marginLeft": "0.25em",
+                    }
+                  }
+                >
+                  Exome
+                </span>
+              </li>
+              <li
+                className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+              >
+                <svg
+                  height={16}
+                  width={16}
+                >
+                  <rect
+                    fill="#73ab3d"
+                    height={16}
+                    stroke="#000"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                </svg>
+                <span
+                  style={
+                    {
+                      "marginLeft": "0.25em",
+                    }
+                  }
+                >
+                  Genome
+                </span>
+              </li>
+            </ul>
+            <ul
+              className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+            >
+              <li
+                className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+              >
+                <svg
+                  height={16}
+                  width={16}
+                >
+                  <rect
+                    fill="#999"
+                    height={16}
+                    stroke="#000"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                </svg>
+                <span
+                  style={
+                    {
+                      "marginLeft": "0.25em",
+                    }
+                  }
+                >
+                  Variant carriers
+                </span>
+              </li>
+              <li
+                className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+              >
+                <svg
+                  height={16}
+                  width={16}
+                >
+                  <defs>
+                    <pattern
+                      height={4}
+                      id="age-distribution-legend-swatch-stripes"
+                      patternTransform="rotate(45)"
+                      patternUnits="userSpaceOnUse"
+                      width={4}
+                    >
+                      <rect
+                        fill="#fff"
+                        height={4}
+                        transform="translate(0,0)"
+                        width={3}
+                      />
+                    </pattern>
+                    <mask
+                      id="age-distribution-legend-swatch-mask"
+                    >
+                      <rect
+                        fill="url(#age-distribution-legend-swatch-stripes)"
+                        height="100%"
+                        width="100%"
+                        x={0}
+                        y={0}
+                      />
+                    </mask>
+                  </defs>
+                  <rect
+                    fill="#999"
+                    height={16}
+                    mask="url(#age-distribution-legend-swatch-mask)"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                  <rect
+                    fill="none"
+                    height={16}
+                    stroke="#333"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                </svg>
+                <span
+                  style={
+                    {
+                      "marginLeft": "0.25em",
+                    }
+                  }
+                >
+                  All individuals
+                </span>
+              </li>
+            </ul>
+          </div>
+          <div
+            style={
+              {
+                "height": "100%",
+                "width": "100%",
+              }
+            }
+          />
+          <div
+            className="ControlSection__Wrapper-sc-rro5al-1 dSZUkP"
+          >
+            <span
+              className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+            >
+              <div
+                className="GnomadAgeDistribution__CheckboxWrapper-sc-ty24oq-1 fatvfk"
+              >
+                <label
+                  className="Checkbox__Label-hrpa6b-0 gtTKXr"
+                  htmlFor="age-distribution-include-heterozygotes"
+                >
+                  <input
+                    checked={true}
+                    className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                    disabled={false}
+                    id="age-distribution-include-heterozygotes"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Include heterozygous variant carriers
+                </label>
+                <label
+                  className="Checkbox__Label-hrpa6b-0 gtTKXr"
+                  htmlFor="age-distribution-include-homozygotes"
+                >
+                  <input
+                    checked={true}
+                    className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                    disabled={false}
+                    id="age-distribution-include-homozygotes"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Include homozygous variant carriers
+                </label>
+                <label
+                  className="Checkbox__Label-hrpa6b-0 gtTKXr"
+                  htmlFor="age-distribution-show-all-individuals"
+                >
+                  <input
+                    checked={true}
+                    className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                    disabled={false}
+                    id="age-distribution-show-all-individuals"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Compare to all individuals
+                </label>
+              </div>
+            </span>
+            <span
+              className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+            >
+              <label
+                htmlFor="age-distribution-sequencing-type"
+              >
+                Sequencing types: 
+                <select
+                  className="Select-sc-1lkyg9e-0 ivadCR"
+                  disabled={true}
+                  id="age-distribution-sequencing-type"
+                  onChange={[Function]}
+                  value="g"
+                >
+                  <option
+                    value="eg"
+                  >
+                    Exome and Genome
+                  </option>
+                  <option
+                    value="e"
+                  >
+                    Exome
+                  </option>
+                  <option
+                    value="g"
+                  >
+                    Genome
+                  </option>
+                </select>
+              </label>
+            </span>
+          </div>
+        </div>
+      </section>
+    </div>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+    >
+      <h2>
+        Genotype Quality Metrics
+      </h2>
+      <div>
+        <div>
+          <div
+            role="tablist"
+          >
+            <ul
+              className="Tabs__TabListWrapper-jzgyty-0 gUVxKq"
+            >
+              <li>
+                <div
+                  aria-controls="genotype_quality-panel"
+                  aria-selected={true}
+                  className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                  id="genotype_quality"
+                  onFocus={[Function]}
+                  role="tab"
+                  tabIndex={0}
+                >
+                  <div
+                    className="Tabs__TabLabel-jzgyty-2 dcUyBp"
+                  >
+                    Genotype quality
+                  </div>
+                </div>
+              </li>
+              <li>
+                <div
+                  aria-controls="genotype_depth-panel"
+                  aria-selected={false}
+                  className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                  id="genotype_depth"
+                  onFocus={[Function]}
+                  role="tab"
+                  tabIndex={-1}
+                >
+                  <div
+                    className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                  >
+                    Depth
+                  </div>
+                </div>
+              </li>
+              <li>
+                <div
+                  aria-controls="allele_balance-panel"
+                  aria-selected={false}
+                  className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                  id="allele_balance"
+                  onFocus={[Function]}
+                  role="tab"
+                  tabIndex={-1}
+                >
+                  <div
+                    className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                  >
+                    Allele balance for heterozygotes
+                  </div>
+                </div>
+              </li>
+            </ul>
+          </div>
+          <div>
+            <div
+              aria-describedby="genotype_quality"
+              aria-hidden={false}
+              className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+              id="genotype_quality-panel"
+              onKeyDown={[Function]}
+              role="tabpanel"
+              style={{}}
+            >
+              <div
+                className="VariantGenotypeQualityMetrics__LegendWrapper-sc-tgmwmq-0 ihxxGK"
+              >
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#428bca"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Exome
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#73ab3d"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Genome
+                    </span>
+                  </li>
+                </ul>
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#999"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Variant carriers
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <defs>
+                        <pattern
+                          height={4}
+                          id="genotype-quality-legend-swatch-stripes"
+                          patternTransform="rotate(45)"
+                          patternUnits="userSpaceOnUse"
+                          width={4}
+                        >
+                          <rect
+                            fill="#fff"
+                            height={4}
+                            transform="translate(0,0)"
+                            width={3}
+                          />
+                        </pattern>
+                        <mask
+                          id="genotype-quality-legend-swatch-mask"
+                        >
+                          <rect
+                            fill="url(#genotype-quality-legend-swatch-stripes)"
+                            height="100%"
+                            width="100%"
+                            x={0}
+                            y={0}
+                          />
+                        </mask>
+                      </defs>
+                      <rect
+                        fill="#999"
+                        height={16}
+                        mask="url(#genotype-quality-legend-swatch-mask)"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                      <rect
+                        fill="none"
+                        height={16}
+                        stroke="#333"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      All individuals
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                style={
+                  {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              />
+            </div>
+            <div
+              aria-describedby="genotype_depth"
+              aria-hidden={true}
+              className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+              id="genotype_depth-panel"
+              onKeyDown={[Function]}
+              role="tabpanel"
+              style={
+                {
+                  "display": "none",
+                }
+              }
+            >
+              <div
+                className="VariantGenotypeQualityMetrics__LegendWrapper-sc-tgmwmq-0 ihxxGK"
+                style={
+                  {
+                    "marginTop": "1em",
+                  }
+                }
+              >
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#428bca"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Exome
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#73ab3d"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Genome
+                    </span>
+                  </li>
+                </ul>
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#999"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Variant carriers
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <defs>
+                        <pattern
+                          height={4}
+                          id="depth-legend-swatch-stripes"
+                          patternTransform="rotate(45)"
+                          patternUnits="userSpaceOnUse"
+                          width={4}
+                        >
+                          <rect
+                            fill="#fff"
+                            height={4}
+                            transform="translate(0,0)"
+                            width={3}
+                          />
+                        </pattern>
+                        <mask
+                          id="depth-legend-swatch-mask"
+                        >
+                          <rect
+                            fill="url(#depth-legend-swatch-stripes)"
+                            height="100%"
+                            width="100%"
+                            x={0}
+                            y={0}
+                          />
+                        </mask>
+                      </defs>
+                      <rect
+                        fill="#999"
+                        height={16}
+                        mask="url(#depth-legend-swatch-mask)"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                      <rect
+                        fill="none"
+                        height={16}
+                        stroke="#333"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      All individuals
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                style={
+                  {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              />
+            </div>
+            <div
+              aria-describedby="allele_balance"
+              aria-hidden={true}
+              className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+              id="allele_balance-panel"
+              onKeyDown={[Function]}
+              role="tabpanel"
+              style={
+                {
+                  "display": "none",
+                }
+              }
+            >
+              <div
+                className="VariantGenotypeQualityMetrics__LegendWrapper-sc-tgmwmq-0 ihxxGK"
+                style={
+                  {
+                    "marginTop": "1em",
+                  }
+                }
+              >
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#428bca"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Exome
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#73ab3d"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Genome
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                style={
+                  {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          className="ControlSection__Wrapper-sc-rro5al-1 dSZUkP"
+        >
+          <span
+            className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+          >
+            <label
+              className="Checkbox__Label-hrpa6b-0 gtTKXr"
+              htmlFor="genotype-quality-metrics-show-all-individuals"
+            >
+              <input
+                checked={true}
+                className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                disabled={false}
+                id="genotype-quality-metrics-show-all-individuals"
+                onChange={[Function]}
+                type="checkbox"
+              />
+              Compare to all individuals
+            </label>
+          </span>
+          <span
+            className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+          >
+            <label
+              htmlFor="genotype-quality-metrics-sequencing-type"
+            >
+              Sequencing types: 
+              <select
+                className="Select-sc-1lkyg9e-0 ivadCR"
+                disabled={true}
+                id="genotype-quality-metrics-sequencing-type"
+                onChange={[Function]}
+                value="g"
+              >
+                <option
+                  value="eg"
+                >
+                  Exome and Genome
+                </option>
+                <option
+                  value="e"
+                >
+                  Exome
+                </option>
+                <option
+                  value="g"
+                >
+                  Genome
+                </option>
+              </select>
+            </label>
+          </span>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+    >
+      <h2>
+        Site Quality Metrics
+      </h2>
+      <div>
+        <div
+          role="tablist"
+        >
+          <ul
+            className="Tabs__TabListWrapper-jzgyty-0 gUVxKq"
+          >
+            <li>
+              <div
+                aria-controls="distribution-panel"
+                aria-selected={true}
+                className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                id="distribution"
+                onFocus={[Function]}
+                role="tab"
+                tabIndex={0}
+              >
+                <div
+                  className="Tabs__TabLabel-jzgyty-2 dcUyBp"
+                >
+                  Metric distribution
+                </div>
+              </div>
+            </li>
+            <li>
+              <div
+                aria-controls="values-panel"
+                aria-selected={false}
+                className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                id="values"
+                onFocus={[Function]}
+                role="tab"
+                tabIndex={-1}
+              >
+                <div
+                  className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                >
+                  All metric values
+                </div>
+              </div>
+            </li>
+          </ul>
+        </div>
+        <div>
+          <div
+            aria-describedby="distribution"
+            aria-hidden={false}
+            className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+            id="distribution-panel"
+            onKeyDown={[Function]}
+            role="tabpanel"
+            style={{}}
+          >
+            <div>
+              <div
+                className="VariantSiteQualityMetrics__LegendWrapper-sc-186wx2k-2 gDWfxF"
+              >
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#428bca"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Exome
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#73ab3d"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Genome
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                style={
+                  {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              />
+              <div
+                style={
+                  {
+                    "marginBottom": "0.5rem",
+                    "overflow": "hidden",
+                  }
+                }
+              />
+              <div
+                className="ControlSection__Wrapper-sc-rro5al-1 dSZUkP"
+              >
+                <span
+                  className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+                >
+                  <label
+                    htmlFor="site-quality-metrics-metric"
+                  >
+                    Metric: 
+                    <select
+                      className="Select-sc-1lkyg9e-0 ivadCR"
+                      id="site-quality-metrics-metric"
+                      onChange={[Function]}
+                      value="SiteQuality"
+                    >
+                      <option
+                        value="SiteQuality"
+                      >
+                        SiteQuality
+                      </option>
+                      <option
+                        value="InbreedingCoeff"
+                      >
+                        InbreedingCoeff
+                      </option>
+                      <option
+                        value="AS_FS"
+                      >
+                        AS_FS
+                      </option>
+                      <option
+                        value="AS_MQ"
+                      >
+                        AS_MQ
+                      </option>
+                      <option
+                        value="AS_MQRankSum"
+                      >
+                        AS_MQRankSum
+                      </option>
+                      <option
+                        value="AS_pab_max"
+                      >
+                        AS_pab_max
+                      </option>
+                      <option
+                        value="AS_QUALapprox"
+                      >
+                        AS_QUALapprox
+                      </option>
+                      <option
+                        value="AS_QD"
+                      >
+                        AS_QD
+                      </option>
+                      <option
+                        value="AS_ReadPosRankSum"
+                      >
+                        AS_ReadPosRankSum
+                      </option>
+                      <option
+                        value="AS_SOR"
+                      >
+                        AS_SOR
+                      </option>
+                      <option
+                        value="AS_VarDP"
+                      >
+                        AS_VarDP
+                      </option>
+                      <option
+                        value="AS_VQSLOD"
+                      >
+                        AS_VQSLOD
+                      </option>
+                    </select>
+                  </label>
+                </span>
+                <span
+                  className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+                >
+                  <label
+                    htmlFor="site-quality-metrics-sequencing-type"
+                  >
+                    Sequencing types: 
+                    <select
+                      className="Select-sc-1lkyg9e-0 ivadCR"
+                      disabled={true}
+                      id="site-quality-metrics-sequencing-type"
+                      onChange={[Function]}
+                      value="g"
+                    >
+                      <option
+                        value="eg"
+                      >
+                        Exome and Genome
+                      </option>
+                      <option
+                        value="e"
+                      >
+                        Exome
+                      </option>
+                      <option
+                        value="g"
+                      >
+                        Genome
+                      </option>
+                    </select>
+                  </label>
+                </span>
+              </div>
+              <p>
+                Value: 
+                0 (genome samples)
+              </p>
+              <p>
+                Site quality approximation for all variants with 0 &lt;= AF &lt; 0.00005.
+              </p>
+            </div>
+          </div>
+          <div
+            aria-describedby="values"
+            aria-hidden={true}
+            className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+            id="values-panel"
+            onKeyDown={[Function]}
+            role="tabpanel"
+            style={
+              {
+                "display": "none",
+              }
+            }
+          >
+            <table
+              className="Table__BaseTable-sc-7fgtt2-0 dIBzV"
+              style={
+                {
+                  "width": "100%",
+                }
+              }
+            >
+              <thead>
+                <tr>
+                  <th
+                    scope="col"
+                  >
+                    Metric
+                  </th>
+                  <th
+                    scope="col"
+                  >
+                    Genome samples
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      SiteQuality
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      InbreedingCoeff
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_FS
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_MQ
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_MQRankSum
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_pab_max
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    AS_QUALapprox
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_QD
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_ReadPosRankSum
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_SOR
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_VarDP
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_VQSLOD
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 CMQAN"
+    >
+      <h2>
+        Read Data
+      </h2>
+      <div>
+        <p>
+          No read data available for this variant.
+        </p>
+      </div>
+    </section>
+  </div>
+</div>
+`;
+
+exports[`VariantPage with dataset "gnomad_r3_non_v2" has no unexpected changes 1`] = `
+<div
+  className="Page-w7h773-0 dRYfBS"
+>
+  <div
+    className="GnomadPageHeading__PageHeadingWrapper-sc-sgz3rr-0 gcOcdP"
+  >
+    <div
+      className="GnomadPageHeading__PageHeadingInnerWrapper-sc-sgz3rr-1 dLZzAa"
+    >
+      <h1
+        className="GnomadPageHeading__PageHeadingText-sc-sgz3rr-3 edXBqX"
+      >
+        <span
+          className="VariantPageTitle__TitleWrapper-sc-16g6pnt-0 bAAXLa"
+        >
+          <span>
+            Single nucleotide variant
+          </span>
+          <span
+            className="VariantPageTitle__Separator-sc-16g6pnt-1 jsfCLA"
+            style={
+              {
+                "width": "1ch",
+              }
+            }
+          >
+            :
+          </span>
+          <span
+            className="VariantPageTitle__VariantIdWrapper-sc-16g6pnt-2 jxIjmG"
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+          >
+            <span>
+              13
+              -
+              123
+            </span>
+            <span
+              className="VariantPageTitle__VariantIdSeparator-sc-16g6pnt-3 gwKaru"
+            >
+              -
+            </span>
+            <span
+              className="VariantPageTitle__TitleAlleles-sc-16g6pnt-4 dgrTjT"
+            >
+              A
+              -
+              C
+            </span>
+          </span>
+          <span
+            className="VariantPageTitle__Separator-sc-16g6pnt-1 jsfCLA"
+          >
+             
+          </span>
+          <span>
+            (
+            GRCh38
+            )
+          </span>
+        </span>
+      </h1>
+    </div>
+    <div
+      className="GnomadPageHeading__PageControlsWrapper-sc-sgz3rr-4 liqJpb"
+    >
+      <span
+        className="GnomadPageHeading__Label-sc-sgz3rr-5 dOhShJ"
+      >
+        Dataset
+      </span>
+      <ul
+        className="DatasetSelector__NavigationMenuWrapper-sc-1p2fxbn-0 ebZvwy"
+      >
+        <li
+          className="DatasetSelector__NavigationMenuItem-sc-1p2fxbn-2 ifirRc"
+        >
+          <a
+            className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
+            data-item="current_short_variant"
+            href="/?dataset=gnomad_r3_non_v2"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+          >
+            gnomAD v3.1.2 (non-v2)
+          </a>
+        </li>
+        <li
+          className="DatasetSelector__NavigationMenuItem-sc-1p2fxbn-2 ifirRc"
+        >
+          <a
+            aria-expanded={false}
+            aria-haspopup="true"
+            aria-label="More datasets"
+            className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
+            data-item="other_short_variant"
+            href="/"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="button"
+          >
+            <span
+              className="DatasetSelector__MoreIcon-sc-1p2fxbn-3 hTYFQu"
+            >
+              <img
+                alt=""
+                aria-hidden="true"
+                src="test-file-stub"
+              />
+            </span>
+          </a>
+          <ul
+            className="DatasetSelector__SubNavigationMenu-sc-1p2fxbn-4 epYyTQ"
+          >
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r3"
+                href="/?dataset=gnomad_r3"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v3.1.2
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  76,156 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r3_non_cancer"
+                href="/?dataset=gnomad_r3_non_cancer"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v3.1.2 (non-cancer)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  74,023 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r3_non_neuro"
+                href="/?dataset=gnomad_r3_non_neuro"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v3.1.2 (non-neuro)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  67,442 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r3_non_v2"
+                href="/?dataset=gnomad_r3_non_v2"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v3.1.2 (non-v2)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  57,344 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r3_non_topmed"
+                href="/?dataset=gnomad_r3_non_topmed"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v3.1.2 (non-TOPMed)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  40,433 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r3_controls_and_biobanks"
+                href="/?dataset=gnomad_r3_controls_and_biobanks"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v3.1.2 (controls/biobanks)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  16,465 samples
+                </div>
+              </a>
+            </li>
+          </ul>
+        </li>
+      </ul>
+      <span>
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+          >
+            More information
+          </span>
+        </button>
+      </span>
+    </div>
+  </div>
+  <div
+    className="VariantPage__FlexWrapper-sc-hd87ur-2 bjkoAa"
+  >
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+    >
+      <div
+        className="TableWrapper-sc-1ep26r3-0 edvjZa"
+      >
+        <div>
+          <table
+            className="VariantOccurrenceTable__Table-sc-8b13g7-0 iwAwP"
+          >
+            <tbody>
+              <tr>
+                <td />
+                <th
+                  scope="col"
+                >
+                  Genomes
+                </th>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Filters
+                  </span>
+                </th>
+                <td>
+                  <span
+                    className="Badge__BadgeWrapper-j4izdp-1 bhuqae"
+                  >
+                    Pass
+                  </span>
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Count
+                  </span>
+                </th>
+                <td>
+                  0
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Number
+                  </span>
+                </th>
+                <td>
+                  0
+                   *
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Frequency
+                  </span>
+                </th>
+                <td>
+                  0.000
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="VariantOccurrenceTable__NoWrap-sc-8b13g7-1 kmxNQ"
+                  >
+                    Popmax Filtering AF 
+                    <button
+                      className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <img
+                        alt=""
+                        aria-hidden="true"
+                        src="test-file-stub"
+                      />
+                      <span
+                        style={
+                          {
+                            "border": "0",
+                            "clip": "rect(0 0 0 0)",
+                            "height": "1px",
+                            "margin": "-1px",
+                            "overflow": "hidden",
+                            "padding": "0",
+                            "position": "absolute",
+                            "whiteSpace": "nowrap",
+                            "width": "1px",
+                          }
+                        }
+                      >
+                        More information
+                      </span>
+                    </button>
+                  </span>
+                  <br />
+                  (95% confidence)
+                </th>
+                <td>
+                  <span>
+                    0
+                  </span>
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Number of homozygotes
+                  </span>
+                </th>
+                <td>
+                  0
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Mean depth of coverage
+                  </span>
+                </th>
+                <td>
+                  –
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <p>
+            <span
+              className="Badge__BadgeWrapper-j4izdp-1 bbjxGL"
+            >
+              Warning
+            </span>
+             This variant is covered in fewer than 50% of individuals in 
+            gnomAD v3.1.2 (non-v2) genomes
+            .
+             
+            This may indicate a low-quality site
+            .
+          </p>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+    >
+      <h2>
+        External Resources
+      </h2>
+      <ul
+        className="List-sc-4j87st-0 fQRmhM"
+      >
+        <li
+          className="List__ListItem-sc-4j87st-1 gGPLUe"
+        >
+          <a
+            className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+            href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&highlight=hg38.chr13%3A123-123&position=chr13%3A98-148"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            UCSC
+          </a>
+        </li>
+      </ul>
+      <h2>
+        Feedback
+      </h2>
+      <a
+        className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+        href="mailto:gnomad@broadinstitute.org"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        Report an issue with this variant
+      </a>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 CMQAN"
+    >
+      <h2>
+        Population Frequencies 
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
+      <div>
+        <div
+          role="tablist"
+        >
+          <ul
+            className="Tabs__TabListWrapper-jzgyty-0 gUVxKq"
+          >
+            <li>
+              <div
+                aria-controls="gnomAD-panel"
+                aria-selected={true}
+                className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                id="gnomAD"
+                onFocus={[Function]}
+                role="tab"
+                tabIndex={0}
+              >
+                <div
+                  className="Tabs__TabLabel-jzgyty-2 dcUyBp"
+                >
+                  gnomAD
+                </div>
+              </div>
+            </li>
+            <li>
+              <div
+                aria-controls="HGDP-panel"
+                aria-selected={false}
+                className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                id="HGDP"
+                onFocus={[Function]}
+                role="tab"
+                tabIndex={-1}
+              >
+                <div
+                  className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                >
+                  HGDP
+                </div>
+              </div>
+            </li>
+            <li>
+              <div
+                aria-controls="1KG-panel"
+                aria-selected={false}
+                className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                id="1KG"
+                onFocus={[Function]}
+                role="tab"
+                tabIndex={-1}
+              >
+                <div
+                  className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                >
+                  1KG
+                </div>
+              </div>
+            </li>
+            <li>
+              <div
+                aria-controls="local-ancestry-panel"
+                aria-selected={false}
+                className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                id="local-ancestry"
+                onFocus={[Function]}
+                role="tab"
+                tabIndex={-1}
+              >
+                <div
+                  className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                >
+                  Local Ancestry
+                </div>
+              </div>
+            </li>
+          </ul>
+        </div>
+        <div>
+          <div
+            aria-describedby="gnomAD"
+            aria-hidden={false}
+            className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+            id="gnomAD-panel"
+            onKeyDown={[Function]}
+            role="tabpanel"
+            style={{}}
+          >
+            <div
+              className="TableWrapper-sc-1ep26r3-0 edvjZa"
+            >
+              <table
+                className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+              >
+                <thead>
+                  <tr>
+                    <th
+                      aria-sort="none"
+                      colSpan={2}
+                      scope="col"
+                    >
+                      <button
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        Population
+                      </button>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      className="right-align"
+                      scope="col"
+                    >
+                      <button
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <span
+                          className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                        >
+                          Allele Count
+                        </span>
+                      </button>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      className="right-align"
+                      scope="col"
+                    >
+                      <button
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <span
+                          className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                        >
+                          Allele Number
+                        </span>
+                      </button>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      className="right-align"
+                      scope="col"
+                    >
+                      <button
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <span
+                          className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                        >
+                          Number of Homozygotes
+                        </span>
+                      </button>
+                    </th>
+                    <th
+                      aria-sort="descending"
+                      scope="col"
+                      style={
+                        {
+                          "paddingLeft": "25px",
+                        }
+                      }
+                    >
+                      <button
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <span
+                          className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                        >
+                          Allele Frequency
+                        </span>
+                      </button>
+                    </th>
+                  </tr>
+                </thead>
+                <tfoot>
+                  <tr
+                    className="border"
+                  >
+                    <th
+                      colSpan={2}
+                      scope="row"
+                    >
+                      Total
+                    </th>
+                    <td
+                      className="right-align"
+                    >
+                      0
+                    </td>
+                    <td
+                      className="right-align"
+                    >
+                      0
+                    </td>
+                    <td
+                      className="right-align"
+                    >
+                      0
+                    </td>
+                    <td
+                      style={
+                        {
+                          "paddingLeft": "25px",
+                        }
+                      }
+                    >
+                      0.000
+                    </td>
+                  </tr>
+                </tfoot>
+              </table>
+              <div
+                className="GnomadPopulationsTable__ControlSection-sc-1ghxck9-0 bsALfR"
+              >
+                Include:
+                <label
+                  className="Checkbox__Label-hrpa6b-0 gtTKXr"
+                  htmlFor="includeExomePopulations"
+                >
+                  <input
+                    checked={false}
+                    className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                    disabled={true}
+                    id="includeExomePopulations"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Exomes
+                </label>
+                <label
+                  className="Checkbox__Label-hrpa6b-0 gtTKXr"
+                  htmlFor="includeGenomePopulations"
+                >
+                  <input
+                    checked={false}
+                    className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                    disabled={true}
+                    id="includeGenomePopulations"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Genomes
+                </label>
+              </div>
+            </div>
+          </div>
+          <div
+            aria-describedby="HGDP"
+            aria-hidden={true}
+            className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+            id="HGDP-panel"
+            onKeyDown={[Function]}
+            role="tabpanel"
+            style={
+              {
+                "display": "none",
+              }
+            }
+          >
+            <p>
+              HGDP population frequencies are not available for this variant.
+            </p>
+          </div>
+          <div
+            aria-describedby="1KG"
+            aria-hidden={true}
+            className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+            id="1KG-panel"
+            onKeyDown={[Function]}
+            role="tabpanel"
+            style={
+              {
+                "display": "none",
+              }
+            }
+          >
+            <p>
+              1000 Genomes Project population frequencies are not available for this variant.
+            </p>
+          </div>
+          <div
+            aria-describedby="local-ancestry"
+            aria-hidden={true}
+            className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+            id="local-ancestry-panel"
+            onKeyDown={[Function]}
+            role="tabpanel"
+            style={
+              {
+                "display": "none",
+              }
+            }
+          >
+            <p>
+              Local ancestry is not available for subsets of gnomAD v3.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 CMQAN"
+    >
+      <h2>
+        Related Variants
+      </h2>
+      <div
+        className="VariantRelatedVariants__Wrapper-sc-y59fw8-0 bOggsA"
+      >
+        <div
+          className="VariantRelatedVariants__Item-sc-y59fw8-1 kqiRIK"
+        >
+          <h3>
+            Nearby Variants
+          </h3>
+          <p>
+            <a
+              className="Link-sc-14lgydv-0-Link jBvaYQ"
+              href="/region/13-103-143"
+              onClick={[Function]}
+            >
+              View variants located within 20 bases of this variant.
+            </a>
+          </p>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 CMQAN"
+    >
+      <h2>
+        Variant Effect Predictor
+      </h2>
+      <div>
+        <p>
+          This variant falls on 
+          0
+           transcript
+          s
+           in 
+          0
+           
+          gene
+          s
+          .
+        </p>
+        <p>
+          <span
+            className="Badge__BadgeWrapper-j4izdp-1 cJObdY"
+          >
+            Note
+          </span>
+           The gene symbols shown below are provided by VEP and may differ from the symbol shown on gene pages.
+        </p>
+        <ol
+          className="TranscriptConsequenceList__ConsequenceListWrapper-sc-qi0gmz-1 cXJgYo"
+        />
+      </div>
+    </section>
+    <div
+      className="VariantPage__FlexWrapper-sc-hd87ur-2 bjkoAa"
+    >
+      <section
+        className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+      >
+        <h2>
+          Genomic Constraint of Surrounding 1kb Region
+        </h2>
+        This variant does not have non coding constraint data for the surrounding region.
+      </section>
+    </div>
+    <div
+      className="VariantPage__FlexWrapper-sc-hd87ur-2 bjkoAa"
+    >
+      <section
+        className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+      >
+        <h2>
+          Age Distribution 
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
+        <p>
+          Age distribution is based on the full gnomAD dataset, not the selected subset.
+        </p>
+        <div>
+          <div
+            className="GnomadAgeDistribution__LegendWrapper-sc-ty24oq-0 kOKZpq"
+          >
+            <ul
+              className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+            >
+              <li
+                className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+              >
+                <svg
+                  height={16}
+                  width={16}
+                >
+                  <rect
+                    fill="#428bca"
+                    height={16}
+                    stroke="#000"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                </svg>
+                <span
+                  style={
+                    {
+                      "marginLeft": "0.25em",
+                    }
+                  }
+                >
+                  Exome
+                </span>
+              </li>
+              <li
+                className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+              >
+                <svg
+                  height={16}
+                  width={16}
+                >
+                  <rect
+                    fill="#73ab3d"
+                    height={16}
+                    stroke="#000"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                </svg>
+                <span
+                  style={
+                    {
+                      "marginLeft": "0.25em",
+                    }
+                  }
+                >
+                  Genome
+                </span>
+              </li>
+            </ul>
+            <ul
+              className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+            >
+              <li
+                className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+              >
+                <svg
+                  height={16}
+                  width={16}
+                >
+                  <rect
+                    fill="#999"
+                    height={16}
+                    stroke="#000"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                </svg>
+                <span
+                  style={
+                    {
+                      "marginLeft": "0.25em",
+                    }
+                  }
+                >
+                  Variant carriers
+                </span>
+              </li>
+              <li
+                className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+              >
+                <svg
+                  height={16}
+                  width={16}
+                >
+                  <defs>
+                    <pattern
+                      height={4}
+                      id="age-distribution-legend-swatch-stripes"
+                      patternTransform="rotate(45)"
+                      patternUnits="userSpaceOnUse"
+                      width={4}
+                    >
+                      <rect
+                        fill="#fff"
+                        height={4}
+                        transform="translate(0,0)"
+                        width={3}
+                      />
+                    </pattern>
+                    <mask
+                      id="age-distribution-legend-swatch-mask"
+                    >
+                      <rect
+                        fill="url(#age-distribution-legend-swatch-stripes)"
+                        height="100%"
+                        width="100%"
+                        x={0}
+                        y={0}
+                      />
+                    </mask>
+                  </defs>
+                  <rect
+                    fill="#999"
+                    height={16}
+                    mask="url(#age-distribution-legend-swatch-mask)"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                  <rect
+                    fill="none"
+                    height={16}
+                    stroke="#333"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                </svg>
+                <span
+                  style={
+                    {
+                      "marginLeft": "0.25em",
+                    }
+                  }
+                >
+                  All individuals
+                </span>
+              </li>
+            </ul>
+          </div>
+          <div
+            style={
+              {
+                "height": "100%",
+                "width": "100%",
+              }
+            }
+          />
+          <div
+            className="ControlSection__Wrapper-sc-rro5al-1 dSZUkP"
+          >
+            <span
+              className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+            >
+              <div
+                className="GnomadAgeDistribution__CheckboxWrapper-sc-ty24oq-1 fatvfk"
+              >
+                <label
+                  className="Checkbox__Label-hrpa6b-0 gtTKXr"
+                  htmlFor="age-distribution-include-heterozygotes"
+                >
+                  <input
+                    checked={true}
+                    className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                    disabled={false}
+                    id="age-distribution-include-heterozygotes"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Include heterozygous variant carriers
+                </label>
+                <label
+                  className="Checkbox__Label-hrpa6b-0 gtTKXr"
+                  htmlFor="age-distribution-include-homozygotes"
+                >
+                  <input
+                    checked={true}
+                    className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                    disabled={false}
+                    id="age-distribution-include-homozygotes"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Include homozygous variant carriers
+                </label>
+                <label
+                  className="Checkbox__Label-hrpa6b-0 gtTKXr"
+                  htmlFor="age-distribution-show-all-individuals"
+                >
+                  <input
+                    checked={true}
+                    className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                    disabled={false}
+                    id="age-distribution-show-all-individuals"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Compare to all individuals
+                </label>
+              </div>
+            </span>
+            <span
+              className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+            >
+              <label
+                htmlFor="age-distribution-sequencing-type"
+              >
+                Sequencing types: 
+                <select
+                  className="Select-sc-1lkyg9e-0 ivadCR"
+                  disabled={true}
+                  id="age-distribution-sequencing-type"
+                  onChange={[Function]}
+                  value="g"
+                >
+                  <option
+                    value="eg"
+                  >
+                    Exome and Genome
+                  </option>
+                  <option
+                    value="e"
+                  >
+                    Exome
+                  </option>
+                  <option
+                    value="g"
+                  >
+                    Genome
+                  </option>
+                </select>
+              </label>
+            </span>
+          </div>
+        </div>
+      </section>
+    </div>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+    >
+      <h2>
+        Genotype Quality Metrics
+      </h2>
+      <div>
+        <div>
+          <div
+            role="tablist"
+          >
+            <ul
+              className="Tabs__TabListWrapper-jzgyty-0 gUVxKq"
+            >
+              <li>
+                <div
+                  aria-controls="genotype_quality-panel"
+                  aria-selected={true}
+                  className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                  id="genotype_quality"
+                  onFocus={[Function]}
+                  role="tab"
+                  tabIndex={0}
+                >
+                  <div
+                    className="Tabs__TabLabel-jzgyty-2 dcUyBp"
+                  >
+                    Genotype quality
+                  </div>
+                </div>
+              </li>
+              <li>
+                <div
+                  aria-controls="genotype_depth-panel"
+                  aria-selected={false}
+                  className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                  id="genotype_depth"
+                  onFocus={[Function]}
+                  role="tab"
+                  tabIndex={-1}
+                >
+                  <div
+                    className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                  >
+                    Depth
+                  </div>
+                </div>
+              </li>
+              <li>
+                <div
+                  aria-controls="allele_balance-panel"
+                  aria-selected={false}
+                  className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                  id="allele_balance"
+                  onFocus={[Function]}
+                  role="tab"
+                  tabIndex={-1}
+                >
+                  <div
+                    className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                  >
+                    Allele balance for heterozygotes
+                  </div>
+                </div>
+              </li>
+            </ul>
+          </div>
+          <div>
+            <div
+              aria-describedby="genotype_quality"
+              aria-hidden={false}
+              className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+              id="genotype_quality-panel"
+              onKeyDown={[Function]}
+              role="tabpanel"
+              style={{}}
+            >
+              <div
+                className="VariantGenotypeQualityMetrics__LegendWrapper-sc-tgmwmq-0 ihxxGK"
+              >
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#428bca"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Exome
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#73ab3d"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Genome
+                    </span>
+                  </li>
+                </ul>
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#999"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Variant carriers
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <defs>
+                        <pattern
+                          height={4}
+                          id="genotype-quality-legend-swatch-stripes"
+                          patternTransform="rotate(45)"
+                          patternUnits="userSpaceOnUse"
+                          width={4}
+                        >
+                          <rect
+                            fill="#fff"
+                            height={4}
+                            transform="translate(0,0)"
+                            width={3}
+                          />
+                        </pattern>
+                        <mask
+                          id="genotype-quality-legend-swatch-mask"
+                        >
+                          <rect
+                            fill="url(#genotype-quality-legend-swatch-stripes)"
+                            height="100%"
+                            width="100%"
+                            x={0}
+                            y={0}
+                          />
+                        </mask>
+                      </defs>
+                      <rect
+                        fill="#999"
+                        height={16}
+                        mask="url(#genotype-quality-legend-swatch-mask)"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                      <rect
+                        fill="none"
+                        height={16}
+                        stroke="#333"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      All individuals
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                style={
+                  {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              />
+            </div>
+            <div
+              aria-describedby="genotype_depth"
+              aria-hidden={true}
+              className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+              id="genotype_depth-panel"
+              onKeyDown={[Function]}
+              role="tabpanel"
+              style={
+                {
+                  "display": "none",
+                }
+              }
+            >
+              <div
+                className="VariantGenotypeQualityMetrics__LegendWrapper-sc-tgmwmq-0 ihxxGK"
+                style={
+                  {
+                    "marginTop": "1em",
+                  }
+                }
+              >
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#428bca"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Exome
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#73ab3d"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Genome
+                    </span>
+                  </li>
+                </ul>
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#999"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Variant carriers
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <defs>
+                        <pattern
+                          height={4}
+                          id="depth-legend-swatch-stripes"
+                          patternTransform="rotate(45)"
+                          patternUnits="userSpaceOnUse"
+                          width={4}
+                        >
+                          <rect
+                            fill="#fff"
+                            height={4}
+                            transform="translate(0,0)"
+                            width={3}
+                          />
+                        </pattern>
+                        <mask
+                          id="depth-legend-swatch-mask"
+                        >
+                          <rect
+                            fill="url(#depth-legend-swatch-stripes)"
+                            height="100%"
+                            width="100%"
+                            x={0}
+                            y={0}
+                          />
+                        </mask>
+                      </defs>
+                      <rect
+                        fill="#999"
+                        height={16}
+                        mask="url(#depth-legend-swatch-mask)"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                      <rect
+                        fill="none"
+                        height={16}
+                        stroke="#333"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      All individuals
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                style={
+                  {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              />
+            </div>
+            <div
+              aria-describedby="allele_balance"
+              aria-hidden={true}
+              className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+              id="allele_balance-panel"
+              onKeyDown={[Function]}
+              role="tabpanel"
+              style={
+                {
+                  "display": "none",
+                }
+              }
+            >
+              <div
+                className="VariantGenotypeQualityMetrics__LegendWrapper-sc-tgmwmq-0 ihxxGK"
+                style={
+                  {
+                    "marginTop": "1em",
+                  }
+                }
+              >
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#428bca"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Exome
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#73ab3d"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Genome
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                style={
+                  {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          className="ControlSection__Wrapper-sc-rro5al-1 dSZUkP"
+        >
+          <span
+            className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+          >
+            <label
+              className="Checkbox__Label-hrpa6b-0 gtTKXr"
+              htmlFor="genotype-quality-metrics-show-all-individuals"
+            >
+              <input
+                checked={true}
+                className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                disabled={false}
+                id="genotype-quality-metrics-show-all-individuals"
+                onChange={[Function]}
+                type="checkbox"
+              />
+              Compare to all individuals
+            </label>
+          </span>
+          <span
+            className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+          >
+            <label
+              htmlFor="genotype-quality-metrics-sequencing-type"
+            >
+              Sequencing types: 
+              <select
+                className="Select-sc-1lkyg9e-0 ivadCR"
+                disabled={true}
+                id="genotype-quality-metrics-sequencing-type"
+                onChange={[Function]}
+                value="g"
+              >
+                <option
+                  value="eg"
+                >
+                  Exome and Genome
+                </option>
+                <option
+                  value="e"
+                >
+                  Exome
+                </option>
+                <option
+                  value="g"
+                >
+                  Genome
+                </option>
+              </select>
+            </label>
+          </span>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+    >
+      <h2>
+        Site Quality Metrics
+      </h2>
+      <div>
+        <div
+          role="tablist"
+        >
+          <ul
+            className="Tabs__TabListWrapper-jzgyty-0 gUVxKq"
+          >
+            <li>
+              <div
+                aria-controls="distribution-panel"
+                aria-selected={true}
+                className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                id="distribution"
+                onFocus={[Function]}
+                role="tab"
+                tabIndex={0}
+              >
+                <div
+                  className="Tabs__TabLabel-jzgyty-2 dcUyBp"
+                >
+                  Metric distribution
+                </div>
+              </div>
+            </li>
+            <li>
+              <div
+                aria-controls="values-panel"
+                aria-selected={false}
+                className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                id="values"
+                onFocus={[Function]}
+                role="tab"
+                tabIndex={-1}
+              >
+                <div
+                  className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                >
+                  All metric values
+                </div>
+              </div>
+            </li>
+          </ul>
+        </div>
+        <div>
+          <div
+            aria-describedby="distribution"
+            aria-hidden={false}
+            className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+            id="distribution-panel"
+            onKeyDown={[Function]}
+            role="tabpanel"
+            style={{}}
+          >
+            <div>
+              <div
+                className="VariantSiteQualityMetrics__LegendWrapper-sc-186wx2k-2 gDWfxF"
+              >
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#428bca"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Exome
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#73ab3d"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Genome
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                style={
+                  {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              />
+              <div
+                style={
+                  {
+                    "marginBottom": "0.5rem",
+                    "overflow": "hidden",
+                  }
+                }
+              />
+              <div
+                className="ControlSection__Wrapper-sc-rro5al-1 dSZUkP"
+              >
+                <span
+                  className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+                >
+                  <label
+                    htmlFor="site-quality-metrics-metric"
+                  >
+                    Metric: 
+                    <select
+                      className="Select-sc-1lkyg9e-0 ivadCR"
+                      id="site-quality-metrics-metric"
+                      onChange={[Function]}
+                      value="SiteQuality"
+                    >
+                      <option
+                        value="SiteQuality"
+                      >
+                        SiteQuality
+                      </option>
+                      <option
+                        value="InbreedingCoeff"
+                      >
+                        InbreedingCoeff
+                      </option>
+                      <option
+                        value="AS_FS"
+                      >
+                        AS_FS
+                      </option>
+                      <option
+                        value="AS_MQ"
+                      >
+                        AS_MQ
+                      </option>
+                      <option
+                        value="AS_MQRankSum"
+                      >
+                        AS_MQRankSum
+                      </option>
+                      <option
+                        value="AS_pab_max"
+                      >
+                        AS_pab_max
+                      </option>
+                      <option
+                        value="AS_QUALapprox"
+                      >
+                        AS_QUALapprox
+                      </option>
+                      <option
+                        value="AS_QD"
+                      >
+                        AS_QD
+                      </option>
+                      <option
+                        value="AS_ReadPosRankSum"
+                      >
+                        AS_ReadPosRankSum
+                      </option>
+                      <option
+                        value="AS_SOR"
+                      >
+                        AS_SOR
+                      </option>
+                      <option
+                        value="AS_VarDP"
+                      >
+                        AS_VarDP
+                      </option>
+                      <option
+                        value="AS_VQSLOD"
+                      >
+                        AS_VQSLOD
+                      </option>
+                    </select>
+                  </label>
+                </span>
+                <span
+                  className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+                >
+                  <label
+                    htmlFor="site-quality-metrics-sequencing-type"
+                  >
+                    Sequencing types: 
+                    <select
+                      className="Select-sc-1lkyg9e-0 ivadCR"
+                      disabled={true}
+                      id="site-quality-metrics-sequencing-type"
+                      onChange={[Function]}
+                      value="g"
+                    >
+                      <option
+                        value="eg"
+                      >
+                        Exome and Genome
+                      </option>
+                      <option
+                        value="e"
+                      >
+                        Exome
+                      </option>
+                      <option
+                        value="g"
+                      >
+                        Genome
+                      </option>
+                    </select>
+                  </label>
+                </span>
+              </div>
+              <p>
+                Value: 
+                0 (genome samples)
+              </p>
+              <p>
+                Site quality approximation for all variants with 0 &lt;= AF &lt; 0.00005.
+              </p>
+            </div>
+          </div>
+          <div
+            aria-describedby="values"
+            aria-hidden={true}
+            className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+            id="values-panel"
+            onKeyDown={[Function]}
+            role="tabpanel"
+            style={
+              {
+                "display": "none",
+              }
+            }
+          >
+            <table
+              className="Table__BaseTable-sc-7fgtt2-0 dIBzV"
+              style={
+                {
+                  "width": "100%",
+                }
+              }
+            >
+              <thead>
+                <tr>
+                  <th
+                    scope="col"
+                  >
+                    Metric
+                  </th>
+                  <th
+                    scope="col"
+                  >
+                    Genome samples
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      SiteQuality
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      InbreedingCoeff
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_FS
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_MQ
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_MQRankSum
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_pab_max
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    AS_QUALapprox
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_QD
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_ReadPosRankSum
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_SOR
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_VarDP
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      AS_VQSLOD
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 CMQAN"
+    >
+      <h2>
+        Read Data
+      </h2>
+      <div>
+        <p>
+          No read data available for this variant.
+        </p>
+      </div>
+    </section>
+  </div>
+</div>
+`;

--- a/browser/src/VariantPage/__snapshots__/VariantPage.spec.tsx.snap
+++ b/browser/src/VariantPage/__snapshots__/VariantPage.spec.tsx.snap
@@ -13448,3 +13448,10963 @@ exports[`VariantPage with dataset "gnomad_r3_non_v2" has no unexpected changes 1
   </div>
 </div>
 `;
+
+exports[`VariantPage with dataset gnomad_r2_1 has no unexpected changes 1`] = `
+<div
+  className="Page-w7h773-0 dRYfBS"
+>
+  <div
+    className="GnomadPageHeading__PageHeadingWrapper-sc-sgz3rr-0 gcOcdP"
+  >
+    <div
+      className="GnomadPageHeading__PageHeadingInnerWrapper-sc-sgz3rr-1 dLZzAa"
+    >
+      <h1
+        className="GnomadPageHeading__PageHeadingText-sc-sgz3rr-3 edXBqX"
+      >
+        <span
+          className="VariantPageTitle__TitleWrapper-sc-16g6pnt-0 bAAXLa"
+        >
+          <span>
+            Single nucleotide variant
+          </span>
+          <span
+            className="VariantPageTitle__Separator-sc-16g6pnt-1 jsfCLA"
+            style={
+              {
+                "width": "1ch",
+              }
+            }
+          >
+            :
+          </span>
+          <span
+            className="VariantPageTitle__VariantIdWrapper-sc-16g6pnt-2 jxIjmG"
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+          >
+            <span>
+              13
+              -
+              123
+            </span>
+            <span
+              className="VariantPageTitle__VariantIdSeparator-sc-16g6pnt-3 gwKaru"
+            >
+              -
+            </span>
+            <span
+              className="VariantPageTitle__TitleAlleles-sc-16g6pnt-4 dgrTjT"
+            >
+              A
+              -
+              C
+            </span>
+          </span>
+          <span
+            className="VariantPageTitle__Separator-sc-16g6pnt-1 jsfCLA"
+          >
+             
+          </span>
+          <span>
+            (
+            GRCh37
+            )
+          </span>
+        </span>
+      </h1>
+    </div>
+    <div
+      className="GnomadPageHeading__PageControlsWrapper-sc-sgz3rr-4 liqJpb"
+    >
+      <span
+        className="GnomadPageHeading__Label-sc-sgz3rr-5 dOhShJ"
+      >
+        Dataset
+      </span>
+      <ul
+        className="DatasetSelector__NavigationMenuWrapper-sc-1p2fxbn-0 ebZvwy"
+      >
+        <li
+          className="DatasetSelector__NavigationMenuItem-sc-1p2fxbn-2 ifirRc"
+        >
+          <a
+            className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
+            data-item="current_short_variant"
+            href="/?dataset=gnomad_r2_1"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+          >
+            gnomAD v2.1.1
+          </a>
+        </li>
+        <li
+          className="DatasetSelector__NavigationMenuItem-sc-1p2fxbn-2 ifirRc"
+        >
+          <a
+            aria-expanded={false}
+            aria-haspopup="true"
+            aria-label="More datasets"
+            className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
+            data-item="other_short_variant"
+            href="/"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="button"
+          >
+            <span
+              className="DatasetSelector__MoreIcon-sc-1p2fxbn-3 hTYFQu"
+            >
+              <img
+                alt=""
+                aria-hidden="true"
+                src="test-file-stub"
+              />
+            </span>
+          </a>
+          <ul
+            className="DatasetSelector__SubNavigationMenu-sc-1p2fxbn-4 epYyTQ"
+          >
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r2_1"
+                href="/?dataset=gnomad_r2_1"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v2.1.1
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  141,456 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r2_1_non_topmed"
+                href="/?dataset=gnomad_r2_1_non_topmed"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v2.1.1 (non-TOPMed)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  135,743 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r2_1_non_cancer"
+                href="/?dataset=gnomad_r2_1_non_cancer"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v2.1.1 (non-cancer)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  134,187 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r2_1_non_neuro"
+                href="/?dataset=gnomad_r2_1_non_neuro"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v2.1.1 (non-neuro)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  114,704 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r2_1_controls"
+                href="/?dataset=gnomad_r2_1_controls"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v2.1.1 (controls)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  60,146 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="exac"
+                href="/?dataset=exac"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                ExAC v1.0
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  60,706 samples
+                </div>
+              </a>
+            </li>
+          </ul>
+        </li>
+      </ul>
+      <span>
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+          >
+            More information
+          </span>
+        </button>
+      </span>
+    </div>
+  </div>
+  <div
+    className="VariantPage__FlexWrapper-sc-hd87ur-2 bjkoAa"
+  >
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+    >
+      <div
+        className="TableWrapper-sc-1ep26r3-0 edvjZa"
+      >
+        <div>
+          <table
+            className="VariantOccurrenceTable__Table-sc-8b13g7-0 iwAwP"
+          >
+            <tbody>
+              <tr>
+                <td />
+                <th
+                  scope="col"
+                >
+                  Exomes
+                </th>
+                <th
+                  scope="col"
+                >
+                  Genomes
+                </th>
+                <th
+                  scope="col"
+                >
+                  Total
+                </th>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Filters
+                  </span>
+                </th>
+                <td>
+                  <span
+                    className="Badge__BadgeWrapper-j4izdp-1 bhuqae"
+                  >
+                    Pass
+                  </span>
+                </td>
+                <td>
+                  <span
+                    className="Badge__BadgeWrapper-j4izdp-1 bbjxGL"
+                  >
+                    No variant
+                  </span>
+                </td>
+                <td />
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Count
+                  </span>
+                </th>
+                <td>
+                  0
+                </td>
+                <td />
+                <td>
+                  0
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Number
+                  </span>
+                </th>
+                <td>
+                  0
+                   *
+                </td>
+                <td />
+                <td>
+                  0
+                   *
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Frequency
+                  </span>
+                </th>
+                <td>
+                  0.000
+                </td>
+                <td />
+                <td>
+                  0.000
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="VariantOccurrenceTable__NoWrap-sc-8b13g7-1 kmxNQ"
+                  >
+                    Popmax Filtering AF 
+                    <button
+                      className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <img
+                        alt=""
+                        aria-hidden="true"
+                        src="test-file-stub"
+                      />
+                      <span
+                        style={
+                          {
+                            "border": "0",
+                            "clip": "rect(0 0 0 0)",
+                            "height": "1px",
+                            "margin": "-1px",
+                            "overflow": "hidden",
+                            "padding": "0",
+                            "position": "absolute",
+                            "whiteSpace": "nowrap",
+                            "width": "1px",
+                          }
+                        }
+                      >
+                        More information
+                      </span>
+                    </button>
+                  </span>
+                  <br />
+                  (95% confidence)
+                </th>
+                <td>
+                  <span>
+                    0
+                  </span>
+                </td>
+                <td />
+                <td />
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Number of homozygotes
+                  </span>
+                </th>
+                <td>
+                  0
+                </td>
+                <td />
+                <td>
+                  0
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Mean depth of coverage
+                  </span>
+                </th>
+                <td>
+                  –
+                </td>
+                <td>
+                  –
+                </td>
+                <td />
+              </tr>
+            </tbody>
+          </table>
+          <p>
+            <span
+              className="Badge__BadgeWrapper-j4izdp-1 dyHZPQ"
+            >
+              Warning
+            </span>
+             This variant is covered in fewer than 50% of individuals in 
+            gnomAD v2.1.1 exomes
+            .
+             
+            Allele frequency estimates may not be reliable
+            .
+          </p>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+    >
+      <h2>
+        External Resources
+      </h2>
+      <ul
+        className="List-sc-4j87st-0 fQRmhM"
+      >
+        <li
+          className="List__ListItem-sc-4j87st-1 gGPLUe"
+        >
+          <a
+            className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+            href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&highlight=hg19.chr13%3A123-123&position=chr13%3A98-148"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            UCSC
+          </a>
+        </li>
+      </ul>
+      <h2>
+        Feedback
+      </h2>
+      <a
+        className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+        href="mailto:gnomad@broadinstitute.org"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        Report an issue with this variant
+      </a>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 CMQAN"
+    >
+      <h2>
+        Population Frequencies 
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
+      <div
+        className="TableWrapper-sc-1ep26r3-0 edvjZa"
+      >
+        <table
+          className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+        >
+          <thead>
+            <tr>
+              <th
+                aria-sort="none"
+                colSpan={2}
+                scope="col"
+              >
+                <button
+                  onClick={[Function]}
+                  type="button"
+                >
+                  Population
+                </button>
+              </th>
+              <th
+                aria-sort="none"
+                className="right-align"
+                scope="col"
+              >
+                <button
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Count
+                  </span>
+                </button>
+              </th>
+              <th
+                aria-sort="none"
+                className="right-align"
+                scope="col"
+              >
+                <button
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Number
+                  </span>
+                </button>
+              </th>
+              <th
+                aria-sort="none"
+                className="right-align"
+                scope="col"
+              >
+                <button
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Number of Homozygotes
+                  </span>
+                </button>
+              </th>
+              <th
+                aria-sort="descending"
+                scope="col"
+                style={
+                  {
+                    "paddingLeft": "25px",
+                  }
+                }
+              >
+                <button
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Frequency
+                  </span>
+                </button>
+              </th>
+            </tr>
+          </thead>
+          <tfoot>
+            <tr
+              className="border"
+            >
+              <th
+                colSpan={2}
+                scope="row"
+              >
+                Total
+              </th>
+              <td
+                className="right-align"
+              >
+                0
+              </td>
+              <td
+                className="right-align"
+              >
+                0
+              </td>
+              <td
+                className="right-align"
+              >
+                0
+              </td>
+              <td
+                style={
+                  {
+                    "paddingLeft": "25px",
+                  }
+                }
+              >
+                0.000
+              </td>
+            </tr>
+          </tfoot>
+        </table>
+        <div
+          className="GnomadPopulationsTable__ControlSection-sc-1ghxck9-0 bsALfR"
+        >
+          Include:
+          <label
+            className="Checkbox__Label-hrpa6b-0 gtTKXr"
+            htmlFor="includeExomePopulations"
+          >
+            <input
+              checked={false}
+              className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+              disabled={true}
+              id="includeExomePopulations"
+              onChange={[Function]}
+              type="checkbox"
+            />
+            Exomes
+          </label>
+          <label
+            className="Checkbox__Label-hrpa6b-0 gtTKXr"
+            htmlFor="includeGenomePopulations"
+          >
+            <input
+              checked={false}
+              className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+              disabled={true}
+              id="includeGenomePopulations"
+              onChange={[Function]}
+              type="checkbox"
+            />
+            Genomes
+          </label>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 CMQAN"
+    >
+      <h2>
+        Related Variants
+      </h2>
+      <div
+        className="VariantRelatedVariants__Wrapper-sc-y59fw8-0 bOggsA"
+      >
+        <div
+          className="VariantRelatedVariants__Item-sc-y59fw8-1 kqiRIK"
+        >
+          <h3>
+            Nearby Variants
+          </h3>
+          <p>
+            <a
+              className="Link-sc-14lgydv-0-Link jBvaYQ"
+              href="/region/13-103-143"
+              onClick={[Function]}
+            >
+              View variants located within 20 bases of this variant.
+            </a>
+          </p>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 CMQAN"
+    >
+      <h2>
+        Variant Effect Predictor
+      </h2>
+      <div>
+        <p>
+          This variant falls on 
+          0
+           transcript
+          s
+           in 
+          0
+           
+          gene
+          s
+          .
+        </p>
+        <p>
+          <span
+            className="Badge__BadgeWrapper-j4izdp-1 cJObdY"
+          >
+            Note
+          </span>
+           The gene symbols shown below are provided by VEP and may differ from the symbol shown on gene pages.
+        </p>
+        <ol
+          className="TranscriptConsequenceList__ConsequenceListWrapper-sc-qi0gmz-1 cXJgYo"
+        />
+      </div>
+    </section>
+    <div
+      className="VariantPage__FlexWrapper-sc-hd87ur-2 bjkoAa"
+    />
+    <div
+      className="VariantPage__FlexWrapper-sc-hd87ur-2 bjkoAa"
+    >
+      <section
+        className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+      >
+        <h2>
+          Age Distribution 
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
+        <div>
+          <div
+            className="GnomadAgeDistribution__LegendWrapper-sc-ty24oq-0 kOKZpq"
+          >
+            <ul
+              className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+            >
+              <li
+                className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+              >
+                <svg
+                  height={16}
+                  width={16}
+                >
+                  <rect
+                    fill="#428bca"
+                    height={16}
+                    stroke="#000"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                </svg>
+                <span
+                  style={
+                    {
+                      "marginLeft": "0.25em",
+                    }
+                  }
+                >
+                  Exome
+                </span>
+              </li>
+              <li
+                className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+              >
+                <svg
+                  height={16}
+                  width={16}
+                >
+                  <rect
+                    fill="#73ab3d"
+                    height={16}
+                    stroke="#000"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                </svg>
+                <span
+                  style={
+                    {
+                      "marginLeft": "0.25em",
+                    }
+                  }
+                >
+                  Genome
+                </span>
+              </li>
+            </ul>
+            <ul
+              className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+            >
+              <li
+                className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+              >
+                <svg
+                  height={16}
+                  width={16}
+                >
+                  <rect
+                    fill="#999"
+                    height={16}
+                    stroke="#000"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                </svg>
+                <span
+                  style={
+                    {
+                      "marginLeft": "0.25em",
+                    }
+                  }
+                >
+                  Variant carriers
+                </span>
+              </li>
+              <li
+                className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+              >
+                <svg
+                  height={16}
+                  width={16}
+                >
+                  <defs>
+                    <pattern
+                      height={4}
+                      id="age-distribution-legend-swatch-stripes"
+                      patternTransform="rotate(45)"
+                      patternUnits="userSpaceOnUse"
+                      width={4}
+                    >
+                      <rect
+                        fill="#fff"
+                        height={4}
+                        transform="translate(0,0)"
+                        width={3}
+                      />
+                    </pattern>
+                    <mask
+                      id="age-distribution-legend-swatch-mask"
+                    >
+                      <rect
+                        fill="url(#age-distribution-legend-swatch-stripes)"
+                        height="100%"
+                        width="100%"
+                        x={0}
+                        y={0}
+                      />
+                    </mask>
+                  </defs>
+                  <rect
+                    fill="#999"
+                    height={16}
+                    mask="url(#age-distribution-legend-swatch-mask)"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                  <rect
+                    fill="none"
+                    height={16}
+                    stroke="#333"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                </svg>
+                <span
+                  style={
+                    {
+                      "marginLeft": "0.25em",
+                    }
+                  }
+                >
+                  All individuals
+                </span>
+              </li>
+            </ul>
+          </div>
+          <div
+            style={
+              {
+                "height": "100%",
+                "width": "100%",
+              }
+            }
+          />
+          <div
+            className="ControlSection__Wrapper-sc-rro5al-1 dSZUkP"
+          >
+            <span
+              className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+            >
+              <div
+                className="GnomadAgeDistribution__CheckboxWrapper-sc-ty24oq-1 fatvfk"
+              >
+                <label
+                  className="Checkbox__Label-hrpa6b-0 gtTKXr"
+                  htmlFor="age-distribution-include-heterozygotes"
+                >
+                  <input
+                    checked={true}
+                    className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                    disabled={false}
+                    id="age-distribution-include-heterozygotes"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Include heterozygous variant carriers
+                </label>
+                <label
+                  className="Checkbox__Label-hrpa6b-0 gtTKXr"
+                  htmlFor="age-distribution-include-homozygotes"
+                >
+                  <input
+                    checked={true}
+                    className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                    disabled={false}
+                    id="age-distribution-include-homozygotes"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Include homozygous variant carriers
+                </label>
+                <label
+                  className="Checkbox__Label-hrpa6b-0 gtTKXr"
+                  htmlFor="age-distribution-show-all-individuals"
+                >
+                  <input
+                    checked={true}
+                    className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                    disabled={false}
+                    id="age-distribution-show-all-individuals"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Compare to all individuals
+                </label>
+              </div>
+            </span>
+            <span
+              className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+            >
+              <label
+                htmlFor="age-distribution-sequencing-type"
+              >
+                Sequencing types: 
+                <select
+                  className="Select-sc-1lkyg9e-0 ivadCR"
+                  disabled={true}
+                  id="age-distribution-sequencing-type"
+                  onChange={[Function]}
+                  value="e"
+                >
+                  <option
+                    value="eg"
+                  >
+                    Exome and Genome
+                  </option>
+                  <option
+                    value="e"
+                  >
+                    Exome
+                  </option>
+                  <option
+                    value="g"
+                  >
+                    Genome
+                  </option>
+                </select>
+              </label>
+            </span>
+          </div>
+        </div>
+      </section>
+    </div>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+    >
+      <h2>
+        Genotype Quality Metrics
+      </h2>
+      <div>
+        <div>
+          <div
+            role="tablist"
+          >
+            <ul
+              className="Tabs__TabListWrapper-jzgyty-0 gUVxKq"
+            >
+              <li>
+                <div
+                  aria-controls="genotype_quality-panel"
+                  aria-selected={true}
+                  className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                  id="genotype_quality"
+                  onFocus={[Function]}
+                  role="tab"
+                  tabIndex={0}
+                >
+                  <div
+                    className="Tabs__TabLabel-jzgyty-2 dcUyBp"
+                  >
+                    Genotype quality
+                  </div>
+                </div>
+              </li>
+              <li>
+                <div
+                  aria-controls="genotype_depth-panel"
+                  aria-selected={false}
+                  className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                  id="genotype_depth"
+                  onFocus={[Function]}
+                  role="tab"
+                  tabIndex={-1}
+                >
+                  <div
+                    className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                  >
+                    Depth
+                  </div>
+                </div>
+              </li>
+              <li>
+                <div
+                  aria-controls="allele_balance-panel"
+                  aria-selected={false}
+                  className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                  id="allele_balance"
+                  onFocus={[Function]}
+                  role="tab"
+                  tabIndex={-1}
+                >
+                  <div
+                    className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                  >
+                    Allele balance for heterozygotes
+                  </div>
+                </div>
+              </li>
+            </ul>
+          </div>
+          <div>
+            <div
+              aria-describedby="genotype_quality"
+              aria-hidden={false}
+              className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+              id="genotype_quality-panel"
+              onKeyDown={[Function]}
+              role="tabpanel"
+              style={{}}
+            >
+              <div
+                className="VariantGenotypeQualityMetrics__LegendWrapper-sc-tgmwmq-0 ihxxGK"
+              >
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#428bca"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Exome
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#73ab3d"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Genome
+                    </span>
+                  </li>
+                </ul>
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#999"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Variant carriers
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <defs>
+                        <pattern
+                          height={4}
+                          id="genotype-quality-legend-swatch-stripes"
+                          patternTransform="rotate(45)"
+                          patternUnits="userSpaceOnUse"
+                          width={4}
+                        >
+                          <rect
+                            fill="#fff"
+                            height={4}
+                            transform="translate(0,0)"
+                            width={3}
+                          />
+                        </pattern>
+                        <mask
+                          id="genotype-quality-legend-swatch-mask"
+                        >
+                          <rect
+                            fill="url(#genotype-quality-legend-swatch-stripes)"
+                            height="100%"
+                            width="100%"
+                            x={0}
+                            y={0}
+                          />
+                        </mask>
+                      </defs>
+                      <rect
+                        fill="#999"
+                        height={16}
+                        mask="url(#genotype-quality-legend-swatch-mask)"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                      <rect
+                        fill="none"
+                        height={16}
+                        stroke="#333"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      All individuals
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                style={
+                  {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              />
+            </div>
+            <div
+              aria-describedby="genotype_depth"
+              aria-hidden={true}
+              className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+              id="genotype_depth-panel"
+              onKeyDown={[Function]}
+              role="tabpanel"
+              style={
+                {
+                  "display": "none",
+                }
+              }
+            >
+              <div
+                className="VariantGenotypeQualityMetrics__LegendWrapper-sc-tgmwmq-0 ihxxGK"
+                style={
+                  {
+                    "marginTop": "1em",
+                  }
+                }
+              >
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#428bca"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Exome
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#73ab3d"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Genome
+                    </span>
+                  </li>
+                </ul>
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#999"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Variant carriers
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <defs>
+                        <pattern
+                          height={4}
+                          id="depth-legend-swatch-stripes"
+                          patternTransform="rotate(45)"
+                          patternUnits="userSpaceOnUse"
+                          width={4}
+                        >
+                          <rect
+                            fill="#fff"
+                            height={4}
+                            transform="translate(0,0)"
+                            width={3}
+                          />
+                        </pattern>
+                        <mask
+                          id="depth-legend-swatch-mask"
+                        >
+                          <rect
+                            fill="url(#depth-legend-swatch-stripes)"
+                            height="100%"
+                            width="100%"
+                            x={0}
+                            y={0}
+                          />
+                        </mask>
+                      </defs>
+                      <rect
+                        fill="#999"
+                        height={16}
+                        mask="url(#depth-legend-swatch-mask)"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                      <rect
+                        fill="none"
+                        height={16}
+                        stroke="#333"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      All individuals
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                style={
+                  {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              />
+            </div>
+            <div
+              aria-describedby="allele_balance"
+              aria-hidden={true}
+              className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+              id="allele_balance-panel"
+              onKeyDown={[Function]}
+              role="tabpanel"
+              style={
+                {
+                  "display": "none",
+                }
+              }
+            >
+              <div
+                className="VariantGenotypeQualityMetrics__LegendWrapper-sc-tgmwmq-0 ihxxGK"
+                style={
+                  {
+                    "marginTop": "1em",
+                  }
+                }
+              >
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#428bca"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Exome
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#73ab3d"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Genome
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                style={
+                  {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          className="ControlSection__Wrapper-sc-rro5al-1 dSZUkP"
+        >
+          <span
+            className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+          >
+            <label
+              className="Checkbox__Label-hrpa6b-0 gtTKXr"
+              htmlFor="genotype-quality-metrics-show-all-individuals"
+            >
+              <input
+                checked={true}
+                className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                disabled={false}
+                id="genotype-quality-metrics-show-all-individuals"
+                onChange={[Function]}
+                type="checkbox"
+              />
+              Compare to all individuals
+            </label>
+          </span>
+          <span
+            className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+          >
+            <label
+              htmlFor="genotype-quality-metrics-sequencing-type"
+            >
+              Sequencing types: 
+              <select
+                className="Select-sc-1lkyg9e-0 ivadCR"
+                disabled={true}
+                id="genotype-quality-metrics-sequencing-type"
+                onChange={[Function]}
+                value="e"
+              >
+                <option
+                  value="eg"
+                >
+                  Exome and Genome
+                </option>
+                <option
+                  value="e"
+                >
+                  Exome
+                </option>
+                <option
+                  value="g"
+                >
+                  Genome
+                </option>
+              </select>
+            </label>
+          </span>
+        </div>
+        <p>
+          Note: This plot may include low-quality genotypes that were excluded from allele counts in the tables above.
+        </p>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+    >
+      <h2>
+        Site Quality Metrics
+      </h2>
+      <div>
+        <div
+          role="tablist"
+        >
+          <ul
+            className="Tabs__TabListWrapper-jzgyty-0 gUVxKq"
+          >
+            <li>
+              <div
+                aria-controls="distribution-panel"
+                aria-selected={true}
+                className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                id="distribution"
+                onFocus={[Function]}
+                role="tab"
+                tabIndex={0}
+              >
+                <div
+                  className="Tabs__TabLabel-jzgyty-2 dcUyBp"
+                >
+                  Metric distribution
+                </div>
+              </div>
+            </li>
+            <li>
+              <div
+                aria-controls="values-panel"
+                aria-selected={false}
+                className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                id="values"
+                onFocus={[Function]}
+                role="tab"
+                tabIndex={-1}
+              >
+                <div
+                  className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                >
+                  All metric values
+                </div>
+              </div>
+            </li>
+          </ul>
+        </div>
+        <div>
+          <div
+            aria-describedby="distribution"
+            aria-hidden={false}
+            className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+            id="distribution-panel"
+            onKeyDown={[Function]}
+            role="tabpanel"
+            style={{}}
+          >
+            <div>
+              <div
+                className="VariantSiteQualityMetrics__LegendWrapper-sc-186wx2k-2 gDWfxF"
+              >
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#428bca"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Exome
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#73ab3d"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Genome
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                style={
+                  {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              />
+              <div
+                style={
+                  {
+                    "marginBottom": "0.5rem",
+                    "overflow": "hidden",
+                  }
+                }
+              />
+              <div
+                className="ControlSection__Wrapper-sc-rro5al-1 dSZUkP"
+              >
+                <span
+                  className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+                >
+                  <label
+                    htmlFor="site-quality-metrics-metric"
+                  >
+                    Metric: 
+                    <select
+                      className="Select-sc-1lkyg9e-0 ivadCR"
+                      id="site-quality-metrics-metric"
+                      onChange={[Function]}
+                      value="SiteQuality"
+                    >
+                      <option
+                        value="BaseQRankSum"
+                      >
+                        BaseQRankSum
+                      </option>
+                      <option
+                        value="ClippingRankSum"
+                      >
+                        ClippingRankSum
+                      </option>
+                      <option
+                        value="DP"
+                      >
+                        DP
+                      </option>
+                      <option
+                        value="FS"
+                      >
+                        FS
+                      </option>
+                      <option
+                        value="InbreedingCoeff"
+                      >
+                        InbreedingCoeff
+                      </option>
+                      <option
+                        value="MQ"
+                      >
+                        MQ
+                      </option>
+                      <option
+                        value="MQRankSum"
+                      >
+                        MQRankSum
+                      </option>
+                      <option
+                        value="pab_max"
+                      >
+                        pab_max
+                      </option>
+                      <option
+                        value="QD"
+                      >
+                        QD
+                      </option>
+                      <option
+                        value="ReadPosRankSum"
+                      >
+                        ReadPosRankSum
+                      </option>
+                      <option
+                        value="RF"
+                      >
+                        RF
+                      </option>
+                      <option
+                        value="SiteQuality"
+                      >
+                        SiteQuality
+                      </option>
+                      <option
+                        value="SOR"
+                      >
+                        SOR
+                      </option>
+                      <option
+                        value="VQSLOD"
+                      >
+                        VQSLOD
+                      </option>
+                    </select>
+                  </label>
+                </span>
+                <span
+                  className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+                >
+                  <label
+                    htmlFor="site-quality-metrics-sequencing-type"
+                  >
+                    Sequencing types: 
+                    <select
+                      className="Select-sc-1lkyg9e-0 ivadCR"
+                      disabled={true}
+                      id="site-quality-metrics-sequencing-type"
+                      onChange={[Function]}
+                      value="e"
+                    >
+                      <option
+                        value="eg"
+                      >
+                        Exome and Genome
+                      </option>
+                      <option
+                        value="e"
+                      >
+                        Exome
+                      </option>
+                      <option
+                        value="g"
+                      >
+                        Genome
+                      </option>
+                    </select>
+                  </label>
+                </span>
+              </div>
+              <p>
+                Value: 
+                0 (exome samples)
+              </p>
+              <p>
+                This is the site quality distribution for all exome variants with 0 &lt;= AF &lt; 0.00005.
+              </p>
+              <p>
+                Note: These are site-level quality metrics, they may be unpredictable for multi-allelic sites.
+              </p>
+            </div>
+          </div>
+          <div
+            aria-describedby="values"
+            aria-hidden={true}
+            className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+            id="values-panel"
+            onKeyDown={[Function]}
+            role="tabpanel"
+            style={
+              {
+                "display": "none",
+              }
+            }
+          >
+            <table
+              className="Table__BaseTable-sc-7fgtt2-0 dIBzV"
+              style={
+                {
+                  "width": "100%",
+                }
+              }
+            >
+              <thead>
+                <tr>
+                  <th
+                    scope="col"
+                  >
+                    Metric
+                  </th>
+                  <th
+                    scope="col"
+                  >
+                    Exome samples
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      BaseQRankSum
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      ClippingRankSum
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      DP
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      FS
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      InbreedingCoeff
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      MQ
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      MQRankSum
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      pab_max
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      QD
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      ReadPosRankSum
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      RF
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      SiteQuality
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      SOR
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      VQSLOD
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 CMQAN"
+    >
+      <h2>
+        Read Data
+      </h2>
+      <div>
+        <p>
+          No read data available for this variant.
+        </p>
+        <p>
+          <span
+            className="Badge__BadgeWrapper-j4izdp-1 cJObdY"
+          >
+            Note
+          </span>
+           Read data for non-coding regions is not available in gnomAD v2.1.1 and ExAC.
+        </p>
+      </div>
+    </section>
+  </div>
+</div>
+`;
+
+exports[`VariantPage with dataset gnomad_r2_1_controls has no unexpected changes 1`] = `
+<div
+  className="Page-w7h773-0 dRYfBS"
+>
+  <div
+    className="GnomadPageHeading__PageHeadingWrapper-sc-sgz3rr-0 gcOcdP"
+  >
+    <div
+      className="GnomadPageHeading__PageHeadingInnerWrapper-sc-sgz3rr-1 dLZzAa"
+    >
+      <h1
+        className="GnomadPageHeading__PageHeadingText-sc-sgz3rr-3 edXBqX"
+      >
+        <span
+          className="VariantPageTitle__TitleWrapper-sc-16g6pnt-0 bAAXLa"
+        >
+          <span>
+            Single nucleotide variant
+          </span>
+          <span
+            className="VariantPageTitle__Separator-sc-16g6pnt-1 jsfCLA"
+            style={
+              {
+                "width": "1ch",
+              }
+            }
+          >
+            :
+          </span>
+          <span
+            className="VariantPageTitle__VariantIdWrapper-sc-16g6pnt-2 jxIjmG"
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+          >
+            <span>
+              13
+              -
+              123
+            </span>
+            <span
+              className="VariantPageTitle__VariantIdSeparator-sc-16g6pnt-3 gwKaru"
+            >
+              -
+            </span>
+            <span
+              className="VariantPageTitle__TitleAlleles-sc-16g6pnt-4 dgrTjT"
+            >
+              A
+              -
+              C
+            </span>
+          </span>
+          <span
+            className="VariantPageTitle__Separator-sc-16g6pnt-1 jsfCLA"
+          >
+             
+          </span>
+          <span>
+            (
+            GRCh37
+            )
+          </span>
+        </span>
+      </h1>
+    </div>
+    <div
+      className="GnomadPageHeading__PageControlsWrapper-sc-sgz3rr-4 liqJpb"
+    >
+      <span
+        className="GnomadPageHeading__Label-sc-sgz3rr-5 dOhShJ"
+      >
+        Dataset
+      </span>
+      <ul
+        className="DatasetSelector__NavigationMenuWrapper-sc-1p2fxbn-0 ebZvwy"
+      >
+        <li
+          className="DatasetSelector__NavigationMenuItem-sc-1p2fxbn-2 ifirRc"
+        >
+          <a
+            className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
+            data-item="current_short_variant"
+            href="/?dataset=gnomad_r2_1_controls"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+          >
+            gnomAD v2.1.1 (controls)
+          </a>
+        </li>
+        <li
+          className="DatasetSelector__NavigationMenuItem-sc-1p2fxbn-2 ifirRc"
+        >
+          <a
+            aria-expanded={false}
+            aria-haspopup="true"
+            aria-label="More datasets"
+            className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
+            data-item="other_short_variant"
+            href="/"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="button"
+          >
+            <span
+              className="DatasetSelector__MoreIcon-sc-1p2fxbn-3 hTYFQu"
+            >
+              <img
+                alt=""
+                aria-hidden="true"
+                src="test-file-stub"
+              />
+            </span>
+          </a>
+          <ul
+            className="DatasetSelector__SubNavigationMenu-sc-1p2fxbn-4 epYyTQ"
+          >
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r2_1"
+                href="/?dataset=gnomad_r2_1"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v2.1.1
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  141,456 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r2_1_non_topmed"
+                href="/?dataset=gnomad_r2_1_non_topmed"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v2.1.1 (non-TOPMed)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  135,743 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r2_1_non_cancer"
+                href="/?dataset=gnomad_r2_1_non_cancer"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v2.1.1 (non-cancer)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  134,187 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r2_1_non_neuro"
+                href="/?dataset=gnomad_r2_1_non_neuro"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v2.1.1 (non-neuro)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  114,704 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r2_1_controls"
+                href="/?dataset=gnomad_r2_1_controls"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v2.1.1 (controls)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  60,146 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="exac"
+                href="/?dataset=exac"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                ExAC v1.0
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  60,706 samples
+                </div>
+              </a>
+            </li>
+          </ul>
+        </li>
+      </ul>
+      <span>
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+          >
+            More information
+          </span>
+        </button>
+      </span>
+    </div>
+  </div>
+  <div
+    className="VariantPage__FlexWrapper-sc-hd87ur-2 bjkoAa"
+  >
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+    >
+      <div
+        className="TableWrapper-sc-1ep26r3-0 edvjZa"
+      >
+        <div>
+          <table
+            className="VariantOccurrenceTable__Table-sc-8b13g7-0 iwAwP"
+          >
+            <tbody>
+              <tr>
+                <td />
+                <th
+                  scope="col"
+                >
+                  Exomes
+                </th>
+                <th
+                  scope="col"
+                >
+                  Genomes
+                </th>
+                <th
+                  scope="col"
+                >
+                  Total
+                </th>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Filters
+                  </span>
+                </th>
+                <td>
+                  <span
+                    className="Badge__BadgeWrapper-j4izdp-1 bhuqae"
+                  >
+                    Pass
+                  </span>
+                </td>
+                <td>
+                  <span
+                    className="Badge__BadgeWrapper-j4izdp-1 bbjxGL"
+                  >
+                    No variant
+                  </span>
+                </td>
+                <td />
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Count
+                  </span>
+                </th>
+                <td>
+                  0
+                </td>
+                <td />
+                <td>
+                  0
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Number
+                  </span>
+                </th>
+                <td>
+                  0
+                   *
+                </td>
+                <td />
+                <td>
+                  0
+                   *
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Frequency
+                  </span>
+                </th>
+                <td>
+                  0.000
+                </td>
+                <td />
+                <td>
+                  0.000
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="VariantOccurrenceTable__NoWrap-sc-8b13g7-1 kmxNQ"
+                  >
+                    Popmax Filtering AF 
+                    <button
+                      className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <img
+                        alt=""
+                        aria-hidden="true"
+                        src="test-file-stub"
+                      />
+                      <span
+                        style={
+                          {
+                            "border": "0",
+                            "clip": "rect(0 0 0 0)",
+                            "height": "1px",
+                            "margin": "-1px",
+                            "overflow": "hidden",
+                            "padding": "0",
+                            "position": "absolute",
+                            "whiteSpace": "nowrap",
+                            "width": "1px",
+                          }
+                        }
+                      >
+                        More information
+                      </span>
+                    </button>
+                  </span>
+                  <br />
+                  (95% confidence)
+                </th>
+                <td>
+                  <span>
+                    0
+                  </span>
+                </td>
+                <td />
+                <td />
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Number of homozygotes
+                  </span>
+                </th>
+                <td>
+                  0
+                </td>
+                <td />
+                <td>
+                  0
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Mean depth of coverage
+                  </span>
+                </th>
+                <td>
+                  –
+                </td>
+                <td>
+                  –
+                </td>
+                <td />
+              </tr>
+            </tbody>
+          </table>
+          <p>
+            <span
+              className="Badge__BadgeWrapper-j4izdp-1 dyHZPQ"
+            >
+              Warning
+            </span>
+             This variant is covered in fewer than 50% of individuals in 
+            gnomAD v2.1.1 (controls) exomes
+            .
+             
+            Allele frequency estimates may not be reliable
+            .
+          </p>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+    >
+      <h2>
+        External Resources
+      </h2>
+      <ul
+        className="List-sc-4j87st-0 fQRmhM"
+      >
+        <li
+          className="List__ListItem-sc-4j87st-1 gGPLUe"
+        >
+          <a
+            className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+            href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&highlight=hg19.chr13%3A123-123&position=chr13%3A98-148"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            UCSC
+          </a>
+        </li>
+      </ul>
+      <h2>
+        Feedback
+      </h2>
+      <a
+        className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+        href="mailto:gnomad@broadinstitute.org"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        Report an issue with this variant
+      </a>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 CMQAN"
+    >
+      <h2>
+        Population Frequencies 
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
+      <div
+        className="TableWrapper-sc-1ep26r3-0 edvjZa"
+      >
+        <table
+          className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+        >
+          <thead>
+            <tr>
+              <th
+                aria-sort="none"
+                colSpan={2}
+                scope="col"
+              >
+                <button
+                  onClick={[Function]}
+                  type="button"
+                >
+                  Population
+                </button>
+              </th>
+              <th
+                aria-sort="none"
+                className="right-align"
+                scope="col"
+              >
+                <button
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Count
+                  </span>
+                </button>
+              </th>
+              <th
+                aria-sort="none"
+                className="right-align"
+                scope="col"
+              >
+                <button
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Number
+                  </span>
+                </button>
+              </th>
+              <th
+                aria-sort="none"
+                className="right-align"
+                scope="col"
+              >
+                <button
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Number of Homozygotes
+                  </span>
+                </button>
+              </th>
+              <th
+                aria-sort="descending"
+                scope="col"
+                style={
+                  {
+                    "paddingLeft": "25px",
+                  }
+                }
+              >
+                <button
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Frequency
+                  </span>
+                </button>
+              </th>
+            </tr>
+          </thead>
+          <tfoot>
+            <tr
+              className="border"
+            >
+              <th
+                colSpan={2}
+                scope="row"
+              >
+                Total
+              </th>
+              <td
+                className="right-align"
+              >
+                0
+              </td>
+              <td
+                className="right-align"
+              >
+                0
+              </td>
+              <td
+                className="right-align"
+              >
+                0
+              </td>
+              <td
+                style={
+                  {
+                    "paddingLeft": "25px",
+                  }
+                }
+              >
+                0.000
+              </td>
+            </tr>
+          </tfoot>
+        </table>
+        <div
+          className="GnomadPopulationsTable__ControlSection-sc-1ghxck9-0 bsALfR"
+        >
+          Include:
+          <label
+            className="Checkbox__Label-hrpa6b-0 gtTKXr"
+            htmlFor="includeExomePopulations"
+          >
+            <input
+              checked={false}
+              className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+              disabled={true}
+              id="includeExomePopulations"
+              onChange={[Function]}
+              type="checkbox"
+            />
+            Exomes
+          </label>
+          <label
+            className="Checkbox__Label-hrpa6b-0 gtTKXr"
+            htmlFor="includeGenomePopulations"
+          >
+            <input
+              checked={false}
+              className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+              disabled={true}
+              id="includeGenomePopulations"
+              onChange={[Function]}
+              type="checkbox"
+            />
+            Genomes
+          </label>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 CMQAN"
+    >
+      <h2>
+        Related Variants
+      </h2>
+      <div
+        className="VariantRelatedVariants__Wrapper-sc-y59fw8-0 bOggsA"
+      >
+        <div
+          className="VariantRelatedVariants__Item-sc-y59fw8-1 kqiRIK"
+        >
+          <h3>
+            Nearby Variants
+          </h3>
+          <p>
+            <a
+              className="Link-sc-14lgydv-0-Link jBvaYQ"
+              href="/region/13-103-143"
+              onClick={[Function]}
+            >
+              View variants located within 20 bases of this variant.
+            </a>
+          </p>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 CMQAN"
+    >
+      <h2>
+        Variant Effect Predictor
+      </h2>
+      <div>
+        <p>
+          This variant falls on 
+          0
+           transcript
+          s
+           in 
+          0
+           
+          gene
+          s
+          .
+        </p>
+        <p>
+          <span
+            className="Badge__BadgeWrapper-j4izdp-1 cJObdY"
+          >
+            Note
+          </span>
+           The gene symbols shown below are provided by VEP and may differ from the symbol shown on gene pages.
+        </p>
+        <ol
+          className="TranscriptConsequenceList__ConsequenceListWrapper-sc-qi0gmz-1 cXJgYo"
+        />
+      </div>
+    </section>
+    <div
+      className="VariantPage__FlexWrapper-sc-hd87ur-2 bjkoAa"
+    />
+    <div
+      className="VariantPage__FlexWrapper-sc-hd87ur-2 bjkoAa"
+    >
+      <section
+        className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+      >
+        <h2>
+          Age Distribution 
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
+        <div>
+          <div
+            className="GnomadAgeDistribution__LegendWrapper-sc-ty24oq-0 kOKZpq"
+          >
+            <ul
+              className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+            >
+              <li
+                className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+              >
+                <svg
+                  height={16}
+                  width={16}
+                >
+                  <rect
+                    fill="#428bca"
+                    height={16}
+                    stroke="#000"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                </svg>
+                <span
+                  style={
+                    {
+                      "marginLeft": "0.25em",
+                    }
+                  }
+                >
+                  Exome
+                </span>
+              </li>
+              <li
+                className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+              >
+                <svg
+                  height={16}
+                  width={16}
+                >
+                  <rect
+                    fill="#73ab3d"
+                    height={16}
+                    stroke="#000"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                </svg>
+                <span
+                  style={
+                    {
+                      "marginLeft": "0.25em",
+                    }
+                  }
+                >
+                  Genome
+                </span>
+              </li>
+            </ul>
+            <ul
+              className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+            >
+              <li
+                className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+              >
+                <svg
+                  height={16}
+                  width={16}
+                >
+                  <rect
+                    fill="#999"
+                    height={16}
+                    stroke="#000"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                </svg>
+                <span
+                  style={
+                    {
+                      "marginLeft": "0.25em",
+                    }
+                  }
+                >
+                  Variant carriers
+                </span>
+              </li>
+              <li
+                className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+              >
+                <svg
+                  height={16}
+                  width={16}
+                >
+                  <defs>
+                    <pattern
+                      height={4}
+                      id="age-distribution-legend-swatch-stripes"
+                      patternTransform="rotate(45)"
+                      patternUnits="userSpaceOnUse"
+                      width={4}
+                    >
+                      <rect
+                        fill="#fff"
+                        height={4}
+                        transform="translate(0,0)"
+                        width={3}
+                      />
+                    </pattern>
+                    <mask
+                      id="age-distribution-legend-swatch-mask"
+                    >
+                      <rect
+                        fill="url(#age-distribution-legend-swatch-stripes)"
+                        height="100%"
+                        width="100%"
+                        x={0}
+                        y={0}
+                      />
+                    </mask>
+                  </defs>
+                  <rect
+                    fill="#999"
+                    height={16}
+                    mask="url(#age-distribution-legend-swatch-mask)"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                  <rect
+                    fill="none"
+                    height={16}
+                    stroke="#333"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                </svg>
+                <span
+                  style={
+                    {
+                      "marginLeft": "0.25em",
+                    }
+                  }
+                >
+                  All individuals
+                </span>
+              </li>
+            </ul>
+          </div>
+          <div
+            style={
+              {
+                "height": "100%",
+                "width": "100%",
+              }
+            }
+          />
+          <div
+            className="ControlSection__Wrapper-sc-rro5al-1 dSZUkP"
+          >
+            <span
+              className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+            >
+              <div
+                className="GnomadAgeDistribution__CheckboxWrapper-sc-ty24oq-1 fatvfk"
+              >
+                <label
+                  className="Checkbox__Label-hrpa6b-0 gtTKXr"
+                  htmlFor="age-distribution-include-heterozygotes"
+                >
+                  <input
+                    checked={true}
+                    className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                    disabled={false}
+                    id="age-distribution-include-heterozygotes"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Include heterozygous variant carriers
+                </label>
+                <label
+                  className="Checkbox__Label-hrpa6b-0 gtTKXr"
+                  htmlFor="age-distribution-include-homozygotes"
+                >
+                  <input
+                    checked={true}
+                    className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                    disabled={false}
+                    id="age-distribution-include-homozygotes"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Include homozygous variant carriers
+                </label>
+                <label
+                  className="Checkbox__Label-hrpa6b-0 gtTKXr"
+                  htmlFor="age-distribution-show-all-individuals"
+                >
+                  <input
+                    checked={true}
+                    className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                    disabled={false}
+                    id="age-distribution-show-all-individuals"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Compare to all individuals
+                </label>
+              </div>
+            </span>
+            <span
+              className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+            >
+              <label
+                htmlFor="age-distribution-sequencing-type"
+              >
+                Sequencing types: 
+                <select
+                  className="Select-sc-1lkyg9e-0 ivadCR"
+                  disabled={true}
+                  id="age-distribution-sequencing-type"
+                  onChange={[Function]}
+                  value="e"
+                >
+                  <option
+                    value="eg"
+                  >
+                    Exome and Genome
+                  </option>
+                  <option
+                    value="e"
+                  >
+                    Exome
+                  </option>
+                  <option
+                    value="g"
+                  >
+                    Genome
+                  </option>
+                </select>
+              </label>
+            </span>
+          </div>
+        </div>
+      </section>
+    </div>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+    >
+      <h2>
+        Genotype Quality Metrics
+      </h2>
+      <div>
+        <div>
+          <div
+            role="tablist"
+          >
+            <ul
+              className="Tabs__TabListWrapper-jzgyty-0 gUVxKq"
+            >
+              <li>
+                <div
+                  aria-controls="genotype_quality-panel"
+                  aria-selected={true}
+                  className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                  id="genotype_quality"
+                  onFocus={[Function]}
+                  role="tab"
+                  tabIndex={0}
+                >
+                  <div
+                    className="Tabs__TabLabel-jzgyty-2 dcUyBp"
+                  >
+                    Genotype quality
+                  </div>
+                </div>
+              </li>
+              <li>
+                <div
+                  aria-controls="genotype_depth-panel"
+                  aria-selected={false}
+                  className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                  id="genotype_depth"
+                  onFocus={[Function]}
+                  role="tab"
+                  tabIndex={-1}
+                >
+                  <div
+                    className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                  >
+                    Depth
+                  </div>
+                </div>
+              </li>
+              <li>
+                <div
+                  aria-controls="allele_balance-panel"
+                  aria-selected={false}
+                  className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                  id="allele_balance"
+                  onFocus={[Function]}
+                  role="tab"
+                  tabIndex={-1}
+                >
+                  <div
+                    className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                  >
+                    Allele balance for heterozygotes
+                  </div>
+                </div>
+              </li>
+            </ul>
+          </div>
+          <div>
+            <div
+              aria-describedby="genotype_quality"
+              aria-hidden={false}
+              className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+              id="genotype_quality-panel"
+              onKeyDown={[Function]}
+              role="tabpanel"
+              style={{}}
+            >
+              <div
+                className="VariantGenotypeQualityMetrics__LegendWrapper-sc-tgmwmq-0 ihxxGK"
+              >
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#428bca"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Exome
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#73ab3d"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Genome
+                    </span>
+                  </li>
+                </ul>
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#999"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Variant carriers
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <defs>
+                        <pattern
+                          height={4}
+                          id="genotype-quality-legend-swatch-stripes"
+                          patternTransform="rotate(45)"
+                          patternUnits="userSpaceOnUse"
+                          width={4}
+                        >
+                          <rect
+                            fill="#fff"
+                            height={4}
+                            transform="translate(0,0)"
+                            width={3}
+                          />
+                        </pattern>
+                        <mask
+                          id="genotype-quality-legend-swatch-mask"
+                        >
+                          <rect
+                            fill="url(#genotype-quality-legend-swatch-stripes)"
+                            height="100%"
+                            width="100%"
+                            x={0}
+                            y={0}
+                          />
+                        </mask>
+                      </defs>
+                      <rect
+                        fill="#999"
+                        height={16}
+                        mask="url(#genotype-quality-legend-swatch-mask)"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                      <rect
+                        fill="none"
+                        height={16}
+                        stroke="#333"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      All individuals
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                style={
+                  {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              />
+            </div>
+            <div
+              aria-describedby="genotype_depth"
+              aria-hidden={true}
+              className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+              id="genotype_depth-panel"
+              onKeyDown={[Function]}
+              role="tabpanel"
+              style={
+                {
+                  "display": "none",
+                }
+              }
+            >
+              <div
+                className="VariantGenotypeQualityMetrics__LegendWrapper-sc-tgmwmq-0 ihxxGK"
+                style={
+                  {
+                    "marginTop": "1em",
+                  }
+                }
+              >
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#428bca"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Exome
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#73ab3d"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Genome
+                    </span>
+                  </li>
+                </ul>
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#999"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Variant carriers
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <defs>
+                        <pattern
+                          height={4}
+                          id="depth-legend-swatch-stripes"
+                          patternTransform="rotate(45)"
+                          patternUnits="userSpaceOnUse"
+                          width={4}
+                        >
+                          <rect
+                            fill="#fff"
+                            height={4}
+                            transform="translate(0,0)"
+                            width={3}
+                          />
+                        </pattern>
+                        <mask
+                          id="depth-legend-swatch-mask"
+                        >
+                          <rect
+                            fill="url(#depth-legend-swatch-stripes)"
+                            height="100%"
+                            width="100%"
+                            x={0}
+                            y={0}
+                          />
+                        </mask>
+                      </defs>
+                      <rect
+                        fill="#999"
+                        height={16}
+                        mask="url(#depth-legend-swatch-mask)"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                      <rect
+                        fill="none"
+                        height={16}
+                        stroke="#333"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      All individuals
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                style={
+                  {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              />
+            </div>
+            <div
+              aria-describedby="allele_balance"
+              aria-hidden={true}
+              className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+              id="allele_balance-panel"
+              onKeyDown={[Function]}
+              role="tabpanel"
+              style={
+                {
+                  "display": "none",
+                }
+              }
+            >
+              <div
+                className="VariantGenotypeQualityMetrics__LegendWrapper-sc-tgmwmq-0 ihxxGK"
+                style={
+                  {
+                    "marginTop": "1em",
+                  }
+                }
+              >
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#428bca"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Exome
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#73ab3d"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Genome
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                style={
+                  {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          className="ControlSection__Wrapper-sc-rro5al-1 dSZUkP"
+        >
+          <span
+            className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+          >
+            <label
+              className="Checkbox__Label-hrpa6b-0 gtTKXr"
+              htmlFor="genotype-quality-metrics-show-all-individuals"
+            >
+              <input
+                checked={true}
+                className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                disabled={false}
+                id="genotype-quality-metrics-show-all-individuals"
+                onChange={[Function]}
+                type="checkbox"
+              />
+              Compare to all individuals
+            </label>
+          </span>
+          <span
+            className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+          >
+            <label
+              htmlFor="genotype-quality-metrics-sequencing-type"
+            >
+              Sequencing types: 
+              <select
+                className="Select-sc-1lkyg9e-0 ivadCR"
+                disabled={true}
+                id="genotype-quality-metrics-sequencing-type"
+                onChange={[Function]}
+                value="e"
+              >
+                <option
+                  value="eg"
+                >
+                  Exome and Genome
+                </option>
+                <option
+                  value="e"
+                >
+                  Exome
+                </option>
+                <option
+                  value="g"
+                >
+                  Genome
+                </option>
+              </select>
+            </label>
+          </span>
+        </div>
+        <p>
+          Note: This plot may include low-quality genotypes that were excluded from allele counts in the tables above.
+        </p>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+    >
+      <h2>
+        Site Quality Metrics
+      </h2>
+      <div>
+        <div
+          role="tablist"
+        >
+          <ul
+            className="Tabs__TabListWrapper-jzgyty-0 gUVxKq"
+          >
+            <li>
+              <div
+                aria-controls="distribution-panel"
+                aria-selected={true}
+                className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                id="distribution"
+                onFocus={[Function]}
+                role="tab"
+                tabIndex={0}
+              >
+                <div
+                  className="Tabs__TabLabel-jzgyty-2 dcUyBp"
+                >
+                  Metric distribution
+                </div>
+              </div>
+            </li>
+            <li>
+              <div
+                aria-controls="values-panel"
+                aria-selected={false}
+                className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                id="values"
+                onFocus={[Function]}
+                role="tab"
+                tabIndex={-1}
+              >
+                <div
+                  className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                >
+                  All metric values
+                </div>
+              </div>
+            </li>
+          </ul>
+        </div>
+        <div>
+          <div
+            aria-describedby="distribution"
+            aria-hidden={false}
+            className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+            id="distribution-panel"
+            onKeyDown={[Function]}
+            role="tabpanel"
+            style={{}}
+          >
+            <div>
+              <div
+                className="VariantSiteQualityMetrics__LegendWrapper-sc-186wx2k-2 gDWfxF"
+              >
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#428bca"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Exome
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#73ab3d"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Genome
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                style={
+                  {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              />
+              <div
+                style={
+                  {
+                    "marginBottom": "0.5rem",
+                    "overflow": "hidden",
+                  }
+                }
+              />
+              <div
+                className="ControlSection__Wrapper-sc-rro5al-1 dSZUkP"
+              >
+                <span
+                  className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+                >
+                  <label
+                    htmlFor="site-quality-metrics-metric"
+                  >
+                    Metric: 
+                    <select
+                      className="Select-sc-1lkyg9e-0 ivadCR"
+                      id="site-quality-metrics-metric"
+                      onChange={[Function]}
+                      value="SiteQuality"
+                    >
+                      <option
+                        value="BaseQRankSum"
+                      >
+                        BaseQRankSum
+                      </option>
+                      <option
+                        value="ClippingRankSum"
+                      >
+                        ClippingRankSum
+                      </option>
+                      <option
+                        value="DP"
+                      >
+                        DP
+                      </option>
+                      <option
+                        value="FS"
+                      >
+                        FS
+                      </option>
+                      <option
+                        value="InbreedingCoeff"
+                      >
+                        InbreedingCoeff
+                      </option>
+                      <option
+                        value="MQ"
+                      >
+                        MQ
+                      </option>
+                      <option
+                        value="MQRankSum"
+                      >
+                        MQRankSum
+                      </option>
+                      <option
+                        value="pab_max"
+                      >
+                        pab_max
+                      </option>
+                      <option
+                        value="QD"
+                      >
+                        QD
+                      </option>
+                      <option
+                        value="ReadPosRankSum"
+                      >
+                        ReadPosRankSum
+                      </option>
+                      <option
+                        value="RF"
+                      >
+                        RF
+                      </option>
+                      <option
+                        value="SiteQuality"
+                      >
+                        SiteQuality
+                      </option>
+                      <option
+                        value="SOR"
+                      >
+                        SOR
+                      </option>
+                      <option
+                        value="VQSLOD"
+                      >
+                        VQSLOD
+                      </option>
+                    </select>
+                  </label>
+                </span>
+                <span
+                  className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+                >
+                  <label
+                    htmlFor="site-quality-metrics-sequencing-type"
+                  >
+                    Sequencing types: 
+                    <select
+                      className="Select-sc-1lkyg9e-0 ivadCR"
+                      disabled={true}
+                      id="site-quality-metrics-sequencing-type"
+                      onChange={[Function]}
+                      value="e"
+                    >
+                      <option
+                        value="eg"
+                      >
+                        Exome and Genome
+                      </option>
+                      <option
+                        value="e"
+                      >
+                        Exome
+                      </option>
+                      <option
+                        value="g"
+                      >
+                        Genome
+                      </option>
+                    </select>
+                  </label>
+                </span>
+              </div>
+              <p>
+                Value: 
+                0 (exome samples)
+              </p>
+              <p>
+                This is the site quality distribution for all exome variants with 0 &lt;= AF &lt; 0.00005.
+              </p>
+              <p>
+                Note: These are site-level quality metrics, they may be unpredictable for multi-allelic sites.
+              </p>
+            </div>
+          </div>
+          <div
+            aria-describedby="values"
+            aria-hidden={true}
+            className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+            id="values-panel"
+            onKeyDown={[Function]}
+            role="tabpanel"
+            style={
+              {
+                "display": "none",
+              }
+            }
+          >
+            <table
+              className="Table__BaseTable-sc-7fgtt2-0 dIBzV"
+              style={
+                {
+                  "width": "100%",
+                }
+              }
+            >
+              <thead>
+                <tr>
+                  <th
+                    scope="col"
+                  >
+                    Metric
+                  </th>
+                  <th
+                    scope="col"
+                  >
+                    Exome samples
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      BaseQRankSum
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      ClippingRankSum
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      DP
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      FS
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      InbreedingCoeff
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      MQ
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      MQRankSum
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      pab_max
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      QD
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      ReadPosRankSum
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      RF
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      SiteQuality
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      SOR
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      VQSLOD
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 CMQAN"
+    >
+      <h2>
+        Read Data
+      </h2>
+      <div>
+        <p>
+          No read data available for this variant.
+        </p>
+        <p>
+          <span
+            className="Badge__BadgeWrapper-j4izdp-1 cJObdY"
+          >
+            Note
+          </span>
+           Read data for non-coding regions is not available in gnomAD v2.1.1 and ExAC.
+        </p>
+      </div>
+    </section>
+  </div>
+</div>
+`;
+
+exports[`VariantPage with dataset gnomad_r2_1_non_cancer has no unexpected changes 1`] = `
+<div
+  className="Page-w7h773-0 dRYfBS"
+>
+  <div
+    className="GnomadPageHeading__PageHeadingWrapper-sc-sgz3rr-0 gcOcdP"
+  >
+    <div
+      className="GnomadPageHeading__PageHeadingInnerWrapper-sc-sgz3rr-1 dLZzAa"
+    >
+      <h1
+        className="GnomadPageHeading__PageHeadingText-sc-sgz3rr-3 edXBqX"
+      >
+        <span
+          className="VariantPageTitle__TitleWrapper-sc-16g6pnt-0 bAAXLa"
+        >
+          <span>
+            Single nucleotide variant
+          </span>
+          <span
+            className="VariantPageTitle__Separator-sc-16g6pnt-1 jsfCLA"
+            style={
+              {
+                "width": "1ch",
+              }
+            }
+          >
+            :
+          </span>
+          <span
+            className="VariantPageTitle__VariantIdWrapper-sc-16g6pnt-2 jxIjmG"
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+          >
+            <span>
+              13
+              -
+              123
+            </span>
+            <span
+              className="VariantPageTitle__VariantIdSeparator-sc-16g6pnt-3 gwKaru"
+            >
+              -
+            </span>
+            <span
+              className="VariantPageTitle__TitleAlleles-sc-16g6pnt-4 dgrTjT"
+            >
+              A
+              -
+              C
+            </span>
+          </span>
+          <span
+            className="VariantPageTitle__Separator-sc-16g6pnt-1 jsfCLA"
+          >
+             
+          </span>
+          <span>
+            (
+            GRCh37
+            )
+          </span>
+        </span>
+      </h1>
+    </div>
+    <div
+      className="GnomadPageHeading__PageControlsWrapper-sc-sgz3rr-4 liqJpb"
+    >
+      <span
+        className="GnomadPageHeading__Label-sc-sgz3rr-5 dOhShJ"
+      >
+        Dataset
+      </span>
+      <ul
+        className="DatasetSelector__NavigationMenuWrapper-sc-1p2fxbn-0 ebZvwy"
+      >
+        <li
+          className="DatasetSelector__NavigationMenuItem-sc-1p2fxbn-2 ifirRc"
+        >
+          <a
+            className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
+            data-item="current_short_variant"
+            href="/?dataset=gnomad_r2_1_non_cancer"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+          >
+            gnomAD v2.1.1 (non-cancer)
+          </a>
+        </li>
+        <li
+          className="DatasetSelector__NavigationMenuItem-sc-1p2fxbn-2 ifirRc"
+        >
+          <a
+            aria-expanded={false}
+            aria-haspopup="true"
+            aria-label="More datasets"
+            className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
+            data-item="other_short_variant"
+            href="/"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="button"
+          >
+            <span
+              className="DatasetSelector__MoreIcon-sc-1p2fxbn-3 hTYFQu"
+            >
+              <img
+                alt=""
+                aria-hidden="true"
+                src="test-file-stub"
+              />
+            </span>
+          </a>
+          <ul
+            className="DatasetSelector__SubNavigationMenu-sc-1p2fxbn-4 epYyTQ"
+          >
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r2_1"
+                href="/?dataset=gnomad_r2_1"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v2.1.1
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  141,456 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r2_1_non_topmed"
+                href="/?dataset=gnomad_r2_1_non_topmed"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v2.1.1 (non-TOPMed)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  135,743 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r2_1_non_cancer"
+                href="/?dataset=gnomad_r2_1_non_cancer"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v2.1.1 (non-cancer)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  134,187 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r2_1_non_neuro"
+                href="/?dataset=gnomad_r2_1_non_neuro"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v2.1.1 (non-neuro)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  114,704 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r2_1_controls"
+                href="/?dataset=gnomad_r2_1_controls"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v2.1.1 (controls)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  60,146 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="exac"
+                href="/?dataset=exac"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                ExAC v1.0
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  60,706 samples
+                </div>
+              </a>
+            </li>
+          </ul>
+        </li>
+      </ul>
+      <span>
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+          >
+            More information
+          </span>
+        </button>
+      </span>
+    </div>
+  </div>
+  <div
+    className="VariantPage__FlexWrapper-sc-hd87ur-2 bjkoAa"
+  >
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+    >
+      <div
+        className="TableWrapper-sc-1ep26r3-0 edvjZa"
+      >
+        <div>
+          <table
+            className="VariantOccurrenceTable__Table-sc-8b13g7-0 iwAwP"
+          >
+            <tbody>
+              <tr>
+                <td />
+                <th
+                  scope="col"
+                >
+                  Exomes
+                </th>
+                <th
+                  scope="col"
+                >
+                  Genomes
+                </th>
+                <th
+                  scope="col"
+                >
+                  Total
+                </th>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Filters
+                  </span>
+                </th>
+                <td>
+                  <span
+                    className="Badge__BadgeWrapper-j4izdp-1 bhuqae"
+                  >
+                    Pass
+                  </span>
+                </td>
+                <td>
+                  <span
+                    className="Badge__BadgeWrapper-j4izdp-1 bbjxGL"
+                  >
+                    No variant
+                  </span>
+                </td>
+                <td />
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Count
+                  </span>
+                </th>
+                <td>
+                  0
+                </td>
+                <td />
+                <td>
+                  0
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Number
+                  </span>
+                </th>
+                <td>
+                  0
+                   *
+                </td>
+                <td />
+                <td>
+                  0
+                   *
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Frequency
+                  </span>
+                </th>
+                <td>
+                  0.000
+                </td>
+                <td />
+                <td>
+                  0.000
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="VariantOccurrenceTable__NoWrap-sc-8b13g7-1 kmxNQ"
+                  >
+                    Popmax Filtering AF 
+                    <button
+                      className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <img
+                        alt=""
+                        aria-hidden="true"
+                        src="test-file-stub"
+                      />
+                      <span
+                        style={
+                          {
+                            "border": "0",
+                            "clip": "rect(0 0 0 0)",
+                            "height": "1px",
+                            "margin": "-1px",
+                            "overflow": "hidden",
+                            "padding": "0",
+                            "position": "absolute",
+                            "whiteSpace": "nowrap",
+                            "width": "1px",
+                          }
+                        }
+                      >
+                        More information
+                      </span>
+                    </button>
+                  </span>
+                  <br />
+                  (95% confidence)
+                </th>
+                <td>
+                  <span>
+                    0
+                  </span>
+                </td>
+                <td />
+                <td />
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Number of homozygotes
+                  </span>
+                </th>
+                <td>
+                  0
+                </td>
+                <td />
+                <td>
+                  0
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Mean depth of coverage
+                  </span>
+                </th>
+                <td>
+                  –
+                </td>
+                <td>
+                  –
+                </td>
+                <td />
+              </tr>
+            </tbody>
+          </table>
+          <p>
+            <span
+              className="Badge__BadgeWrapper-j4izdp-1 dyHZPQ"
+            >
+              Warning
+            </span>
+             This variant is covered in fewer than 50% of individuals in 
+            gnomAD v2.1.1 (non-cancer) exomes
+            .
+             
+            Allele frequency estimates may not be reliable
+            .
+          </p>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+    >
+      <h2>
+        External Resources
+      </h2>
+      <ul
+        className="List-sc-4j87st-0 fQRmhM"
+      >
+        <li
+          className="List__ListItem-sc-4j87st-1 gGPLUe"
+        >
+          <a
+            className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+            href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&highlight=hg19.chr13%3A123-123&position=chr13%3A98-148"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            UCSC
+          </a>
+        </li>
+      </ul>
+      <h2>
+        Feedback
+      </h2>
+      <a
+        className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+        href="mailto:gnomad@broadinstitute.org"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        Report an issue with this variant
+      </a>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 CMQAN"
+    >
+      <h2>
+        Population Frequencies 
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
+      <div
+        className="TableWrapper-sc-1ep26r3-0 edvjZa"
+      >
+        <table
+          className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+        >
+          <thead>
+            <tr>
+              <th
+                aria-sort="none"
+                colSpan={2}
+                scope="col"
+              >
+                <button
+                  onClick={[Function]}
+                  type="button"
+                >
+                  Population
+                </button>
+              </th>
+              <th
+                aria-sort="none"
+                className="right-align"
+                scope="col"
+              >
+                <button
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Count
+                  </span>
+                </button>
+              </th>
+              <th
+                aria-sort="none"
+                className="right-align"
+                scope="col"
+              >
+                <button
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Number
+                  </span>
+                </button>
+              </th>
+              <th
+                aria-sort="none"
+                className="right-align"
+                scope="col"
+              >
+                <button
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Number of Homozygotes
+                  </span>
+                </button>
+              </th>
+              <th
+                aria-sort="descending"
+                scope="col"
+                style={
+                  {
+                    "paddingLeft": "25px",
+                  }
+                }
+              >
+                <button
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Frequency
+                  </span>
+                </button>
+              </th>
+            </tr>
+          </thead>
+          <tfoot>
+            <tr
+              className="border"
+            >
+              <th
+                colSpan={2}
+                scope="row"
+              >
+                Total
+              </th>
+              <td
+                className="right-align"
+              >
+                0
+              </td>
+              <td
+                className="right-align"
+              >
+                0
+              </td>
+              <td
+                className="right-align"
+              >
+                0
+              </td>
+              <td
+                style={
+                  {
+                    "paddingLeft": "25px",
+                  }
+                }
+              >
+                0.000
+              </td>
+            </tr>
+          </tfoot>
+        </table>
+        <div
+          className="GnomadPopulationsTable__ControlSection-sc-1ghxck9-0 bsALfR"
+        >
+          Include:
+          <label
+            className="Checkbox__Label-hrpa6b-0 gtTKXr"
+            htmlFor="includeExomePopulations"
+          >
+            <input
+              checked={false}
+              className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+              disabled={true}
+              id="includeExomePopulations"
+              onChange={[Function]}
+              type="checkbox"
+            />
+            Exomes
+          </label>
+          <label
+            className="Checkbox__Label-hrpa6b-0 gtTKXr"
+            htmlFor="includeGenomePopulations"
+          >
+            <input
+              checked={false}
+              className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+              disabled={true}
+              id="includeGenomePopulations"
+              onChange={[Function]}
+              type="checkbox"
+            />
+            Genomes
+          </label>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 CMQAN"
+    >
+      <h2>
+        Related Variants
+      </h2>
+      <div
+        className="VariantRelatedVariants__Wrapper-sc-y59fw8-0 bOggsA"
+      >
+        <div
+          className="VariantRelatedVariants__Item-sc-y59fw8-1 kqiRIK"
+        >
+          <h3>
+            Nearby Variants
+          </h3>
+          <p>
+            <a
+              className="Link-sc-14lgydv-0-Link jBvaYQ"
+              href="/region/13-103-143"
+              onClick={[Function]}
+            >
+              View variants located within 20 bases of this variant.
+            </a>
+          </p>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 CMQAN"
+    >
+      <h2>
+        Variant Effect Predictor
+      </h2>
+      <div>
+        <p>
+          This variant falls on 
+          0
+           transcript
+          s
+           in 
+          0
+           
+          gene
+          s
+          .
+        </p>
+        <p>
+          <span
+            className="Badge__BadgeWrapper-j4izdp-1 cJObdY"
+          >
+            Note
+          </span>
+           The gene symbols shown below are provided by VEP and may differ from the symbol shown on gene pages.
+        </p>
+        <ol
+          className="TranscriptConsequenceList__ConsequenceListWrapper-sc-qi0gmz-1 cXJgYo"
+        />
+      </div>
+    </section>
+    <div
+      className="VariantPage__FlexWrapper-sc-hd87ur-2 bjkoAa"
+    />
+    <div
+      className="VariantPage__FlexWrapper-sc-hd87ur-2 bjkoAa"
+    >
+      <section
+        className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+      >
+        <h2>
+          Age Distribution 
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
+        <div>
+          <div
+            className="GnomadAgeDistribution__LegendWrapper-sc-ty24oq-0 kOKZpq"
+          >
+            <ul
+              className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+            >
+              <li
+                className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+              >
+                <svg
+                  height={16}
+                  width={16}
+                >
+                  <rect
+                    fill="#428bca"
+                    height={16}
+                    stroke="#000"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                </svg>
+                <span
+                  style={
+                    {
+                      "marginLeft": "0.25em",
+                    }
+                  }
+                >
+                  Exome
+                </span>
+              </li>
+              <li
+                className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+              >
+                <svg
+                  height={16}
+                  width={16}
+                >
+                  <rect
+                    fill="#73ab3d"
+                    height={16}
+                    stroke="#000"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                </svg>
+                <span
+                  style={
+                    {
+                      "marginLeft": "0.25em",
+                    }
+                  }
+                >
+                  Genome
+                </span>
+              </li>
+            </ul>
+            <ul
+              className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+            >
+              <li
+                className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+              >
+                <svg
+                  height={16}
+                  width={16}
+                >
+                  <rect
+                    fill="#999"
+                    height={16}
+                    stroke="#000"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                </svg>
+                <span
+                  style={
+                    {
+                      "marginLeft": "0.25em",
+                    }
+                  }
+                >
+                  Variant carriers
+                </span>
+              </li>
+              <li
+                className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+              >
+                <svg
+                  height={16}
+                  width={16}
+                >
+                  <defs>
+                    <pattern
+                      height={4}
+                      id="age-distribution-legend-swatch-stripes"
+                      patternTransform="rotate(45)"
+                      patternUnits="userSpaceOnUse"
+                      width={4}
+                    >
+                      <rect
+                        fill="#fff"
+                        height={4}
+                        transform="translate(0,0)"
+                        width={3}
+                      />
+                    </pattern>
+                    <mask
+                      id="age-distribution-legend-swatch-mask"
+                    >
+                      <rect
+                        fill="url(#age-distribution-legend-swatch-stripes)"
+                        height="100%"
+                        width="100%"
+                        x={0}
+                        y={0}
+                      />
+                    </mask>
+                  </defs>
+                  <rect
+                    fill="#999"
+                    height={16}
+                    mask="url(#age-distribution-legend-swatch-mask)"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                  <rect
+                    fill="none"
+                    height={16}
+                    stroke="#333"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                </svg>
+                <span
+                  style={
+                    {
+                      "marginLeft": "0.25em",
+                    }
+                  }
+                >
+                  All individuals
+                </span>
+              </li>
+            </ul>
+          </div>
+          <div
+            style={
+              {
+                "height": "100%",
+                "width": "100%",
+              }
+            }
+          />
+          <div
+            className="ControlSection__Wrapper-sc-rro5al-1 dSZUkP"
+          >
+            <span
+              className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+            >
+              <div
+                className="GnomadAgeDistribution__CheckboxWrapper-sc-ty24oq-1 fatvfk"
+              >
+                <label
+                  className="Checkbox__Label-hrpa6b-0 gtTKXr"
+                  htmlFor="age-distribution-include-heterozygotes"
+                >
+                  <input
+                    checked={true}
+                    className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                    disabled={false}
+                    id="age-distribution-include-heterozygotes"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Include heterozygous variant carriers
+                </label>
+                <label
+                  className="Checkbox__Label-hrpa6b-0 gtTKXr"
+                  htmlFor="age-distribution-include-homozygotes"
+                >
+                  <input
+                    checked={true}
+                    className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                    disabled={false}
+                    id="age-distribution-include-homozygotes"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Include homozygous variant carriers
+                </label>
+                <label
+                  className="Checkbox__Label-hrpa6b-0 gtTKXr"
+                  htmlFor="age-distribution-show-all-individuals"
+                >
+                  <input
+                    checked={true}
+                    className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                    disabled={false}
+                    id="age-distribution-show-all-individuals"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Compare to all individuals
+                </label>
+              </div>
+            </span>
+            <span
+              className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+            >
+              <label
+                htmlFor="age-distribution-sequencing-type"
+              >
+                Sequencing types: 
+                <select
+                  className="Select-sc-1lkyg9e-0 ivadCR"
+                  disabled={true}
+                  id="age-distribution-sequencing-type"
+                  onChange={[Function]}
+                  value="e"
+                >
+                  <option
+                    value="eg"
+                  >
+                    Exome and Genome
+                  </option>
+                  <option
+                    value="e"
+                  >
+                    Exome
+                  </option>
+                  <option
+                    value="g"
+                  >
+                    Genome
+                  </option>
+                </select>
+              </label>
+            </span>
+          </div>
+        </div>
+      </section>
+    </div>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+    >
+      <h2>
+        Genotype Quality Metrics
+      </h2>
+      <div>
+        <div>
+          <div
+            role="tablist"
+          >
+            <ul
+              className="Tabs__TabListWrapper-jzgyty-0 gUVxKq"
+            >
+              <li>
+                <div
+                  aria-controls="genotype_quality-panel"
+                  aria-selected={true}
+                  className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                  id="genotype_quality"
+                  onFocus={[Function]}
+                  role="tab"
+                  tabIndex={0}
+                >
+                  <div
+                    className="Tabs__TabLabel-jzgyty-2 dcUyBp"
+                  >
+                    Genotype quality
+                  </div>
+                </div>
+              </li>
+              <li>
+                <div
+                  aria-controls="genotype_depth-panel"
+                  aria-selected={false}
+                  className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                  id="genotype_depth"
+                  onFocus={[Function]}
+                  role="tab"
+                  tabIndex={-1}
+                >
+                  <div
+                    className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                  >
+                    Depth
+                  </div>
+                </div>
+              </li>
+              <li>
+                <div
+                  aria-controls="allele_balance-panel"
+                  aria-selected={false}
+                  className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                  id="allele_balance"
+                  onFocus={[Function]}
+                  role="tab"
+                  tabIndex={-1}
+                >
+                  <div
+                    className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                  >
+                    Allele balance for heterozygotes
+                  </div>
+                </div>
+              </li>
+            </ul>
+          </div>
+          <div>
+            <div
+              aria-describedby="genotype_quality"
+              aria-hidden={false}
+              className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+              id="genotype_quality-panel"
+              onKeyDown={[Function]}
+              role="tabpanel"
+              style={{}}
+            >
+              <div
+                className="VariantGenotypeQualityMetrics__LegendWrapper-sc-tgmwmq-0 ihxxGK"
+              >
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#428bca"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Exome
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#73ab3d"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Genome
+                    </span>
+                  </li>
+                </ul>
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#999"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Variant carriers
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <defs>
+                        <pattern
+                          height={4}
+                          id="genotype-quality-legend-swatch-stripes"
+                          patternTransform="rotate(45)"
+                          patternUnits="userSpaceOnUse"
+                          width={4}
+                        >
+                          <rect
+                            fill="#fff"
+                            height={4}
+                            transform="translate(0,0)"
+                            width={3}
+                          />
+                        </pattern>
+                        <mask
+                          id="genotype-quality-legend-swatch-mask"
+                        >
+                          <rect
+                            fill="url(#genotype-quality-legend-swatch-stripes)"
+                            height="100%"
+                            width="100%"
+                            x={0}
+                            y={0}
+                          />
+                        </mask>
+                      </defs>
+                      <rect
+                        fill="#999"
+                        height={16}
+                        mask="url(#genotype-quality-legend-swatch-mask)"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                      <rect
+                        fill="none"
+                        height={16}
+                        stroke="#333"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      All individuals
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                style={
+                  {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              />
+            </div>
+            <div
+              aria-describedby="genotype_depth"
+              aria-hidden={true}
+              className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+              id="genotype_depth-panel"
+              onKeyDown={[Function]}
+              role="tabpanel"
+              style={
+                {
+                  "display": "none",
+                }
+              }
+            >
+              <div
+                className="VariantGenotypeQualityMetrics__LegendWrapper-sc-tgmwmq-0 ihxxGK"
+                style={
+                  {
+                    "marginTop": "1em",
+                  }
+                }
+              >
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#428bca"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Exome
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#73ab3d"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Genome
+                    </span>
+                  </li>
+                </ul>
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#999"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Variant carriers
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <defs>
+                        <pattern
+                          height={4}
+                          id="depth-legend-swatch-stripes"
+                          patternTransform="rotate(45)"
+                          patternUnits="userSpaceOnUse"
+                          width={4}
+                        >
+                          <rect
+                            fill="#fff"
+                            height={4}
+                            transform="translate(0,0)"
+                            width={3}
+                          />
+                        </pattern>
+                        <mask
+                          id="depth-legend-swatch-mask"
+                        >
+                          <rect
+                            fill="url(#depth-legend-swatch-stripes)"
+                            height="100%"
+                            width="100%"
+                            x={0}
+                            y={0}
+                          />
+                        </mask>
+                      </defs>
+                      <rect
+                        fill="#999"
+                        height={16}
+                        mask="url(#depth-legend-swatch-mask)"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                      <rect
+                        fill="none"
+                        height={16}
+                        stroke="#333"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      All individuals
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                style={
+                  {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              />
+            </div>
+            <div
+              aria-describedby="allele_balance"
+              aria-hidden={true}
+              className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+              id="allele_balance-panel"
+              onKeyDown={[Function]}
+              role="tabpanel"
+              style={
+                {
+                  "display": "none",
+                }
+              }
+            >
+              <div
+                className="VariantGenotypeQualityMetrics__LegendWrapper-sc-tgmwmq-0 ihxxGK"
+                style={
+                  {
+                    "marginTop": "1em",
+                  }
+                }
+              >
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#428bca"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Exome
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#73ab3d"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Genome
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                style={
+                  {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          className="ControlSection__Wrapper-sc-rro5al-1 dSZUkP"
+        >
+          <span
+            className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+          >
+            <label
+              className="Checkbox__Label-hrpa6b-0 gtTKXr"
+              htmlFor="genotype-quality-metrics-show-all-individuals"
+            >
+              <input
+                checked={true}
+                className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                disabled={false}
+                id="genotype-quality-metrics-show-all-individuals"
+                onChange={[Function]}
+                type="checkbox"
+              />
+              Compare to all individuals
+            </label>
+          </span>
+          <span
+            className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+          >
+            <label
+              htmlFor="genotype-quality-metrics-sequencing-type"
+            >
+              Sequencing types: 
+              <select
+                className="Select-sc-1lkyg9e-0 ivadCR"
+                disabled={true}
+                id="genotype-quality-metrics-sequencing-type"
+                onChange={[Function]}
+                value="e"
+              >
+                <option
+                  value="eg"
+                >
+                  Exome and Genome
+                </option>
+                <option
+                  value="e"
+                >
+                  Exome
+                </option>
+                <option
+                  value="g"
+                >
+                  Genome
+                </option>
+              </select>
+            </label>
+          </span>
+        </div>
+        <p>
+          Note: This plot may include low-quality genotypes that were excluded from allele counts in the tables above.
+        </p>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+    >
+      <h2>
+        Site Quality Metrics
+      </h2>
+      <div>
+        <div
+          role="tablist"
+        >
+          <ul
+            className="Tabs__TabListWrapper-jzgyty-0 gUVxKq"
+          >
+            <li>
+              <div
+                aria-controls="distribution-panel"
+                aria-selected={true}
+                className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                id="distribution"
+                onFocus={[Function]}
+                role="tab"
+                tabIndex={0}
+              >
+                <div
+                  className="Tabs__TabLabel-jzgyty-2 dcUyBp"
+                >
+                  Metric distribution
+                </div>
+              </div>
+            </li>
+            <li>
+              <div
+                aria-controls="values-panel"
+                aria-selected={false}
+                className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                id="values"
+                onFocus={[Function]}
+                role="tab"
+                tabIndex={-1}
+              >
+                <div
+                  className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                >
+                  All metric values
+                </div>
+              </div>
+            </li>
+          </ul>
+        </div>
+        <div>
+          <div
+            aria-describedby="distribution"
+            aria-hidden={false}
+            className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+            id="distribution-panel"
+            onKeyDown={[Function]}
+            role="tabpanel"
+            style={{}}
+          >
+            <div>
+              <div
+                className="VariantSiteQualityMetrics__LegendWrapper-sc-186wx2k-2 gDWfxF"
+              >
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#428bca"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Exome
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#73ab3d"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Genome
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                style={
+                  {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              />
+              <div
+                style={
+                  {
+                    "marginBottom": "0.5rem",
+                    "overflow": "hidden",
+                  }
+                }
+              />
+              <div
+                className="ControlSection__Wrapper-sc-rro5al-1 dSZUkP"
+              >
+                <span
+                  className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+                >
+                  <label
+                    htmlFor="site-quality-metrics-metric"
+                  >
+                    Metric: 
+                    <select
+                      className="Select-sc-1lkyg9e-0 ivadCR"
+                      id="site-quality-metrics-metric"
+                      onChange={[Function]}
+                      value="SiteQuality"
+                    >
+                      <option
+                        value="BaseQRankSum"
+                      >
+                        BaseQRankSum
+                      </option>
+                      <option
+                        value="ClippingRankSum"
+                      >
+                        ClippingRankSum
+                      </option>
+                      <option
+                        value="DP"
+                      >
+                        DP
+                      </option>
+                      <option
+                        value="FS"
+                      >
+                        FS
+                      </option>
+                      <option
+                        value="InbreedingCoeff"
+                      >
+                        InbreedingCoeff
+                      </option>
+                      <option
+                        value="MQ"
+                      >
+                        MQ
+                      </option>
+                      <option
+                        value="MQRankSum"
+                      >
+                        MQRankSum
+                      </option>
+                      <option
+                        value="pab_max"
+                      >
+                        pab_max
+                      </option>
+                      <option
+                        value="QD"
+                      >
+                        QD
+                      </option>
+                      <option
+                        value="ReadPosRankSum"
+                      >
+                        ReadPosRankSum
+                      </option>
+                      <option
+                        value="RF"
+                      >
+                        RF
+                      </option>
+                      <option
+                        value="SiteQuality"
+                      >
+                        SiteQuality
+                      </option>
+                      <option
+                        value="SOR"
+                      >
+                        SOR
+                      </option>
+                      <option
+                        value="VQSLOD"
+                      >
+                        VQSLOD
+                      </option>
+                    </select>
+                  </label>
+                </span>
+                <span
+                  className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+                >
+                  <label
+                    htmlFor="site-quality-metrics-sequencing-type"
+                  >
+                    Sequencing types: 
+                    <select
+                      className="Select-sc-1lkyg9e-0 ivadCR"
+                      disabled={true}
+                      id="site-quality-metrics-sequencing-type"
+                      onChange={[Function]}
+                      value="e"
+                    >
+                      <option
+                        value="eg"
+                      >
+                        Exome and Genome
+                      </option>
+                      <option
+                        value="e"
+                      >
+                        Exome
+                      </option>
+                      <option
+                        value="g"
+                      >
+                        Genome
+                      </option>
+                    </select>
+                  </label>
+                </span>
+              </div>
+              <p>
+                Value: 
+                0 (exome samples)
+              </p>
+              <p>
+                This is the site quality distribution for all exome variants with 0 &lt;= AF &lt; 0.00005.
+              </p>
+              <p>
+                Note: These are site-level quality metrics, they may be unpredictable for multi-allelic sites.
+              </p>
+            </div>
+          </div>
+          <div
+            aria-describedby="values"
+            aria-hidden={true}
+            className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+            id="values-panel"
+            onKeyDown={[Function]}
+            role="tabpanel"
+            style={
+              {
+                "display": "none",
+              }
+            }
+          >
+            <table
+              className="Table__BaseTable-sc-7fgtt2-0 dIBzV"
+              style={
+                {
+                  "width": "100%",
+                }
+              }
+            >
+              <thead>
+                <tr>
+                  <th
+                    scope="col"
+                  >
+                    Metric
+                  </th>
+                  <th
+                    scope="col"
+                  >
+                    Exome samples
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      BaseQRankSum
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      ClippingRankSum
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      DP
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      FS
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      InbreedingCoeff
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      MQ
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      MQRankSum
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      pab_max
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      QD
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      ReadPosRankSum
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      RF
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      SiteQuality
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      SOR
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      VQSLOD
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 CMQAN"
+    >
+      <h2>
+        Read Data
+      </h2>
+      <div>
+        <p>
+          No read data available for this variant.
+        </p>
+        <p>
+          <span
+            className="Badge__BadgeWrapper-j4izdp-1 cJObdY"
+          >
+            Note
+          </span>
+           Read data for non-coding regions is not available in gnomAD v2.1.1 and ExAC.
+        </p>
+      </div>
+    </section>
+  </div>
+</div>
+`;
+
+exports[`VariantPage with dataset gnomad_r2_1_non_neuro has no unexpected changes 1`] = `
+<div
+  className="Page-w7h773-0 dRYfBS"
+>
+  <div
+    className="GnomadPageHeading__PageHeadingWrapper-sc-sgz3rr-0 gcOcdP"
+  >
+    <div
+      className="GnomadPageHeading__PageHeadingInnerWrapper-sc-sgz3rr-1 dLZzAa"
+    >
+      <h1
+        className="GnomadPageHeading__PageHeadingText-sc-sgz3rr-3 edXBqX"
+      >
+        <span
+          className="VariantPageTitle__TitleWrapper-sc-16g6pnt-0 bAAXLa"
+        >
+          <span>
+            Single nucleotide variant
+          </span>
+          <span
+            className="VariantPageTitle__Separator-sc-16g6pnt-1 jsfCLA"
+            style={
+              {
+                "width": "1ch",
+              }
+            }
+          >
+            :
+          </span>
+          <span
+            className="VariantPageTitle__VariantIdWrapper-sc-16g6pnt-2 jxIjmG"
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+          >
+            <span>
+              13
+              -
+              123
+            </span>
+            <span
+              className="VariantPageTitle__VariantIdSeparator-sc-16g6pnt-3 gwKaru"
+            >
+              -
+            </span>
+            <span
+              className="VariantPageTitle__TitleAlleles-sc-16g6pnt-4 dgrTjT"
+            >
+              A
+              -
+              C
+            </span>
+          </span>
+          <span
+            className="VariantPageTitle__Separator-sc-16g6pnt-1 jsfCLA"
+          >
+             
+          </span>
+          <span>
+            (
+            GRCh37
+            )
+          </span>
+        </span>
+      </h1>
+    </div>
+    <div
+      className="GnomadPageHeading__PageControlsWrapper-sc-sgz3rr-4 liqJpb"
+    >
+      <span
+        className="GnomadPageHeading__Label-sc-sgz3rr-5 dOhShJ"
+      >
+        Dataset
+      </span>
+      <ul
+        className="DatasetSelector__NavigationMenuWrapper-sc-1p2fxbn-0 ebZvwy"
+      >
+        <li
+          className="DatasetSelector__NavigationMenuItem-sc-1p2fxbn-2 ifirRc"
+        >
+          <a
+            className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
+            data-item="current_short_variant"
+            href="/?dataset=gnomad_r2_1_non_neuro"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+          >
+            gnomAD v2.1.1 (non-neuro)
+          </a>
+        </li>
+        <li
+          className="DatasetSelector__NavigationMenuItem-sc-1p2fxbn-2 ifirRc"
+        >
+          <a
+            aria-expanded={false}
+            aria-haspopup="true"
+            aria-label="More datasets"
+            className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
+            data-item="other_short_variant"
+            href="/"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="button"
+          >
+            <span
+              className="DatasetSelector__MoreIcon-sc-1p2fxbn-3 hTYFQu"
+            >
+              <img
+                alt=""
+                aria-hidden="true"
+                src="test-file-stub"
+              />
+            </span>
+          </a>
+          <ul
+            className="DatasetSelector__SubNavigationMenu-sc-1p2fxbn-4 epYyTQ"
+          >
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r2_1"
+                href="/?dataset=gnomad_r2_1"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v2.1.1
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  141,456 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r2_1_non_topmed"
+                href="/?dataset=gnomad_r2_1_non_topmed"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v2.1.1 (non-TOPMed)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  135,743 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r2_1_non_cancer"
+                href="/?dataset=gnomad_r2_1_non_cancer"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v2.1.1 (non-cancer)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  134,187 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r2_1_non_neuro"
+                href="/?dataset=gnomad_r2_1_non_neuro"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v2.1.1 (non-neuro)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  114,704 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r2_1_controls"
+                href="/?dataset=gnomad_r2_1_controls"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v2.1.1 (controls)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  60,146 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="exac"
+                href="/?dataset=exac"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                ExAC v1.0
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  60,706 samples
+                </div>
+              </a>
+            </li>
+          </ul>
+        </li>
+      </ul>
+      <span>
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+          >
+            More information
+          </span>
+        </button>
+      </span>
+    </div>
+  </div>
+  <div
+    className="VariantPage__FlexWrapper-sc-hd87ur-2 bjkoAa"
+  >
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+    >
+      <div
+        className="TableWrapper-sc-1ep26r3-0 edvjZa"
+      >
+        <div>
+          <table
+            className="VariantOccurrenceTable__Table-sc-8b13g7-0 iwAwP"
+          >
+            <tbody>
+              <tr>
+                <td />
+                <th
+                  scope="col"
+                >
+                  Exomes
+                </th>
+                <th
+                  scope="col"
+                >
+                  Genomes
+                </th>
+                <th
+                  scope="col"
+                >
+                  Total
+                </th>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Filters
+                  </span>
+                </th>
+                <td>
+                  <span
+                    className="Badge__BadgeWrapper-j4izdp-1 bhuqae"
+                  >
+                    Pass
+                  </span>
+                </td>
+                <td>
+                  <span
+                    className="Badge__BadgeWrapper-j4izdp-1 bbjxGL"
+                  >
+                    No variant
+                  </span>
+                </td>
+                <td />
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Count
+                  </span>
+                </th>
+                <td>
+                  0
+                </td>
+                <td />
+                <td>
+                  0
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Number
+                  </span>
+                </th>
+                <td>
+                  0
+                   *
+                </td>
+                <td />
+                <td>
+                  0
+                   *
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Frequency
+                  </span>
+                </th>
+                <td>
+                  0.000
+                </td>
+                <td />
+                <td>
+                  0.000
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="VariantOccurrenceTable__NoWrap-sc-8b13g7-1 kmxNQ"
+                  >
+                    Popmax Filtering AF 
+                    <button
+                      className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <img
+                        alt=""
+                        aria-hidden="true"
+                        src="test-file-stub"
+                      />
+                      <span
+                        style={
+                          {
+                            "border": "0",
+                            "clip": "rect(0 0 0 0)",
+                            "height": "1px",
+                            "margin": "-1px",
+                            "overflow": "hidden",
+                            "padding": "0",
+                            "position": "absolute",
+                            "whiteSpace": "nowrap",
+                            "width": "1px",
+                          }
+                        }
+                      >
+                        More information
+                      </span>
+                    </button>
+                  </span>
+                  <br />
+                  (95% confidence)
+                </th>
+                <td>
+                  <span>
+                    0
+                  </span>
+                </td>
+                <td />
+                <td />
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Number of homozygotes
+                  </span>
+                </th>
+                <td>
+                  0
+                </td>
+                <td />
+                <td>
+                  0
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Mean depth of coverage
+                  </span>
+                </th>
+                <td>
+                  –
+                </td>
+                <td>
+                  –
+                </td>
+                <td />
+              </tr>
+            </tbody>
+          </table>
+          <p>
+            <span
+              className="Badge__BadgeWrapper-j4izdp-1 dyHZPQ"
+            >
+              Warning
+            </span>
+             This variant is covered in fewer than 50% of individuals in 
+            gnomAD v2.1.1 (non-neuro) exomes
+            .
+             
+            Allele frequency estimates may not be reliable
+            .
+          </p>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+    >
+      <h2>
+        External Resources
+      </h2>
+      <ul
+        className="List-sc-4j87st-0 fQRmhM"
+      >
+        <li
+          className="List__ListItem-sc-4j87st-1 gGPLUe"
+        >
+          <a
+            className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+            href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&highlight=hg19.chr13%3A123-123&position=chr13%3A98-148"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            UCSC
+          </a>
+        </li>
+      </ul>
+      <h2>
+        Feedback
+      </h2>
+      <a
+        className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+        href="mailto:gnomad@broadinstitute.org"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        Report an issue with this variant
+      </a>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 CMQAN"
+    >
+      <h2>
+        Population Frequencies 
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
+      <div
+        className="TableWrapper-sc-1ep26r3-0 edvjZa"
+      >
+        <table
+          className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+        >
+          <thead>
+            <tr>
+              <th
+                aria-sort="none"
+                colSpan={2}
+                scope="col"
+              >
+                <button
+                  onClick={[Function]}
+                  type="button"
+                >
+                  Population
+                </button>
+              </th>
+              <th
+                aria-sort="none"
+                className="right-align"
+                scope="col"
+              >
+                <button
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Count
+                  </span>
+                </button>
+              </th>
+              <th
+                aria-sort="none"
+                className="right-align"
+                scope="col"
+              >
+                <button
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Number
+                  </span>
+                </button>
+              </th>
+              <th
+                aria-sort="none"
+                className="right-align"
+                scope="col"
+              >
+                <button
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Number of Homozygotes
+                  </span>
+                </button>
+              </th>
+              <th
+                aria-sort="descending"
+                scope="col"
+                style={
+                  {
+                    "paddingLeft": "25px",
+                  }
+                }
+              >
+                <button
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Frequency
+                  </span>
+                </button>
+              </th>
+            </tr>
+          </thead>
+          <tfoot>
+            <tr
+              className="border"
+            >
+              <th
+                colSpan={2}
+                scope="row"
+              >
+                Total
+              </th>
+              <td
+                className="right-align"
+              >
+                0
+              </td>
+              <td
+                className="right-align"
+              >
+                0
+              </td>
+              <td
+                className="right-align"
+              >
+                0
+              </td>
+              <td
+                style={
+                  {
+                    "paddingLeft": "25px",
+                  }
+                }
+              >
+                0.000
+              </td>
+            </tr>
+          </tfoot>
+        </table>
+        <div
+          className="GnomadPopulationsTable__ControlSection-sc-1ghxck9-0 bsALfR"
+        >
+          Include:
+          <label
+            className="Checkbox__Label-hrpa6b-0 gtTKXr"
+            htmlFor="includeExomePopulations"
+          >
+            <input
+              checked={false}
+              className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+              disabled={true}
+              id="includeExomePopulations"
+              onChange={[Function]}
+              type="checkbox"
+            />
+            Exomes
+          </label>
+          <label
+            className="Checkbox__Label-hrpa6b-0 gtTKXr"
+            htmlFor="includeGenomePopulations"
+          >
+            <input
+              checked={false}
+              className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+              disabled={true}
+              id="includeGenomePopulations"
+              onChange={[Function]}
+              type="checkbox"
+            />
+            Genomes
+          </label>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 CMQAN"
+    >
+      <h2>
+        Related Variants
+      </h2>
+      <div
+        className="VariantRelatedVariants__Wrapper-sc-y59fw8-0 bOggsA"
+      >
+        <div
+          className="VariantRelatedVariants__Item-sc-y59fw8-1 kqiRIK"
+        >
+          <h3>
+            Nearby Variants
+          </h3>
+          <p>
+            <a
+              className="Link-sc-14lgydv-0-Link jBvaYQ"
+              href="/region/13-103-143"
+              onClick={[Function]}
+            >
+              View variants located within 20 bases of this variant.
+            </a>
+          </p>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 CMQAN"
+    >
+      <h2>
+        Variant Effect Predictor
+      </h2>
+      <div>
+        <p>
+          This variant falls on 
+          0
+           transcript
+          s
+           in 
+          0
+           
+          gene
+          s
+          .
+        </p>
+        <p>
+          <span
+            className="Badge__BadgeWrapper-j4izdp-1 cJObdY"
+          >
+            Note
+          </span>
+           The gene symbols shown below are provided by VEP and may differ from the symbol shown on gene pages.
+        </p>
+        <ol
+          className="TranscriptConsequenceList__ConsequenceListWrapper-sc-qi0gmz-1 cXJgYo"
+        />
+      </div>
+    </section>
+    <div
+      className="VariantPage__FlexWrapper-sc-hd87ur-2 bjkoAa"
+    />
+    <div
+      className="VariantPage__FlexWrapper-sc-hd87ur-2 bjkoAa"
+    >
+      <section
+        className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+      >
+        <h2>
+          Age Distribution 
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
+        <div>
+          <div
+            className="GnomadAgeDistribution__LegendWrapper-sc-ty24oq-0 kOKZpq"
+          >
+            <ul
+              className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+            >
+              <li
+                className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+              >
+                <svg
+                  height={16}
+                  width={16}
+                >
+                  <rect
+                    fill="#428bca"
+                    height={16}
+                    stroke="#000"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                </svg>
+                <span
+                  style={
+                    {
+                      "marginLeft": "0.25em",
+                    }
+                  }
+                >
+                  Exome
+                </span>
+              </li>
+              <li
+                className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+              >
+                <svg
+                  height={16}
+                  width={16}
+                >
+                  <rect
+                    fill="#73ab3d"
+                    height={16}
+                    stroke="#000"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                </svg>
+                <span
+                  style={
+                    {
+                      "marginLeft": "0.25em",
+                    }
+                  }
+                >
+                  Genome
+                </span>
+              </li>
+            </ul>
+            <ul
+              className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+            >
+              <li
+                className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+              >
+                <svg
+                  height={16}
+                  width={16}
+                >
+                  <rect
+                    fill="#999"
+                    height={16}
+                    stroke="#000"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                </svg>
+                <span
+                  style={
+                    {
+                      "marginLeft": "0.25em",
+                    }
+                  }
+                >
+                  Variant carriers
+                </span>
+              </li>
+              <li
+                className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+              >
+                <svg
+                  height={16}
+                  width={16}
+                >
+                  <defs>
+                    <pattern
+                      height={4}
+                      id="age-distribution-legend-swatch-stripes"
+                      patternTransform="rotate(45)"
+                      patternUnits="userSpaceOnUse"
+                      width={4}
+                    >
+                      <rect
+                        fill="#fff"
+                        height={4}
+                        transform="translate(0,0)"
+                        width={3}
+                      />
+                    </pattern>
+                    <mask
+                      id="age-distribution-legend-swatch-mask"
+                    >
+                      <rect
+                        fill="url(#age-distribution-legend-swatch-stripes)"
+                        height="100%"
+                        width="100%"
+                        x={0}
+                        y={0}
+                      />
+                    </mask>
+                  </defs>
+                  <rect
+                    fill="#999"
+                    height={16}
+                    mask="url(#age-distribution-legend-swatch-mask)"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                  <rect
+                    fill="none"
+                    height={16}
+                    stroke="#333"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                </svg>
+                <span
+                  style={
+                    {
+                      "marginLeft": "0.25em",
+                    }
+                  }
+                >
+                  All individuals
+                </span>
+              </li>
+            </ul>
+          </div>
+          <div
+            style={
+              {
+                "height": "100%",
+                "width": "100%",
+              }
+            }
+          />
+          <div
+            className="ControlSection__Wrapper-sc-rro5al-1 dSZUkP"
+          >
+            <span
+              className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+            >
+              <div
+                className="GnomadAgeDistribution__CheckboxWrapper-sc-ty24oq-1 fatvfk"
+              >
+                <label
+                  className="Checkbox__Label-hrpa6b-0 gtTKXr"
+                  htmlFor="age-distribution-include-heterozygotes"
+                >
+                  <input
+                    checked={true}
+                    className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                    disabled={false}
+                    id="age-distribution-include-heterozygotes"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Include heterozygous variant carriers
+                </label>
+                <label
+                  className="Checkbox__Label-hrpa6b-0 gtTKXr"
+                  htmlFor="age-distribution-include-homozygotes"
+                >
+                  <input
+                    checked={true}
+                    className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                    disabled={false}
+                    id="age-distribution-include-homozygotes"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Include homozygous variant carriers
+                </label>
+                <label
+                  className="Checkbox__Label-hrpa6b-0 gtTKXr"
+                  htmlFor="age-distribution-show-all-individuals"
+                >
+                  <input
+                    checked={true}
+                    className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                    disabled={false}
+                    id="age-distribution-show-all-individuals"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Compare to all individuals
+                </label>
+              </div>
+            </span>
+            <span
+              className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+            >
+              <label
+                htmlFor="age-distribution-sequencing-type"
+              >
+                Sequencing types: 
+                <select
+                  className="Select-sc-1lkyg9e-0 ivadCR"
+                  disabled={true}
+                  id="age-distribution-sequencing-type"
+                  onChange={[Function]}
+                  value="e"
+                >
+                  <option
+                    value="eg"
+                  >
+                    Exome and Genome
+                  </option>
+                  <option
+                    value="e"
+                  >
+                    Exome
+                  </option>
+                  <option
+                    value="g"
+                  >
+                    Genome
+                  </option>
+                </select>
+              </label>
+            </span>
+          </div>
+        </div>
+      </section>
+    </div>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+    >
+      <h2>
+        Genotype Quality Metrics
+      </h2>
+      <div>
+        <div>
+          <div
+            role="tablist"
+          >
+            <ul
+              className="Tabs__TabListWrapper-jzgyty-0 gUVxKq"
+            >
+              <li>
+                <div
+                  aria-controls="genotype_quality-panel"
+                  aria-selected={true}
+                  className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                  id="genotype_quality"
+                  onFocus={[Function]}
+                  role="tab"
+                  tabIndex={0}
+                >
+                  <div
+                    className="Tabs__TabLabel-jzgyty-2 dcUyBp"
+                  >
+                    Genotype quality
+                  </div>
+                </div>
+              </li>
+              <li>
+                <div
+                  aria-controls="genotype_depth-panel"
+                  aria-selected={false}
+                  className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                  id="genotype_depth"
+                  onFocus={[Function]}
+                  role="tab"
+                  tabIndex={-1}
+                >
+                  <div
+                    className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                  >
+                    Depth
+                  </div>
+                </div>
+              </li>
+              <li>
+                <div
+                  aria-controls="allele_balance-panel"
+                  aria-selected={false}
+                  className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                  id="allele_balance"
+                  onFocus={[Function]}
+                  role="tab"
+                  tabIndex={-1}
+                >
+                  <div
+                    className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                  >
+                    Allele balance for heterozygotes
+                  </div>
+                </div>
+              </li>
+            </ul>
+          </div>
+          <div>
+            <div
+              aria-describedby="genotype_quality"
+              aria-hidden={false}
+              className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+              id="genotype_quality-panel"
+              onKeyDown={[Function]}
+              role="tabpanel"
+              style={{}}
+            >
+              <div
+                className="VariantGenotypeQualityMetrics__LegendWrapper-sc-tgmwmq-0 ihxxGK"
+              >
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#428bca"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Exome
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#73ab3d"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Genome
+                    </span>
+                  </li>
+                </ul>
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#999"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Variant carriers
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <defs>
+                        <pattern
+                          height={4}
+                          id="genotype-quality-legend-swatch-stripes"
+                          patternTransform="rotate(45)"
+                          patternUnits="userSpaceOnUse"
+                          width={4}
+                        >
+                          <rect
+                            fill="#fff"
+                            height={4}
+                            transform="translate(0,0)"
+                            width={3}
+                          />
+                        </pattern>
+                        <mask
+                          id="genotype-quality-legend-swatch-mask"
+                        >
+                          <rect
+                            fill="url(#genotype-quality-legend-swatch-stripes)"
+                            height="100%"
+                            width="100%"
+                            x={0}
+                            y={0}
+                          />
+                        </mask>
+                      </defs>
+                      <rect
+                        fill="#999"
+                        height={16}
+                        mask="url(#genotype-quality-legend-swatch-mask)"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                      <rect
+                        fill="none"
+                        height={16}
+                        stroke="#333"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      All individuals
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                style={
+                  {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              />
+            </div>
+            <div
+              aria-describedby="genotype_depth"
+              aria-hidden={true}
+              className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+              id="genotype_depth-panel"
+              onKeyDown={[Function]}
+              role="tabpanel"
+              style={
+                {
+                  "display": "none",
+                }
+              }
+            >
+              <div
+                className="VariantGenotypeQualityMetrics__LegendWrapper-sc-tgmwmq-0 ihxxGK"
+                style={
+                  {
+                    "marginTop": "1em",
+                  }
+                }
+              >
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#428bca"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Exome
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#73ab3d"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Genome
+                    </span>
+                  </li>
+                </ul>
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#999"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Variant carriers
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <defs>
+                        <pattern
+                          height={4}
+                          id="depth-legend-swatch-stripes"
+                          patternTransform="rotate(45)"
+                          patternUnits="userSpaceOnUse"
+                          width={4}
+                        >
+                          <rect
+                            fill="#fff"
+                            height={4}
+                            transform="translate(0,0)"
+                            width={3}
+                          />
+                        </pattern>
+                        <mask
+                          id="depth-legend-swatch-mask"
+                        >
+                          <rect
+                            fill="url(#depth-legend-swatch-stripes)"
+                            height="100%"
+                            width="100%"
+                            x={0}
+                            y={0}
+                          />
+                        </mask>
+                      </defs>
+                      <rect
+                        fill="#999"
+                        height={16}
+                        mask="url(#depth-legend-swatch-mask)"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                      <rect
+                        fill="none"
+                        height={16}
+                        stroke="#333"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      All individuals
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                style={
+                  {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              />
+            </div>
+            <div
+              aria-describedby="allele_balance"
+              aria-hidden={true}
+              className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+              id="allele_balance-panel"
+              onKeyDown={[Function]}
+              role="tabpanel"
+              style={
+                {
+                  "display": "none",
+                }
+              }
+            >
+              <div
+                className="VariantGenotypeQualityMetrics__LegendWrapper-sc-tgmwmq-0 ihxxGK"
+                style={
+                  {
+                    "marginTop": "1em",
+                  }
+                }
+              >
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#428bca"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Exome
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#73ab3d"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Genome
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                style={
+                  {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          className="ControlSection__Wrapper-sc-rro5al-1 dSZUkP"
+        >
+          <span
+            className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+          >
+            <label
+              className="Checkbox__Label-hrpa6b-0 gtTKXr"
+              htmlFor="genotype-quality-metrics-show-all-individuals"
+            >
+              <input
+                checked={true}
+                className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                disabled={false}
+                id="genotype-quality-metrics-show-all-individuals"
+                onChange={[Function]}
+                type="checkbox"
+              />
+              Compare to all individuals
+            </label>
+          </span>
+          <span
+            className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+          >
+            <label
+              htmlFor="genotype-quality-metrics-sequencing-type"
+            >
+              Sequencing types: 
+              <select
+                className="Select-sc-1lkyg9e-0 ivadCR"
+                disabled={true}
+                id="genotype-quality-metrics-sequencing-type"
+                onChange={[Function]}
+                value="e"
+              >
+                <option
+                  value="eg"
+                >
+                  Exome and Genome
+                </option>
+                <option
+                  value="e"
+                >
+                  Exome
+                </option>
+                <option
+                  value="g"
+                >
+                  Genome
+                </option>
+              </select>
+            </label>
+          </span>
+        </div>
+        <p>
+          Note: This plot may include low-quality genotypes that were excluded from allele counts in the tables above.
+        </p>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+    >
+      <h2>
+        Site Quality Metrics
+      </h2>
+      <div>
+        <div
+          role="tablist"
+        >
+          <ul
+            className="Tabs__TabListWrapper-jzgyty-0 gUVxKq"
+          >
+            <li>
+              <div
+                aria-controls="distribution-panel"
+                aria-selected={true}
+                className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                id="distribution"
+                onFocus={[Function]}
+                role="tab"
+                tabIndex={0}
+              >
+                <div
+                  className="Tabs__TabLabel-jzgyty-2 dcUyBp"
+                >
+                  Metric distribution
+                </div>
+              </div>
+            </li>
+            <li>
+              <div
+                aria-controls="values-panel"
+                aria-selected={false}
+                className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                id="values"
+                onFocus={[Function]}
+                role="tab"
+                tabIndex={-1}
+              >
+                <div
+                  className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                >
+                  All metric values
+                </div>
+              </div>
+            </li>
+          </ul>
+        </div>
+        <div>
+          <div
+            aria-describedby="distribution"
+            aria-hidden={false}
+            className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+            id="distribution-panel"
+            onKeyDown={[Function]}
+            role="tabpanel"
+            style={{}}
+          >
+            <div>
+              <div
+                className="VariantSiteQualityMetrics__LegendWrapper-sc-186wx2k-2 gDWfxF"
+              >
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#428bca"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Exome
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#73ab3d"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Genome
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                style={
+                  {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              />
+              <div
+                style={
+                  {
+                    "marginBottom": "0.5rem",
+                    "overflow": "hidden",
+                  }
+                }
+              />
+              <div
+                className="ControlSection__Wrapper-sc-rro5al-1 dSZUkP"
+              >
+                <span
+                  className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+                >
+                  <label
+                    htmlFor="site-quality-metrics-metric"
+                  >
+                    Metric: 
+                    <select
+                      className="Select-sc-1lkyg9e-0 ivadCR"
+                      id="site-quality-metrics-metric"
+                      onChange={[Function]}
+                      value="SiteQuality"
+                    >
+                      <option
+                        value="BaseQRankSum"
+                      >
+                        BaseQRankSum
+                      </option>
+                      <option
+                        value="ClippingRankSum"
+                      >
+                        ClippingRankSum
+                      </option>
+                      <option
+                        value="DP"
+                      >
+                        DP
+                      </option>
+                      <option
+                        value="FS"
+                      >
+                        FS
+                      </option>
+                      <option
+                        value="InbreedingCoeff"
+                      >
+                        InbreedingCoeff
+                      </option>
+                      <option
+                        value="MQ"
+                      >
+                        MQ
+                      </option>
+                      <option
+                        value="MQRankSum"
+                      >
+                        MQRankSum
+                      </option>
+                      <option
+                        value="pab_max"
+                      >
+                        pab_max
+                      </option>
+                      <option
+                        value="QD"
+                      >
+                        QD
+                      </option>
+                      <option
+                        value="ReadPosRankSum"
+                      >
+                        ReadPosRankSum
+                      </option>
+                      <option
+                        value="RF"
+                      >
+                        RF
+                      </option>
+                      <option
+                        value="SiteQuality"
+                      >
+                        SiteQuality
+                      </option>
+                      <option
+                        value="SOR"
+                      >
+                        SOR
+                      </option>
+                      <option
+                        value="VQSLOD"
+                      >
+                        VQSLOD
+                      </option>
+                    </select>
+                  </label>
+                </span>
+                <span
+                  className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+                >
+                  <label
+                    htmlFor="site-quality-metrics-sequencing-type"
+                  >
+                    Sequencing types: 
+                    <select
+                      className="Select-sc-1lkyg9e-0 ivadCR"
+                      disabled={true}
+                      id="site-quality-metrics-sequencing-type"
+                      onChange={[Function]}
+                      value="e"
+                    >
+                      <option
+                        value="eg"
+                      >
+                        Exome and Genome
+                      </option>
+                      <option
+                        value="e"
+                      >
+                        Exome
+                      </option>
+                      <option
+                        value="g"
+                      >
+                        Genome
+                      </option>
+                    </select>
+                  </label>
+                </span>
+              </div>
+              <p>
+                Value: 
+                0 (exome samples)
+              </p>
+              <p>
+                This is the site quality distribution for all exome variants with 0 &lt;= AF &lt; 0.00005.
+              </p>
+              <p>
+                Note: These are site-level quality metrics, they may be unpredictable for multi-allelic sites.
+              </p>
+            </div>
+          </div>
+          <div
+            aria-describedby="values"
+            aria-hidden={true}
+            className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+            id="values-panel"
+            onKeyDown={[Function]}
+            role="tabpanel"
+            style={
+              {
+                "display": "none",
+              }
+            }
+          >
+            <table
+              className="Table__BaseTable-sc-7fgtt2-0 dIBzV"
+              style={
+                {
+                  "width": "100%",
+                }
+              }
+            >
+              <thead>
+                <tr>
+                  <th
+                    scope="col"
+                  >
+                    Metric
+                  </th>
+                  <th
+                    scope="col"
+                  >
+                    Exome samples
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      BaseQRankSum
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      ClippingRankSum
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      DP
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      FS
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      InbreedingCoeff
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      MQ
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      MQRankSum
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      pab_max
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      QD
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      ReadPosRankSum
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      RF
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      SiteQuality
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      SOR
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      VQSLOD
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 CMQAN"
+    >
+      <h2>
+        Read Data
+      </h2>
+      <div>
+        <p>
+          No read data available for this variant.
+        </p>
+        <p>
+          <span
+            className="Badge__BadgeWrapper-j4izdp-1 cJObdY"
+          >
+            Note
+          </span>
+           Read data for non-coding regions is not available in gnomAD v2.1.1 and ExAC.
+        </p>
+      </div>
+    </section>
+  </div>
+</div>
+`;
+
+exports[`VariantPage with dataset gnomad_r2_1_non_topmed has no unexpected changes 1`] = `
+<div
+  className="Page-w7h773-0 dRYfBS"
+>
+  <div
+    className="GnomadPageHeading__PageHeadingWrapper-sc-sgz3rr-0 gcOcdP"
+  >
+    <div
+      className="GnomadPageHeading__PageHeadingInnerWrapper-sc-sgz3rr-1 dLZzAa"
+    >
+      <h1
+        className="GnomadPageHeading__PageHeadingText-sc-sgz3rr-3 edXBqX"
+      >
+        <span
+          className="VariantPageTitle__TitleWrapper-sc-16g6pnt-0 bAAXLa"
+        >
+          <span>
+            Single nucleotide variant
+          </span>
+          <span
+            className="VariantPageTitle__Separator-sc-16g6pnt-1 jsfCLA"
+            style={
+              {
+                "width": "1ch",
+              }
+            }
+          >
+            :
+          </span>
+          <span
+            className="VariantPageTitle__VariantIdWrapper-sc-16g6pnt-2 jxIjmG"
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+          >
+            <span>
+              13
+              -
+              123
+            </span>
+            <span
+              className="VariantPageTitle__VariantIdSeparator-sc-16g6pnt-3 gwKaru"
+            >
+              -
+            </span>
+            <span
+              className="VariantPageTitle__TitleAlleles-sc-16g6pnt-4 dgrTjT"
+            >
+              A
+              -
+              C
+            </span>
+          </span>
+          <span
+            className="VariantPageTitle__Separator-sc-16g6pnt-1 jsfCLA"
+          >
+             
+          </span>
+          <span>
+            (
+            GRCh37
+            )
+          </span>
+        </span>
+      </h1>
+    </div>
+    <div
+      className="GnomadPageHeading__PageControlsWrapper-sc-sgz3rr-4 liqJpb"
+    >
+      <span
+        className="GnomadPageHeading__Label-sc-sgz3rr-5 dOhShJ"
+      >
+        Dataset
+      </span>
+      <ul
+        className="DatasetSelector__NavigationMenuWrapper-sc-1p2fxbn-0 ebZvwy"
+      >
+        <li
+          className="DatasetSelector__NavigationMenuItem-sc-1p2fxbn-2 ifirRc"
+        >
+          <a
+            className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
+            data-item="current_short_variant"
+            href="/?dataset=gnomad_r2_1_non_topmed"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+          >
+            gnomAD v2.1.1 (non-TOPMed)
+          </a>
+        </li>
+        <li
+          className="DatasetSelector__NavigationMenuItem-sc-1p2fxbn-2 ifirRc"
+        >
+          <a
+            aria-expanded={false}
+            aria-haspopup="true"
+            aria-label="More datasets"
+            className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
+            data-item="other_short_variant"
+            href="/"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="button"
+          >
+            <span
+              className="DatasetSelector__MoreIcon-sc-1p2fxbn-3 hTYFQu"
+            >
+              <img
+                alt=""
+                aria-hidden="true"
+                src="test-file-stub"
+              />
+            </span>
+          </a>
+          <ul
+            className="DatasetSelector__SubNavigationMenu-sc-1p2fxbn-4 epYyTQ"
+          >
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r2_1"
+                href="/?dataset=gnomad_r2_1"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v2.1.1
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  141,456 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r2_1_non_topmed"
+                href="/?dataset=gnomad_r2_1_non_topmed"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v2.1.1 (non-TOPMed)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  135,743 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r2_1_non_cancer"
+                href="/?dataset=gnomad_r2_1_non_cancer"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v2.1.1 (non-cancer)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  134,187 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r2_1_non_neuro"
+                href="/?dataset=gnomad_r2_1_non_neuro"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v2.1.1 (non-neuro)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  114,704 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="gnomad_r2_1_controls"
+                href="/?dataset=gnomad_r2_1_controls"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                gnomAD v2.1.1 (controls)
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  60,146 samples
+                </div>
+              </a>
+            </li>
+            <li>
+              <a
+                className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                data-item="exac"
+                href="/?dataset=exac"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                ExAC v1.0
+                <div
+                  className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 hlVhHR"
+                >
+                  60,706 samples
+                </div>
+              </a>
+            </li>
+          </ul>
+        </li>
+      </ul>
+      <span>
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+          >
+            More information
+          </span>
+        </button>
+      </span>
+    </div>
+  </div>
+  <div
+    className="VariantPage__FlexWrapper-sc-hd87ur-2 bjkoAa"
+  >
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+    >
+      <div
+        className="TableWrapper-sc-1ep26r3-0 edvjZa"
+      >
+        <div>
+          <table
+            className="VariantOccurrenceTable__Table-sc-8b13g7-0 iwAwP"
+          >
+            <tbody>
+              <tr>
+                <td />
+                <th
+                  scope="col"
+                >
+                  Exomes
+                </th>
+                <th
+                  scope="col"
+                >
+                  Genomes
+                </th>
+                <th
+                  scope="col"
+                >
+                  Total
+                </th>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Filters
+                  </span>
+                </th>
+                <td>
+                  <span
+                    className="Badge__BadgeWrapper-j4izdp-1 bhuqae"
+                  >
+                    Pass
+                  </span>
+                </td>
+                <td>
+                  <span
+                    className="Badge__BadgeWrapper-j4izdp-1 bbjxGL"
+                  >
+                    No variant
+                  </span>
+                </td>
+                <td />
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Count
+                  </span>
+                </th>
+                <td>
+                  0
+                </td>
+                <td />
+                <td>
+                  0
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Number
+                  </span>
+                </th>
+                <td>
+                  0
+                   *
+                </td>
+                <td />
+                <td>
+                  0
+                   *
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Frequency
+                  </span>
+                </th>
+                <td>
+                  0.000
+                </td>
+                <td />
+                <td>
+                  0.000
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="VariantOccurrenceTable__NoWrap-sc-8b13g7-1 kmxNQ"
+                  >
+                    Popmax Filtering AF 
+                    <button
+                      className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <img
+                        alt=""
+                        aria-hidden="true"
+                        src="test-file-stub"
+                      />
+                      <span
+                        style={
+                          {
+                            "border": "0",
+                            "clip": "rect(0 0 0 0)",
+                            "height": "1px",
+                            "margin": "-1px",
+                            "overflow": "hidden",
+                            "padding": "0",
+                            "position": "absolute",
+                            "whiteSpace": "nowrap",
+                            "width": "1px",
+                          }
+                        }
+                      >
+                        More information
+                      </span>
+                    </button>
+                  </span>
+                  <br />
+                  (95% confidence)
+                </th>
+                <td>
+                  <span>
+                    0
+                  </span>
+                </td>
+                <td />
+                <td />
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Number of homozygotes
+                  </span>
+                </th>
+                <td>
+                  0
+                </td>
+                <td />
+                <td>
+                  0
+                </td>
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Mean depth of coverage
+                  </span>
+                </th>
+                <td>
+                  –
+                </td>
+                <td>
+                  –
+                </td>
+                <td />
+              </tr>
+            </tbody>
+          </table>
+          <p>
+            <span
+              className="Badge__BadgeWrapper-j4izdp-1 dyHZPQ"
+            >
+              Warning
+            </span>
+             This variant is covered in fewer than 50% of individuals in 
+            gnomAD v2.1.1 (non-TOPMed) exomes
+            .
+             
+            Allele frequency estimates may not be reliable
+            .
+          </p>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+    >
+      <h2>
+        External Resources
+      </h2>
+      <ul
+        className="List-sc-4j87st-0 fQRmhM"
+      >
+        <li
+          className="List__ListItem-sc-4j87st-1 gGPLUe"
+        >
+          <a
+            className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+            href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&highlight=hg19.chr13%3A123-123&position=chr13%3A98-148"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            UCSC
+          </a>
+        </li>
+      </ul>
+      <h2>
+        Feedback
+      </h2>
+      <a
+        className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+        href="mailto:gnomad@broadinstitute.org"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        Report an issue with this variant
+      </a>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 CMQAN"
+    >
+      <h2>
+        Population Frequencies 
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
+      <div
+        className="TableWrapper-sc-1ep26r3-0 edvjZa"
+      >
+        <table
+          className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+        >
+          <thead>
+            <tr>
+              <th
+                aria-sort="none"
+                colSpan={2}
+                scope="col"
+              >
+                <button
+                  onClick={[Function]}
+                  type="button"
+                >
+                  Population
+                </button>
+              </th>
+              <th
+                aria-sort="none"
+                className="right-align"
+                scope="col"
+              >
+                <button
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Count
+                  </span>
+                </button>
+              </th>
+              <th
+                aria-sort="none"
+                className="right-align"
+                scope="col"
+              >
+                <button
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Number
+                  </span>
+                </button>
+              </th>
+              <th
+                aria-sort="none"
+                className="right-align"
+                scope="col"
+              >
+                <button
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Number of Homozygotes
+                  </span>
+                </button>
+              </th>
+              <th
+                aria-sort="descending"
+                scope="col"
+                style={
+                  {
+                    "paddingLeft": "25px",
+                  }
+                }
+              >
+                <button
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <span
+                    className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Allele Frequency
+                  </span>
+                </button>
+              </th>
+            </tr>
+          </thead>
+          <tfoot>
+            <tr
+              className="border"
+            >
+              <th
+                colSpan={2}
+                scope="row"
+              >
+                Total
+              </th>
+              <td
+                className="right-align"
+              >
+                0
+              </td>
+              <td
+                className="right-align"
+              >
+                0
+              </td>
+              <td
+                className="right-align"
+              >
+                0
+              </td>
+              <td
+                style={
+                  {
+                    "paddingLeft": "25px",
+                  }
+                }
+              >
+                0.000
+              </td>
+            </tr>
+          </tfoot>
+        </table>
+        <div
+          className="GnomadPopulationsTable__ControlSection-sc-1ghxck9-0 bsALfR"
+        >
+          Include:
+          <label
+            className="Checkbox__Label-hrpa6b-0 gtTKXr"
+            htmlFor="includeExomePopulations"
+          >
+            <input
+              checked={false}
+              className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+              disabled={true}
+              id="includeExomePopulations"
+              onChange={[Function]}
+              type="checkbox"
+            />
+            Exomes
+          </label>
+          <label
+            className="Checkbox__Label-hrpa6b-0 gtTKXr"
+            htmlFor="includeGenomePopulations"
+          >
+            <input
+              checked={false}
+              className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+              disabled={true}
+              id="includeGenomePopulations"
+              onChange={[Function]}
+              type="checkbox"
+            />
+            Genomes
+          </label>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 CMQAN"
+    >
+      <h2>
+        Related Variants
+      </h2>
+      <div
+        className="VariantRelatedVariants__Wrapper-sc-y59fw8-0 bOggsA"
+      >
+        <div
+          className="VariantRelatedVariants__Item-sc-y59fw8-1 kqiRIK"
+        >
+          <h3>
+            Nearby Variants
+          </h3>
+          <p>
+            <a
+              className="Link-sc-14lgydv-0-Link jBvaYQ"
+              href="/region/13-103-143"
+              onClick={[Function]}
+            >
+              View variants located within 20 bases of this variant.
+            </a>
+          </p>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 CMQAN"
+    >
+      <h2>
+        Variant Effect Predictor
+      </h2>
+      <div>
+        <p>
+          This variant falls on 
+          0
+           transcript
+          s
+           in 
+          0
+           
+          gene
+          s
+          .
+        </p>
+        <p>
+          <span
+            className="Badge__BadgeWrapper-j4izdp-1 cJObdY"
+          >
+            Note
+          </span>
+           The gene symbols shown below are provided by VEP and may differ from the symbol shown on gene pages.
+        </p>
+        <ol
+          className="TranscriptConsequenceList__ConsequenceListWrapper-sc-qi0gmz-1 cXJgYo"
+        />
+      </div>
+    </section>
+    <div
+      className="VariantPage__FlexWrapper-sc-hd87ur-2 bjkoAa"
+    />
+    <div
+      className="VariantPage__FlexWrapper-sc-hd87ur-2 bjkoAa"
+    >
+      <section
+        className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+      >
+        <h2>
+          Age Distribution 
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
+        <div>
+          <div
+            className="GnomadAgeDistribution__LegendWrapper-sc-ty24oq-0 kOKZpq"
+          >
+            <ul
+              className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+            >
+              <li
+                className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+              >
+                <svg
+                  height={16}
+                  width={16}
+                >
+                  <rect
+                    fill="#428bca"
+                    height={16}
+                    stroke="#000"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                </svg>
+                <span
+                  style={
+                    {
+                      "marginLeft": "0.25em",
+                    }
+                  }
+                >
+                  Exome
+                </span>
+              </li>
+              <li
+                className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+              >
+                <svg
+                  height={16}
+                  width={16}
+                >
+                  <rect
+                    fill="#73ab3d"
+                    height={16}
+                    stroke="#000"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                </svg>
+                <span
+                  style={
+                    {
+                      "marginLeft": "0.25em",
+                    }
+                  }
+                >
+                  Genome
+                </span>
+              </li>
+            </ul>
+            <ul
+              className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+            >
+              <li
+                className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+              >
+                <svg
+                  height={16}
+                  width={16}
+                >
+                  <rect
+                    fill="#999"
+                    height={16}
+                    stroke="#000"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                </svg>
+                <span
+                  style={
+                    {
+                      "marginLeft": "0.25em",
+                    }
+                  }
+                >
+                  Variant carriers
+                </span>
+              </li>
+              <li
+                className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+              >
+                <svg
+                  height={16}
+                  width={16}
+                >
+                  <defs>
+                    <pattern
+                      height={4}
+                      id="age-distribution-legend-swatch-stripes"
+                      patternTransform="rotate(45)"
+                      patternUnits="userSpaceOnUse"
+                      width={4}
+                    >
+                      <rect
+                        fill="#fff"
+                        height={4}
+                        transform="translate(0,0)"
+                        width={3}
+                      />
+                    </pattern>
+                    <mask
+                      id="age-distribution-legend-swatch-mask"
+                    >
+                      <rect
+                        fill="url(#age-distribution-legend-swatch-stripes)"
+                        height="100%"
+                        width="100%"
+                        x={0}
+                        y={0}
+                      />
+                    </mask>
+                  </defs>
+                  <rect
+                    fill="#999"
+                    height={16}
+                    mask="url(#age-distribution-legend-swatch-mask)"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                  <rect
+                    fill="none"
+                    height={16}
+                    stroke="#333"
+                    width={16}
+                    x={0}
+                    y={0}
+                  />
+                </svg>
+                <span
+                  style={
+                    {
+                      "marginLeft": "0.25em",
+                    }
+                  }
+                >
+                  All individuals
+                </span>
+              </li>
+            </ul>
+          </div>
+          <div
+            style={
+              {
+                "height": "100%",
+                "width": "100%",
+              }
+            }
+          />
+          <div
+            className="ControlSection__Wrapper-sc-rro5al-1 dSZUkP"
+          >
+            <span
+              className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+            >
+              <div
+                className="GnomadAgeDistribution__CheckboxWrapper-sc-ty24oq-1 fatvfk"
+              >
+                <label
+                  className="Checkbox__Label-hrpa6b-0 gtTKXr"
+                  htmlFor="age-distribution-include-heterozygotes"
+                >
+                  <input
+                    checked={true}
+                    className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                    disabled={false}
+                    id="age-distribution-include-heterozygotes"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Include heterozygous variant carriers
+                </label>
+                <label
+                  className="Checkbox__Label-hrpa6b-0 gtTKXr"
+                  htmlFor="age-distribution-include-homozygotes"
+                >
+                  <input
+                    checked={true}
+                    className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                    disabled={false}
+                    id="age-distribution-include-homozygotes"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Include homozygous variant carriers
+                </label>
+                <label
+                  className="Checkbox__Label-hrpa6b-0 gtTKXr"
+                  htmlFor="age-distribution-show-all-individuals"
+                >
+                  <input
+                    checked={true}
+                    className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                    disabled={false}
+                    id="age-distribution-show-all-individuals"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Compare to all individuals
+                </label>
+              </div>
+            </span>
+            <span
+              className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+            >
+              <label
+                htmlFor="age-distribution-sequencing-type"
+              >
+                Sequencing types: 
+                <select
+                  className="Select-sc-1lkyg9e-0 ivadCR"
+                  disabled={true}
+                  id="age-distribution-sequencing-type"
+                  onChange={[Function]}
+                  value="e"
+                >
+                  <option
+                    value="eg"
+                  >
+                    Exome and Genome
+                  </option>
+                  <option
+                    value="e"
+                  >
+                    Exome
+                  </option>
+                  <option
+                    value="g"
+                  >
+                    Genome
+                  </option>
+                </select>
+              </label>
+            </span>
+          </div>
+        </div>
+      </section>
+    </div>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+    >
+      <h2>
+        Genotype Quality Metrics
+      </h2>
+      <div>
+        <div>
+          <div
+            role="tablist"
+          >
+            <ul
+              className="Tabs__TabListWrapper-jzgyty-0 gUVxKq"
+            >
+              <li>
+                <div
+                  aria-controls="genotype_quality-panel"
+                  aria-selected={true}
+                  className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                  id="genotype_quality"
+                  onFocus={[Function]}
+                  role="tab"
+                  tabIndex={0}
+                >
+                  <div
+                    className="Tabs__TabLabel-jzgyty-2 dcUyBp"
+                  >
+                    Genotype quality
+                  </div>
+                </div>
+              </li>
+              <li>
+                <div
+                  aria-controls="genotype_depth-panel"
+                  aria-selected={false}
+                  className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                  id="genotype_depth"
+                  onFocus={[Function]}
+                  role="tab"
+                  tabIndex={-1}
+                >
+                  <div
+                    className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                  >
+                    Depth
+                  </div>
+                </div>
+              </li>
+              <li>
+                <div
+                  aria-controls="allele_balance-panel"
+                  aria-selected={false}
+                  className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                  id="allele_balance"
+                  onFocus={[Function]}
+                  role="tab"
+                  tabIndex={-1}
+                >
+                  <div
+                    className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                  >
+                    Allele balance for heterozygotes
+                  </div>
+                </div>
+              </li>
+            </ul>
+          </div>
+          <div>
+            <div
+              aria-describedby="genotype_quality"
+              aria-hidden={false}
+              className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+              id="genotype_quality-panel"
+              onKeyDown={[Function]}
+              role="tabpanel"
+              style={{}}
+            >
+              <div
+                className="VariantGenotypeQualityMetrics__LegendWrapper-sc-tgmwmq-0 ihxxGK"
+              >
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#428bca"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Exome
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#73ab3d"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Genome
+                    </span>
+                  </li>
+                </ul>
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#999"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Variant carriers
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <defs>
+                        <pattern
+                          height={4}
+                          id="genotype-quality-legend-swatch-stripes"
+                          patternTransform="rotate(45)"
+                          patternUnits="userSpaceOnUse"
+                          width={4}
+                        >
+                          <rect
+                            fill="#fff"
+                            height={4}
+                            transform="translate(0,0)"
+                            width={3}
+                          />
+                        </pattern>
+                        <mask
+                          id="genotype-quality-legend-swatch-mask"
+                        >
+                          <rect
+                            fill="url(#genotype-quality-legend-swatch-stripes)"
+                            height="100%"
+                            width="100%"
+                            x={0}
+                            y={0}
+                          />
+                        </mask>
+                      </defs>
+                      <rect
+                        fill="#999"
+                        height={16}
+                        mask="url(#genotype-quality-legend-swatch-mask)"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                      <rect
+                        fill="none"
+                        height={16}
+                        stroke="#333"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      All individuals
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                style={
+                  {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              />
+            </div>
+            <div
+              aria-describedby="genotype_depth"
+              aria-hidden={true}
+              className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+              id="genotype_depth-panel"
+              onKeyDown={[Function]}
+              role="tabpanel"
+              style={
+                {
+                  "display": "none",
+                }
+              }
+            >
+              <div
+                className="VariantGenotypeQualityMetrics__LegendWrapper-sc-tgmwmq-0 ihxxGK"
+                style={
+                  {
+                    "marginTop": "1em",
+                  }
+                }
+              >
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#428bca"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Exome
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#73ab3d"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Genome
+                    </span>
+                  </li>
+                </ul>
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#999"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Variant carriers
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <defs>
+                        <pattern
+                          height={4}
+                          id="depth-legend-swatch-stripes"
+                          patternTransform="rotate(45)"
+                          patternUnits="userSpaceOnUse"
+                          width={4}
+                        >
+                          <rect
+                            fill="#fff"
+                            height={4}
+                            transform="translate(0,0)"
+                            width={3}
+                          />
+                        </pattern>
+                        <mask
+                          id="depth-legend-swatch-mask"
+                        >
+                          <rect
+                            fill="url(#depth-legend-swatch-stripes)"
+                            height="100%"
+                            width="100%"
+                            x={0}
+                            y={0}
+                          />
+                        </mask>
+                      </defs>
+                      <rect
+                        fill="#999"
+                        height={16}
+                        mask="url(#depth-legend-swatch-mask)"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                      <rect
+                        fill="none"
+                        height={16}
+                        stroke="#333"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      All individuals
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                style={
+                  {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              />
+            </div>
+            <div
+              aria-describedby="allele_balance"
+              aria-hidden={true}
+              className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+              id="allele_balance-panel"
+              onKeyDown={[Function]}
+              role="tabpanel"
+              style={
+                {
+                  "display": "none",
+                }
+              }
+            >
+              <div
+                className="VariantGenotypeQualityMetrics__LegendWrapper-sc-tgmwmq-0 ihxxGK"
+                style={
+                  {
+                    "marginTop": "1em",
+                  }
+                }
+              >
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#428bca"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Exome
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#73ab3d"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Genome
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                style={
+                  {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          className="ControlSection__Wrapper-sc-rro5al-1 dSZUkP"
+        >
+          <span
+            className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+          >
+            <label
+              className="Checkbox__Label-hrpa6b-0 gtTKXr"
+              htmlFor="genotype-quality-metrics-show-all-individuals"
+            >
+              <input
+                checked={true}
+                className="Checkbox__CheckboxInput-hrpa6b-1 hkusMN"
+                disabled={false}
+                id="genotype-quality-metrics-show-all-individuals"
+                onChange={[Function]}
+                type="checkbox"
+              />
+              Compare to all individuals
+            </label>
+          </span>
+          <span
+            className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+          >
+            <label
+              htmlFor="genotype-quality-metrics-sequencing-type"
+            >
+              Sequencing types: 
+              <select
+                className="Select-sc-1lkyg9e-0 ivadCR"
+                disabled={true}
+                id="genotype-quality-metrics-sequencing-type"
+                onChange={[Function]}
+                value="e"
+              >
+                <option
+                  value="eg"
+                >
+                  Exome and Genome
+                </option>
+                <option
+                  value="e"
+                >
+                  Exome
+                </option>
+                <option
+                  value="g"
+                >
+                  Genome
+                </option>
+              </select>
+            </label>
+          </span>
+        </div>
+        <p>
+          Note: This plot may include low-quality genotypes that were excluded from allele counts in the tables above.
+        </p>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 fqvCSG"
+    >
+      <h2>
+        Site Quality Metrics
+      </h2>
+      <div>
+        <div
+          role="tablist"
+        >
+          <ul
+            className="Tabs__TabListWrapper-jzgyty-0 gUVxKq"
+          >
+            <li>
+              <div
+                aria-controls="distribution-panel"
+                aria-selected={true}
+                className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                id="distribution"
+                onFocus={[Function]}
+                role="tab"
+                tabIndex={0}
+              >
+                <div
+                  className="Tabs__TabLabel-jzgyty-2 dcUyBp"
+                >
+                  Metric distribution
+                </div>
+              </div>
+            </li>
+            <li>
+              <div
+                aria-controls="values-panel"
+                aria-selected={false}
+                className="Tabs__StyledTab-jzgyty-1 hwAiRa"
+                id="values"
+                onFocus={[Function]}
+                role="tab"
+                tabIndex={-1}
+              >
+                <div
+                  className="Tabs__TabLabel-jzgyty-2 hQplSX"
+                >
+                  All metric values
+                </div>
+              </div>
+            </li>
+          </ul>
+        </div>
+        <div>
+          <div
+            aria-describedby="distribution"
+            aria-hidden={false}
+            className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+            id="distribution-panel"
+            onKeyDown={[Function]}
+            role="tabpanel"
+            style={{}}
+          >
+            <div>
+              <div
+                className="VariantSiteQualityMetrics__LegendWrapper-sc-186wx2k-2 gDWfxF"
+              >
+                <ul
+                  className="Legend__LegendWrapper-sc-14kdszv-0 brnjtE"
+                >
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#428bca"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Exome
+                    </span>
+                  </li>
+                  <li
+                    className="Legend__LegendItem-sc-14kdszv-1 jAnCbe"
+                  >
+                    <svg
+                      height={16}
+                      width={16}
+                    >
+                      <rect
+                        fill="#73ab3d"
+                        height={16}
+                        stroke="#000"
+                        width={16}
+                        x={0}
+                        y={0}
+                      />
+                    </svg>
+                    <span
+                      style={
+                        {
+                          "marginLeft": "0.25em",
+                        }
+                      }
+                    >
+                      Genome
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                style={
+                  {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              />
+              <div
+                style={
+                  {
+                    "marginBottom": "0.5rem",
+                    "overflow": "hidden",
+                  }
+                }
+              />
+              <div
+                className="ControlSection__Wrapper-sc-rro5al-1 dSZUkP"
+              >
+                <span
+                  className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+                >
+                  <label
+                    htmlFor="site-quality-metrics-metric"
+                  >
+                    Metric: 
+                    <select
+                      className="Select-sc-1lkyg9e-0 ivadCR"
+                      id="site-quality-metrics-metric"
+                      onChange={[Function]}
+                      value="SiteQuality"
+                    >
+                      <option
+                        value="BaseQRankSum"
+                      >
+                        BaseQRankSum
+                      </option>
+                      <option
+                        value="ClippingRankSum"
+                      >
+                        ClippingRankSum
+                      </option>
+                      <option
+                        value="DP"
+                      >
+                        DP
+                      </option>
+                      <option
+                        value="FS"
+                      >
+                        FS
+                      </option>
+                      <option
+                        value="InbreedingCoeff"
+                      >
+                        InbreedingCoeff
+                      </option>
+                      <option
+                        value="MQ"
+                      >
+                        MQ
+                      </option>
+                      <option
+                        value="MQRankSum"
+                      >
+                        MQRankSum
+                      </option>
+                      <option
+                        value="pab_max"
+                      >
+                        pab_max
+                      </option>
+                      <option
+                        value="QD"
+                      >
+                        QD
+                      </option>
+                      <option
+                        value="ReadPosRankSum"
+                      >
+                        ReadPosRankSum
+                      </option>
+                      <option
+                        value="RF"
+                      >
+                        RF
+                      </option>
+                      <option
+                        value="SiteQuality"
+                      >
+                        SiteQuality
+                      </option>
+                      <option
+                        value="SOR"
+                      >
+                        SOR
+                      </option>
+                      <option
+                        value="VQSLOD"
+                      >
+                        VQSLOD
+                      </option>
+                    </select>
+                  </label>
+                </span>
+                <span
+                  className="ControlSection__ControlWrapper-sc-rro5al-0 gxhpge"
+                >
+                  <label
+                    htmlFor="site-quality-metrics-sequencing-type"
+                  >
+                    Sequencing types: 
+                    <select
+                      className="Select-sc-1lkyg9e-0 ivadCR"
+                      disabled={true}
+                      id="site-quality-metrics-sequencing-type"
+                      onChange={[Function]}
+                      value="e"
+                    >
+                      <option
+                        value="eg"
+                      >
+                        Exome and Genome
+                      </option>
+                      <option
+                        value="e"
+                      >
+                        Exome
+                      </option>
+                      <option
+                        value="g"
+                      >
+                        Genome
+                      </option>
+                    </select>
+                  </label>
+                </span>
+              </div>
+              <p>
+                Value: 
+                0 (exome samples)
+              </p>
+              <p>
+                This is the site quality distribution for all exome variants with 0 &lt;= AF &lt; 0.00005.
+              </p>
+              <p>
+                Note: These are site-level quality metrics, they may be unpredictable for multi-allelic sites.
+              </p>
+            </div>
+          </div>
+          <div
+            aria-describedby="values"
+            aria-hidden={true}
+            className="Tabs__StyledTabPanel-jzgyty-3 IifIF"
+            id="values-panel"
+            onKeyDown={[Function]}
+            role="tabpanel"
+            style={
+              {
+                "display": "none",
+              }
+            }
+          >
+            <table
+              className="Table__BaseTable-sc-7fgtt2-0 dIBzV"
+              style={
+                {
+                  "width": "100%",
+                }
+              }
+            >
+              <thead>
+                <tr>
+                  <th
+                    scope="col"
+                  >
+                    Metric
+                  </th>
+                  <th
+                    scope="col"
+                  >
+                    Exome samples
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      BaseQRankSum
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      ClippingRankSum
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      DP
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      FS
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      InbreedingCoeff
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      MQ
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      MQRankSum
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      pab_max
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      QD
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      ReadPosRankSum
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      RF
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      SiteQuality
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      SOR
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+                <tr>
+                  <th
+                    scope="row"
+                  >
+                    <span
+                      className="VariantSiteQualityMetrics__TooltipHint-sc-186wx2k-3 fDuBFy"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                    >
+                      VQSLOD
+                    </span>
+                  </th>
+                  <td>
+                    0
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section
+      className="VariantPage__Section-sc-hd87ur-0 CMQAN"
+    >
+      <h2>
+        Read Data
+      </h2>
+      <div>
+        <p>
+          No read data available for this variant.
+        </p>
+        <p>
+          <span
+            className="Badge__BadgeWrapper-j4izdp-1 cJObdY"
+          >
+            Note
+          </span>
+           Read data for non-coding regions is not available in gnomAD v2.1.1 and ExAC.
+        </p>
+      </div>
+    </section>
+  </div>
+</div>
+`;

--- a/browser/src/__factories__/Variant.ts
+++ b/browser/src/__factories__/Variant.ts
@@ -79,12 +79,17 @@ export const sequencingFactory = Factory.define<SequencingType>(({ params, assoc
       genotype_depth: { all: defaultHistogram, alt: defaultHistogram },
       genotype_quality: { all: defaultHistogram, alt: defaultHistogram },
     },
-    faf95 = { popmax: 0, popmax_population: 'nfe' },
+    faf95 = {
+      popmax: 0,
+      popmax_population: 'nfe',
+    },
   } = associations
 
   return {
     ac,
     an,
+    ac_hemi,
+    ac_hom,
     homozygote_count,
     hemizygote_count,
     filters,
@@ -92,8 +97,6 @@ export const sequencingFactory = Factory.define<SequencingType>(({ params, assoc
     local_ancestry_populations,
     age_distribution,
     quality_metrics,
-    ac_hemi,
-    ac_hom,
     faf95,
   }
 })

--- a/browser/src/__factories__/Variant.ts
+++ b/browser/src/__factories__/Variant.ts
@@ -1,0 +1,127 @@
+import { Factory } from 'fishery'
+import { Variant, SequencingType } from '../VariantPage/VariantPage'
+
+const defaultHistogram = {
+  bin_edges: [0.5],
+  bin_freq: [100],
+  n_larger: 0,
+  n_smaller: 0,
+}
+
+const variantFactory = Factory.define<Variant>(({ params, associations }) => {
+  const {
+    reference_genome = 'GRCh37',
+    variant_id = '13-123-A-C',
+    caid = null,
+    pos = 123,
+    ref = 'A',
+    alt = 'C',
+    chrom = '13',
+    flags = [],
+    lof_curations = null,
+    in_silico_predictors = null,
+    rsids = null,
+    colocated_variants = [],
+    transcript_consequences = [],
+    liftover = null,
+    liftover_sources = null,
+  } = params
+
+  const {
+    exome = null,
+    genome = null,
+    non_coding_constraint = null,
+    clinvar = null,
+    coverage = { exome: null, genome: null },
+  } = associations
+  return {
+    reference_genome,
+    variant_id,
+    chrom,
+    caid,
+    pos,
+    ref,
+    alt,
+    flags,
+    clinvar,
+    exome,
+    genome,
+    lof_curations,
+    in_silico_predictors,
+    non_coding_constraint,
+    rsids,
+    colocated_variants,
+    transcript_consequences,
+    coverage,
+    liftover,
+    liftover_sources,
+  }
+})
+
+export const sequencingFactory = Factory.define<SequencingType>(({ params, associations }) => {
+  const {
+    ac = 0,
+    an = 0,
+    homozygote_count = null,
+    hemizygote_count = null,
+    filters = [],
+    populations = [],
+    local_ancestry_populations = [],
+    ac_hemi = 0,
+    ac_hom = 0,
+  } = params
+
+  const {
+    age_distribution = { het: defaultHistogram, hom: defaultHistogram },
+    quality_metrics = {
+      site_quality_metrics: [],
+      allele_balance: { alt: defaultHistogram },
+      genotype_depth: { all: defaultHistogram, alt: defaultHistogram },
+      genotype_quality: { all: defaultHistogram, alt: defaultHistogram },
+    },
+    faf95 = { popmax: 0, popmax_population: 'nfe' },
+  } = associations
+
+  return {
+    ac,
+    an,
+    homozygote_count,
+    hemizygote_count,
+    filters,
+    populations,
+    local_ancestry_populations,
+    age_distribution,
+    quality_metrics,
+    ac_hemi,
+    ac_hom,
+    faf95,
+  }
+})
+
+export const v3SequencingFactory = sequencingFactory.associations({
+  quality_metrics: {
+    allele_balance: { alt: defaultHistogram },
+    genotype_depth: { all: defaultHistogram, alt: defaultHistogram },
+    genotype_quality: { all: defaultHistogram, alt: defaultHistogram },
+    site_quality_metrics: [
+      { metric: 'SiteQuality', value: 0 },
+      { metric: 'InbreedingCoeff', value: 0 },
+      { metric: 'AS_FS', value: 0 },
+      { metric: 'AS_MQ', value: 0 },
+      { metric: 'AS_MQRankSum', value: 0 },
+      { metric: 'AS_pab_max', value: 0 },
+      { metric: 'AS_QUALapprox', value: 0 },
+      { metric: 'AS_QD', value: 0 },
+      { metric: 'AS_ReadPosRankSum', value: 0 },
+      { metric: 'AS_SOR', value: 0 },
+      { metric: 'AS_VarDP', value: 0 },
+      { metric: 'AS_VQSLOD', value: 0 },
+    ],
+  },
+})
+
+export const v3VariantFactory = variantFactory
+  .params({ reference_genome: 'GRCh38' })
+  .associations({ exome: null, genome: v3SequencingFactory.build() })
+
+export default variantFactory

--- a/browser/src/__factories__/Variant.ts
+++ b/browser/src/__factories__/Variant.ts
@@ -98,6 +98,30 @@ export const sequencingFactory = Factory.define<SequencingType>(({ params, assoc
   }
 })
 
+export const v2SequencingFactory = sequencingFactory.associations({
+  quality_metrics: {
+    allele_balance: { alt: defaultHistogram },
+    genotype_depth: { all: defaultHistogram, alt: defaultHistogram },
+    genotype_quality: { all: defaultHistogram, alt: defaultHistogram },
+    site_quality_metrics: [
+      { metric: 'BaseQRankSum', value: 0 },
+      { metric: 'ClippingRankSum', value: 0 },
+      { metric: 'DP', value: 0 },
+      { metric: 'FS', value: 0 },
+      { metric: 'InbreedingCoeff', value: 0 },
+      { metric: 'MQ', value: 0 },
+      { metric: 'MQRankSum', value: 0 },
+      { metric: 'pab_max', value: 0 },
+      { metric: 'QD', value: 0 },
+      { metric: 'ReadPosRankSum', value: 0 },
+      { metric: 'RF', value: 0 },
+      { metric: 'SiteQuality', value: 0 },
+      { metric: 'SOR', value: 0 },
+      { metric: 'VQSLOD', value: 0 },
+    ],
+  },
+})
+
 export const v3SequencingFactory = sequencingFactory.associations({
   quality_metrics: {
     allele_balance: { alt: defaultHistogram },
@@ -120,8 +144,10 @@ export const v3SequencingFactory = sequencingFactory.associations({
   },
 })
 
+export const v2VariantFactory = variantFactory
+  .params({ reference_genome: 'GRCh37' })
+  .associations({ exome: v2SequencingFactory.build(), genome: null })
+
 export const v3VariantFactory = variantFactory
   .params({ reference_genome: 'GRCh38' })
   .associations({ exome: null, genome: v3SequencingFactory.build() })
-
-export default variantFactory

--- a/browser/src/queryHelperExample.spec.tsx
+++ b/browser/src/queryHelperExample.spec.tsx
@@ -34,8 +34,8 @@ const {
 // You can do this on a test-by-test basis too, rather than beforeEach.
 beforeEach(() => {
   Query.mockImplementation(
-    jest.fn(({ children, operationName, variables }) =>
-      simulateApiResponse('Query', children, operationName, variables)
+    jest.fn(({ query, children, operationName, variables }) =>
+      simulateApiResponse('Query', query, children, operationName, variables)
     )
   )
   // The semicolon is due to a quirk of JS/TS parsing--try taking it out and
@@ -43,8 +43,8 @@ beforeEach(() => {
   // Also, it's not clear why we have to cast BaseQuery here but not Query
   // above.
   ;(BaseQuery as any).mockImplementation(
-    jest.fn(({ children, operationName, variables }) =>
-      simulateApiResponse('BaseQuery', children, operationName, variables)
+    jest.fn(({ query, children, operationName, variables }) =>
+      simulateApiResponse('BaseQuery', query, children, operationName, variables)
     )
   )
 })

--- a/dataset-metadata/metadata.ts
+++ b/dataset-metadata/metadata.ts
@@ -27,15 +27,31 @@ const fullDatasetIds = allDatasetIds.filter(
   (datasetId) => datasetId === 'exac' || datasetId.match(/_r\d+(_\d+)*$/)
 )
 
-export type DatasetMetadata = {
+type DatasetMetadata = {
+  referenceGenome: ReferenceGenome
   label: string
   isSubset: boolean
   hasShortVariants: boolean
   hasStructuralVariants: boolean
   hasConstraints: boolean
   hasNonCodingConstraints: boolean
+  hasExome: boolean
   hasExomeCoverage: boolean
-  referenceGenome: ReferenceGenome
+  hasLocalAncestryPopulations: boolean
+  isLiftoverSource: boolean
+  isLiftoverTarget: boolean
+  isV3Subset: boolean
+  usesGrch37: boolean
+  usesGrch38: boolean
+  isV2: boolean
+  isV3: boolean
+  isExac: boolean
+  hasGenome: boolean
+  metricsIncludeLowQualityGenotypes: boolean
+  has1000GenomesPopulationFrequencies: boolean
+  hasAlleleBalance: boolean
+  hasRelatedVariants: boolean
+  showAllIndividualsInAgeDistributionByDefault: boolean
 }
 
 const structuralVariantDatasetIds = allDatasetIds.filter((datasetId) =>
@@ -45,12 +61,29 @@ const structuralVariantDatasetIds = allDatasetIds.filter((datasetId) =>
 const metadataForDataset = (datasetId: DatasetId): DatasetMetadata => ({
   label: datasetLabels[datasetId],
   isSubset: !fullDatasetIds.includes(datasetId),
+  isV3Subset: !fullDatasetIds.includes(datasetId) && datasetId.startsWith('gnomad_r3'),
   hasShortVariants: !structuralVariantDatasetIds.includes(datasetId),
   hasStructuralVariants: structuralVariantDatasetIds.includes(datasetId),
   hasConstraints: !datasetId.startsWith('gnomad_r3'),
   hasNonCodingConstraints: datasetId.startsWith('gnomad_r3'),
   referenceGenome: datasetId.startsWith('gnomad_r3') ? 'GRCh38' : 'GRCh37',
+  hasExome: !datasetId.startsWith('gnomad_r3'),
   hasExomeCoverage: !datasetId.startsWith('gnomad_r3'),
+  hasLocalAncestryPopulations: datasetId.startsWith('gnomad_r3'),
+  isLiftoverSource: datasetId.startsWith('gnomad_r2_1'),
+  isLiftoverTarget: datasetId.startsWith('gnomad_r3'),
+  usesGrch37: !datasetId.startsWith('gnomad_r3'),
+  usesGrch38: datasetId.startsWith('gnomad_r3'),
+  isV2: datasetId.startsWith('gnomad_r2'),
+  isV3: datasetId.startsWith('gnomad_r3'),
+  isExac: datasetId === 'exac',
+  hasGenome: datasetId.startsWith('gnomad_r2'),
+  metricsIncludeLowQualityGenotypes: datasetId.startsWith('gnomad_r2') || datasetId === 'exac',
+  has1000GenomesPopulationFrequencies:
+    datasetId.startsWith('gnomad_r3') && datasetId !== 'gnomad_r3_non_v2',
+  hasAlleleBalance: datasetId !== 'exac',
+  hasRelatedVariants: datasetId !== 'gnomad_r2_1',
+  showAllIndividualsInAgeDistributionByDefault: datasetId !== 'exac',
 })
 
 const metadata = allDatasetIds.reduce(
@@ -75,6 +108,8 @@ export const hasConstraints = (datsetId: DatasetId) => getMetadata(datsetId, 'ha
 export const hasNonCodingConstraints = (datasetId: DatasetId) =>
   getMetadata(datasetId, 'hasNonCodingConstraints')
 
+export const hasExome = (datsetId: DatasetId) => getMetadata(datsetId, 'hasExome')
+
 export const hasExomeCoverage = (datsetId: DatasetId) => getMetadata(datsetId, 'hasExomeCoverage')
 
 export const hasShortVariants = (datasetId: DatasetId) => getMetadata(datasetId, 'hasShortVariants')
@@ -82,4 +117,39 @@ export const hasShortVariants = (datasetId: DatasetId) => getMetadata(datasetId,
 export const hasStructuralVariants = (datasetId: DatasetId) =>
   getMetadata(datasetId, 'hasStructuralVariants')
 
+export const hasLocalAncestryPopulations = (datasetId: DatasetId) =>
+  getMetadata(datasetId, 'hasLocalAncestryPopulations')
+
+export const isLiftoverSource = (datasetId: DatasetId) => getMetadata(datasetId, 'isLiftoverSource')
+
+export const isLiftoverTarget = (datasetId: DatasetId) => getMetadata(datasetId, 'isLiftoverTarget')
+
 export const referenceGenome = (datasetId: DatasetId) => getMetadata(datasetId, 'referenceGenome')
+
+export const usesGrch37 = (datasetId: DatasetId) => getMetadata(datasetId, 'usesGrch37')
+
+export const usesGrch38 = (datasetId: DatasetId) => getMetadata(datasetId, 'usesGrch38')
+
+export const isV3Subset = (datasetId: DatasetId) => getMetadata(datasetId, 'isV3Subset')
+
+export const isV2 = (datasetId: DatasetId) => getMetadata(datasetId, 'isV2')
+
+export const isV3 = (datasetId: DatasetId) => getMetadata(datasetId, 'isV3')
+
+export const isExac = (datasetId: DatasetId) => getMetadata(datasetId, 'isExac')
+
+export const hasGenome = (datasetId: DatasetId) => getMetadata(datasetId, 'hasExome')
+
+export const metricsIncludeLowQualityGenotypes = (datasetId: DatasetId) =>
+  getMetadata(datasetId, 'metricsIncludeLowQualityGenotypes')
+
+export const has1000GenomesPopulationFrequencies = (datasetId: DatasetId) =>
+  getMetadata(datasetId, 'has1000GenomesPopulationFrequencies')
+
+export const hasAlleleBalance = (datasetId: DatasetId) => getMetadata(datasetId, 'hasAlleleBalance')
+
+export const hasRelatedVariants = (datasetId: DatasetId) =>
+  getMetadata(datasetId, 'hasRelatedVariants')
+
+export const showAllIndividualsInAgeDistributionByDefault = (datasetId: DatasetId) =>
+  getMetadata(datasetId, 'showAllIndividualsInAgeDistributionByDefault')

--- a/tests/__helpers__/queries.tsx
+++ b/tests/__helpers__/queries.tsx
@@ -28,6 +28,7 @@ export const mockQueries = () => {
 
   const simulateApiResponse = (
     mockedComponentName: string,
+    query: string,
     children: Children,
     operationName: string,
     variables: Record<string, any>
@@ -38,7 +39,11 @@ export const mockQueries = () => {
       const mockApiResponse = mockApiResponseFactory()
       return <>{children({ data: mockApiResponse })}</>
     }
-    throw new Error(`${mockedComponentName} got unmocked operation "${operationName}"`)
+    throw new Error(
+      `${mockedComponentName} got unmocked operation "${JSON.stringify(
+        operationName
+      )}"\nquery was:\n\n${JSON.stringify(query)}`
+    )
   }
 
   const setMockApiResponses = (newResponses: MockApiResponses) => {


### PR DESCRIPTION
Here I continue the process of removing explicit checks of the dataset ID throughout the code, and replacing them with helpers that reveal the intention of the code better.

In the past, my approach has been to introduce one helper at a time, but here I switch to doing a page at a time; this seems to be more efficient.