### PR TITLE
Update Feedback page for clarity, rename to Contact page

### DIFF
--- a/browser/cypress/e2e/nav_bar_pages.cy.ts
+++ b/browser/cypress/e2e/nav_bar_pages.cy.ts
@@ -54,8 +54,8 @@ describe('Home Page', () => {
         pageHeader: 'publications from the gnomAD group',
       },
       {
-        pageTitle: 'Feedback',
-        pageUrl: '/feedback',
+        pageTitle: 'Contact',
+        pageUrl: '/contact',
         pageHeader: 'Tell us how you use gnomAD',
       },
       {

--- a/browser/src/ContactPage.spec.tsx
+++ b/browser/src/ContactPage.spec.tsx
@@ -4,11 +4,11 @@ import 'jest-styled-components'
 import React from 'react'
 import renderer from 'react-test-renderer'
 
-import FeedbackPage from './FeedbackPage'
+import ContactPage from './ContactPage'
 
 import { withDummyRouter } from '../../tests/__helpers__/router'
 
-test('Feedback Page has no unexpected changes', () => {
-  const tree = renderer.create(withDummyRouter(<FeedbackPage />))
+test('Contact Page has no unexpected changes', () => {
+  const tree = renderer.create(withDummyRouter(<ContactPage />))
   expect(tree).toMatchSnapshot()
 })

--- a/browser/src/ContactPage.tsx
+++ b/browser/src/ContactPage.tsx
@@ -7,8 +7,8 @@ import InfoPage from './InfoPage'
 
 export default () => (
   <InfoPage>
-    <DocumentTitle title="Feedback" />
-    <PageHeading>Feedback</PageHeading>
+    <DocumentTitle title="Contact" />
+    <PageHeading>Contact</PageHeading>
 
     <p>
       Tell us how you use gnomAD and your wish list by filling out{' '}
@@ -27,9 +27,21 @@ export default () => (
       {/* @ts-expect-error TS(2786) FIXME: 'ExternalLink' cannot be used as a JSX component. */}
       <ExternalLink href="https://github.com/broadinstitute/gnomad-browser/issues">
         GitHub
-      </ExternalLink>{' '}
+      </ExternalLink>
+      .
+    </p>
+
+    <p>
+      For questions about gnomAD, check out the{' '}
       {/* @ts-expect-error TS(2786) FIXME: 'ExternalLink' cannot be used as a JSX component. */}
-      or by <ExternalLink href="mailto:gnomad@broadinstitute.org">email</ExternalLink>.
+      <ExternalLink href="/help">help page</ExternalLink>.
+    </p>
+
+    <p>
+      Note that, for many reasons (including consent and data usage restrictions), we do not have
+      (and cannot share) phenotype information. Overall, we have limited information that we can
+      share for some cohorts, such as last known age in bins of 5 years (when known) and chromosomal
+      sex.
     </p>
 
     <p>

--- a/browser/src/NavBar.tsx
+++ b/browser/src/NavBar.tsx
@@ -132,8 +132,8 @@ const NavBar = () => {
           </Link>
         </li>
         <li>
-          <Link to="/feedback" onClick={closeMenu}>
-            Feedback
+          <Link to="/contact" onClick={closeMenu}>
+            Contact
           </Link>
         </li>
         <li>

--- a/browser/src/Routes.tsx
+++ b/browser/src/Routes.tsx
@@ -10,7 +10,7 @@ import DocumentTitle from './DocumentTitle'
 // Content pages
 const AboutPage = lazy(() => import('./AboutPage'))
 const TeamPage = lazy(() => import('./TeamPage/TeamPage'))
-const FeedbackPage = lazy(() => import('./FeedbackPage'))
+const ContactPage = lazy(() => import('./ContactPage'))
 const DownloadsPage = lazy(() => import('./DownloadsPage/DownloadsPage'))
 const HelpPage = lazy(() => import('./help/HelpPage'))
 const HelpTopicPage = lazy(() => import('./help/HelpTopicPage'))
@@ -26,8 +26,8 @@ const VariantPageRouter = lazy(() => import('./VariantPageRouter'))
 
 const ShortTandemRepeatPage = lazy(() => import('./ShortTandemRepeatPage/ShortTandemRepeatPage'))
 const ShortTandemRepeatsPage = lazy(() => import('./ShortTandemRepeatsPage/ShortTandemRepeatsPage'))
-const VariantCooccurrencePage = lazy(() =>
-  import('./VariantCooccurrencePage/VariantCooccurrencePage')
+const VariantCooccurrencePage = lazy(
+  () => import('./VariantCooccurrencePage/VariantCooccurrencePage')
 )
 
 // Other pages
@@ -161,9 +161,9 @@ const Routes = () => {
 
       <Route exact path="/publications" component={PublicationsPage} />
 
-      <Route exact path="/feedback" component={FeedbackPage} />
+      <Route exact path="/contact" component={ContactPage} />
 
-      <Route exact path="/contact" render={() => <Redirect to="/feedback" />} />
+      <Route exact path="/feedback" render={() => <Redirect to="/contact" />} />
 
       <Route exact path="/mou" component={MOUPage} />
 

--- a/browser/src/__snapshots__/ContactPage.spec.tsx.snap
+++ b/browser/src/__snapshots__/ContactPage.spec.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Feedback Page has no unexpected changes 1`] = `
+exports[`Contact Page has no unexpected changes 1`] = `
 .c3 {
   color: #1173bb;
   -webkit-text-decoration: none;
@@ -96,7 +96,7 @@ exports[`Feedback Page has no unexpected changes 1`] = `
     <h1
       className="c2"
     >
-      Feedback
+      Contact
     </h1>
   </div>
   <p>
@@ -136,17 +136,23 @@ exports[`Feedback Page has no unexpected changes 1`] = `
     >
       GitHub
     </a>
+    .
+  </p>
+  <p>
+    For questions about gnomAD, check out the
      
-    or by 
     <a
       className="c3"
-      href="mailto:gnomad@broadinstitute.org"
+      href="/help"
       rel="noopener noreferrer"
       target="_blank"
     >
-      email
+      help page
     </a>
     .
+  </p>
+  <p>
+    Note that, for many reasons (including consent and data usage restrictions), we do not have (and cannot share) phenotype information. Overall, we have limited information that we can share for some cohorts, such as last known age in bins of 5 years (when known) and chromosomal sex.
   </p>
   <p>
     Follow us on Twitter

--- a/browser/src/robots.txt
+++ b/browser/src/robots.txt
@@ -8,5 +8,5 @@ Allow: /news/changelog/
 Allow: /downloads/
 Allow: /policies/
 Allow: /publications/
-Allow: /feedback/
+Allow: /contact/
 Allow: /help/


### PR DESCRIPTION
Resolves #1122 

- Renames the feedback page to be named the contact page
- Updates the contact page with suggested edits for clarity

![contact-page-edits](https://github.com/broadinstitute/gnomad-browser/assets/59549713/7bb0d112-9a0f-4278-b64e-5ffbb1eca9a2)
