### PR TITLE
Modify coocurrence table to only render on v2 data

### DIFF
--- a/browser/src/GenePage/GenePage.spec.tsx
+++ b/browser/src/GenePage/GenePage.spec.tsx
@@ -3,7 +3,11 @@ import renderer from 'react-test-renderer'
 import { jest, describe, expect, test } from '@jest/globals'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { DatasetId, ReferenceGenome } from '@gnomad/dataset-metadata/metadata'
+import {
+  DatasetId,
+  hasVariantCoocurrence,
+  ReferenceGenome,
+} from '@gnomad/dataset-metadata/metadata'
 import { mockQueries } from '../../../tests/__helpers__/queries'
 import Query, { BaseQuery } from '../Query'
 
@@ -89,7 +93,11 @@ forDatasetsNotMatching(svRegexp, 'GenePage with non-SV dataset "%s"', (datasetId
 
     await userEvent.click(cooccurrenceButton)
     expect(screen.queryByText(constraintModeMatcher)).toBeNull()
-    expect(screen.queryAllByText(cooccurrenceModeMatcher)).not.toEqual([])
+    if (hasVariantCoocurrence(datasetId)) {
+      expect(screen.queryAllByText(cooccurrenceModeMatcher)).not.toEqual([])
+    } else {
+      expect(screen.queryAllByText(cooccurrenceModeMatcher)).toEqual([])
+    }
 
     await userEvent.click(constraintButton)
     expect(screen.queryByText(constraintModeMatcher)).not.toBeNull()

--- a/browser/src/GenePage/GenePage.tsx
+++ b/browser/src/GenePage/GenePage.tsx
@@ -388,6 +388,7 @@ const GenePage = ({ datasetId, gene, geneId }: Props) => {
               <ConstraintTable datasetId={datasetId} geneOrTranscript={gene} />
             ) : (
               <VariantCooccurrenceCountsTable
+                datasetId={datasetId}
                 heterozygous_variant_cooccurrence_counts={
                   gene.heterozygous_variant_cooccurrence_counts!
                 }

--- a/browser/src/GenePage/VariantCooccurrenceCountsTable.spec.tsx
+++ b/browser/src/GenePage/VariantCooccurrenceCountsTable.spec.tsx
@@ -7,6 +7,50 @@ import {
 } from '../__factories__/VariantCooccurrenceCountsPerSeverityAndAf'
 
 import VariantCooccurrenceCountsTable from './VariantCooccurrenceCountsTable'
+import { forDatasetsMatching, forDatasetsNotMatching } from '../../../tests/__helpers__/datasets'
+
+const v2Regexp = /_r2/
+
+forDatasetsNotMatching(
+  v2Regexp,
+  'VariantCoocurrenceCountsTable with non v2 dataset "%s"',
+  (datasetId) => {
+    test('has no unexpected changes and renders as placeholder text', () => {
+      const heterozygousCounts =
+        HeterozygousVariantCooccurrenceCountsPerSeverityAndAfFactory.build()
+      const homozygousCounts = HomozygousVariantCooccurrenceCountsPerSeverityAndAfFactory.build()
+      const tableContent = render(
+        <VariantCooccurrenceCountsTable
+          datasetId={datasetId}
+          heterozygous_variant_cooccurrence_counts={heterozygousCounts}
+          homozygous_variant_cooccurrence_counts={homozygousCounts}
+        />
+      )
+      const normalContentFragment = tableContent.asFragment()
+      expect(normalContentFragment.querySelectorAll('p').length).toEqual(1)
+      expect(normalContentFragment.querySelectorAll('table').length).toEqual(0)
+      expect(normalContentFragment).toMatchSnapshot()
+    })
+  }
+)
+
+forDatasetsMatching(v2Regexp, 'VariantCoocurrenceCountsTable with v2 dataset "%s"', (datasetId) => {
+  test('has no unexpected changes and renders as a table', () => {
+    const heterozygousCounts = HeterozygousVariantCooccurrenceCountsPerSeverityAndAfFactory.build()
+    const homozygousCounts = HomozygousVariantCooccurrenceCountsPerSeverityAndAfFactory.build()
+    const tableContent = render(
+      <VariantCooccurrenceCountsTable
+        datasetId={datasetId}
+        heterozygous_variant_cooccurrence_counts={heterozygousCounts}
+        homozygous_variant_cooccurrence_counts={homozygousCounts}
+      />
+    )
+    const normalContentFragment = tableContent.asFragment()
+    expect(normalContentFragment.querySelectorAll('p').length).toEqual(0)
+    expect(normalContentFragment.querySelectorAll('table').length).toEqual(2)
+    expect(normalContentFragment).toMatchSnapshot()
+  })
+})
 
 describe('VariantCooccurrenceCountsTable', () => {
   test('renders correct data into correct table cells in both regular and extended mode', () => {
@@ -14,6 +58,7 @@ describe('VariantCooccurrenceCountsTable', () => {
     const homozygousCounts = HomozygousVariantCooccurrenceCountsPerSeverityAndAfFactory.build()
     const tableContent = render(
       <VariantCooccurrenceCountsTable
+        datasetId="gnomad_r2_1"
         heterozygous_variant_cooccurrence_counts={heterozygousCounts}
         homozygous_variant_cooccurrence_counts={homozygousCounts}
       />
@@ -42,6 +87,7 @@ describe('VariantCooccurrenceCountsTable', () => {
   test('fills in missing data with zeroes', () => {
     const tableContent = render(
       <VariantCooccurrenceCountsTable
+        datasetId="gnomad_r2_1"
         heterozygous_variant_cooccurrence_counts={{}}
         homozygous_variant_cooccurrence_counts={{}}
       />

--- a/browser/src/GenePage/VariantCooccurrenceCountsTable.tsx
+++ b/browser/src/GenePage/VariantCooccurrenceCountsTable.tsx
@@ -2,6 +2,7 @@ import React, { useState, Dispatch, SetStateAction, ReactNode } from 'react'
 import styled from 'styled-components'
 
 import { BaseTable, TooltipAnchor, TooltipHint, Button } from '@gnomad/ui'
+import { DatasetId, hasVariantCoocurrence } from '@gnomad/dataset-metadata/metadata'
 
 export const heterozygousVariantCooccurrenceSeverities = [
   'lof_lof',
@@ -505,13 +506,19 @@ const HomozygousCaption = () => (
 )
 
 const VariantCooccurrenceCountsTable = ({
+  datasetId,
   heterozygous_variant_cooccurrence_counts,
   homozygous_variant_cooccurrence_counts,
 }: {
+  datasetId: DatasetId
   heterozygous_variant_cooccurrence_counts: HeterozygousVariantCooccurrenceCountsPerSeverityAndAf
   homozygous_variant_cooccurrence_counts: HomozygousVariantCooccurrenceCountsPerSeverityAndAf
 }) => {
   const [tableMode, setTableMode] = useState<TableMode>('normal')
+
+  if (!hasVariantCoocurrence(datasetId)) {
+    return <p>Variant co-occurrence is only available for gnomAD v2.</p>
+  }
 
   const buttonLabel = tableMode === 'normal' ? 'expand' : 'collapse'
   const clickCallback = () => toggleTableMode(tableMode, setTableMode)

--- a/browser/src/GenePage/__snapshots__/VariantCooccurrenceCountsTable.spec.tsx.snap
+++ b/browser/src/GenePage/__snapshots__/VariantCooccurrenceCountsTable.spec.tsx.snap
@@ -1985,3 +1985,3419 @@ exports[`VariantCooccurrenceCountsTable renders correct data into correct table 
   </div>
 </DocumentFragment>
 `;
+
+exports[`VariantCoocurrenceCountsTable with non v2 dataset "exac" has no unexpected changes and renders as placeholder text 1`] = `
+<DocumentFragment>
+  <p>
+    Variant co-occurrence is only available for gnomAD v2.
+  </p>
+</DocumentFragment>
+`;
+
+exports[`VariantCoocurrenceCountsTable with non v2 dataset "gnomad_r3" has no unexpected changes and renders as placeholder text 1`] = `
+<DocumentFragment>
+  <p>
+    Variant co-occurrence is only available for gnomAD v2.
+  </p>
+</DocumentFragment>
+`;
+
+exports[`VariantCoocurrenceCountsTable with non v2 dataset "gnomad_r3_controls_and_biobanks" has no unexpected changes and renders as placeholder text 1`] = `
+<DocumentFragment>
+  <p>
+    Variant co-occurrence is only available for gnomAD v2.
+  </p>
+</DocumentFragment>
+`;
+
+exports[`VariantCoocurrenceCountsTable with non v2 dataset "gnomad_r3_non_cancer" has no unexpected changes and renders as placeholder text 1`] = `
+<DocumentFragment>
+  <p>
+    Variant co-occurrence is only available for gnomAD v2.
+  </p>
+</DocumentFragment>
+`;
+
+exports[`VariantCoocurrenceCountsTable with non v2 dataset "gnomad_r3_non_neuro" has no unexpected changes and renders as placeholder text 1`] = `
+<DocumentFragment>
+  <p>
+    Variant co-occurrence is only available for gnomAD v2.
+  </p>
+</DocumentFragment>
+`;
+
+exports[`VariantCoocurrenceCountsTable with non v2 dataset "gnomad_r3_non_topmed" has no unexpected changes and renders as placeholder text 1`] = `
+<DocumentFragment>
+  <p>
+    Variant co-occurrence is only available for gnomAD v2.
+  </p>
+</DocumentFragment>
+`;
+
+exports[`VariantCoocurrenceCountsTable with non v2 dataset "gnomad_r3_non_v2" has no unexpected changes and renders as placeholder text 1`] = `
+<DocumentFragment>
+  <p>
+    Variant co-occurrence is only available for gnomAD v2.
+  </p>
+</DocumentFragment>
+`;
+
+exports[`VariantCoocurrenceCountsTable with v2 dataset "gnomad_r2_1" has no unexpected changes and renders as a table 1`] = `
+<DocumentFragment>
+  <div>
+    <table
+      class="Table__BaseTable-sc-7fgtt2-0 VariantCooccurrenceCountsTable__Table-sc-64zbq9-0 bqCaTV"
+    >
+      <colgroup>
+        <col
+          style="width: 45%;"
+        />
+        <col
+          style="width: 15%;"
+        />
+        <col
+          style="width: 15%;"
+        />
+        <col
+          style="width: 15%;"
+        />
+      </colgroup>
+      <thead>
+        <tr>
+          <th
+            colspan="4"
+          >
+            Individuals with 
+            <strong>
+              two heterozygous
+            </strong>
+             rare variants 
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              (number predicted in 
+              <i>
+                trans
+              </i>
+              )
+            </span>
+          </th>
+        </tr>
+        <tr>
+          <th>
+            Consequence
+          </th>
+          <th
+            colspan="3"
+          >
+            Allele frequency
+          </th>
+        </tr>
+        <tr>
+          <th />
+          <th>
+            ≤ 5%
+          </th>
+          <th>
+            ≤ 1%
+          </th>
+          <th>
+            ≤ 0.5%
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              pLoF + pLoF
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              28512 (14859)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              28524 (14863)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              16027 (8917)
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              strong missense or worse + strong missense or worse
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              17591 (1669)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              17603 (1673)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              40907 (19183)
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              moderate missense or worse + moderate missense or worse
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              42889 (18949)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              42901 (18953)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              42749 (13007)
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              weak missense or worse + weak missense or worse
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              34432 (13475)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              34444 (13479)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              21947 (7533)
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              missense or worse + missense or worse
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              18922 (3251)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              18934 (3255)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              42238 (20765)
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              synonymous or worse + synonymous or worse
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              47943 (18569)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              47955 (18573)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              47803 (12627)
+            </span>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <button
+      class="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 VariantCooccurrenceCountsTable__ModeToggle-sc-64zbq9-1 gdedLW"
+      type="button"
+    >
+      expand
+    </button>
+    <table
+      class="Table__BaseTable-sc-7fgtt2-0 VariantCooccurrenceCountsTable__Table-sc-64zbq9-0 bqCaTV"
+    >
+      <colgroup>
+        <col
+          style="width: 45%;"
+        />
+        <col
+          style="width: 15%;"
+        />
+        <col
+          style="width: 15%;"
+        />
+        <col
+          style="width: 15%;"
+        />
+      </colgroup>
+      <thead>
+        <tr>
+          <th
+            colspan="4"
+          >
+            Individuals with 
+            <strong>
+              homozygous
+            </strong>
+             rare variants
+          </th>
+        </tr>
+        <tr>
+          <th>
+            Consequence
+          </th>
+          <th
+            colspan="3"
+          >
+            Allele frequency
+          </th>
+        </tr>
+        <tr>
+          <th />
+          <th>
+            ≤ 5%
+          </th>
+          <th>
+            ≤ 1%
+          </th>
+          <th>
+            ≤ 0.5%
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              pLoF
+            </span>
+          </td>
+          <td>
+            20287
+          </td>
+          <td>
+            20291
+          </td>
+          <td>
+            23379
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              strong missense or worse
+            </span>
+          </td>
+          <td>
+            44405
+          </td>
+          <td>
+            44409
+          </td>
+          <td>
+            1819
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              moderate missense or worse
+            </span>
+          </td>
+          <td>
+            13167
+          </td>
+          <td>
+            13171
+          </td>
+          <td>
+            16259
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              weak missense or worse
+            </span>
+          </td>
+          <td>
+            13501
+          </td>
+          <td>
+            13505
+          </td>
+          <td>
+            16593
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              missense or worse
+            </span>
+          </td>
+          <td>
+            14048
+          </td>
+          <td>
+            14052
+          </td>
+          <td>
+            17140
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              synonymous or worse
+            </span>
+          </td>
+          <td>
+            4233
+          </td>
+          <td>
+            4237
+          </td>
+          <td>
+            7325
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`VariantCoocurrenceCountsTable with v2 dataset "gnomad_r2_1_controls" has no unexpected changes and renders as a table 1`] = `
+<DocumentFragment>
+  <div>
+    <table
+      class="Table__BaseTable-sc-7fgtt2-0 VariantCooccurrenceCountsTable__Table-sc-64zbq9-0 bqCaTV"
+    >
+      <colgroup>
+        <col
+          style="width: 45%;"
+        />
+        <col
+          style="width: 15%;"
+        />
+        <col
+          style="width: 15%;"
+        />
+        <col
+          style="width: 15%;"
+        />
+      </colgroup>
+      <thead>
+        <tr>
+          <th
+            colspan="4"
+          >
+            Individuals with 
+            <strong>
+              two heterozygous
+            </strong>
+             rare variants 
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              (number predicted in 
+              <i>
+                trans
+              </i>
+              )
+            </span>
+          </th>
+        </tr>
+        <tr>
+          <th>
+            Consequence
+          </th>
+          <th
+            colspan="3"
+          >
+            Allele frequency
+          </th>
+        </tr>
+        <tr>
+          <th />
+          <th>
+            ≤ 5%
+          </th>
+          <th>
+            ≤ 1%
+          </th>
+          <th>
+            ≤ 0.5%
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              pLoF + pLoF
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              28512 (14859)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              28524 (14863)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              16027 (8917)
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              strong missense or worse + strong missense or worse
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              17591 (1669)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              17603 (1673)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              40907 (19183)
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              moderate missense or worse + moderate missense or worse
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              42889 (18949)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              42901 (18953)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              42749 (13007)
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              weak missense or worse + weak missense or worse
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              34432 (13475)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              34444 (13479)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              21947 (7533)
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              missense or worse + missense or worse
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              18922 (3251)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              18934 (3255)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              42238 (20765)
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              synonymous or worse + synonymous or worse
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              47943 (18569)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              47955 (18573)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              47803 (12627)
+            </span>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <button
+      class="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 VariantCooccurrenceCountsTable__ModeToggle-sc-64zbq9-1 gdedLW"
+      type="button"
+    >
+      expand
+    </button>
+    <table
+      class="Table__BaseTable-sc-7fgtt2-0 VariantCooccurrenceCountsTable__Table-sc-64zbq9-0 bqCaTV"
+    >
+      <colgroup>
+        <col
+          style="width: 45%;"
+        />
+        <col
+          style="width: 15%;"
+        />
+        <col
+          style="width: 15%;"
+        />
+        <col
+          style="width: 15%;"
+        />
+      </colgroup>
+      <thead>
+        <tr>
+          <th
+            colspan="4"
+          >
+            Individuals with 
+            <strong>
+              homozygous
+            </strong>
+             rare variants
+          </th>
+        </tr>
+        <tr>
+          <th>
+            Consequence
+          </th>
+          <th
+            colspan="3"
+          >
+            Allele frequency
+          </th>
+        </tr>
+        <tr>
+          <th />
+          <th>
+            ≤ 5%
+          </th>
+          <th>
+            ≤ 1%
+          </th>
+          <th>
+            ≤ 0.5%
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              pLoF
+            </span>
+          </td>
+          <td>
+            20287
+          </td>
+          <td>
+            20291
+          </td>
+          <td>
+            23379
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              strong missense or worse
+            </span>
+          </td>
+          <td>
+            44405
+          </td>
+          <td>
+            44409
+          </td>
+          <td>
+            1819
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              moderate missense or worse
+            </span>
+          </td>
+          <td>
+            13167
+          </td>
+          <td>
+            13171
+          </td>
+          <td>
+            16259
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              weak missense or worse
+            </span>
+          </td>
+          <td>
+            13501
+          </td>
+          <td>
+            13505
+          </td>
+          <td>
+            16593
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              missense or worse
+            </span>
+          </td>
+          <td>
+            14048
+          </td>
+          <td>
+            14052
+          </td>
+          <td>
+            17140
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              synonymous or worse
+            </span>
+          </td>
+          <td>
+            4233
+          </td>
+          <td>
+            4237
+          </td>
+          <td>
+            7325
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`VariantCoocurrenceCountsTable with v2 dataset "gnomad_r2_1_non_cancer" has no unexpected changes and renders as a table 1`] = `
+<DocumentFragment>
+  <div>
+    <table
+      class="Table__BaseTable-sc-7fgtt2-0 VariantCooccurrenceCountsTable__Table-sc-64zbq9-0 bqCaTV"
+    >
+      <colgroup>
+        <col
+          style="width: 45%;"
+        />
+        <col
+          style="width: 15%;"
+        />
+        <col
+          style="width: 15%;"
+        />
+        <col
+          style="width: 15%;"
+        />
+      </colgroup>
+      <thead>
+        <tr>
+          <th
+            colspan="4"
+          >
+            Individuals with 
+            <strong>
+              two heterozygous
+            </strong>
+             rare variants 
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              (number predicted in 
+              <i>
+                trans
+              </i>
+              )
+            </span>
+          </th>
+        </tr>
+        <tr>
+          <th>
+            Consequence
+          </th>
+          <th
+            colspan="3"
+          >
+            Allele frequency
+          </th>
+        </tr>
+        <tr>
+          <th />
+          <th>
+            ≤ 5%
+          </th>
+          <th>
+            ≤ 1%
+          </th>
+          <th>
+            ≤ 0.5%
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              pLoF + pLoF
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              28512 (14859)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              28524 (14863)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              16027 (8917)
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              strong missense or worse + strong missense or worse
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              17591 (1669)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              17603 (1673)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              40907 (19183)
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              moderate missense or worse + moderate missense or worse
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              42889 (18949)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              42901 (18953)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              42749 (13007)
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              weak missense or worse + weak missense or worse
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              34432 (13475)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              34444 (13479)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              21947 (7533)
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              missense or worse + missense or worse
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              18922 (3251)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              18934 (3255)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              42238 (20765)
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              synonymous or worse + synonymous or worse
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              47943 (18569)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              47955 (18573)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              47803 (12627)
+            </span>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <button
+      class="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 VariantCooccurrenceCountsTable__ModeToggle-sc-64zbq9-1 gdedLW"
+      type="button"
+    >
+      expand
+    </button>
+    <table
+      class="Table__BaseTable-sc-7fgtt2-0 VariantCooccurrenceCountsTable__Table-sc-64zbq9-0 bqCaTV"
+    >
+      <colgroup>
+        <col
+          style="width: 45%;"
+        />
+        <col
+          style="width: 15%;"
+        />
+        <col
+          style="width: 15%;"
+        />
+        <col
+          style="width: 15%;"
+        />
+      </colgroup>
+      <thead>
+        <tr>
+          <th
+            colspan="4"
+          >
+            Individuals with 
+            <strong>
+              homozygous
+            </strong>
+             rare variants
+          </th>
+        </tr>
+        <tr>
+          <th>
+            Consequence
+          </th>
+          <th
+            colspan="3"
+          >
+            Allele frequency
+          </th>
+        </tr>
+        <tr>
+          <th />
+          <th>
+            ≤ 5%
+          </th>
+          <th>
+            ≤ 1%
+          </th>
+          <th>
+            ≤ 0.5%
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              pLoF
+            </span>
+          </td>
+          <td>
+            20287
+          </td>
+          <td>
+            20291
+          </td>
+          <td>
+            23379
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              strong missense or worse
+            </span>
+          </td>
+          <td>
+            44405
+          </td>
+          <td>
+            44409
+          </td>
+          <td>
+            1819
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              moderate missense or worse
+            </span>
+          </td>
+          <td>
+            13167
+          </td>
+          <td>
+            13171
+          </td>
+          <td>
+            16259
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              weak missense or worse
+            </span>
+          </td>
+          <td>
+            13501
+          </td>
+          <td>
+            13505
+          </td>
+          <td>
+            16593
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              missense or worse
+            </span>
+          </td>
+          <td>
+            14048
+          </td>
+          <td>
+            14052
+          </td>
+          <td>
+            17140
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              synonymous or worse
+            </span>
+          </td>
+          <td>
+            4233
+          </td>
+          <td>
+            4237
+          </td>
+          <td>
+            7325
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`VariantCoocurrenceCountsTable with v2 dataset "gnomad_r2_1_non_neuro" has no unexpected changes and renders as a table 1`] = `
+<DocumentFragment>
+  <div>
+    <table
+      class="Table__BaseTable-sc-7fgtt2-0 VariantCooccurrenceCountsTable__Table-sc-64zbq9-0 bqCaTV"
+    >
+      <colgroup>
+        <col
+          style="width: 45%;"
+        />
+        <col
+          style="width: 15%;"
+        />
+        <col
+          style="width: 15%;"
+        />
+        <col
+          style="width: 15%;"
+        />
+      </colgroup>
+      <thead>
+        <tr>
+          <th
+            colspan="4"
+          >
+            Individuals with 
+            <strong>
+              two heterozygous
+            </strong>
+             rare variants 
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              (number predicted in 
+              <i>
+                trans
+              </i>
+              )
+            </span>
+          </th>
+        </tr>
+        <tr>
+          <th>
+            Consequence
+          </th>
+          <th
+            colspan="3"
+          >
+            Allele frequency
+          </th>
+        </tr>
+        <tr>
+          <th />
+          <th>
+            ≤ 5%
+          </th>
+          <th>
+            ≤ 1%
+          </th>
+          <th>
+            ≤ 0.5%
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              pLoF + pLoF
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              28512 (14859)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              28524 (14863)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              16027 (8917)
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              strong missense or worse + strong missense or worse
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              17591 (1669)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              17603 (1673)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              40907 (19183)
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              moderate missense or worse + moderate missense or worse
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              42889 (18949)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              42901 (18953)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              42749 (13007)
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              weak missense or worse + weak missense or worse
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              34432 (13475)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              34444 (13479)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              21947 (7533)
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              missense or worse + missense or worse
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              18922 (3251)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              18934 (3255)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              42238 (20765)
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              synonymous or worse + synonymous or worse
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              47943 (18569)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              47955 (18573)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              47803 (12627)
+            </span>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <button
+      class="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 VariantCooccurrenceCountsTable__ModeToggle-sc-64zbq9-1 gdedLW"
+      type="button"
+    >
+      expand
+    </button>
+    <table
+      class="Table__BaseTable-sc-7fgtt2-0 VariantCooccurrenceCountsTable__Table-sc-64zbq9-0 bqCaTV"
+    >
+      <colgroup>
+        <col
+          style="width: 45%;"
+        />
+        <col
+          style="width: 15%;"
+        />
+        <col
+          style="width: 15%;"
+        />
+        <col
+          style="width: 15%;"
+        />
+      </colgroup>
+      <thead>
+        <tr>
+          <th
+            colspan="4"
+          >
+            Individuals with 
+            <strong>
+              homozygous
+            </strong>
+             rare variants
+          </th>
+        </tr>
+        <tr>
+          <th>
+            Consequence
+          </th>
+          <th
+            colspan="3"
+          >
+            Allele frequency
+          </th>
+        </tr>
+        <tr>
+          <th />
+          <th>
+            ≤ 5%
+          </th>
+          <th>
+            ≤ 1%
+          </th>
+          <th>
+            ≤ 0.5%
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              pLoF
+            </span>
+          </td>
+          <td>
+            20287
+          </td>
+          <td>
+            20291
+          </td>
+          <td>
+            23379
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              strong missense or worse
+            </span>
+          </td>
+          <td>
+            44405
+          </td>
+          <td>
+            44409
+          </td>
+          <td>
+            1819
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              moderate missense or worse
+            </span>
+          </td>
+          <td>
+            13167
+          </td>
+          <td>
+            13171
+          </td>
+          <td>
+            16259
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              weak missense or worse
+            </span>
+          </td>
+          <td>
+            13501
+          </td>
+          <td>
+            13505
+          </td>
+          <td>
+            16593
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              missense or worse
+            </span>
+          </td>
+          <td>
+            14048
+          </td>
+          <td>
+            14052
+          </td>
+          <td>
+            17140
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              synonymous or worse
+            </span>
+          </td>
+          <td>
+            4233
+          </td>
+          <td>
+            4237
+          </td>
+          <td>
+            7325
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`VariantCoocurrenceCountsTable with v2 dataset "gnomad_r2_1_non_topmed" has no unexpected changes and renders as a table 1`] = `
+<DocumentFragment>
+  <div>
+    <table
+      class="Table__BaseTable-sc-7fgtt2-0 VariantCooccurrenceCountsTable__Table-sc-64zbq9-0 bqCaTV"
+    >
+      <colgroup>
+        <col
+          style="width: 45%;"
+        />
+        <col
+          style="width: 15%;"
+        />
+        <col
+          style="width: 15%;"
+        />
+        <col
+          style="width: 15%;"
+        />
+      </colgroup>
+      <thead>
+        <tr>
+          <th
+            colspan="4"
+          >
+            Individuals with 
+            <strong>
+              two heterozygous
+            </strong>
+             rare variants 
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              (number predicted in 
+              <i>
+                trans
+              </i>
+              )
+            </span>
+          </th>
+        </tr>
+        <tr>
+          <th>
+            Consequence
+          </th>
+          <th
+            colspan="3"
+          >
+            Allele frequency
+          </th>
+        </tr>
+        <tr>
+          <th />
+          <th>
+            ≤ 5%
+          </th>
+          <th>
+            ≤ 1%
+          </th>
+          <th>
+            ≤ 0.5%
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              pLoF + pLoF
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              28512 (14859)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              28524 (14863)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              16027 (8917)
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              strong missense or worse + strong missense or worse
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              17591 (1669)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              17603 (1673)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              40907 (19183)
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              moderate missense or worse + moderate missense or worse
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              42889 (18949)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              42901 (18953)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              42749 (13007)
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              weak missense or worse + weak missense or worse
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              34432 (13475)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              34444 (13479)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              21947 (7533)
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              missense or worse + missense or worse
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              18922 (3251)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              18934 (3255)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              42238 (20765)
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              synonymous or worse + synonymous or worse
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              47943 (18569)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              47955 (18573)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              47803 (12627)
+            </span>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <button
+      class="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 VariantCooccurrenceCountsTable__ModeToggle-sc-64zbq9-1 gdedLW"
+      type="button"
+    >
+      expand
+    </button>
+    <table
+      class="Table__BaseTable-sc-7fgtt2-0 VariantCooccurrenceCountsTable__Table-sc-64zbq9-0 bqCaTV"
+    >
+      <colgroup>
+        <col
+          style="width: 45%;"
+        />
+        <col
+          style="width: 15%;"
+        />
+        <col
+          style="width: 15%;"
+        />
+        <col
+          style="width: 15%;"
+        />
+      </colgroup>
+      <thead>
+        <tr>
+          <th
+            colspan="4"
+          >
+            Individuals with 
+            <strong>
+              homozygous
+            </strong>
+             rare variants
+          </th>
+        </tr>
+        <tr>
+          <th>
+            Consequence
+          </th>
+          <th
+            colspan="3"
+          >
+            Allele frequency
+          </th>
+        </tr>
+        <tr>
+          <th />
+          <th>
+            ≤ 5%
+          </th>
+          <th>
+            ≤ 1%
+          </th>
+          <th>
+            ≤ 0.5%
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              pLoF
+            </span>
+          </td>
+          <td>
+            20287
+          </td>
+          <td>
+            20291
+          </td>
+          <td>
+            23379
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              strong missense or worse
+            </span>
+          </td>
+          <td>
+            44405
+          </td>
+          <td>
+            44409
+          </td>
+          <td>
+            1819
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              moderate missense or worse
+            </span>
+          </td>
+          <td>
+            13167
+          </td>
+          <td>
+            13171
+          </td>
+          <td>
+            16259
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              weak missense or worse
+            </span>
+          </td>
+          <td>
+            13501
+          </td>
+          <td>
+            13505
+          </td>
+          <td>
+            16593
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              missense or worse
+            </span>
+          </td>
+          <td>
+            14048
+          </td>
+          <td>
+            14052
+          </td>
+          <td>
+            17140
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              synonymous or worse
+            </span>
+          </td>
+          <td>
+            4233
+          </td>
+          <td>
+            4237
+          </td>
+          <td>
+            7325
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`VariantCoocurrenceCountsTable with v2 dataset "gnomad_sv_r2_1" has no unexpected changes and renders as a table 1`] = `
+<DocumentFragment>
+  <div>
+    <table
+      class="Table__BaseTable-sc-7fgtt2-0 VariantCooccurrenceCountsTable__Table-sc-64zbq9-0 bqCaTV"
+    >
+      <colgroup>
+        <col
+          style="width: 45%;"
+        />
+        <col
+          style="width: 15%;"
+        />
+        <col
+          style="width: 15%;"
+        />
+        <col
+          style="width: 15%;"
+        />
+      </colgroup>
+      <thead>
+        <tr>
+          <th
+            colspan="4"
+          >
+            Individuals with 
+            <strong>
+              two heterozygous
+            </strong>
+             rare variants 
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              (number predicted in 
+              <i>
+                trans
+              </i>
+              )
+            </span>
+          </th>
+        </tr>
+        <tr>
+          <th>
+            Consequence
+          </th>
+          <th
+            colspan="3"
+          >
+            Allele frequency
+          </th>
+        </tr>
+        <tr>
+          <th />
+          <th>
+            ≤ 5%
+          </th>
+          <th>
+            ≤ 1%
+          </th>
+          <th>
+            ≤ 0.5%
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              pLoF + pLoF
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              28512 (14859)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              28524 (14863)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              16027 (8917)
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              strong missense or worse + strong missense or worse
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              17591 (1669)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              17603 (1673)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              40907 (19183)
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              moderate missense or worse + moderate missense or worse
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              42889 (18949)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              42901 (18953)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              42749 (13007)
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              weak missense or worse + weak missense or worse
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              34432 (13475)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              34444 (13479)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              21947 (7533)
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              missense or worse + missense or worse
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              18922 (3251)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              18934 (3255)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              42238 (20765)
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              synonymous or worse + synonymous or worse
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              47943 (18569)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              47955 (18573)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              47803 (12627)
+            </span>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <button
+      class="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 VariantCooccurrenceCountsTable__ModeToggle-sc-64zbq9-1 gdedLW"
+      type="button"
+    >
+      expand
+    </button>
+    <table
+      class="Table__BaseTable-sc-7fgtt2-0 VariantCooccurrenceCountsTable__Table-sc-64zbq9-0 bqCaTV"
+    >
+      <colgroup>
+        <col
+          style="width: 45%;"
+        />
+        <col
+          style="width: 15%;"
+        />
+        <col
+          style="width: 15%;"
+        />
+        <col
+          style="width: 15%;"
+        />
+      </colgroup>
+      <thead>
+        <tr>
+          <th
+            colspan="4"
+          >
+            Individuals with 
+            <strong>
+              homozygous
+            </strong>
+             rare variants
+          </th>
+        </tr>
+        <tr>
+          <th>
+            Consequence
+          </th>
+          <th
+            colspan="3"
+          >
+            Allele frequency
+          </th>
+        </tr>
+        <tr>
+          <th />
+          <th>
+            ≤ 5%
+          </th>
+          <th>
+            ≤ 1%
+          </th>
+          <th>
+            ≤ 0.5%
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              pLoF
+            </span>
+          </td>
+          <td>
+            20287
+          </td>
+          <td>
+            20291
+          </td>
+          <td>
+            23379
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              strong missense or worse
+            </span>
+          </td>
+          <td>
+            44405
+          </td>
+          <td>
+            44409
+          </td>
+          <td>
+            1819
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              moderate missense or worse
+            </span>
+          </td>
+          <td>
+            13167
+          </td>
+          <td>
+            13171
+          </td>
+          <td>
+            16259
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              weak missense or worse
+            </span>
+          </td>
+          <td>
+            13501
+          </td>
+          <td>
+            13505
+          </td>
+          <td>
+            16593
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              missense or worse
+            </span>
+          </td>
+          <td>
+            14048
+          </td>
+          <td>
+            14052
+          </td>
+          <td>
+            17140
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              synonymous or worse
+            </span>
+          </td>
+          <td>
+            4233
+          </td>
+          <td>
+            4237
+          </td>
+          <td>
+            7325
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`VariantCoocurrenceCountsTable with v2 dataset "gnomad_sv_r2_1_controls" has no unexpected changes and renders as a table 1`] = `
+<DocumentFragment>
+  <div>
+    <table
+      class="Table__BaseTable-sc-7fgtt2-0 VariantCooccurrenceCountsTable__Table-sc-64zbq9-0 bqCaTV"
+    >
+      <colgroup>
+        <col
+          style="width: 45%;"
+        />
+        <col
+          style="width: 15%;"
+        />
+        <col
+          style="width: 15%;"
+        />
+        <col
+          style="width: 15%;"
+        />
+      </colgroup>
+      <thead>
+        <tr>
+          <th
+            colspan="4"
+          >
+            Individuals with 
+            <strong>
+              two heterozygous
+            </strong>
+             rare variants 
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              (number predicted in 
+              <i>
+                trans
+              </i>
+              )
+            </span>
+          </th>
+        </tr>
+        <tr>
+          <th>
+            Consequence
+          </th>
+          <th
+            colspan="3"
+          >
+            Allele frequency
+          </th>
+        </tr>
+        <tr>
+          <th />
+          <th>
+            ≤ 5%
+          </th>
+          <th>
+            ≤ 1%
+          </th>
+          <th>
+            ≤ 0.5%
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              pLoF + pLoF
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              28512 (14859)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              28524 (14863)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              16027 (8917)
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              strong missense or worse + strong missense or worse
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              17591 (1669)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              17603 (1673)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              40907 (19183)
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              moderate missense or worse + moderate missense or worse
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              42889 (18949)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              42901 (18953)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              42749 (13007)
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              weak missense or worse + weak missense or worse
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              34432 (13475)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              34444 (13479)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              21947 (7533)
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              missense or worse + missense or worse
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              18922 (3251)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              18934 (3255)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              42238 (20765)
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              synonymous or worse + synonymous or worse
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              47943 (18569)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              47955 (18573)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              47803 (12627)
+            </span>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <button
+      class="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 VariantCooccurrenceCountsTable__ModeToggle-sc-64zbq9-1 gdedLW"
+      type="button"
+    >
+      expand
+    </button>
+    <table
+      class="Table__BaseTable-sc-7fgtt2-0 VariantCooccurrenceCountsTable__Table-sc-64zbq9-0 bqCaTV"
+    >
+      <colgroup>
+        <col
+          style="width: 45%;"
+        />
+        <col
+          style="width: 15%;"
+        />
+        <col
+          style="width: 15%;"
+        />
+        <col
+          style="width: 15%;"
+        />
+      </colgroup>
+      <thead>
+        <tr>
+          <th
+            colspan="4"
+          >
+            Individuals with 
+            <strong>
+              homozygous
+            </strong>
+             rare variants
+          </th>
+        </tr>
+        <tr>
+          <th>
+            Consequence
+          </th>
+          <th
+            colspan="3"
+          >
+            Allele frequency
+          </th>
+        </tr>
+        <tr>
+          <th />
+          <th>
+            ≤ 5%
+          </th>
+          <th>
+            ≤ 1%
+          </th>
+          <th>
+            ≤ 0.5%
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              pLoF
+            </span>
+          </td>
+          <td>
+            20287
+          </td>
+          <td>
+            20291
+          </td>
+          <td>
+            23379
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              strong missense or worse
+            </span>
+          </td>
+          <td>
+            44405
+          </td>
+          <td>
+            44409
+          </td>
+          <td>
+            1819
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              moderate missense or worse
+            </span>
+          </td>
+          <td>
+            13167
+          </td>
+          <td>
+            13171
+          </td>
+          <td>
+            16259
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              weak missense or worse
+            </span>
+          </td>
+          <td>
+            13501
+          </td>
+          <td>
+            13505
+          </td>
+          <td>
+            16593
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              missense or worse
+            </span>
+          </td>
+          <td>
+            14048
+          </td>
+          <td>
+            14052
+          </td>
+          <td>
+            17140
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              synonymous or worse
+            </span>
+          </td>
+          <td>
+            4233
+          </td>
+          <td>
+            4237
+          </td>
+          <td>
+            7325
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`VariantCoocurrenceCountsTable with v2 dataset "gnomad_sv_r2_1_non_neuro" has no unexpected changes and renders as a table 1`] = `
+<DocumentFragment>
+  <div>
+    <table
+      class="Table__BaseTable-sc-7fgtt2-0 VariantCooccurrenceCountsTable__Table-sc-64zbq9-0 bqCaTV"
+    >
+      <colgroup>
+        <col
+          style="width: 45%;"
+        />
+        <col
+          style="width: 15%;"
+        />
+        <col
+          style="width: 15%;"
+        />
+        <col
+          style="width: 15%;"
+        />
+      </colgroup>
+      <thead>
+        <tr>
+          <th
+            colspan="4"
+          >
+            Individuals with 
+            <strong>
+              two heterozygous
+            </strong>
+             rare variants 
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              (number predicted in 
+              <i>
+                trans
+              </i>
+              )
+            </span>
+          </th>
+        </tr>
+        <tr>
+          <th>
+            Consequence
+          </th>
+          <th
+            colspan="3"
+          >
+            Allele frequency
+          </th>
+        </tr>
+        <tr>
+          <th />
+          <th>
+            ≤ 5%
+          </th>
+          <th>
+            ≤ 1%
+          </th>
+          <th>
+            ≤ 0.5%
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              pLoF + pLoF
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              28512 (14859)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              28524 (14863)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              16027 (8917)
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              strong missense or worse + strong missense or worse
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              17591 (1669)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              17603 (1673)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              40907 (19183)
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              moderate missense or worse + moderate missense or worse
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              42889 (18949)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              42901 (18953)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              42749 (13007)
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              weak missense or worse + weak missense or worse
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              34432 (13475)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              34444 (13479)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              21947 (7533)
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              missense or worse + missense or worse
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              18922 (3251)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              18934 (3255)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              42238 (20765)
+            </span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              synonymous or worse + synonymous or worse
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              47943 (18569)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              47955 (18573)
+            </span>
+          </td>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              47803 (12627)
+            </span>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <button
+      class="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 VariantCooccurrenceCountsTable__ModeToggle-sc-64zbq9-1 gdedLW"
+      type="button"
+    >
+      expand
+    </button>
+    <table
+      class="Table__BaseTable-sc-7fgtt2-0 VariantCooccurrenceCountsTable__Table-sc-64zbq9-0 bqCaTV"
+    >
+      <colgroup>
+        <col
+          style="width: 45%;"
+        />
+        <col
+          style="width: 15%;"
+        />
+        <col
+          style="width: 15%;"
+        />
+        <col
+          style="width: 15%;"
+        />
+      </colgroup>
+      <thead>
+        <tr>
+          <th
+            colspan="4"
+          >
+            Individuals with 
+            <strong>
+              homozygous
+            </strong>
+             rare variants
+          </th>
+        </tr>
+        <tr>
+          <th>
+            Consequence
+          </th>
+          <th
+            colspan="3"
+          >
+            Allele frequency
+          </th>
+        </tr>
+        <tr>
+          <th />
+          <th>
+            ≤ 5%
+          </th>
+          <th>
+            ≤ 1%
+          </th>
+          <th>
+            ≤ 0.5%
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              pLoF
+            </span>
+          </td>
+          <td>
+            20287
+          </td>
+          <td>
+            20291
+          </td>
+          <td>
+            23379
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              strong missense or worse
+            </span>
+          </td>
+          <td>
+            44405
+          </td>
+          <td>
+            44409
+          </td>
+          <td>
+            1819
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              moderate missense or worse
+            </span>
+          </td>
+          <td>
+            13167
+          </td>
+          <td>
+            13171
+          </td>
+          <td>
+            16259
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              weak missense or worse
+            </span>
+          </td>
+          <td>
+            13501
+          </td>
+          <td>
+            13505
+          </td>
+          <td>
+            16593
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              missense or worse
+            </span>
+          </td>
+          <td>
+            14048
+          </td>
+          <td>
+            14052
+          </td>
+          <td>
+            17140
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span
+              class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+            >
+              synonymous or worse
+            </span>
+          </td>
+          <td>
+            4233
+          </td>
+          <td>
+            4237
+          </td>
+          <td>
+            7325
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</DocumentFragment>
+`;

--- a/dataset-metadata/metadata.ts
+++ b/dataset-metadata/metadata.ts
@@ -75,6 +75,7 @@ type DatasetMetadata = {
   hasShortVariants: boolean
   hasStructuralVariants: boolean
   hasConstraints: boolean
+  hasVariantCoocurrence: boolean
   hasNonCodingConstraints: boolean
   hasExome: boolean
   genesHaveExomeCoverage: boolean
@@ -118,6 +119,7 @@ const metadataForDataset = (datasetId: DatasetId): DatasetMetadata => ({
   hasShortVariants: !structuralVariantDatasetIds.includes(datasetId),
   hasStructuralVariants: structuralVariantDatasetIds.includes(datasetId),
   hasConstraints: !datasetId.startsWith('gnomad_r3'),
+  hasVariantCoocurrence: datasetId.startsWith('gnomad') && datasetId.includes('r2'),
   hasNonCodingConstraints: datasetId.startsWith('gnomad_r3'),
   referenceGenome: datasetId.startsWith('gnomad_r3') ? 'GRCh38' : 'GRCh37',
   hasExome: !datasetId.startsWith('gnomad_r3'),
@@ -170,6 +172,9 @@ export const isSubset = (datasetId: DatasetId) => getMetadata(datasetId, 'isSubs
 export const labelForDataset = (datasetId: DatasetId) => getMetadata(datasetId, 'label')
 
 export const hasConstraints = (datsetId: DatasetId) => getMetadata(datsetId, 'hasConstraints')
+
+export const hasVariantCoocurrence = (datasetId: DatasetId) =>
+  getMetadata(datasetId, 'hasVariantCoocurrence')
 
 export const hasNonCodingConstraints = (datasetId: DatasetId) =>
   getMetadata(datasetId, 'hasNonCodingConstraints')


### PR DESCRIPTION
Resolves #1140 

Adds a metadata predicate to only render the variant co-ocurrence table on v2 datasets.