### PR TITLE
Update bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_Report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.md
@@ -15,21 +15,24 @@ about: Report a bug or unexpected behavior
 -->
 
 ### What you did:
+
 <!-- What you were doing. Include a link to the page you were viewing. -->
 
 ### What you expected to see after you did that:
+
 <!-- What would have been on the screen after your interaction, if everything had gone according to your expectations. -->
 
 ### What you actually saw after you did that:
+
 <!-- What was actually on the screen after your interaction, focusing on the difference between that and the expected state above. -->
 
 Any of the following information will be helpful:
 
-* Screenshots
-   How to take a screenshot on macOS: https://support.apple.com/en-us/HT201361
-   How to attach an image to an issue: https://help.github.com/articles/file-attachments-on-issues-and-pull-requests/
+- Screenshots
+  How to take a screenshot on macOS: https://support.apple.com/en-us/HT201361
+  How to attach an image to an issue: https://help.github.com/articles/file-attachments-on-issues-and-pull-requests/
 
-* Error messages that appear on the page or in the browser console
-   How to open the console on Chrome: https://developers.google.com/web/tools/chrome-devtools/console/#opening_the_console
+- Error messages that appear on the page or in the browser console
+  How to open the console on Chrome: https://developers.google.com/web/tools/chrome-devtools/console/#opening_the_console
 
 -->

--- a/.github/ISSUE_TEMPLATE/Bug_Report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.md
@@ -26,6 +26,8 @@ about: Report a bug or unexpected behavior
 
 <!-- What was actually on the screen after your interaction, focusing on the difference between that and the expected state above. -->
 
+<!--
+
 Any of the following information will be helpful:
 
 - Screenshots


### PR DESCRIPTION
Adds an open comment (`<!--`) to the bug template to match the close comment at the end of the file. This prevents the comment text from erroneously being present in user submitted bug reports.