### PR TITLE
Viewing context when searching variant table

### DIFF
--- a/browser/src/VariantList/VariantFilterControls.tsx
+++ b/browser/src/VariantList/VariantFilterControls.tsx
@@ -70,6 +70,7 @@ type Props = {
     includeFilteredVariants: boolean
     includeSNVs: boolean
     includeIndels: boolean
+    includeContext: boolean
     searchText: string
   }
 }
@@ -159,7 +160,7 @@ const VariantFilterControls = ({ onChange, value }: Props) => {
           <span>
             <Checkbox
               checked={value.includeFilteredVariants}
-              id="qc-variant-fil;ter"
+              id="qc-variant-filter"
               label="Filtered variants"
               onChange={(includeFilteredVariants) => {
                 onChange({ ...value, includeFilteredVariants })
@@ -167,6 +168,14 @@ const VariantFilterControls = ({ onChange, value }: Props) => {
             />
             <InfoButton topic="include-filtered-variants" />
           </span>
+          <Checkbox
+              checked={value.includeContext}
+              id="context-variant-filter"
+              label="Context"
+              onChange={(includeContext) => {
+                onChange({ ...value, includeContext })
+              }}
+            />
         </CheckboxSection>
       </CheckboxFiltersWrapper>
 

--- a/browser/src/VariantList/VariantFilterControls.tsx
+++ b/browser/src/VariantList/VariantFilterControls.tsx
@@ -174,7 +174,7 @@ const VariantFilterControls = ({ onChange, value, jumpToRow, position }: Props) 
           <Checkbox
             checked={value.includeContext}
             id="context-variant-filter"
-            label="Preserve search context"
+            label="Display neighboring variants"
             onChange={(includeContext) => {
               onChange({ ...value, includeContext })
             }}

--- a/browser/src/VariantList/VariantFilterControls.tsx
+++ b/browser/src/VariantList/VariantFilterControls.tsx
@@ -73,9 +73,11 @@ type Props = {
     includeContext: boolean
     searchText: string
   }
+  jumpToRow: (...args: any[]) => any
+  position: number
 }
 
-const VariantFilterControls = ({ onChange, value }: Props) => {
+const VariantFilterControls = ({ onChange, value, jumpToRow, position }: Props) => {
   const searchInput = useRef(null)
 
   return (
@@ -169,13 +171,13 @@ const VariantFilterControls = ({ onChange, value }: Props) => {
             <InfoButton topic="include-filtered-variants" />
           </span>
           <Checkbox
-              checked={value.includeContext}
-              id="context-variant-filter"
-              label="Context"
-              onChange={(includeContext) => {
-                onChange({ ...value, includeContext })
-              }}
-            />
+            checked={value.includeContext}
+            id="context-variant-filter"
+            label="Preserve context"
+            onChange={(includeContext) => {
+              onChange({ ...value, includeContext })
+            }}
+          />
         </CheckboxSection>
       </CheckboxFiltersWrapper>
 
@@ -187,6 +189,7 @@ const VariantFilterControls = ({ onChange, value }: Props) => {
           style={{ marginBottom: '1em', width: '210px' }}
           value={value.searchText}
           onChange={(searchText) => {
+            jumpToRow(position)
             onChange({ ...value, searchText })
           }}
         />
@@ -198,7 +201,7 @@ const VariantFilterControls = ({ onChange, value }: Props) => {
             // preventDefault to avoid typing a "/" in the search input
             e.preventDefault()
             if (searchInput.current) {
-              ;(searchInput.current as any).focus()
+              ; (searchInput.current as any).focus()
             }
           }}
         />

--- a/browser/src/VariantList/VariantFilterControls.tsx
+++ b/browser/src/VariantList/VariantFilterControls.tsx
@@ -170,14 +170,16 @@ const VariantFilterControls = ({ onChange, value, jumpToRow, position }: Props) 
             />
             <InfoButton topic="include-filtered-variants" />
           </span>
+          <span>
           <Checkbox
             checked={value.includeContext}
             id="context-variant-filter"
-            label="Preserve context"
+            label="Preserve search context"
             onChange={(includeContext) => {
               onChange({ ...value, includeContext })
             }}
           />
+          </span>
         </CheckboxSection>
       </CheckboxFiltersWrapper>
 

--- a/browser/src/VariantList/Variants.spec.tsx
+++ b/browser/src/VariantList/Variants.spec.tsx
@@ -7,8 +7,8 @@ import { describe, it, expect } from '@jest/globals'
 describe('getFirstIndexFromSearchText', () => {
     const mockVariantsSearched: Variant[] = []
 
-    for (let i = 0; i < 50; i++) {
-        mockVariantsSearched[i] = v2VariantFactory.build({variant_id: "example" + i, pos: i})
+    for (let i = 0; i < 50; i += 1) {
+        mockVariantsSearched[i] = v2VariantFactory.build({variant_id: `example${i}`, pos: i})
     }
   
     const mockVariantsTableColumns = [  {
@@ -20,7 +20,7 @@ describe('getFirstIndexFromSearchText', () => {
         grow: 1,
         compareFunction: () => (1),
         getSearchTerms: (variant: any) => [variant.variant_id].concat(variant.rsids || []),
-        render: (row: any, key: any, { highlightWords }: any) => (1),
+        render: () => (1),
       }]
   
     it('returns expected index when searchedVariants has length > 0 and firstIndex > visibleVariantWindow[0]', () => {

--- a/browser/src/VariantList/Variants.spec.tsx
+++ b/browser/src/VariantList/Variants.spec.tsx
@@ -1,0 +1,113 @@
+import { Variant } from '../VariantPage/VariantPage';
+import { v2VariantFactory } from '../__factories__/Variant';
+import { getFirstIndexFromSearchText } from './Variants'
+import { describe, it, expect } from '@jest/globals'
+
+
+describe('getFirstIndexFromSearchText', () => {
+    const mockVariantsSearched: Variant[] = []
+
+    for (let i = 0; i < 50; i++) {
+        mockVariantsSearched[i] = v2VariantFactory.build({variant_id: "example" + i, pos: i})
+    }
+  
+    const mockVariantsTableColumns = [  {
+        key: 'variant_id',
+        heading: 'Variant ID',
+        description: 'Chromosome-position-reference-alternate',
+        isRowHeader: true,
+        minWidth: 150,
+        grow: 1,
+        compareFunction: () => (1),
+        getSearchTerms: (variant: any) => [variant.variant_id].concat(variant.rsids || []),
+        render: (row: any, key: any, { highlightWords }: any) => (1),
+      }]
+  
+    it('returns expected index when searchedVariants has length > 0 and firstIndex > visibleVariantWindow[0]', () => {
+        const mockSearchFilter = {
+            includeCategories: {
+              lof: true,
+              missense: true,
+              synonymous: true,
+              other: true,
+            },
+            includeFilteredVariants: false,
+            includeSNVs: true,
+            includeIndels: true,
+            includeExomes: true,
+            includeGenomes: true,
+            includeContext: true,
+            searchText: 'example35', 
+          };
+        
+        const mockVisibleVariantWindow = [0,19]
+
+   
+      expect(getFirstIndexFromSearchText(
+        mockSearchFilter,
+        mockVariantsSearched, 
+        mockVariantsTableColumns,
+        mockVisibleVariantWindow
+      )).toBe(45);
+
+    });
+
+    it('returns expected index when searchedVariants has length > 0 and firstIndex < visibleVariantWindow[0]', () => {
+        const mockSearchFilter = {
+            includeCategories: {
+              lof: true,
+              missense: true,
+              synonymous: true,
+              other: true,
+            },
+            includeFilteredVariants: false,
+            includeSNVs: true,
+            includeIndels: true,
+            includeExomes: true,
+            includeGenomes: true,
+            includeContext: true,
+            searchText: 'example16', 
+          };
+        
+        const mockVisibleVariantWindow = [20,39]
+
+   
+      expect(getFirstIndexFromSearchText(
+        mockSearchFilter,
+        mockVariantsSearched, 
+        mockVariantsTableColumns,
+        mockVisibleVariantWindow
+      )).toBe(6);
+
+    });
+
+    it('returns expected index when searchedVariants has length of 0, no results found', () => {
+        const mockSearchFilter = {
+            includeCategories: {
+              lof: true,
+              missense: true,
+              synonymous: true,
+              other: true,
+            },
+            includeFilteredVariants: false,
+            includeSNVs: true,
+            includeIndels: true,
+            includeExomes: true,
+            includeGenomes: true,
+            includeContext: true,
+            searchText: '1234', 
+          };
+        
+        const mockVisibleVariantWindow = [0,19]
+
+   
+      expect(getFirstIndexFromSearchText(
+        mockSearchFilter,
+        mockVariantsSearched, 
+        mockVariantsTableColumns,
+        mockVisibleVariantWindow
+      )).toBe(0);
+
+    });
+  
+  });

--- a/browser/src/VariantList/Variants.tsx
+++ b/browser/src/VariantList/Variants.tsx
@@ -60,6 +60,31 @@ const variantsDefaultProps = {
 
 type VariantsProps = OwnVariantsProps & typeof variantsDefaultProps
 
+export function getFirstIndexFromSearchText(
+  searchFilter: VariantFilterState,
+  variantSearched: Variant[],
+  variantsTableColumns: any,
+  variantWindow: number[],
+) {
+  const searchedVariants = getFilteredVariants(
+    searchFilter,
+    variantSearched,
+    variantsTableColumns
+  )
+
+  if (searchedVariants.length > 0) {
+    const firstVariant = searchedVariants[0]
+    const firstIndex = variantSearched.findIndex(
+      (variant: Variant) => variant.pos === firstVariant.pos
+    )
+    if (variantWindow[0] !== null && firstIndex < variantWindow[0]) {
+      return firstIndex - 10
+    }
+    return firstIndex + 10
+  }
+  return 0 
+}
+
 const Variants = ({
   children,
   clinvarReleaseDate,
@@ -211,41 +236,16 @@ const Variants = ({
     table.current.scrollToDataRow(index)
   }, [positionLastClicked]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  function getFirstIndexFromSearchText(
-    searchFilter: VariantFilterState,
-    variantSearched: Variant[],
-    variantsTableColumns: any
-  ) {
-    const searchedVariants = getFilteredVariants(
-      searchFilter,
-      variantSearched,
-      variantsTableColumns
-    )
-
-    if (searchedVariants.length > 0) {
-      const firstVariant = searchedVariants[0]
-      const firstIndex = renderedVariants.findIndex(
-        (variant: Variant) => variant.pos === firstVariant.pos
-      )
-      if (visibleVariantWindow[0] !== null && firstIndex < visibleVariantWindow[0]) {
-        return firstIndex - 10
-      }
-
-      return firstIndex + 10
-    }
-    return 0
-  }
 
   useEffect(() => {
-    const searchIndex = getFirstIndexFromSearchText(filter, renderedVariants, renderedTableColumns)
+    const searchIndex = getFirstIndexFromSearchText(filter, renderedVariants, renderedTableColumns, visibleVariantWindow)
     setCurrentSearchIndex(searchIndex)
-    
+
     if (termLastSearched === null) {
       return
     }
     // @ts-expect-error TS(2531) FIXME: Object is possibly 'null'.
     table.current.scrollToDataRow(searchIndex)
-
   }, [termLastSearched]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const datasetLabel = labelForDataset(datasetId)

--- a/browser/src/VariantList/Variants.tsx
+++ b/browser/src/VariantList/Variants.tsx
@@ -108,7 +108,9 @@ const Variants = ({
     includeIndels: true,
     includeExomes: true,
     includeGenomes: true,
+    includeContext: true,
     searchText: '',
+    
   })
 
   const [sortState, setSortState] = useState({
@@ -164,6 +166,8 @@ const Variants = ({
   )
 
   const [positionLastClicked, setPositionLastClicked] = useState(null)
+  const [termLastSearched, setTermLastSearched] = useState(null)
+
   // @ts-expect-error TS(7006) FIXME: Parameter 'position' implicitly has an 'any' type.
   const onNavigatorClick = useCallback((position) => {
     setSortState({
@@ -172,6 +176,18 @@ const Variants = ({
     })
     setPositionLastClicked(position)
   }, [])
+  
+    // @ts-expect-error TS(7006) FIXME: Parameter 'position' implicitly has an 'any' type.
+  const onSearchResult = useCallback((position) => {
+    console.log("Searched row:", position);
+  
+    setSortState({
+      sortKey: 'variant_id',
+      sortOrder: 'ascending',
+    });
+    setTermLastSearched(position);
+  }, []);
+
 
   useEffect(() => {
     if (positionLastClicked === null) {

--- a/browser/src/VariantList/Variants.tsx
+++ b/browser/src/VariantList/Variants.tsx
@@ -232,20 +232,27 @@ const Variants = ({
     if (index === -1) {
       index = renderedVariants.length - 1
     }
+
     // @ts-expect-error TS(2531) FIXME: Object is possibly 'null'.
     table.current.scrollToDataRow(index)
   }, [positionLastClicked]) // eslint-disable-line react-hooks/exhaustive-deps
 
 
   useEffect(() => {
-    const searchIndex = getFirstIndexFromSearchText(filter, renderedVariants, renderedTableColumns, visibleVariantWindow)
-    setCurrentSearchIndex(searchIndex)
-
     if (termLastSearched === null) {
+      setCurrentSearchIndex(-1)
       return
     }
+
+    const searchIndex = getFirstIndexFromSearchText(filter, renderedVariants, renderedTableColumns, visibleVariantWindow)
+
+    if (searchIndex !== -1) {
+      setCurrentSearchIndex(searchIndex)
+    }
+    
     // @ts-expect-error TS(2531) FIXME: Object is possibly 'null'.
-    table.current.scrollToDataRow(searchIndex)
+    table.current.scrollToDataRow(searchIndex);
+
   }, [termLastSearched]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const datasetLabel = labelForDataset(datasetId)

--- a/browser/src/VariantList/Variants.tsx
+++ b/browser/src/VariantList/Variants.tsx
@@ -45,7 +45,7 @@ const sortVariants = (variants: any, { sortKey, sortOrder }: any) => {
 }
 
 type OwnVariantsProps = {
-  children?: React.ReactNode
+  children?: any
   clinvarReleaseDate: string
   context: Gene
   datasetId: DatasetId
@@ -223,25 +223,27 @@ const Variants = ({
 
     if (searchedVariants.length > 0) {
       const firstVariant = searchedVariants[0]
-      const firstIndex = renderedVariants.findIndex((variant: Variant) => variant.pos === firstVariant.pos)
-      if (positionLastClicked !== null && firstVariant.pos < positionLastClicked) {
+      const firstIndex = renderedVariants.findIndex(
+        (variant: Variant) => variant.pos === firstVariant.pos
+      )
+      if (visibleVariantWindow[0] !== null && firstIndex < visibleVariantWindow[0]) {
         return firstIndex - 10
       }
+
       return firstIndex + 10
     }
     return 0
   }
 
-  const searchIndex = getFirstIndexFromSearchText(filter, renderedVariants, renderedTableColumns)
-
   useEffect(() => {
+    const searchIndex = getFirstIndexFromSearchText(filter, renderedVariants, renderedTableColumns)
+
     if (termLastSearched === null) {
       return
     }
-      // @ts-expect-error TS(2531) FIXME: Object is possibly 'null'.
-      table.current.scrollToDataRow(searchIndex)
-    
-  }, [termLastSearched, searchIndex]) // eslint-disable-line react-hooks/exhaustive-deps
+    // @ts-expect-error TS(2531) FIXME: Object is possibly 'null'.
+    table.current.scrollToDataRow(searchIndex)
+  }, [termLastSearched]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const datasetLabel = labelForDataset(datasetId)
 
@@ -286,7 +288,7 @@ const Variants = ({
           onChange={setFilter}
           value={filter}
           jumpToRow={onSearchResult}
-          position={searchIndex}
+          position={getFirstIndexFromSearchText(filter, renderedVariants, renderedTableColumns)}
         />
         <div>
           <ExportVariantsButton

--- a/browser/src/VariantList/Variants.tsx
+++ b/browser/src/VariantList/Variants.tsx
@@ -46,17 +46,15 @@ const sortVariants = (variants: any, { sortKey, sortOrder }: any) => {
 function getFirstIndexFromSearchText(
   filter: VariantFilterState,
   variants: Variant[],
-  variantTableColumns: any
+  variantsTableColumns: any
 ) {
-  const searchedVariants = getFilteredVariants(filter, variants, variantTableColumns)
+  const searchedVariants = getFilteredVariants(filter, variants, variantsTableColumns)
 
   if (searchedVariants.length > 0) {
     const firstVariant = searchedVariants[0]
     return variants.findIndex((variant: Variant) => variant.pos === firstVariant.pos)
-  } else {
-    return 0
   }
-
+  return 0
 }
 
 type OwnVariantsProps = {
@@ -186,16 +184,16 @@ const Variants = ({
   const [positionLastClicked, setPositionLastClicked] = useState(null)
   const [termLastSearched, setTermLastSearched] = useState(null)
 
-  const createCallback = (sortKey: string, stateSetter: any) => (position: number) => {
+  const createCallback = useCallback((sortByKey: string, stateSetter: any) => (position: number) => {
     setSortState({
-      sortKey,
+      sortKey: sortByKey,
       sortOrder: 'ascending',
-    })
-    stateSetter(position)
-  }
+    });
+    stateSetter(position);
+  }, [])
 
-  const onNavigatorClick = useCallback(createCallback('variant_id', setPositionLastClicked), [])
-  const onSearchResult = useCallback(createCallback('variant_id', setTermLastSearched), [])
+  const onNavigatorClick = createCallback('variant_id', setPositionLastClicked)
+  const onSearchResult = createCallback('variant_id', setTermLastSearched)
 
   useEffect(() => {
     if (positionLastClicked === null) {

--- a/browser/src/VariantList/Variants.tsx
+++ b/browser/src/VariantList/Variants.tsx
@@ -196,8 +196,6 @@ const Variants = ({
   )
 
   const [positionLastClicked, setPositionLastClicked] = useState(null)
-  const [termLastSearched, setTermLastSearched] = useState(null)
-
   const createCallback = useCallback(
     (sortByKey: string, stateSetter: any) => (position: number) => {
       setSortState({
@@ -210,7 +208,7 @@ const Variants = ({
   )
 
   const onNavigatorClick = createCallback('variant_id', setPositionLastClicked)
-  const onSearchResult = createCallback('variant_id', setTermLastSearched)
+  const onSearchResult = createCallback('variant_id', setFilter)
 
   useEffect(() => {
     if (positionLastClicked === null) {
@@ -239,7 +237,7 @@ const Variants = ({
 
 
   useEffect(() => {
-    if (termLastSearched === null) {
+    if (filter.searchText === '') {
       setCurrentSearchIndex(-1)
       return
     }
@@ -253,7 +251,7 @@ const Variants = ({
     // @ts-expect-error TS(2531) FIXME: Object is possibly 'null'.
     table.current.scrollToDataRow(searchIndex);
 
-  }, [termLastSearched]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [filter.searchText]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const datasetLabel = labelForDataset(datasetId)
 

--- a/browser/src/VariantList/Variants.tsx
+++ b/browser/src/VariantList/Variants.tsx
@@ -204,15 +204,14 @@ const Variants = ({
 
     // @ts-expect-error TS(2531) FIXME: Object is possibly 'null'.
     table.current.scrollToDataRow(index)
-    console.log("pos last clicked", positionLastClicked);
   }, [positionLastClicked]) // eslint-disable-line react-hooks/exhaustive-deps
 
   function getFirstIndexFromSearchText(
-    filter: VariantFilterState,
-    variants: Variant[],
+    searchFilter: VariantFilterState,
+    variantSearched: Variant[],
     variantsTableColumns: any
   ) {
-    const searchedVariants = getFilteredVariants(filter, variants, variantsTableColumns)
+    const searchedVariants = getFilteredVariants(searchFilter, variantSearched, variantsTableColumns)
   
     if (searchedVariants.length > 0) {
       const firstVariant = searchedVariants[0]
@@ -234,10 +233,8 @@ const Variants = ({
     
 
     if (searchIndex > 10) {
-      console.log(searchIndex);
       // @ts-expect-error TS(2531) FIXME: Object is possibly 'null'.
       table.current.scrollToDataRow(searchIndex + 10)
-      console.log(searchIndex + 10);
     }
   }, [termLastSearched, searchIndex]) // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/browser/src/VariantList/Variants.tsx
+++ b/browser/src/VariantList/Variants.tsx
@@ -82,7 +82,7 @@ export function getFirstIndexFromSearchText(
     }
     return firstIndex + 10
   }
-  return 0 
+  return variantWindow[0]
 }
 
 const Variants = ({

--- a/browser/src/VariantList/Variants.tsx
+++ b/browser/src/VariantList/Variants.tsx
@@ -43,19 +43,6 @@ const sortVariants = (variants: any, { sortKey, sortOrder }: any) => {
   return [...variants].sort((v1, v2) => sortColumn.compareFunction(v1, v2, sortOrder))
 }
 
-function getFirstIndexFromSearchText(
-  filter: VariantFilterState,
-  variants: Variant[],
-  variantsTableColumns: any
-) {
-  const searchedVariants = getFilteredVariants(filter, variants, variantsTableColumns)
-
-  if (searchedVariants.length > 0) {
-    const firstVariant = searchedVariants[0]
-    return variants.findIndex((variant: Variant) => variant.pos === firstVariant.pos)
-  }
-  return 0
-}
 
 type OwnVariantsProps = {
   children?: React.ReactNode
@@ -158,7 +145,6 @@ const Variants = ({
     return sortVariants(filteredVariants, sortState)
   }, [filteredVariants, sortState])
 
-  const searchIndex = getFirstIndexFromSearchText(filter, renderedVariants, renderedTableColumns)
 
   const [showTableConfigurationModal, setShowTableConfigurationModal] = useState(false)
   const [variantHoveredInTable, setVariantHoveredInTable] = useState(null)
@@ -218,16 +204,40 @@ const Variants = ({
 
     // @ts-expect-error TS(2531) FIXME: Object is possibly 'null'.
     table.current.scrollToDataRow(index)
+    console.log("pos last clicked", positionLastClicked);
   }, [positionLastClicked]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  function getFirstIndexFromSearchText(
+    filter: VariantFilterState,
+    variants: Variant[],
+    variantsTableColumns: any
+  ) {
+    const searchedVariants = getFilteredVariants(filter, variants, variantsTableColumns)
+  
+    if (searchedVariants.length > 0) {
+      const firstVariant = searchedVariants[0]
+      const firstIndex = variants.findIndex((variant: Variant) => variant.pos === firstVariant.pos)
+      if (positionLastClicked !== null && firstVariant.pos < positionLastClicked) {
+        return firstIndex - 20
+      }
+      return firstIndex
+    }
+    return 0
+  }
+
+  const searchIndex = getFirstIndexFromSearchText(filter, renderedVariants, renderedTableColumns)
 
   useEffect(() => {
     if (termLastSearched === null) {
       return
     }
+    
 
     if (searchIndex > 10) {
+      console.log(searchIndex);
       // @ts-expect-error TS(2531) FIXME: Object is possibly 'null'.
       table.current.scrollToDataRow(searchIndex + 10)
+      console.log(searchIndex + 10);
     }
   }, [termLastSearched, searchIndex]) // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/browser/src/VariantList/Variants.tsx
+++ b/browser/src/VariantList/Variants.tsx
@@ -152,6 +152,7 @@ const Variants = ({
   const [variantHoveredInTable, setVariantHoveredInTable] = useState(null)
   const [variantHoveredInTrack, setVariantHoveredInTrack] = useState(null)
   const [visibleVariantWindow, setVisibleVariantWindow] = useState([0, 19])
+  const [currentSearchIndex, setCurrentSearchIndex] = useState(0)
 
   const onHoverVariantsInTrack = useMemo(
     () =>
@@ -237,12 +238,14 @@ const Variants = ({
 
   useEffect(() => {
     const searchIndex = getFirstIndexFromSearchText(filter, renderedVariants, renderedTableColumns)
-
+    setCurrentSearchIndex(searchIndex)
+    
     if (termLastSearched === null) {
       return
     }
     // @ts-expect-error TS(2531) FIXME: Object is possibly 'null'.
     table.current.scrollToDataRow(searchIndex)
+
   }, [termLastSearched]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const datasetLabel = labelForDataset(datasetId)
@@ -288,7 +291,7 @@ const Variants = ({
           onChange={setFilter}
           value={filter}
           jumpToRow={onSearchResult}
-          position={getFirstIndexFromSearchText(filter, renderedVariants, renderedTableColumns)}
+          position={currentSearchIndex}
         />
         <div>
           <ExportVariantsButton

--- a/browser/src/VariantList/filterVariants.ts
+++ b/browser/src/VariantList/filterVariants.ts
@@ -1,6 +1,24 @@
 import { getCategoryFromConsequence } from '../vepConsequences'
 
-const filterVariants = (variants: any, filter: any, selectedColumns: any) => {
+type Categories = {
+  lof: true,
+  missense: true,
+  synonymous: true,
+  other: true,
+}
+
+export type VariantFilterState = {
+includeCategories: Categories
+includeFilteredVariants: false,
+includeSNVs: true,
+includeIndels: true,
+includeExomes: true,
+includeGenomes: true,
+includeContext: true,
+searchText: '',
+}
+
+const filterVariants = (variants: any, filter: VariantFilterState, selectedColumns: any) => {
   let filteredVariants = variants
 
   const isEveryConsequenceCategorySelected =
@@ -40,7 +58,7 @@ const filterVariants = (variants: any, filter: any, selectedColumns: any) => {
 
   filteredVariants = filteredVariants.filter((v: any) => v.exome || v.genome)
 
-  if (filter.searchText) {
+  if (filter.searchText ) {
     const searchColumns = selectedColumns.filter((column: any) => !!column.getSearchTerms)
     const getVariantSearchTerms = (variant: any) =>
       searchColumns

--- a/browser/src/VariantList/filterVariants.ts
+++ b/browser/src/VariantList/filterVariants.ts
@@ -1,41 +1,47 @@
 import { Variant } from '../VariantPage/VariantPage'
 import { getCategoryFromConsequence } from '../vepConsequences'
+import { VariantTableColumn } from './variantTableColumns'
 
 type Categories = {
-  lof: boolean,
-  missense: boolean,
-  synonymous: boolean,
-  other: boolean,
+  lof: boolean
+  missense: boolean
+  synonymous: boolean
+  other: boolean
 }
 
 export type VariantFilterState = {
   includeCategories: Categories
-  includeFilteredVariants: boolean,
-  includeSNVs: boolean,
-  includeIndels: boolean,
-  includeExomes: boolean,
-  includeGenomes: boolean,
-  includeContext: boolean,
-  searchText: string,
+  includeFilteredVariants: boolean
+  includeSNVs: boolean
+  includeIndels: boolean
+  includeExomes: boolean
+  includeGenomes: boolean
+  includeContext: boolean
+  searchText: string
 }
 
 export function getFilteredVariants(
   filter: VariantFilterState,
   variants: Variant[],
-  variantTableColumns: any
-){
-  const searchColumns = variantTableColumns.filter((column: any) => !!column.getSearchTerms)
+  variantTableColumns: VariantTableColumn[]
+) {
+  const searchColumns = variantTableColumns.filter((column) => !!column.getSearchTerms)
   const getVariantSearchTerms = (variant: Variant) =>
     searchColumns
-      .flatMap((column: any) => column.getSearchTerms(variant))
+      .flatMap((column) => {
+        if (column.getSearchTerms) {
+          return column.getSearchTerms(variant)
+        }
+        return []
+      })
       .filter(Boolean)
       .map((s: any) => s.toLowerCase())
 
   const searchTerms = filter.searchText
     .toLowerCase()
     .split(',')
-    .map((s: any) => s.trim())
-    .filter((s: any) => s.length > 0)
+    .map((s: string) => s.trim())
+    .filter((s: string) => s.length > 0)
 
   return variants.filter((variant: Variant) =>
     getVariantSearchTerms(variant).some((variantTerm: string) =>
@@ -43,7 +49,6 @@ export function getFilteredVariants(
     )
   )
 }
-
 
 const filterVariants = (variants: Variant[], filter: VariantFilterState, selectedColumns: any) => {
   let filteredVariants = variants
@@ -86,7 +91,7 @@ const filterVariants = (variants: Variant[], filter: VariantFilterState, selecte
   filteredVariants = filteredVariants.filter((v: Variant) => v.exome || v.genome)
 
   if (filter.searchText && !filter.includeContext) {
-     filteredVariants = getFilteredVariants(filter, variants, selectedColumns)
+    filteredVariants = getFilteredVariants(filter, variants, selectedColumns)
   }
 
   // Indel and Snp filters.

--- a/browser/src/VariantList/filterVariants.ts
+++ b/browser/src/VariantList/filterVariants.ts
@@ -1,21 +1,21 @@
 import { getCategoryFromConsequence } from '../vepConsequences'
 
 type Categories = {
-  lof: true,
-  missense: true,
-  synonymous: true,
-  other: true,
+  lof: boolean,
+  missense: boolean,
+  synonymous: boolean,
+  other: boolean,
 }
 
 export type VariantFilterState = {
-includeCategories: Categories
-includeFilteredVariants: false,
-includeSNVs: true,
-includeIndels: true,
-includeExomes: true,
-includeGenomes: true,
-includeContext: true,
-searchText: '',
+  includeCategories: Categories
+  includeFilteredVariants: boolean,
+  includeSNVs: boolean,
+  includeIndels: boolean,
+  includeExomes: boolean,
+  includeGenomes: boolean,
+  includeContext: boolean,
+  searchText: string,
 }
 
 const filterVariants = (variants: any, filter: VariantFilterState, selectedColumns: any) => {
@@ -30,7 +30,7 @@ const filterVariants = (variants: any, filter: VariantFilterState, selectedColum
   if (!isEveryConsequenceCategorySelected) {
     filteredVariants = variants.filter((variant: any) => {
       const category = getCategoryFromConsequence(variant.consequence) || 'other'
-      return filter.includeCategories[category]
+      return (filter.includeCategories as any)[category] // TODO: fix this
     })
   }
 
@@ -58,7 +58,7 @@ const filterVariants = (variants: any, filter: VariantFilterState, selectedColum
 
   filteredVariants = filteredVariants.filter((v: any) => v.exome || v.genome)
 
-  if (filter.searchText ) {
+  if (filter.searchText && !filter.includeContext) {
     const searchColumns = selectedColumns.filter((column: any) => !!column.getSearchTerms)
     const getVariantSearchTerms = (variant: any) =>
       searchColumns

--- a/browser/src/VariantList/filterVariants.ts
+++ b/browser/src/VariantList/filterVariants.ts
@@ -59,12 +59,16 @@ const filterVariants = (variants: Variant[], filter: VariantFilterState, selecte
     filter.includeCategories.synonymous &&
     filter.includeCategories.other
 
+
   if (!isEveryConsequenceCategorySelected) {
     filteredVariants = variants.filter((variant: any) => {
-      const category = getCategoryFromConsequence(variant.consequence) || 'other'
-      return (filter.includeCategories as any)[category] // TODO: fix this
+      const category = getCategoryFromConsequence(variant.consequence) as keyof Categories || 'other'
+      return (filter.includeCategories)[category] 
+      
     })
   }
+  
+
 
   if (!filter.includeFilteredVariants) {
     filteredVariants = filteredVariants.map((v: Variant) => ({

--- a/browser/src/VariantList/variantTableColumns.tsx
+++ b/browser/src/VariantList/variantTableColumns.tsx
@@ -14,6 +14,7 @@ import {
 } from './sortUtilities'
 import VariantCategoryMarker from './VariantCategoryMarker'
 import VariantFlag from './VariantFlag'
+import { Variant } from '../VariantPage/VariantPage'
 
 const categoryColors = {
   lof: '#DD2C00',
@@ -45,8 +46,22 @@ const getConsequenceDescription = (contextType: any) => {
       return ' for consequence in this transcript'
   }
 }
+export type VariantTableColumn = {
+  key: string,
+  heading: string,
+  description?: string;
+  grow?: number,
+  minWidth?: number,
+  compareFunction?: (a: any, b: any) => number,
+  render: (variant: any, key: string, options: any) => JSX.Element | null,
+  shouldShowInContext?: (context: string, contextType: string) => boolean,
+  contextNotes?: string,
+  getSearchTerms?: (variant: Variant) => Variant[],
+  descriptionInContext?: (context: string, contextType: string) => string,
+  isRowHeader?: boolean
+};
 
-const variantTableColumns = [
+const variantTableColumns: VariantTableColumn[] = [
   {
     key: 'ac',
     heading: 'Allele Count',
@@ -93,7 +108,7 @@ const variantTableColumns = [
           })}
       </NumericCell>
     ),
-    shouldShowInContext: (context: any, contextType: any) => contextType === 'gene',
+    shouldShowInContext: (context: string, contextType: string) => contextType === 'gene',
   },
 
   {
@@ -124,7 +139,7 @@ const variantTableColumns = [
     key: 'consequence',
     heading: 'VEP Annotation',
     description: 'Variant Effect Predictor (VEP) annotation',
-    descriptionInContext: (context: any, contextType: any) =>
+    descriptionInContext: (context: string, contextType: string) =>
       `Variant Effect Predictor (VEP) annotation${getConsequenceDescription(contextType)}`,
     grow: 0,
     minWidth: 140,
@@ -177,7 +192,7 @@ const variantTableColumns = [
     grow: 0,
     minWidth: 100,
     compareFunction: makeNumericCompareFunction('ac_hemi'),
-    render: (variant: any) => renderAlleleCountCell(variant, 'ac_hemi'),
+    render: (variant: Variant) => renderAlleleCountCell(variant, 'ac_hemi'),
     shouldShowInContext: (context: any) => context.chrom === 'X' || context.chrom === 'Y',
   },
 


### PR DESCRIPTION
Currently, when a user searches in the Variant table all neighboring rows are removed from the view and only exact search matches are displayed. This removes the context of a variant's position in the table and the surrounding variants.

This pull request creates an option where the user can check off if they would like to preserve the context of the table while searching. When "Preserves context search" is checked off, as the user searches the table jumps to the first result (which is highlighted) of their matched search without removing the rows that aren't a search match. 
 
fixes #312