### PR TITLE
log the upstream cache status so we can track it

### DIFF
--- a/deploy/dockerfiles/browser/browser.nginx.conf
+++ b/deploy/dockerfiles/browser/browser.nginx.conf
@@ -11,7 +11,8 @@ log_format json_combined escape=json
 '"remoteIp":"$remote_addr",'
 '"referer":"$http_referer",'
 '"latency":"${request_time}s",'
-'"protocol":"$server_protocol"'
+'"protocol":"$server_protocol",'
+'"cache_status":"$upstream_cache_status"'
 '}'
 '}';
 


### PR DESCRIPTION
small addendum to the caching PR -- this drops the value that we return with the `X-Cached` header on the response, so that we can track cache hit/miss ratios on the /api requests.