### PR TITLE
Update home page variant interpretation paper link

### DIFF
--- a/browser/src/HomePage.tsx
+++ b/browser/src/HomePage.tsx
@@ -200,9 +200,12 @@ export default () => (
       {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
       <ListItem>
         {/* @ts-expect-error TS(2769) FIXME: No overload matches this call. */}
-        <ExternalLink href="https://arxiv.org/abs/2107.11458">
-          <em>Variant interpretation using population databases: lessons from gnomAD.</em> arXiv{' '}
-          2107.11458 [q-bio.GN] (2021).
+        <ExternalLink href="https://onlinelibrary.wiley.com/doi/10.1002/humu.24309">
+          <em>
+            Gudmundsson et al. Variant interpretation using population databases: Lessons from
+            gnomAD.
+          </em>{' '}
+          Hum Mutat. 2022 Aug;43(8):1012-1030.
         </ExternalLink>
       </ListItem>
       {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}

--- a/browser/src/__snapshots__/HomePage.spec.tsx.snap
+++ b/browser/src/__snapshots__/HomePage.spec.tsx.snap
@@ -469,16 +469,15 @@ exports[`Home Page has no unexpected changes 1`] = `
     >
       <a
         className="c9"
-        href="https://arxiv.org/abs/2107.11458"
+        href="https://onlinelibrary.wiley.com/doi/10.1002/humu.24309"
         rel="noopener noreferrer"
         target="_blank"
       >
         <em>
-          Variant interpretation using population databases: lessons from gnomAD.
+          Gudmundsson et al. Variant interpretation using population databases: Lessons from gnomAD.
         </em>
-         arXiv
          
-        2107.11458 [q-bio.GN] (2021).
+        Hum Mutat. 2022 Aug;43(8):1012-1030.
       </a>
     </li>
     <li


### PR DESCRIPTION
Updates the link on the home page to the more recent "Variant interpretation using population databases" paper, per [this Slack request](https://the-tgg.slack.com/archives/CNLMF0JLV/p1690808412873569).

Screenshot:
![Screenshot 2023-07-31 at 16 45 14](https://github.com/broadinstitute/gnomad-browser/assets/59549713/a4cac9c3-7687-4156-a4ec-8b270c75046d)

