### PR TITLE
Add filtering of ClinVar variants by number of stars

### DIFF
--- a/browser/src/ClinvarVariantsTrack/ClinvarVariantTrack.tsx
+++ b/browser/src/ClinvarVariantsTrack/ClinvarVariantTrack.tsx
@@ -4,7 +4,6 @@ import styled from 'styled-components'
 // @ts-expect-error TS(7016) FIXME: Could not find a declaration file for module '@gno... Remove this comment to see the full error message
 import { Track } from '@gnomad/region-viewer'
 import { Button, Checkbox, Modal } from '@gnomad/ui'
-
 import CategoryFilterControl from '../CategoryFilterControl'
 import InfoButton from '../help/InfoButton'
 import { TrackPageSection } from '../TrackPage'
@@ -87,6 +86,13 @@ const SelectCategoryButton = styled(Button)`
   line-height: 18px;
 `
 
+const FilterRow = styled.div`
+  padding-top: 5px;  
+  display: flex;
+  align-items: center; 
+  gap: 10px;
+`
+
 type Props = {
   referenceGenome: 'GRCh37' | 'GRCh38'
   transcripts: any[]
@@ -119,6 +125,7 @@ const ClinvarVariantTrack = ({ referenceGenome, transcripts, variants }: Props) 
 
   const [showOnlyGnomad, setShowOnlyGnomad] = useState(false)
   const [isExpanded, setIsExpanded] = useState(false)
+  const [starFilter, setStarFilter] = useState(0)
 
   const filteredVariants = variants.filter(
     (v) =>
@@ -126,7 +133,8 @@ const ClinvarVariantTrack = ({ referenceGenome, transcripts, variants }: Props) 
       includedClinicalSignificanceCategories[clinvarVariantClinicalSignificanceCategory(v)] &&
       // @ts-expect-error TS(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
       includedConsequenceCategories[getCategoryFromConsequence(v.major_consequence)] &&
-      (!showOnlyGnomad || v.in_gnomad)
+      (!showOnlyGnomad || v.in_gnomad) &&
+      (starFilter === 0 || v.gold_stars >= starFilter)
   )
 
   return (
@@ -211,14 +219,28 @@ const ClinvarVariantTrack = ({ referenceGenome, transcripts, variants }: Props) 
               {isExpanded ? 'Collapse to bins' : 'Expand to all variants'}
             </Button>
           </ControlRow>
-          <ControlRow>
+          <FilterRow>
             <Checkbox
               id="clinvar-track-in-gnomad"
               label="Only show ClinVar variants that are in gnomAD"
               checked={showOnlyGnomad}
               onChange={setShowOnlyGnomad}
             />
-          </ControlRow>
+            <label htmlFor="star-filtering">
+              Filter by Stars: &nbsp;
+              <select
+                id="clinvar-star-filter"
+                value={starFilter}
+                onChange={(e) => setStarFilter(Number(e.target.value))}
+              >
+                <option value={0}> All Stars </option>
+                <option value={1}> 1+ Stars </option>
+                <option value={2}> 2+ Stars </option>
+                <option value={3}> 3+ Stars </option>
+                <option value={4}> 4 Stars </option>
+              </select>
+            </label>
+          </FilterRow>
         </TopPanel>
       </TrackPageSection>
       <Track


### PR DESCRIPTION
Currently, there is no option to filter the Clinvar Variant Track on each Gene page by the number of Clinvar stars a variant has. 

This PR creates a dropdown to allow the user to filter variants by their Clinvar star value based on the number of stars. This filter is implemented as a "n+ stars" as mentioned in the original issue, "there is likely not a use case for a user wanting to filter to only 4 star variants and 1 star variants".

Any UI suggestions would be appreciated!
![ClinvarStarFilter1](https://github.com/broadinstitute/gnomad-browser/assets/91026581/cadfe068-b94f-419c-9412-1da6d0e7388a)
![ClinvarStarFilter2](https://github.com/broadinstitute/gnomad-browser/assets/91026581/86dd0cc4-6400-4cbb-afd3-39096c9fbbb6)


Fixes #734 