### PR TITLE
Update download links for variant coocurrence

### DIFF
--- a/browser/src/DownloadsPage/GnomadV2Downloads.tsx
+++ b/browser/src/DownloadsPage/GnomadV2Downloads.tsx
@@ -582,6 +582,13 @@ const GnomadV2Downloads = () => {
       <DownloadsSection>
         <SectionTitle id="v2-variant-cooccurrence">Variant co-occurrence</SectionTitle>
         <FileList>
+          {/* @ts-expect-error */}
+          <ListItem>
+            <GenericDownloadLinks
+              label="README"
+              path="/release/2.1.1/secondary_analyses/variant_cooccurrence/readme_for_download_tables.txt"
+            />
+          </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
             <GetUrlButtons
@@ -594,7 +601,6 @@ const GnomadV2Downloads = () => {
             <GetUrlButtons
               label="Variant co-occurrence by gene (homozygous rare variants)"
               path="/release/2.1.1/secondary_analyses/variant_cooccurrence/gnomAD_v2_homozygous_rare_variants_table_for_download.tsv"
-              includeAzure={false}
             />
           </ListItem>
           {/* @ts-expect-error */}
@@ -602,7 +608,6 @@ const GnomadV2Downloads = () => {
             <GetUrlButtons
               label="Variant co-occurrence by gene (two heterozygous rare variants)"
               path="/release/2.1.1/secondary_analyses/variant_cooccurrence/gnomAD_v2_two_heterozygous_rare_variants_table_for_download.tsv"
-              includeAzure={false}
             />
           </ListItem>
         </FileList>

--- a/browser/src/DownloadsPage/__snapshots__/DownloadsPage.spec.tsx.snap
+++ b/browser/src/DownloadsPage/__snapshots__/DownloadsPage.spec.tsx.snap
@@ -7592,6 +7592,47 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           className="c21"
         >
           <span>
+            README
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download README from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/secondary_analyses/variant_cooccurrence/readme_for_download_tables.txt"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download README from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/secondary_analyses/variant_cooccurrence/readme_for_download_tables.txt"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download README from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/secondary_analyses/variant_cooccurrence/readme_for_download_tables.txt"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c21"
+        >
+          <span>
             Variant co-occurrence Hail Table
           </span>
           <br />
@@ -7650,6 +7691,15 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           >
             Amazon
           </button>
+           / 
+          <button
+            aria-label="Show Microsoft URL for Variant co-occurrence by gene (homozygous rare variants)"
+            className="c22"
+            onClick={[Function]}
+            type="button"
+          >
+            Microsoft
+          </button>
         </li>
         <li
           className="c21"
@@ -7676,6 +7726,15 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             type="button"
           >
             Amazon
+          </button>
+           / 
+          <button
+            aria-label="Show Microsoft URL for Variant co-occurrence by gene (two heterozygous rare variants)"
+            className="c22"
+            onClick={[Function]}
+            type="button"
+          >
+            Microsoft
           </button>
         </li>
       </ul>


### PR DESCRIPTION
Resolves #1114 

Removes the flag that was hiding the Microsoft Azure download links for the Variant Coocurrence datasets. Also adds a link to download the README from the 3 cloud providers.