### PR TITLE
Fix v3 subsets on variants page

### DIFF
--- a/browser/src/VariantPage/GnomadPopulationsTable.tsx
+++ b/browser/src/VariantPage/GnomadPopulationsTable.tsx
@@ -6,7 +6,7 @@ import { Checkbox } from '@gnomad/ui'
 import { GNOMAD_POPULATION_NAMES } from '@gnomad/dataset-metadata/gnomadPopulations'
 import { PopulationsTable } from './PopulationsTable'
 import { Population } from './VariantPage'
-import { DatasetId, hasGenome } from '@gnomad/dataset-metadata/metadata'
+import { DatasetId, hasV2Genome } from '@gnomad/dataset-metadata/metadata'
 
 const ControlSection = styled.div`
   margin-top: 1em;
@@ -146,7 +146,7 @@ export class GnomadPopulationsTable extends Component<
     }
 
     let populations = nestPopulations(addPopulationNames(mergePopulations(includedPopulations)))
-    if (hasGenome(datasetId) && includeGenomes) {
+    if (hasV2Genome(datasetId) && includeGenomes) {
       populations = populations.map((pop) => {
         if (pop.id === 'eas') {
           // If the variant is only present in genomes, sub-continental populations won't be present at all.
@@ -181,7 +181,7 @@ export class GnomadPopulationsTable extends Component<
           showHemizygotes={showHemizygotes}
           showHomozygotes={showHomozygotes}
         />
-        {hasGenome(datasetId) && includeGenomes && (
+        {hasV2Genome(datasetId) && includeGenomes && (
           <p>
             * Allele frequencies for some sub-continental populations were not computed for genome
             samples.

--- a/browser/src/VariantPage/VariantPage.tsx
+++ b/browser/src/VariantPage/VariantPage.tsx
@@ -15,6 +15,7 @@ import {
   isLiftoverTarget,
   usesGrch37,
   usesGrch38,
+  isV3,
   isV3Subset,
   isExac,
 } from '@gnomad/dataset-metadata/metadata'
@@ -706,7 +707,7 @@ const checkGeneLink = (transcript_consequences: TranscriptConsequence[] | null) 
 
   if (maneSelectTranscript.length === 1) {
     return {
-      ensembleId: maneSelectTranscript[0].gene_id
+      ensembleId: maneSelectTranscript[0].gene_id,
     }
   }
 
@@ -735,7 +736,7 @@ const VariantPage = ({ datasetId, variantId }: VariantPageProps) => {
         query={variantQuery}
         variables={{
           datasetId,
-          includeLocalAncestry: hasLocalAncestryPopulations(datasetId),
+          includeLocalAncestry: isV3(datasetId) && !isV3Subset(datasetId),
           includeLiftoverAsSource: isLiftoverSource(datasetId),
           includeLiftoverAsTarget: isLiftoverTarget(datasetId),
           referenceGenome: referenceGenome(datasetId),

--- a/dataset-metadata/metadata.ts
+++ b/dataset-metadata/metadata.ts
@@ -46,7 +46,7 @@ type DatasetMetadata = {
   isV2: boolean
   isV3: boolean
   isExac: boolean
-  hasGenome: boolean
+  hasV2Genome: boolean
   metricsIncludeLowQualityGenotypes: boolean
   has1000GenomesPopulationFrequencies: boolean
   hasAlleleBalance: boolean
@@ -81,7 +81,7 @@ const metadataForDataset = (datasetId: DatasetId): DatasetMetadata => ({
   isV2: datasetId.startsWith('gnomad_r2'),
   isV3: datasetId.startsWith('gnomad_r3'),
   isExac: datasetId === 'exac',
-  hasGenome: datasetId.startsWith('gnomad_r2'),
+  hasV2Genome: datasetId.startsWith('gnomad_r2'),
   metricsIncludeLowQualityGenotypes: datasetId.startsWith('gnomad_r2') || datasetId === 'exac',
   has1000GenomesPopulationFrequencies:
     datasetId.startsWith('gnomad_r3') && datasetId !== 'gnomad_r3_non_v2',
@@ -146,7 +146,7 @@ export const isV3 = (datasetId: DatasetId) => getMetadata(datasetId, 'isV3')
 
 export const isExac = (datasetId: DatasetId) => getMetadata(datasetId, 'isExac')
 
-export const hasGenome = (datasetId: DatasetId) => getMetadata(datasetId, 'hasExome')
+export const hasV2Genome = (datasetId: DatasetId) => getMetadata(datasetId, 'hasV2Genome')
 
 export const metricsIncludeLowQualityGenotypes = (datasetId: DatasetId) =>
   getMetadata(datasetId, 'metricsIncludeLowQualityGenotypes')


### PR DESCRIPTION
The variants page was mistakenly trying to load local ancestry populations for all v3 datasets, not just the main v3 dataset. Corrected.