### PR TITLE
Sort gene search results in a more intuitive way

### DIFF
--- a/browser/src/Searchbox.tsx
+++ b/browser/src/Searchbox.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components'
 import { Searchbox, Select } from '@gnomad/ui'
 
 import { fetchSearchResults } from './search'
+import { DatasetId } from '@gnomad/dataset-metadata/metadata'
 
 const Wrapper = styled.div`
   display: flex;
@@ -53,7 +54,7 @@ export default withRouter((props: any) => {
 
   const currentParams = queryString.parse(location.search)
   const defaultSearchDataset = getDefaultSearchDataset(currentParams.dataset)
-  const [searchDataset, setSearchDataset] = useState(defaultSearchDataset)
+  const [searchDataset, setSearchDataset] = useState<DatasetId>(defaultSearchDataset)
 
   // Update search dataset when active dataset changes.
   // Cannot rely on props for this because the top bar does not re-render.

--- a/browser/src/search.spec.ts
+++ b/browser/src/search.spec.ts
@@ -96,6 +96,51 @@ describe('fetchSearchResults', () => {
     ])
   })
 
+  it("sorts gene search results with genes that start with the query ahead of those that don't", async () => {
+    // @ts-expect-error TS(2339) FIXME: Property 'mockReturnValue' does not exist on type ... Remove this comment to see the full error message
+    global.fetch.mockReturnValue(
+      Promise.resolve({
+        json: () =>
+          Promise.resolve({
+            data: {
+              gene_search: [
+                { ensembl_id: 'ENSG000004', symbol: 'ABCD3' },
+                { ensembl_id: 'ENSG000001', symbol: 'QRST3' },
+                { ensembl_id: 'ENSG000005', symbol: 'LMNO2' },
+                { ensembl_id: 'ENSG000002', symbol: 'QRST1' },
+                { ensembl_id: 'ENSG000006', symbol: 'ZXCV1' },
+                { ensembl_id: 'ENSG000003', symbol: 'QRST2' },
+              ],
+            },
+          }),
+      })
+    )
+
+    expect(await fetchSearchResults('gnomad_r3', 'QRS')).toEqual([
+      { label: 'QRST1', value: '/gene/ENSG000002?dataset=gnomad_r3' },
+      {
+        label: 'QRST2',
+        value: '/gene/ENSG000003?dataset=gnomad_r3',
+      },
+      {
+        label: 'QRST3',
+        value: '/gene/ENSG000001?dataset=gnomad_r3',
+      },
+      {
+        label: 'ABCD3',
+        value: '/gene/ENSG000004?dataset=gnomad_r3',
+      },
+      {
+        label: 'LMNO2',
+        value: '/gene/ENSG000005?dataset=gnomad_r3',
+      },
+      {
+        label: 'ZXCV1',
+        value: '/gene/ENSG000006?dataset=gnomad_r3',
+      },
+    ])
+  })
+
   it('should return a link to variant co-occurrence for two variant IDs', async () => {
     expect(await fetchSearchResults('gnomad_r2_1', '1-55505647-G-T and 1-55523855-G-A')).toEqual([
       {

--- a/browser/src/search.ts
+++ b/browser/src/search.ts
@@ -163,12 +163,29 @@ export const fetchSearchResults = (dataset: DatasetId, query: string) => {
           geneSymbolCounts[gene.symbol] += 1
         })
 
-        return genes.map((gene) => ({
-          label:
-            geneSymbolCounts[gene.symbol] > 1 ? `${gene.symbol} (${gene.ensembl_id})` : gene.symbol,
+        return genes
+          .sort((gene1, gene2) => {
+            const symbolPrefix = query.toUpperCase()
+            const symbol1 = gene1.symbol.toUpperCase()
+            const symbol2 = gene2.symbol.toUpperCase()
 
-          value: `/gene/${gene.ensembl_id}?dataset=${dataset}`,
-        }))
+            if (symbol1.startsWith(symbolPrefix) && !symbol2.startsWith(symbolPrefix)) {
+              return -1
+            }
+
+            if (!symbol1.startsWith(symbolPrefix) && symbol2.startsWith(symbolPrefix)) {
+              return 1
+            }
+            return symbol1.localeCompare(symbol2)
+          })
+          .map((gene) => ({
+            label:
+              geneSymbolCounts[gene.symbol] > 1
+                ? `${gene.symbol} (${gene.ensembl_id})`
+                : gene.symbol,
+
+            value: `/gene/${gene.ensembl_id}?dataset=${dataset}`,
+          }))
       })
   }
 

--- a/browser/src/search.ts
+++ b/browser/src/search.ts
@@ -6,10 +6,10 @@ import {
   isRsId,
 } from '@gnomad/identifiers'
 
-import { referenceGenome } from '@gnomad/dataset-metadata/metadata'
+import { DatasetId, referenceGenome } from '@gnomad/dataset-metadata/metadata'
 import { isStructuralVariantId } from './identifiers'
 
-export const fetchSearchResults = (dataset: any, query: any) => {
+export const fetchSearchResults = (dataset: DatasetId, query: string) => {
   if (dataset.startsWith('gnomad_sv')) {
     // ==============================================================================================
     // Structural Variants
@@ -153,22 +153,18 @@ export const fetchSearchResults = (dataset: any, query: any) => {
           throw new Error('Unable to retrieve search results')
         }
 
-        const genes = response.data.gene_search
+        const genes = response.data.gene_search as { ensembl_id: string; symbol: string }[]
 
-        const geneSymbolCounts = {}
-        genes.forEach((gene: any) => {
-          // @ts-expect-error TS(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
+        const geneSymbolCounts: Record<string, number> = {}
+        genes.forEach((gene) => {
           if (geneSymbolCounts[gene.symbol] === undefined) {
-            // @ts-expect-error TS(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
             geneSymbolCounts[gene.symbol] = 0
           }
-          // @ts-expect-error TS(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
           geneSymbolCounts[gene.symbol] += 1
         })
 
-        return genes.map((gene: any) => ({
+        return genes.map((gene) => ({
           label:
-            // @ts-expect-error TS(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
             geneSymbolCounts[gene.symbol] > 1 ? `${gene.symbol} (${gene.ensembl_id})` : gene.symbol,
 
           value: `/gene/${gene.ensembl_id}?dataset=${dataset}`,


### PR DESCRIPTION
This updates search on a gene symbol such that first come all prefix matches for the query string, and then all others, both groups alphabetized.

For example, suppose we got the gene search query `QWE`, and the genes that came back from the API had these symbols respectively:
* `ABCD2`
* `QWE2`
* `CDE1`
* `ABCD1`
* `QWE1`

The order in which these would appear in the dropdown would then be:
* `QWE1`
* `QWE2`
* `ABCD1`
* `ABCD2`
* `CDE1`