### PR TITLE
allow for more cache keys

### DIFF
--- a/deploy/dockerfiles/browser/browser.nginx.conf
+++ b/deploy/dockerfiles/browser/browser.nginx.conf
@@ -16,7 +16,7 @@ log_format json_combined escape=json
 '}'
 '}';
 
-proxy_cache_path /var/cache/nginx keys_zone=gnomadCache:10m max_size=20g inactive=30d;
+proxy_cache_path /var/cache/nginx levels=1:2 keys_zone=gnomadCache:30m max_size=20g inactive=30d;
 
 server {
   listen 80 default_server;


### PR DESCRIPTION
On the prod deployment, we're already approaching the upper bound on what 10MBs of memory space can hold for cache keys (~80K). This change triples the memory zone size, which should fit fine within our browser pod's memory request/limit.

I've also added a levels parameter, which introduces a folder structure to the on-disk cache, which should help key fetching performance (really big directories take a long time to list, and this separates the cache keys into prefixed folders to reduce the number of files in any given place)