### PR TITLE
Fix gene page crashes when filtering variants

### DIFF
--- a/browser/src/VariantList/Variants.tsx
+++ b/browser/src/VariantList/Variants.tsx
@@ -208,7 +208,7 @@ const Variants = ({
 
   // When a user clicks on the bubble track, update the position in the variant table
   useEffect(() => {
-    if (positionLastClicked === null) {
+    if (positionLastClicked === null || table.current === null) {
       return
     }
 
@@ -228,7 +228,7 @@ const Variants = ({
       index = renderedVariants.length - 1
     }
 
-    // @ts-expect-error TS(2531) FIXME: Object is possibly 'null'.
+    // @ts-expect-error TS(2339) FIXME: 'scrollToDataRow' does not exist on type 'never'.
     table.current.scrollToDataRow(index)
   }, [positionLastClicked]) // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/browser/src/VariantList/Variants.tsx
+++ b/browser/src/VariantList/Variants.tsx
@@ -64,13 +64,9 @@ export function getFirstIndexFromSearchText(
   searchFilter: VariantFilterState,
   variantSearched: Variant[],
   variantsTableColumns: any,
-  variantWindow: number[],
+  variantWindow: number[]
 ) {
-  const searchedVariants = getFilteredVariants(
-    searchFilter,
-    variantSearched,
-    variantsTableColumns
-  )
+  const searchedVariants = getFilteredVariants(searchFilter, variantSearched, variantsTableColumns)
 
   if (searchedVariants.length > 0) {
     const firstVariant = searchedVariants[0]
@@ -210,6 +206,7 @@ const Variants = ({
   const onNavigatorClick = createCallback('variant_id', setPositionLastClicked)
   const onSearchResult = createCallback('variant_id', setFilter)
 
+  // When a user clicks on the bubble track, update the position in the variant table
   useEffect(() => {
     if (positionLastClicked === null) {
       return
@@ -235,22 +232,31 @@ const Variants = ({
     table.current.scrollToDataRow(index)
   }, [positionLastClicked]) // eslint-disable-line react-hooks/exhaustive-deps
 
-
+  // When searching the table with context, scroll to the first hit whenever the
+  //   search text changes
   useEffect(() => {
+    if (!filter.includeContext) {
+      return
+    }
+
     if (filter.searchText === '') {
       setCurrentSearchIndex(-1)
       return
     }
 
-    const searchIndex = getFirstIndexFromSearchText(filter, renderedVariants, renderedTableColumns, visibleVariantWindow)
+    const searchIndex = getFirstIndexFromSearchText(
+      filter,
+      renderedVariants,
+      renderedTableColumns,
+      visibleVariantWindow
+    )
 
     if (searchIndex !== -1) {
       setCurrentSearchIndex(searchIndex)
     }
-    
-    // @ts-expect-error TS(2531) FIXME: Object is possibly 'null'.
-    table.current.scrollToDataRow(searchIndex);
 
+    // @ts-expect-error TS(2531) FIXME: Object is possibly 'null'.
+    table.current.scrollToDataRow(searchIndex)
   }, [filter.searchText]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const datasetLabel = labelForDataset(datasetId)


### PR DESCRIPTION
Resolves #1191 

Fixes two errors that cause crashes that are currently present in the Variant tracks.

1. #1191, when keep search context is toggled off, an unmatched search term no longer tries to scroll the table, which prevents the crash observed in the issue
2. When filtering the variants to only those that match the search term, if a user clicks on the bubble type track above when the table is filtered to no results, the page currently crashes as it tries to scroll the null table. A null check in this PR prevents that crash
