### PR TITLE
Add correct link for gcp and aws

### DIFF
--- a/browser/src/DownloadsPage/GnomadV3Downloads.tsx
+++ b/browser/src/DownloadsPage/GnomadV3Downloads.tsx
@@ -552,7 +552,7 @@ const GnomadV3Downloads = () => (
         <ListItem>
           <GetUrlButtons
             label="Phased haplotypes of HGDP+1KG dataset GCS Bucket"
-            path="/resources/hgdp_1kg/phased_haplotypes"
+            path="/resources/hgdp_1kg/phased_haplotypes_v2"
           />
         </ListItem>
 


### PR DESCRIPTION
For the phased HGDP+1kGP haplotypes the current download link paths aren't the correct ones anymore. This pull request updates them to the new GCP and AWS paths below.

`gs://gcp-public-data--gnomad/resources/hgdp_1kg/phased_haplotypes_v2
s3://gnomad-public-us-east-1/resources/hgdp_1kg/phased_haplotypes_v2`

Fixes #1151