### PR TITLE
Update AF display when AN is 0

### DIFF
--- a/browser/src/VariantPage/PopulationsTable.tsx
+++ b/browser/src/VariantPage/PopulationsTable.tsx
@@ -40,6 +40,23 @@ const SEX_IDENTIFIERS = ['XX', 'XY']
 const isSexSpecificPopulation = (pop: any) =>
   SEX_IDENTIFIERS.includes(pop.id) || SEX_IDENTIFIERS.some((id) => pop.id.endsWith(`_${id}`))
 
+// if the allele number (denominator) is 0, return a non-number
+//   to signal to users that there is no information to be displayed about
+//   the frequency, rather than artificially calling it 0
+const calculatePopAF = (ac: number, an: number) => {
+  if (an === 0) {
+    return '-'
+  }
+  return ac / an
+}
+
+const renderPopAF = (af: number | string) => {
+  if (typeof af === 'number') {
+    return af.toPrecision(4)
+  }
+  return af
+}
+
 type OwnPopulationsTableProps = {
   columnLabels?: {
     ac?: string
@@ -162,13 +179,11 @@ export class PopulationsTable extends Component<PopulationsTableProps, Populatio
     const renderedPopulations = populations
       .map((pop) => ({
         ...pop,
-        // af: pop.an !== 0 ? pop.ac / pop.an : 0,
-        af: pop.an !== 0 ? pop.ac / pop.an : 0,
+        af: calculatePopAF(pop.ac, pop.an),
         subpopulations: (pop.subpopulations || [])
           .map((subPop) => ({
             ...subPop,
-            af: subPop.an !== 0 ? subPop.ac / subPop.an : 0,
-            // af: subPop.an !== 0 ? subPop.ac / subPop.an : 0,
+            af: calculatePopAF(subPop.ac, subPop.an),
           }))
           .sort((a, b) => {
             // Sort XX/XY subpopulations to bottom of list
@@ -297,7 +312,7 @@ export class PopulationsTable extends Component<PopulationsTableProps, Populatio
               <td className="right-align">{pop.an}</td>
               {showHomozygotes && <td className="right-align">{pop.ac_hom}</td>}
               {showHemizygotes && <td className="right-align">{pop.ac_hemi}</td>}
-              <td style={{ paddingLeft: '25px' }}>{pop.af.toPrecision(4)}</td>
+              <td style={{ paddingLeft: '25px' }}>{renderPopAF(pop.af)}</td>
             </tr>
             {pop.subpopulations &&
               expandedPopulations[pop.name] &&
@@ -321,7 +336,7 @@ export class PopulationsTable extends Component<PopulationsTableProps, Populatio
                       {subPop.ac_hemi !== null ? subPop.ac_hemi : '—'}
                     </td>
                   )}
-                  <td style={{ paddingLeft: '25px' }}>{subPop.af.toPrecision(4)}</td>
+                  <td style={{ paddingLeft: '25px' }}>{renderPopAF(subPop.af)}</td>
                 </tr>
               ))}
           </tbody>


### PR DESCRIPTION
Resolves #1161 
Relevant [Slack thread](https://atgu.slack.com/archives/CRA2TKTV0/p1692216171078009)

Currently, when the Allele Number (AN) and Allele Count (AC) for a variant are 0, the browser displays the Allele Frequency (AF) in the PopulationTable on the Variant Page, for a given population or subpopulation, as 0. This is misleading, as it implies confidence that there is no variant there, rather than signaling that there is no information on the variant for that population.

This PR updates the `PopulationsTable` component to display a '`-`', as suggested in the Slack thread.

Links for convenience: 
- [Prod link](https://gnomad.broadinstitute.org/variant/1-55505681-G-T) to a Variant with AC and AN of 0
- [Localhost link](http://localhost:8008/variant/1-55505681-G-T) to the same variant (to see the change)

---

![Screenshot 2023-08-17 at 16 34 09](https://github.com/broadinstitute/gnomad-browser/assets/59549713/a7db1911-7c74-44f9-8ce5-fc96ee4f483d)
