### PR TITLE
Add variant page link to All of Us data browser

### DIFF
--- a/browser/src/VariantPage/ReferenceList.tsx
+++ b/browser/src/VariantPage/ReferenceList.tsx
@@ -33,15 +33,17 @@ export const NcbiReference = (variantRsids: string[]) => {
         // @ts-expect-error TS(2746) FIXME: This JSX tag's 'children' prop expects a single ch... Remove this comment to see the full error message
         <ListItem>
           dbSNP ({' '}
-          {(variantRsids
-            .map((rsid) => (
-              // @ts-expect-error TS(2786) FIXME: 'ExternalLink' cannot be used as a JSX component.
-              <ExternalLink key={rsid} href={`https://www.ncbi.nlm.nih.gov/snp/${rsid}`}>
-                {rsid}
-              </ExternalLink>
-            ))
-            // @ts-expect-error TS(2769) FIXME: No overload matches this call.
-            .reduce((acc, el) => [...acc, ', ', el], []) as any).slice(1)}
+          {(
+            variantRsids
+              .map((rsid) => (
+                // @ts-expect-error TS(2786) FIXME: 'ExternalLink' cannot be used as a JSX component.
+                <ExternalLink key={rsid} href={`https://www.ncbi.nlm.nih.gov/snp/${rsid}`}>
+                  {rsid}
+                </ExternalLink>
+              ))
+              // @ts-expect-error TS(2769) FIXME: No overload matches this call.
+              .reduce((acc, el) => [...acc, ', ', el], []) as any
+          ).slice(1)}
           )
         </ListItem>
       )}

--- a/browser/src/VariantPage/ReferenceList.tsx
+++ b/browser/src/VariantPage/ReferenceList.tsx
@@ -71,6 +71,7 @@ export const ReferenceList = ({ variant }: Props) => {
   const ucscURL = `https://genome.ucsc.edu/cgi-bin/hgTracks?db=${ucscReferenceGenomeId}&highlight=${ucscReferenceGenomeId}.chr${chrom}%3A${pos}-${
     pos + (ref.length - 1)
   }&position=chr${chrom}%3A${pos - 25}-${pos + (ref.length - 1) + 25}`
+  const allOfUsURL = `https://databrowser.researchallofus.org/variants/${variant.variant_id}`
 
   return (
     // @ts-expect-error TS(2746) FIXME: This JSX tag's 'children' prop expects a single ch... Remove this comment to see the full error message
@@ -94,6 +95,14 @@ export const ReferenceList = ({ variant }: Props) => {
           >
             ClinGen Allele Registry ({variant.caid})
           </ExternalLink>
+        </ListItem>
+      )}
+
+      {variant.reference_genome === 'GRCh38' && (
+        // @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message
+        <ListItem>
+          {/* @ts-expect-error TS(2786) FIXME: 'ExternalLink' cannot be used as a JSX component. */}
+          <ExternalLink href={allOfUsURL}>All of Us</ExternalLink>
         </ListItem>
       )}
     </List>

--- a/browser/src/VariantPage/__snapshots__/VariantPage.spec.tsx.snap
+++ b/browser/src/VariantPage/__snapshots__/VariantPage.spec.tsx.snap
@@ -482,6 +482,18 @@ exports[`VariantPage with dataset "gnomad_r3" has no unexpected changes 1`] = `
             UCSC
           </a>
         </li>
+        <li
+          className="List__ListItem-sc-4j87st-1 gGPLUe"
+        >
+          <a
+            className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+            href="https://databrowser.researchallofus.org/variants/13-123-A-C"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            All of Us
+          </a>
+        </li>
       </ul>
       <h2>
         Feedback
@@ -9146,6 +9158,18 @@ exports[`VariantPage with dataset "gnomad_r3_controls_and_biobanks" has no unexp
             target="_blank"
           >
             UCSC
+          </a>
+        </li>
+        <li
+          className="List__ListItem-sc-4j87st-1 gGPLUe"
+        >
+          <a
+            className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+            href="https://databrowser.researchallofus.org/variants/13-123-A-C"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            All of Us
           </a>
         </li>
       </ul>
@@ -17817,6 +17841,18 @@ exports[`VariantPage with dataset "gnomad_r3_non_cancer" has no unexpected chang
             UCSC
           </a>
         </li>
+        <li
+          className="List__ListItem-sc-4j87st-1 gGPLUe"
+        >
+          <a
+            className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+            href="https://databrowser.researchallofus.org/variants/13-123-A-C"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            All of Us
+          </a>
+        </li>
       </ul>
       <h2>
         Feedback
@@ -26484,6 +26520,18 @@ exports[`VariantPage with dataset "gnomad_r3_non_neuro" has no unexpected change
             target="_blank"
           >
             UCSC
+          </a>
+        </li>
+        <li
+          className="List__ListItem-sc-4j87st-1 gGPLUe"
+        >
+          <a
+            className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+            href="https://databrowser.researchallofus.org/variants/13-123-A-C"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            All of Us
           </a>
         </li>
       </ul>
@@ -35155,6 +35203,18 @@ exports[`VariantPage with dataset "gnomad_r3_non_topmed" has no unexpected chang
             UCSC
           </a>
         </li>
+        <li
+          className="List__ListItem-sc-4j87st-1 gGPLUe"
+        >
+          <a
+            className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+            href="https://databrowser.researchallofus.org/variants/13-123-A-C"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            All of Us
+          </a>
+        </li>
       </ul>
       <h2>
         Feedback
@@ -43822,6 +43882,18 @@ exports[`VariantPage with dataset "gnomad_r3_non_v2" has no unexpected changes 1
             target="_blank"
           >
             UCSC
+          </a>
+        </li>
+        <li
+          className="List__ListItem-sc-4j87st-1 gGPLUe"
+        >
+          <a
+            className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+            href="https://databrowser.researchallofus.org/variants/13-123-A-C"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            All of Us
           </a>
         </li>
       </ul>


### PR DESCRIPTION
Resolves #1129 

Adds a link to the All of Us Data Browser on v3 variant pages

![variant-page-aou-link](https://github.com/broadinstitute/gnomad-browser/assets/59549713/1e9d70f6-c649-414f-a84d-6f7cfb53e03e)

[Localhost link](http://localhost:8008/variant/5-177212121-G-C?dataset=gnomad_r3) for convenience



