### PR TITLE
Restore stub lodash declaration file

### DIFF
--- a/graphql-api/src/lodash.d.ts
+++ b/graphql-api/src/lodash.d.ts
@@ -1,0 +1,3 @@
+// There's a @types package for lodash but adding it as a dependency
+// doesn't seem to do anything.
+declare module 'lodash'


### PR DESCRIPTION
Despite the existing `@types` declaration, building an image for deploy won't work without this stub. Unclear why.