### PR TITLE
Update download links for ancestry random forest models

### DIFF
--- a/browser/src/DownloadsPage/GnomadV2Downloads.tsx
+++ b/browser/src/DownloadsPage/GnomadV2Downloads.tsx
@@ -390,7 +390,7 @@ const GnomadV2Downloads = () => {
           <ListItem>
             <GenericDownloadLinks
               label="Random forest (RF) model"
-              path="/release/2.1/pca/gnomad.r2.1.RF_fit.pkl"
+              path="/release/2.1/pca/gnomad.r2.1.RF_fit.onnx"
             />
           </ListItem>
         </FileList>

--- a/browser/src/DownloadsPage/GnomadV3Downloads.tsx
+++ b/browser/src/DownloadsPage/GnomadV3Downloads.tsx
@@ -282,7 +282,7 @@ const GnomadV3Downloads = () => (
         <ListItem>
           <GenericDownloadLinks
             label="Random forest (RF) model"
-            path="/release/3.1/pca/gnomad.v3.1.RF_fit.pkl"
+            path="/release/3.1/pca/gnomad.v3.1.RF_fit.onnx"
           />
         </ListItem>
       </FileList>

--- a/browser/src/DownloadsPage/__snapshots__/DownloadsPage.spec.tsx.snap
+++ b/browser/src/DownloadsPage/__snapshots__/DownloadsPage.spec.tsx.snap
@@ -5981,7 +5981,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             <a
               aria-label="Download Random forest (RF) model from Google"
               className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1/pca/gnomad.r2.1.RF_fit.pkl"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1/pca/gnomad.r2.1.RF_fit.onnx"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -5991,7 +5991,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             <a
               aria-label="Download Random forest (RF) model from Amazon"
               className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1/pca/gnomad.r2.1.RF_fit.pkl"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1/pca/gnomad.r2.1.RF_fit.onnx"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -6001,7 +6001,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             <a
               aria-label="Download Random forest (RF) model from Microsoft"
               className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1/pca/gnomad.r2.1.RF_fit.pkl"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1/pca/gnomad.r2.1.RF_fit.onnx"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -17102,7 +17102,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             <a
               aria-label="Download Random forest (RF) model from Google"
               className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/pca/gnomad.v3.1.RF_fit.pkl"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/pca/gnomad.v3.1.RF_fit.onnx"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -17112,7 +17112,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             <a
               aria-label="Download Random forest (RF) model from Amazon"
               className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/pca/gnomad.v3.1.RF_fit.pkl"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/pca/gnomad.v3.1.RF_fit.onnx"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -17122,7 +17122,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             <a
               aria-label="Download Random forest (RF) model from Microsoft"
               className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/pca/gnomad.v3.1.RF_fit.pkl"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/pca/gnomad.v3.1.RF_fit.onnx"
               rel="noopener noreferrer"
               target="_blank"
             >


### PR DESCRIPTION
Resolves #1141 

To be merged and deployed after https://github.com/broadinstitute/gnomad-blog/pull/119 is merged and deployed

Updates the download links on the gnomAD browser to point to the newer ONNX formatted random forest models.