### PR TITLE
Add correct link for DECIPHER

### DIFF
--- a/browser/src/GenePage/GeneReferences.tsx
+++ b/browser/src/GenePage/GeneReferences.tsx
@@ -92,7 +92,7 @@ const GeneReferences = ({ gene }: Props) => {
             <ListItem>
               {/* @ts-expect-error TS(2786) FIXME: 'ExternalLink' cannot be used as a JSX component. */}
               <ExternalLink
-                href={`https://decipher.sanger.ac.uk/gene/${geneId}/overview/protein-genomic-info`}
+                href={`https://deciphergenomics.org/gene/${geneId}/overview/protein-genomic-info`}
               >
                 DECIPHER
               </ExternalLink>


### PR DESCRIPTION
Currently, the DECIPHER link on each gene page is redirecting to the DECIPHER home page (https://www.deciphergenomics.org/) instead of redirecting to the correct DECIPHER gene page. 

This pull request updates the current link to use https://deciphergenomics.org/ instead of the previous http://decipher.sanger.ac.uk/ web address to correctly redirect the user to the corresponding gene page.

fixes #1144 