### PR TITLE
Update tooltip for "Excluded Allele Count"

### DIFF
--- a/browser/src/MitochondrialVariantPage/MitochondrialVariantAttributeList.tsx
+++ b/browser/src/MitochondrialVariantPage/MitochondrialVariantAttributeList.tsx
@@ -73,7 +73,7 @@ const MitochondrialVariantAttributeList = ({ variant }: Props) => (
     {/* @ts-expect-error TS(2604) FIXME: JSX element type 'AttributeList.Item' does not hav... Remove this comment to see the full error message */}
     <AttributeList.Item
       label="Excluded Allele Count"
-      tooltip="Number of individuals with a variant (heteroplasmy 0.10 - 1.00) filtered out due to likely sequencing error, potential NUMT misalignment, or potential sample contamination."
+      tooltip="Number of individuals with a variant filtered out due to failing one of the genotype-level filters (heteroplasmy below 10%, base quality, position, strand bias, weak evidence, and/or contamination)."
     >
       {variant.excluded_ac}
     </AttributeList.Item>


### PR DESCRIPTION
This PR updates the hover over text for "Excluded Allele Count" on the mitochondria variant page to the relevant variant filters used in the pipeline

<img width="884" alt="Screenshot 2023-08-25 at 3 56 01 PM" src="https://github.com/broadinstitute/gnomad-browser/assets/91026581/83169e02-8198-4a2f-892d-0c6a5bc7ed7f">

fixes #1156