### PR TITLE
Fix v3 mitochondrial variant page crash

### DIFF
--- a/browser/src/MitochondrialVariantPage/MitochondrialVariantPage.tsx
+++ b/browser/src/MitochondrialVariantPage/MitochondrialVariantPage.tsx
@@ -162,8 +162,8 @@ const MitochondrialVariantPage = ({ datasetId, variant }: MitochondrialVariantPa
       {(variant as any).clinvar && (
         <ResponsiveSection>
           <h2>ClinVar</h2>
-          {/* @ts-expect-error TS(2741) FIXME: Property 'clinvar' is missing in type 'Mitochondri... Remove this comment to see the full error message */}
-          <VariantClinvarInfo variant={variant} />
+          {/* @ts-expect-error TS(2741) FIXME: Property 'release_date' is missing in t... Remove this comment to see the full error message */}
+          <VariantClinvarInfo clinvar={variant.clinvar} />
         </ResponsiveSection>
       )}
     </Wrapper>


### PR DESCRIPTION
Quick one line PR to resolve a crash on the Mitchondrial Variant page that started at commit 2c6dcf2ac073ecb25d8bf00615ddb51cbf32b0c2, part of https://github.com/broadinstitute/gnomad-browser/pull/1095

Currently, navigating to the mitochondrial variant page while on the `main` branch causes the page to crash. This PR fixes that crash and allows the page to load as before.

As of Apr 03, 2023, this bug is **not** in prod. As such, merging of this PR will nip this issue in the bud before it makes it live.

As part of the ongoing Dataset ID Conditional refactoring, the `<VariantClinvarInfo>` component was reworked to take a more specific prop (`clinvar` as opposed to the old `variant` it was passed). This new prop was not passed correctly to the `<VariantClinvarInfo>` component in `MitochondrialVariantPage.tsx`. A `@ts-expect-error` comment allowed the code to compile.

A quick double check confirms that the other uses of `<VariantClinvarInfo>` correctly pass the `clinvar` prop to it.

Link to the page in question for convenience:
- http://localhost:8008/variant/M-8602-T-C?dataset=gnomad_r3