### PR TITLE
Update style changes for filtering by review status for ClinVar Variant Track

### DIFF
--- a/browser/src/ClinvarVariantsTrack/ClinvarVariantTrack.tsx
+++ b/browser/src/ClinvarVariantsTrack/ClinvarVariantTrack.tsx
@@ -238,10 +238,10 @@ const ClinvarVariantTrack = ({ referenceGenome, transcripts, variants }: Props) 
                 value={starFilter}
                 onChange={(e) => setStarFilter(Number(e.target.value))}
               >
-                <option value={0}> All Stars </option>
-                <option value={1}> 1+ Stars </option>
-                <option value={2}> 2+ Stars </option>
-                <option value={3}> 3+ Stars </option>
+                <option value={0}> 0-4 Stars </option>
+                <option value={1}> {'>'}=1 Stars </option>
+                <option value={2}> {'>'}=2 Stars </option>
+                <option value={3}> {'>'}=3 Stars </option>
                 <option value={4}> 4 Stars </option>
               </select>
             </label>

--- a/browser/src/ClinvarVariantsTrack/ClinvarVariantsTrack.spec.tsx
+++ b/browser/src/ClinvarVariantsTrack/ClinvarVariantsTrack.spec.tsx
@@ -66,10 +66,10 @@ describe('Clinvar Variants Track', () => {
     )
 
     const filterSelect = screen.getByRole('combobox')
-    const allStarOpt = screen.getByRole('option', { name: 'All Stars' }) as HTMLOptionElement
-    const OnePlusStarOpt = screen.getByRole('option', { name: '1+ Stars' }) as HTMLOptionElement
-    const TwoPlusStarOpt = screen.getByRole('option', { name: '2+ Stars' }) as HTMLOptionElement
-    const ThreePlusStarOpt = screen.getByRole('option', { name: '3+ Stars' }) as HTMLOptionElement
+    const allStarOpt = screen.getByRole('option', { name: '0-4 Stars' }) as HTMLOptionElement
+    const OnePlusStarOpt = screen.getByRole('option', { name: '>=1 Stars' }) as HTMLOptionElement
+    const TwoPlusStarOpt = screen.getByRole('option', { name: '>=2 Stars' }) as HTMLOptionElement
+    const ThreePlusStarOpt = screen.getByRole('option', { name: '>=3 Stars' }) as HTMLOptionElement
     const FourStarOpt = screen.getByRole('option', { name: '4 Stars' }) as HTMLOptionElement
 
     expect(allStarOpt.selected).toBe(true)
@@ -113,17 +113,17 @@ describe('Clinvar Variants Track', () => {
     expect(screen.getByText('ClinVar variants (5)')).not.toBeNull()
     await user.selectOptions(
       filterSelect,
-      screen.getByRole('option', { name: '1+ Stars' }) as HTMLOptionElement
+      screen.getByRole('option', { name: '>=1 Stars' }) as HTMLOptionElement
     )
     expect(screen.getByText('ClinVar variants (4)')).not.toBeNull()
     await user.selectOptions(
       filterSelect,
-      screen.getByRole('option', { name: '2+ Stars' }) as HTMLOptionElement
+      screen.getByRole('option', { name: '>=2 Stars' }) as HTMLOptionElement
     )
     expect(screen.getByText('ClinVar variants (3)')).not.toBeNull()
     await user.selectOptions(
       filterSelect,
-      screen.getByRole('option', { name: '3+ Stars' }) as HTMLOptionElement
+      screen.getByRole('option', { name: '>=3 Stars' }) as HTMLOptionElement
     )
     expect(screen.getByText('ClinVar variants (2)')).not.toBeNull()
     await user.selectOptions(

--- a/browser/src/ClinvarVariantsTrack/__snapshots__/ClinvarVariantsTrack.spec.tsx.snap
+++ b/browser/src/ClinvarVariantsTrack/__snapshots__/ClinvarVariantsTrack.spec.tsx.snap
@@ -962,22 +962,28 @@ exports[`Clinvar Variants Track renders correctly with default props 1`] = `
             <option
               value={0}
             >
-               All Stars 
+               0-4 Stars 
             </option>
             <option
               value={1}
             >
-               1+ Stars 
+               
+              &gt;
+              =1 Stars 
             </option>
             <option
               value={2}
             >
-               2+ Stars 
+               
+              &gt;
+              =2 Stars 
             </option>
             <option
               value={3}
             >
-               3+ Stars 
+               
+              &gt;
+              =3 Stars 
             </option>
             <option
               value={4}


### PR DESCRIPTION
In response to gnomAD project meeting, wording changes to the dropdown options have been suggested. Previously: "All Stars", "1+ Stars", "2+ Stars", "3+ Stars", and "4 Stars", this PR changes the options to: "0-4 Stars", ">=1 Stars", ">=2 Stars", ">=3 Stars", and "4 Stars".

Related to #1174 and #734  
![filter-by-review-status](https://github.com/broadinstitute/gnomad-browser/assets/91026581/4f712ca6-fbf0-4793-ade9-46f42bbde23d)
