### PR TITLE
Update the term "Population" to "Genetic Ancestry Group", and "popmax" to "grpmax" on user facing portions of the browser

### DIFF
--- a/browser/src/CopyNumberVariantPage/CNVPopulationsTable.tsx
+++ b/browser/src/CopyNumberVariantPage/CNVPopulationsTable.tsx
@@ -180,7 +180,7 @@ export class CNVPopulationsTable extends Component<
       .map((pop) => {
         const transformedSubpopulations = (pop.subpopulations || [])
           .map((subPop) => ({
-            id: subPop.id, 
+            id: subPop.id,
             name: subPop.name,
             sc: subPop.sc,
             sn: subPop.sn,
@@ -246,7 +246,11 @@ export class CNVPopulationsTable extends Component<
       <Table>
         <thead>
           <tr>
-            {this.renderColumnHeader({ key: 'name', label: 'Population', props: { colSpan: 2 } })}
+            {this.renderColumnHeader({
+              key: 'name',
+              label: 'Genetic ancestry group',
+              props: { colSpan: 2 },
+            })}
             {this.renderColumnHeader({
               key: 'sc',
               label: columnLabels.sc || 'SC',

--- a/browser/src/CopyNumberVariantPage/CopyNumberVariantPage.tsx
+++ b/browser/src/CopyNumberVariantPage/CopyNumberVariantPage.tsx
@@ -84,7 +84,7 @@ const CopyNumberVariantPage = ({ datasetId, variant }: CopyNumberVariantPageProp
     </Wrapper>
 
     <section>
-      <h2>Population Frequencies</h2>
+      <h2>Genetic ancestry group Frequencies</h2>
       <CopyNumberVariantPopulationsTable variant={variant} />
     </section>
 

--- a/browser/src/CopyNumberVariantPage/CopyNumberVariantPage.tsx
+++ b/browser/src/CopyNumberVariantPage/CopyNumberVariantPage.tsx
@@ -84,7 +84,7 @@ const CopyNumberVariantPage = ({ datasetId, variant }: CopyNumberVariantPageProp
     </Wrapper>
 
     <section>
-      <h2>Genetic ancestry group Frequencies</h2>
+      <h2>Genetic Ancestry Group Frequencies</h2>
       <CopyNumberVariantPopulationsTable variant={variant} />
     </section>
 

--- a/browser/src/CopyNumberVariantPage/__snapshots__/CopyNumberVariantPage.spec.tsx.snap
+++ b/browser/src/CopyNumberVariantPage/__snapshots__/CopyNumberVariantPage.spec.tsx.snap
@@ -327,7 +327,7 @@ exports[`CopyNumberVariantPage with dataset gnomad_cnv_r4 with variant of type D
   </div>
   <section>
     <h2>
-      Genetic ancestry group Frequencies
+      Genetic Ancestry Group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 CNVPopulationsTable__Table-sc-1dnyyn-0 iypcwR"
@@ -779,7 +779,7 @@ exports[`CopyNumberVariantPage with dataset gnomad_cnv_r4 with variant of type D
   </div>
   <section>
     <h2>
-      Genetic ancestry group Frequencies
+      Genetic Ancestry Group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 CNVPopulationsTable__Table-sc-1dnyyn-0 iypcwR"

--- a/browser/src/CopyNumberVariantPage/__snapshots__/CopyNumberVariantPage.spec.tsx.snap
+++ b/browser/src/CopyNumberVariantPage/__snapshots__/CopyNumberVariantPage.spec.tsx.snap
@@ -327,7 +327,7 @@ exports[`CopyNumberVariantPage with dataset gnomad_cnv_r4 with variant of type D
   </div>
   <section>
     <h2>
-      Population Frequencies
+      Genetic ancestry group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 CNVPopulationsTable__Table-sc-1dnyyn-0 iypcwR"
@@ -343,7 +343,7 @@ exports[`CopyNumberVariantPage with dataset gnomad_cnv_r4 with variant of type D
               onClick={[Function]}
               type="button"
             >
-              Population
+              Genetic ancestry group
             </button>
           </th>
           <th
@@ -779,7 +779,7 @@ exports[`CopyNumberVariantPage with dataset gnomad_cnv_r4 with variant of type D
   </div>
   <section>
     <h2>
-      Population Frequencies
+      Genetic ancestry group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 CNVPopulationsTable__Table-sc-1dnyyn-0 iypcwR"
@@ -795,7 +795,7 @@ exports[`CopyNumberVariantPage with dataset gnomad_cnv_r4 with variant of type D
               onClick={[Function]}
               type="button"
             >
-              Population
+              Genetic ancestry group
             </button>
           </th>
           <th

--- a/browser/src/MitochondrialVariantPage/MitochondrialVariantPage.tsx
+++ b/browser/src/MitochondrialVariantPage/MitochondrialVariantPage.tsx
@@ -189,7 +189,7 @@ const MitochondrialVariantPage = ({ datasetId, variant }: MitochondrialVariantPa
       </ResponsiveSection>
     </Wrapper>
     <Section>
-      <h2>Population Frequencies</h2>
+      <h2>Genetic ancestry group Frequencies</h2>
       <MitochondrialVariantPopulationFrequenciesTable variant={variant} />
     </Section>
     <Section>

--- a/browser/src/MitochondrialVariantPage/MitochondrialVariantPage.tsx
+++ b/browser/src/MitochondrialVariantPage/MitochondrialVariantPage.tsx
@@ -189,7 +189,7 @@ const MitochondrialVariantPage = ({ datasetId, variant }: MitochondrialVariantPa
       </ResponsiveSection>
     </Wrapper>
     <Section>
-      <h2>Genetic ancestry group Frequencies</h2>
+      <h2>Genetic Ancestry Group Frequencies</h2>
       <MitochondrialVariantPopulationFrequenciesTable variant={variant} />
     </Section>
     <Section>

--- a/browser/src/MitochondrialVariantPage/MitochondrialVariantPopulationFrequenciesTable.tsx
+++ b/browser/src/MitochondrialVariantPage/MitochondrialVariantPopulationFrequenciesTable.tsx
@@ -118,7 +118,7 @@ const MitochondrialVariantPopulationFrequenciesTable = ({
     <Table>
       <thead>
         <tr>
-          {renderColumnHeader('id', 'Population', null)}
+          {renderColumnHeader('id', 'Genetic ancestry group', null)}
           {renderColumnHeader(
             'an',
             'Allele Number',

--- a/browser/src/MitochondrialVariantPage/MitochondrialVariantPopulationFrequenciesTable.tsx
+++ b/browser/src/MitochondrialVariantPage/MitochondrialVariantPopulationFrequenciesTable.tsx
@@ -118,7 +118,7 @@ const MitochondrialVariantPopulationFrequenciesTable = ({
     <Table>
       <thead>
         <tr>
-          {renderColumnHeader('id', 'Genetic ancestry group', null)}
+          {renderColumnHeader('id', 'Genetic Ancestry Group', null)}
           {renderColumnHeader(
             'an',
             'Allele Number',

--- a/browser/src/MitochondrialVariantPage/__snapshots__/MitochondrialVariantPage.spec.tsx.snap
+++ b/browser/src/MitochondrialVariantPage/__snapshots__/MitochondrialVariantPage.spec.tsx.snap
@@ -503,7 +503,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_cnv_r4 has no unexpected c
     className="MitochondrialVariantPage__Section-sc-1h2n2ff-1 hhYAuK"
   >
     <h2>
-      Genetic ancestry group Frequencies
+      Genetic Ancestry Group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 MitochondrialVariantPopulationFrequenciesTable__Table-sc-1esr108-1 ihCgBR"
@@ -518,7 +518,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_cnv_r4 has no unexpected c
               onClick={[Function]}
               type="button"
             >
-              Genetic ancestry group
+              Genetic Ancestry Group
             </button>
           </th>
           <th
@@ -8797,7 +8797,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3 has no unexpected chang
     className="MitochondrialVariantPage__Section-sc-1h2n2ff-1 hhYAuK"
   >
     <h2>
-      Genetic ancestry group Frequencies
+      Genetic Ancestry Group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 MitochondrialVariantPopulationFrequenciesTable__Table-sc-1esr108-1 ihCgBR"
@@ -8812,7 +8812,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3 has no unexpected chang
               onClick={[Function]}
               type="button"
             >
-              Genetic ancestry group
+              Genetic Ancestry Group
             </button>
           </th>
           <th
@@ -17001,7 +17001,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_controls_and_biobanks h
     className="MitochondrialVariantPage__Section-sc-1h2n2ff-1 hhYAuK"
   >
     <h2>
-      Genetic ancestry group Frequencies
+      Genetic Ancestry Group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 MitochondrialVariantPopulationFrequenciesTable__Table-sc-1esr108-1 ihCgBR"
@@ -17016,7 +17016,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_controls_and_biobanks h
               onClick={[Function]}
               type="button"
             >
-              Genetic ancestry group
+              Genetic Ancestry Group
             </button>
           </th>
           <th
@@ -25205,7 +25205,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_non_cancer has no unexp
     className="MitochondrialVariantPage__Section-sc-1h2n2ff-1 hhYAuK"
   >
     <h2>
-      Genetic ancestry group Frequencies
+      Genetic Ancestry Group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 MitochondrialVariantPopulationFrequenciesTable__Table-sc-1esr108-1 ihCgBR"
@@ -25220,7 +25220,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_non_cancer has no unexp
               onClick={[Function]}
               type="button"
             >
-              Genetic ancestry group
+              Genetic Ancestry Group
             </button>
           </th>
           <th
@@ -33409,7 +33409,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_non_neuro has no unexpe
     className="MitochondrialVariantPage__Section-sc-1h2n2ff-1 hhYAuK"
   >
     <h2>
-      Genetic ancestry group Frequencies
+      Genetic Ancestry Group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 MitochondrialVariantPopulationFrequenciesTable__Table-sc-1esr108-1 ihCgBR"
@@ -33424,7 +33424,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_non_neuro has no unexpe
               onClick={[Function]}
               type="button"
             >
-              Genetic ancestry group
+              Genetic Ancestry Group
             </button>
           </th>
           <th
@@ -41613,7 +41613,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_non_topmed has no unexp
     className="MitochondrialVariantPage__Section-sc-1h2n2ff-1 hhYAuK"
   >
     <h2>
-      Genetic ancestry group Frequencies
+      Genetic Ancestry Group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 MitochondrialVariantPopulationFrequenciesTable__Table-sc-1esr108-1 ihCgBR"
@@ -41628,7 +41628,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_non_topmed has no unexp
               onClick={[Function]}
               type="button"
             >
-              Genetic ancestry group
+              Genetic Ancestry Group
             </button>
           </th>
           <th
@@ -49817,7 +49817,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_non_v2 has no unexpecte
     className="MitochondrialVariantPage__Section-sc-1h2n2ff-1 hhYAuK"
   >
     <h2>
-      Genetic ancestry group Frequencies
+      Genetic Ancestry Group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 MitochondrialVariantPopulationFrequenciesTable__Table-sc-1esr108-1 ihCgBR"
@@ -49832,7 +49832,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_non_v2 has no unexpecte
               onClick={[Function]}
               type="button"
             >
-              Genetic ancestry group
+              Genetic Ancestry Group
             </button>
           </th>
           <th
@@ -58021,7 +58021,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_r4 has no unexpected chang
     className="MitochondrialVariantPage__Section-sc-1h2n2ff-1 hhYAuK"
   >
     <h2>
-      Genetic ancestry group Frequencies
+      Genetic Ancestry Group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 MitochondrialVariantPopulationFrequenciesTable__Table-sc-1esr108-1 ihCgBR"
@@ -58036,7 +58036,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_r4 has no unexpected chang
               onClick={[Function]}
               type="button"
             >
-              Genetic ancestry group
+              Genetic Ancestry Group
             </button>
           </th>
           <th
@@ -66225,7 +66225,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_sv_r2_1 has no unexpected 
     className="MitochondrialVariantPage__Section-sc-1h2n2ff-1 hhYAuK"
   >
     <h2>
-      Genetic ancestry group Frequencies
+      Genetic Ancestry Group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 MitochondrialVariantPopulationFrequenciesTable__Table-sc-1esr108-1 ihCgBR"
@@ -66240,7 +66240,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_sv_r2_1 has no unexpected 
               onClick={[Function]}
               type="button"
             >
-              Genetic ancestry group
+              Genetic Ancestry Group
             </button>
           </th>
           <th
@@ -74429,7 +74429,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_sv_r2_1_controls has no un
     className="MitochondrialVariantPage__Section-sc-1h2n2ff-1 hhYAuK"
   >
     <h2>
-      Genetic ancestry group Frequencies
+      Genetic Ancestry Group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 MitochondrialVariantPopulationFrequenciesTable__Table-sc-1esr108-1 ihCgBR"
@@ -74444,7 +74444,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_sv_r2_1_controls has no un
               onClick={[Function]}
               type="button"
             >
-              Genetic ancestry group
+              Genetic Ancestry Group
             </button>
           </th>
           <th
@@ -82633,7 +82633,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_sv_r2_1_non_neuro has no u
     className="MitochondrialVariantPage__Section-sc-1h2n2ff-1 hhYAuK"
   >
     <h2>
-      Genetic ancestry group Frequencies
+      Genetic Ancestry Group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 MitochondrialVariantPopulationFrequenciesTable__Table-sc-1esr108-1 ihCgBR"
@@ -82648,7 +82648,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_sv_r2_1_non_neuro has no u
               onClick={[Function]}
               type="button"
             >
-              Genetic ancestry group
+              Genetic Ancestry Group
             </button>
           </th>
           <th
@@ -90837,7 +90837,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_sv_r4 has no unexpected ch
     className="MitochondrialVariantPage__Section-sc-1h2n2ff-1 hhYAuK"
   >
     <h2>
-      Genetic ancestry group Frequencies
+      Genetic Ancestry Group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 MitochondrialVariantPopulationFrequenciesTable__Table-sc-1esr108-1 ihCgBR"
@@ -90852,7 +90852,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_sv_r4 has no unexpected ch
               onClick={[Function]}
               type="button"
             >
-              Genetic ancestry group
+              Genetic Ancestry Group
             </button>
           </th>
           <th

--- a/browser/src/MitochondrialVariantPage/__snapshots__/MitochondrialVariantPage.spec.tsx.snap
+++ b/browser/src/MitochondrialVariantPage/__snapshots__/MitochondrialVariantPage.spec.tsx.snap
@@ -503,7 +503,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_cnv_r4 has no unexpected c
     className="MitochondrialVariantPage__Section-sc-1h2n2ff-1 hhYAuK"
   >
     <h2>
-      Population Frequencies
+      Genetic ancestry group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 MitochondrialVariantPopulationFrequenciesTable__Table-sc-1esr108-1 ihCgBR"
@@ -518,7 +518,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_cnv_r4 has no unexpected c
               onClick={[Function]}
               type="button"
             >
-              Population
+              Genetic ancestry group
             </button>
           </th>
           <th
@@ -8797,7 +8797,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3 has no unexpected chang
     className="MitochondrialVariantPage__Section-sc-1h2n2ff-1 hhYAuK"
   >
     <h2>
-      Population Frequencies
+      Genetic ancestry group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 MitochondrialVariantPopulationFrequenciesTable__Table-sc-1esr108-1 ihCgBR"
@@ -8812,7 +8812,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3 has no unexpected chang
               onClick={[Function]}
               type="button"
             >
-              Population
+              Genetic ancestry group
             </button>
           </th>
           <th
@@ -17001,7 +17001,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_controls_and_biobanks h
     className="MitochondrialVariantPage__Section-sc-1h2n2ff-1 hhYAuK"
   >
     <h2>
-      Population Frequencies
+      Genetic ancestry group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 MitochondrialVariantPopulationFrequenciesTable__Table-sc-1esr108-1 ihCgBR"
@@ -17016,7 +17016,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_controls_and_biobanks h
               onClick={[Function]}
               type="button"
             >
-              Population
+              Genetic ancestry group
             </button>
           </th>
           <th
@@ -25205,7 +25205,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_non_cancer has no unexp
     className="MitochondrialVariantPage__Section-sc-1h2n2ff-1 hhYAuK"
   >
     <h2>
-      Population Frequencies
+      Genetic ancestry group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 MitochondrialVariantPopulationFrequenciesTable__Table-sc-1esr108-1 ihCgBR"
@@ -25220,7 +25220,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_non_cancer has no unexp
               onClick={[Function]}
               type="button"
             >
-              Population
+              Genetic ancestry group
             </button>
           </th>
           <th
@@ -33409,7 +33409,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_non_neuro has no unexpe
     className="MitochondrialVariantPage__Section-sc-1h2n2ff-1 hhYAuK"
   >
     <h2>
-      Population Frequencies
+      Genetic ancestry group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 MitochondrialVariantPopulationFrequenciesTable__Table-sc-1esr108-1 ihCgBR"
@@ -33424,7 +33424,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_non_neuro has no unexpe
               onClick={[Function]}
               type="button"
             >
-              Population
+              Genetic ancestry group
             </button>
           </th>
           <th
@@ -41613,7 +41613,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_non_topmed has no unexp
     className="MitochondrialVariantPage__Section-sc-1h2n2ff-1 hhYAuK"
   >
     <h2>
-      Population Frequencies
+      Genetic ancestry group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 MitochondrialVariantPopulationFrequenciesTable__Table-sc-1esr108-1 ihCgBR"
@@ -41628,7 +41628,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_non_topmed has no unexp
               onClick={[Function]}
               type="button"
             >
-              Population
+              Genetic ancestry group
             </button>
           </th>
           <th
@@ -49817,7 +49817,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_non_v2 has no unexpecte
     className="MitochondrialVariantPage__Section-sc-1h2n2ff-1 hhYAuK"
   >
     <h2>
-      Population Frequencies
+      Genetic ancestry group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 MitochondrialVariantPopulationFrequenciesTable__Table-sc-1esr108-1 ihCgBR"
@@ -49832,7 +49832,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_non_v2 has no unexpecte
               onClick={[Function]}
               type="button"
             >
-              Population
+              Genetic ancestry group
             </button>
           </th>
           <th
@@ -58021,7 +58021,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_r4 has no unexpected chang
     className="MitochondrialVariantPage__Section-sc-1h2n2ff-1 hhYAuK"
   >
     <h2>
-      Population Frequencies
+      Genetic ancestry group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 MitochondrialVariantPopulationFrequenciesTable__Table-sc-1esr108-1 ihCgBR"
@@ -58036,7 +58036,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_r4 has no unexpected chang
               onClick={[Function]}
               type="button"
             >
-              Population
+              Genetic ancestry group
             </button>
           </th>
           <th
@@ -66225,7 +66225,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_sv_r2_1 has no unexpected 
     className="MitochondrialVariantPage__Section-sc-1h2n2ff-1 hhYAuK"
   >
     <h2>
-      Population Frequencies
+      Genetic ancestry group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 MitochondrialVariantPopulationFrequenciesTable__Table-sc-1esr108-1 ihCgBR"
@@ -66240,7 +66240,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_sv_r2_1 has no unexpected 
               onClick={[Function]}
               type="button"
             >
-              Population
+              Genetic ancestry group
             </button>
           </th>
           <th
@@ -74429,7 +74429,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_sv_r2_1_controls has no un
     className="MitochondrialVariantPage__Section-sc-1h2n2ff-1 hhYAuK"
   >
     <h2>
-      Population Frequencies
+      Genetic ancestry group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 MitochondrialVariantPopulationFrequenciesTable__Table-sc-1esr108-1 ihCgBR"
@@ -74444,7 +74444,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_sv_r2_1_controls has no un
               onClick={[Function]}
               type="button"
             >
-              Population
+              Genetic ancestry group
             </button>
           </th>
           <th
@@ -82633,7 +82633,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_sv_r2_1_non_neuro has no u
     className="MitochondrialVariantPage__Section-sc-1h2n2ff-1 hhYAuK"
   >
     <h2>
-      Population Frequencies
+      Genetic ancestry group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 MitochondrialVariantPopulationFrequenciesTable__Table-sc-1esr108-1 ihCgBR"
@@ -82648,7 +82648,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_sv_r2_1_non_neuro has no u
               onClick={[Function]}
               type="button"
             >
-              Population
+              Genetic ancestry group
             </button>
           </th>
           <th
@@ -90837,7 +90837,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_sv_r4 has no unexpected ch
     className="MitochondrialVariantPage__Section-sc-1h2n2ff-1 hhYAuK"
   >
     <h2>
-      Population Frequencies
+      Genetic ancestry group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 MitochondrialVariantPopulationFrequenciesTable__Table-sc-1esr108-1 ihCgBR"
@@ -90852,7 +90852,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_sv_r4 has no unexpected ch
               onClick={[Function]}
               type="button"
             >
-              Population
+              Genetic ancestry group
             </button>
           </th>
           <th

--- a/browser/src/ShortTandemRepeatPage/ShortTandemRepeatPopulationOptions.tsx
+++ b/browser/src/ShortTandemRepeatPage/ShortTandemRepeatPopulationOptions.tsx
@@ -45,7 +45,8 @@ const ShortTandemRepeatPopulationOptions = ({
   return (
     <Wrapper>
       <label htmlFor={`short-tandem-repeat-${id}-population-options-population`}>
-        Population: {/* @ts-expect-error TS(2769) FIXME: No overload matches this call. */}
+        Genetic ancestry group:{' '}
+        {/* @ts-expect-error TS(2769) FIXME: No overload matches this call. */}
         <Select
           id={`short-tandem-repeat-${id}-population-options-population`}
           value={selectedAncestralPopulation}

--- a/browser/src/StructuralVariantPage/StructuralVariantPage.tsx
+++ b/browser/src/StructuralVariantPage/StructuralVariantPage.tsx
@@ -105,7 +105,7 @@ const StructuralVariantPage = ({ datasetId, variant }: StructuralVariantPageProp
     </Wrapper>
 
     <section>
-      <h2>Population Frequencies</h2>
+      <h2>Genetic ancestry group Frequencies</h2>
       <StructuralVariantPopulationsTable variant={variant} />
     </section>
 

--- a/browser/src/StructuralVariantPage/StructuralVariantPage.tsx
+++ b/browser/src/StructuralVariantPage/StructuralVariantPage.tsx
@@ -105,7 +105,7 @@ const StructuralVariantPage = ({ datasetId, variant }: StructuralVariantPageProp
     </Wrapper>
 
     <section>
-      <h2>Genetic ancestry group Frequencies</h2>
+      <h2>Genetic Ancestry Group Frequencies</h2>
       <StructuralVariantPopulationsTable variant={variant} />
     </section>
 

--- a/browser/src/StructuralVariantPage/__snapshots__/StructuralVariantPage.spec.tsx.snap
+++ b/browser/src/StructuralVariantPage/__snapshots__/StructuralVariantPage.spec.tsx.snap
@@ -400,7 +400,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with a complex varian
   </div>
   <section>
     <h2>
-      Genetic ancestry group Frequencies
+      Genetic Ancestry Group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
@@ -416,7 +416,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with a complex varian
               onClick={[Function]}
               type="button"
             >
-              Genetic ancestry group
+              Genetic Ancestry Group
             </button>
           </th>
           <th
@@ -1009,7 +1009,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with interchromosomal
   </div>
   <section>
     <h2>
-      Genetic ancestry group Frequencies
+      Genetic Ancestry Group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
@@ -1025,7 +1025,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with interchromosomal
               onClick={[Function]}
               type="button"
             >
-              Genetic ancestry group
+              Genetic Ancestry Group
             </button>
           </th>
           <th
@@ -1618,7 +1618,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with interchromosomal
   </div>
   <section>
     <h2>
-      Genetic ancestry group Frequencies
+      Genetic Ancestry Group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
@@ -1634,7 +1634,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with interchromosomal
               onClick={[Function]}
               type="button"
             >
-              Genetic ancestry group
+              Genetic Ancestry Group
             </button>
           </th>
           <th
@@ -2209,7 +2209,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
   </div>
   <section>
     <h2>
-      Genetic ancestry group Frequencies
+      Genetic Ancestry Group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
@@ -2225,7 +2225,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
               onClick={[Function]}
               type="button"
             >
-              Genetic ancestry group
+              Genetic Ancestry Group
             </button>
           </th>
           <th
@@ -2800,7 +2800,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
   </div>
   <section>
     <h2>
-      Genetic ancestry group Frequencies
+      Genetic Ancestry Group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
@@ -2816,7 +2816,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
               onClick={[Function]}
               type="button"
             >
-              Genetic ancestry group
+              Genetic Ancestry Group
             </button>
           </th>
           <th
@@ -3389,7 +3389,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
   </div>
   <section>
     <h2>
-      Genetic ancestry group Frequencies
+      Genetic Ancestry Group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
@@ -3405,7 +3405,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
               onClick={[Function]}
               type="button"
             >
-              Genetic ancestry group
+              Genetic Ancestry Group
             </button>
           </th>
           <th
@@ -3980,7 +3980,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
   </div>
   <section>
     <h2>
-      Genetic ancestry group Frequencies
+      Genetic Ancestry Group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
@@ -3996,7 +3996,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
               onClick={[Function]}
               type="button"
             >
-              Genetic ancestry group
+              Genetic Ancestry Group
             </button>
           </th>
           <th
@@ -4571,7 +4571,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
   </div>
   <section>
     <h2>
-      Genetic ancestry group Frequencies
+      Genetic Ancestry Group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
@@ -4587,7 +4587,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
               onClick={[Function]}
               type="button"
             >
-              Genetic ancestry group
+              Genetic Ancestry Group
             </button>
           </th>
           <th
@@ -5714,7 +5714,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with a compl
   </div>
   <section>
     <h2>
-      Genetic ancestry group Frequencies
+      Genetic Ancestry Group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
@@ -5730,7 +5730,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with a compl
               onClick={[Function]}
               type="button"
             >
-              Genetic ancestry group
+              Genetic Ancestry Group
             </button>
           </th>
           <th
@@ -6323,7 +6323,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with interch
   </div>
   <section>
     <h2>
-      Genetic ancestry group Frequencies
+      Genetic Ancestry Group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
@@ -6339,7 +6339,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with interch
               onClick={[Function]}
               type="button"
             >
-              Genetic ancestry group
+              Genetic Ancestry Group
             </button>
           </th>
           <th
@@ -6932,7 +6932,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with interch
   </div>
   <section>
     <h2>
-      Genetic ancestry group Frequencies
+      Genetic Ancestry Group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
@@ -6948,7 +6948,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with interch
               onClick={[Function]}
               type="button"
             >
-              Genetic ancestry group
+              Genetic Ancestry Group
             </button>
           </th>
           <th
@@ -7523,7 +7523,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
   </div>
   <section>
     <h2>
-      Genetic ancestry group Frequencies
+      Genetic Ancestry Group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
@@ -7539,7 +7539,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
               onClick={[Function]}
               type="button"
             >
-              Genetic ancestry group
+              Genetic Ancestry Group
             </button>
           </th>
           <th
@@ -8114,7 +8114,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
   </div>
   <section>
     <h2>
-      Genetic ancestry group Frequencies
+      Genetic Ancestry Group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
@@ -8130,7 +8130,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
               onClick={[Function]}
               type="button"
             >
-              Genetic ancestry group
+              Genetic Ancestry Group
             </button>
           </th>
           <th
@@ -8703,7 +8703,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
   </div>
   <section>
     <h2>
-      Genetic ancestry group Frequencies
+      Genetic Ancestry Group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
@@ -8719,7 +8719,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
               onClick={[Function]}
               type="button"
             >
-              Genetic ancestry group
+              Genetic Ancestry Group
             </button>
           </th>
           <th
@@ -9294,7 +9294,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
   </div>
   <section>
     <h2>
-      Genetic ancestry group Frequencies
+      Genetic Ancestry Group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
@@ -9310,7 +9310,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
               onClick={[Function]}
               type="button"
             >
-              Genetic ancestry group
+              Genetic Ancestry Group
             </button>
           </th>
           <th
@@ -9885,7 +9885,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
   </div>
   <section>
     <h2>
-      Genetic ancestry group Frequencies
+      Genetic Ancestry Group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
@@ -9901,7 +9901,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
               onClick={[Function]}
               type="button"
             >
-              Genetic ancestry group
+              Genetic Ancestry Group
             </button>
           </th>
           <th
@@ -11028,7 +11028,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with a comp
   </div>
   <section>
     <h2>
-      Genetic ancestry group Frequencies
+      Genetic Ancestry Group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
@@ -11044,7 +11044,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with a comp
               onClick={[Function]}
               type="button"
             >
-              Genetic ancestry group
+              Genetic Ancestry Group
             </button>
           </th>
           <th
@@ -11637,7 +11637,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with interc
   </div>
   <section>
     <h2>
-      Genetic ancestry group Frequencies
+      Genetic Ancestry Group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
@@ -11653,7 +11653,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with interc
               onClick={[Function]}
               type="button"
             >
-              Genetic ancestry group
+              Genetic Ancestry Group
             </button>
           </th>
           <th
@@ -12246,7 +12246,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with interc
   </div>
   <section>
     <h2>
-      Genetic ancestry group Frequencies
+      Genetic Ancestry Group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
@@ -12262,7 +12262,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with interc
               onClick={[Function]}
               type="button"
             >
-              Genetic ancestry group
+              Genetic Ancestry Group
             </button>
           </th>
           <th
@@ -12837,7 +12837,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
   </div>
   <section>
     <h2>
-      Genetic ancestry group Frequencies
+      Genetic Ancestry Group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
@@ -12853,7 +12853,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
               onClick={[Function]}
               type="button"
             >
-              Genetic ancestry group
+              Genetic Ancestry Group
             </button>
           </th>
           <th
@@ -13428,7 +13428,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
   </div>
   <section>
     <h2>
-      Genetic ancestry group Frequencies
+      Genetic Ancestry Group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
@@ -13444,7 +13444,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
               onClick={[Function]}
               type="button"
             >
-              Genetic ancestry group
+              Genetic Ancestry Group
             </button>
           </th>
           <th
@@ -14017,7 +14017,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
   </div>
   <section>
     <h2>
-      Genetic ancestry group Frequencies
+      Genetic Ancestry Group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
@@ -14033,7 +14033,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
               onClick={[Function]}
               type="button"
             >
-              Genetic ancestry group
+              Genetic Ancestry Group
             </button>
           </th>
           <th
@@ -14608,7 +14608,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
   </div>
   <section>
     <h2>
-      Genetic ancestry group Frequencies
+      Genetic Ancestry Group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
@@ -14624,7 +14624,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
               onClick={[Function]}
               type="button"
             >
-              Genetic ancestry group
+              Genetic Ancestry Group
             </button>
           </th>
           <th
@@ -15199,7 +15199,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
   </div>
   <section>
     <h2>
-      Genetic ancestry group Frequencies
+      Genetic Ancestry Group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
@@ -15215,7 +15215,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
               onClick={[Function]}
               type="button"
             >
-              Genetic ancestry group
+              Genetic Ancestry Group
             </button>
           </th>
           <th

--- a/browser/src/StructuralVariantPage/__snapshots__/StructuralVariantPage.spec.tsx.snap
+++ b/browser/src/StructuralVariantPage/__snapshots__/StructuralVariantPage.spec.tsx.snap
@@ -400,7 +400,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with a complex varian
   </div>
   <section>
     <h2>
-      Population Frequencies
+      Genetic ancestry group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
@@ -416,7 +416,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with a complex varian
               onClick={[Function]}
               type="button"
             >
-              Population
+              Genetic ancestry group
             </button>
           </th>
           <th
@@ -1009,7 +1009,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with interchromosomal
   </div>
   <section>
     <h2>
-      Population Frequencies
+      Genetic ancestry group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
@@ -1025,7 +1025,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with interchromosomal
               onClick={[Function]}
               type="button"
             >
-              Population
+              Genetic ancestry group
             </button>
           </th>
           <th
@@ -1618,7 +1618,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with interchromosomal
   </div>
   <section>
     <h2>
-      Population Frequencies
+      Genetic ancestry group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
@@ -1634,7 +1634,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with interchromosomal
               onClick={[Function]}
               type="button"
             >
-              Population
+              Genetic ancestry group
             </button>
           </th>
           <th
@@ -2209,7 +2209,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
   </div>
   <section>
     <h2>
-      Population Frequencies
+      Genetic ancestry group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
@@ -2225,7 +2225,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
               onClick={[Function]}
               type="button"
             >
-              Population
+              Genetic ancestry group
             </button>
           </th>
           <th
@@ -2800,7 +2800,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
   </div>
   <section>
     <h2>
-      Population Frequencies
+      Genetic ancestry group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
@@ -2816,7 +2816,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
               onClick={[Function]}
               type="button"
             >
-              Population
+              Genetic ancestry group
             </button>
           </th>
           <th
@@ -3389,7 +3389,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
   </div>
   <section>
     <h2>
-      Population Frequencies
+      Genetic ancestry group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
@@ -3405,7 +3405,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
               onClick={[Function]}
               type="button"
             >
-              Population
+              Genetic ancestry group
             </button>
           </th>
           <th
@@ -3980,7 +3980,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
   </div>
   <section>
     <h2>
-      Population Frequencies
+      Genetic ancestry group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
@@ -3996,7 +3996,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
               onClick={[Function]}
               type="button"
             >
-              Population
+              Genetic ancestry group
             </button>
           </th>
           <th
@@ -4571,7 +4571,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
   </div>
   <section>
     <h2>
-      Population Frequencies
+      Genetic ancestry group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
@@ -4587,7 +4587,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
               onClick={[Function]}
               type="button"
             >
-              Population
+              Genetic ancestry group
             </button>
           </th>
           <th
@@ -5714,7 +5714,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with a compl
   </div>
   <section>
     <h2>
-      Population Frequencies
+      Genetic ancestry group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
@@ -5730,7 +5730,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with a compl
               onClick={[Function]}
               type="button"
             >
-              Population
+              Genetic ancestry group
             </button>
           </th>
           <th
@@ -6323,7 +6323,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with interch
   </div>
   <section>
     <h2>
-      Population Frequencies
+      Genetic ancestry group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
@@ -6339,7 +6339,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with interch
               onClick={[Function]}
               type="button"
             >
-              Population
+              Genetic ancestry group
             </button>
           </th>
           <th
@@ -6932,7 +6932,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with interch
   </div>
   <section>
     <h2>
-      Population Frequencies
+      Genetic ancestry group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
@@ -6948,7 +6948,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with interch
               onClick={[Function]}
               type="button"
             >
-              Population
+              Genetic ancestry group
             </button>
           </th>
           <th
@@ -7523,7 +7523,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
   </div>
   <section>
     <h2>
-      Population Frequencies
+      Genetic ancestry group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
@@ -7539,7 +7539,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
               onClick={[Function]}
               type="button"
             >
-              Population
+              Genetic ancestry group
             </button>
           </th>
           <th
@@ -8114,7 +8114,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
   </div>
   <section>
     <h2>
-      Population Frequencies
+      Genetic ancestry group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
@@ -8130,7 +8130,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
               onClick={[Function]}
               type="button"
             >
-              Population
+              Genetic ancestry group
             </button>
           </th>
           <th
@@ -8703,7 +8703,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
   </div>
   <section>
     <h2>
-      Population Frequencies
+      Genetic ancestry group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
@@ -8719,7 +8719,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
               onClick={[Function]}
               type="button"
             >
-              Population
+              Genetic ancestry group
             </button>
           </th>
           <th
@@ -9294,7 +9294,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
   </div>
   <section>
     <h2>
-      Population Frequencies
+      Genetic ancestry group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
@@ -9310,7 +9310,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
               onClick={[Function]}
               type="button"
             >
-              Population
+              Genetic ancestry group
             </button>
           </th>
           <th
@@ -9885,7 +9885,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
   </div>
   <section>
     <h2>
-      Population Frequencies
+      Genetic ancestry group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
@@ -9901,7 +9901,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
               onClick={[Function]}
               type="button"
             >
-              Population
+              Genetic ancestry group
             </button>
           </th>
           <th
@@ -11028,7 +11028,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with a comp
   </div>
   <section>
     <h2>
-      Population Frequencies
+      Genetic ancestry group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
@@ -11044,7 +11044,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with a comp
               onClick={[Function]}
               type="button"
             >
-              Population
+              Genetic ancestry group
             </button>
           </th>
           <th
@@ -11637,7 +11637,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with interc
   </div>
   <section>
     <h2>
-      Population Frequencies
+      Genetic ancestry group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
@@ -11653,7 +11653,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with interc
               onClick={[Function]}
               type="button"
             >
-              Population
+              Genetic ancestry group
             </button>
           </th>
           <th
@@ -12246,7 +12246,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with interc
   </div>
   <section>
     <h2>
-      Population Frequencies
+      Genetic ancestry group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
@@ -12262,7 +12262,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with interc
               onClick={[Function]}
               type="button"
             >
-              Population
+              Genetic ancestry group
             </button>
           </th>
           <th
@@ -12837,7 +12837,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
   </div>
   <section>
     <h2>
-      Population Frequencies
+      Genetic ancestry group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
@@ -12853,7 +12853,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
               onClick={[Function]}
               type="button"
             >
-              Population
+              Genetic ancestry group
             </button>
           </th>
           <th
@@ -13428,7 +13428,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
   </div>
   <section>
     <h2>
-      Population Frequencies
+      Genetic ancestry group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
@@ -13444,7 +13444,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
               onClick={[Function]}
               type="button"
             >
-              Population
+              Genetic ancestry group
             </button>
           </th>
           <th
@@ -14017,7 +14017,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
   </div>
   <section>
     <h2>
-      Population Frequencies
+      Genetic ancestry group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
@@ -14033,7 +14033,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
               onClick={[Function]}
               type="button"
             >
-              Population
+              Genetic ancestry group
             </button>
           </th>
           <th
@@ -14608,7 +14608,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
   </div>
   <section>
     <h2>
-      Population Frequencies
+      Genetic ancestry group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
@@ -14624,7 +14624,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
               onClick={[Function]}
               type="button"
             >
-              Population
+              Genetic ancestry group
             </button>
           </th>
           <th
@@ -15199,7 +15199,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
   </div>
   <section>
     <h2>
-      Population Frequencies
+      Genetic ancestry group Frequencies
     </h2>
     <table
       className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
@@ -15215,7 +15215,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
               onClick={[Function]}
               type="button"
             >
-              Population
+              Genetic ancestry group
             </button>
           </th>
           <th

--- a/browser/src/VariantCooccurrencePage/VariantCooccurrencePage.tsx
+++ b/browser/src/VariantCooccurrencePage/VariantCooccurrencePage.tsx
@@ -153,7 +153,7 @@ const VariantCoocurrence = ({ cooccurrenceData }: VariantCoocurrenceProps) => {
         ) && (
           <p>
             * A likely co-occurrence pattern cannot be calculated in some cases, such as when only
-            one of the variants is observed in a population.
+            one of the variants is observed in a genetic ancestry group.
           </p>
         )}
       </Section>
@@ -164,7 +164,10 @@ const VariantCoocurrence = ({ cooccurrenceData }: VariantCoocurrenceProps) => {
           : // @ts-expect-error TS(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
             `Details for ${GNOMAD_POPULATION_NAMES[selectedPopulation]} Population`}
       </h2>
-      <p>Select a population in the overview table to view genotype counts for that population.</p>
+      <p>
+        Select a genetic ancestry group in the overview table to view genotype counts for that
+        group.
+      </p>
       <Wrapper>
         <ResponsiveSection>
           <h3>Genotype Counts</h3>

--- a/browser/src/VariantCooccurrencePage/VariantCooccurrenceSummaryTable.tsx
+++ b/browser/src/VariantCooccurrencePage/VariantCooccurrenceSummaryTable.tsx
@@ -64,7 +64,7 @@ const VariantCooccurrenceSummaryTable = ({
     <Table>
       <thead>
         <tr>
-          <th scope="col">Population</th>
+          <th scope="col">Genetic ancestry group</th>
           <th scope="col">
             Samples consistent with variants appearing in isolation or on different haplotypes
           </th>

--- a/browser/src/VariantPage/PopulationsTable.tsx
+++ b/browser/src/VariantPage/PopulationsTable.tsx
@@ -252,7 +252,7 @@ export class PopulationsTable extends Component<PopulationsTableProps, Populatio
           <tr>
             {this.renderColumnHeader({
               key: 'name',
-              label: 'Genetic ancestry group',
+              label: 'Genetic Ancestry Group',
               props: { colSpan: 2 },
             })}
             {this.renderColumnHeader({

--- a/browser/src/VariantPage/PopulationsTable.tsx
+++ b/browser/src/VariantPage/PopulationsTable.tsx
@@ -250,7 +250,11 @@ export class PopulationsTable extends Component<PopulationsTableProps, Populatio
       <Table>
         <thead>
           <tr>
-            {this.renderColumnHeader({ key: 'name', label: 'Population', props: { colSpan: 2 } })}
+            {this.renderColumnHeader({
+              key: 'name',
+              label: 'Genetic ancestry group',
+              props: { colSpan: 2 },
+            })}
             {this.renderColumnHeader({
               key: 'ac',
               label: columnLabels.ac || 'Allele Count',

--- a/browser/src/VariantPage/VariantOccurrenceTable.tsx
+++ b/browser/src/VariantPage/VariantOccurrenceTable.tsx
@@ -348,7 +348,7 @@ export const GnomadVariantOccurrenceTable = ({
           <tr>
             <th scope="row">
               <NoWrap>
-                Popmax Filtering AF <InfoButton topic="faf" />
+                Grpmax Filtering AF <InfoButton topic="faf" />
               </NoWrap>
               <br />
               (95% confidence)

--- a/browser/src/VariantPage/VariantPage.tsx
+++ b/browser/src/VariantPage/VariantPage.tsx
@@ -330,7 +330,7 @@ export const VariantPageContent = ({ datasetId, variant }: VariantPageContentPro
 
       <Section>
         <h2>
-          Population Frequencies <InfoButton topic="ancestry" />
+          Genetic ancestry group Frequencies <InfoButton topic="ancestry" />
         </h2>
         {hasLocalAncestryPopulations(datasetId) &&
           ((variant.genome && variant.genome.local_ancestry_populations) || []).length > 0 && (

--- a/browser/src/VariantPage/VariantPage.tsx
+++ b/browser/src/VariantPage/VariantPage.tsx
@@ -330,7 +330,7 @@ export const VariantPageContent = ({ datasetId, variant }: VariantPageContentPro
 
       <Section>
         <h2>
-          Genetic ancestry group Frequencies <InfoButton topic="ancestry" />
+          Genetic Ancestry Group Frequencies <InfoButton topic="ancestry" />
         </h2>
         {hasLocalAncestryPopulations(datasetId) &&
           ((variant.genome && variant.genome.local_ancestry_populations) || []).length > 0 && (

--- a/browser/src/VariantPage/__snapshots__/VariantPage.spec.tsx.snap
+++ b/browser/src/VariantPage/__snapshots__/VariantPage.spec.tsx.snap
@@ -518,7 +518,7 @@ exports[`VariantPage with dataset "gnomad_r3" has no unexpected changes 1`] = `
       className="VariantPage__Section-sc-hd87ur-0 CMQAN"
     >
       <h2>
-        Population Frequencies 
+        Genetic ancestry group Frequencies 
         <button
           className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
           onClick={[Function]}
@@ -652,7 +652,7 @@ exports[`VariantPage with dataset "gnomad_r3" has no unexpected changes 1`] = `
                         onClick={[Function]}
                         type="button"
                       >
-                        Population
+                        Genetic ancestry group
                       </button>
                     </th>
                     <th
@@ -9203,7 +9203,7 @@ exports[`VariantPage with dataset "gnomad_r3_controls_and_biobanks" has no unexp
       className="VariantPage__Section-sc-hd87ur-0 CMQAN"
     >
       <h2>
-        Population Frequencies 
+        Genetic ancestry group Frequencies 
         <button
           className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
           onClick={[Function]}
@@ -9337,7 +9337,7 @@ exports[`VariantPage with dataset "gnomad_r3_controls_and_biobanks" has no unexp
                         onClick={[Function]}
                         type="button"
                       >
-                        Population
+                        Genetic ancestry group
                       </button>
                     </th>
                     <th
@@ -17891,7 +17891,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_cancer" has no unexpected chang
       className="VariantPage__Section-sc-hd87ur-0 CMQAN"
     >
       <h2>
-        Population Frequencies 
+        Genetic ancestry group Frequencies 
         <button
           className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
           onClick={[Function]}
@@ -18025,7 +18025,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_cancer" has no unexpected chang
                         onClick={[Function]}
                         type="button"
                       >
-                        Population
+                        Genetic ancestry group
                       </button>
                     </th>
                     <th
@@ -26579,7 +26579,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_neuro" has no unexpected change
       className="VariantPage__Section-sc-hd87ur-0 CMQAN"
     >
       <h2>
-        Population Frequencies 
+        Genetic ancestry group Frequencies 
         <button
           className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
           onClick={[Function]}
@@ -26713,7 +26713,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_neuro" has no unexpected change
                         onClick={[Function]}
                         type="button"
                       >
-                        Population
+                        Genetic ancestry group
                       </button>
                     </th>
                     <th
@@ -35267,7 +35267,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_topmed" has no unexpected chang
       className="VariantPage__Section-sc-hd87ur-0 CMQAN"
     >
       <h2>
-        Population Frequencies 
+        Genetic ancestry group Frequencies 
         <button
           className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
           onClick={[Function]}
@@ -35401,7 +35401,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_topmed" has no unexpected chang
                         onClick={[Function]}
                         type="button"
                       >
-                        Population
+                        Genetic ancestry group
                       </button>
                     </th>
                     <th
@@ -43955,7 +43955,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_v2" has no unexpected changes 1
       className="VariantPage__Section-sc-hd87ur-0 CMQAN"
     >
       <h2>
-        Population Frequencies 
+        Genetic ancestry group Frequencies 
         <button
           className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
           onClick={[Function]}
@@ -44089,7 +44089,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_v2" has no unexpected changes 1
                         onClick={[Function]}
                         type="button"
                       >
-                        Population
+                        Genetic ancestry group
                       </button>
                     </th>
                     <th
@@ -52580,7 +52580,7 @@ exports[`VariantPage with dataset exac has no unexpected changes 1`] = `
       className="VariantPage__Section-sc-hd87ur-0 CMQAN"
     >
       <h2>
-        Population Frequencies 
+        Genetic ancestry group Frequencies 
         <button
           className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
           onClick={[Function]}
@@ -52627,7 +52627,7 @@ exports[`VariantPage with dataset exac has no unexpected changes 1`] = `
                   onClick={[Function]}
                   type="button"
                 >
-                  Population
+                  Genetic ancestry group
                 </button>
               </th>
               <th
@@ -59710,7 +59710,7 @@ exports[`VariantPage with dataset gnomad_r2_1 has no unexpected changes 1`] = `
       className="VariantPage__Section-sc-hd87ur-0 CMQAN"
     >
       <h2>
-        Population Frequencies 
+        Genetic ancestry group Frequencies 
         <button
           className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
           onClick={[Function]}
@@ -59757,7 +59757,7 @@ exports[`VariantPage with dataset gnomad_r2_1 has no unexpected changes 1`] = `
                   onClick={[Function]}
                   type="button"
                 >
-                  Population
+                  Genetic ancestry group
                 </button>
               </th>
               <th
@@ -68448,7 +68448,7 @@ exports[`VariantPage with dataset gnomad_r2_1_controls has no unexpected changes
       className="VariantPage__Section-sc-hd87ur-0 CMQAN"
     >
       <h2>
-        Population Frequencies 
+        Genetic ancestry group Frequencies 
         <button
           className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
           onClick={[Function]}
@@ -68495,7 +68495,7 @@ exports[`VariantPage with dataset gnomad_r2_1_controls has no unexpected changes
                   onClick={[Function]}
                   type="button"
                 >
-                  Population
+                  Genetic ancestry group
                 </button>
               </th>
               <th
@@ -77186,7 +77186,7 @@ exports[`VariantPage with dataset gnomad_r2_1_non_cancer has no unexpected chang
       className="VariantPage__Section-sc-hd87ur-0 CMQAN"
     >
       <h2>
-        Population Frequencies 
+        Genetic ancestry group Frequencies 
         <button
           className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
           onClick={[Function]}
@@ -77233,7 +77233,7 @@ exports[`VariantPage with dataset gnomad_r2_1_non_cancer has no unexpected chang
                   onClick={[Function]}
                   type="button"
                 >
-                  Population
+                  Genetic ancestry group
                 </button>
               </th>
               <th
@@ -85924,7 +85924,7 @@ exports[`VariantPage with dataset gnomad_r2_1_non_neuro has no unexpected change
       className="VariantPage__Section-sc-hd87ur-0 CMQAN"
     >
       <h2>
-        Population Frequencies 
+        Genetic ancestry group Frequencies 
         <button
           className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
           onClick={[Function]}
@@ -85971,7 +85971,7 @@ exports[`VariantPage with dataset gnomad_r2_1_non_neuro has no unexpected change
                   onClick={[Function]}
                   type="button"
                 >
-                  Population
+                  Genetic ancestry group
                 </button>
               </th>
               <th
@@ -94662,7 +94662,7 @@ exports[`VariantPage with dataset gnomad_r2_1_non_topmed has no unexpected chang
       className="VariantPage__Section-sc-hd87ur-0 CMQAN"
     >
       <h2>
-        Population Frequencies 
+        Genetic ancestry group Frequencies 
         <button
           className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
           onClick={[Function]}
@@ -94709,7 +94709,7 @@ exports[`VariantPage with dataset gnomad_r2_1_non_topmed has no unexpected chang
                   onClick={[Function]}
                   type="button"
                 >
-                  Population
+                  Genetic ancestry group
                 </button>
               </th>
               <th

--- a/browser/src/VariantPage/__snapshots__/VariantPage.spec.tsx.snap
+++ b/browser/src/VariantPage/__snapshots__/VariantPage.spec.tsx.snap
@@ -518,7 +518,7 @@ exports[`VariantPage with dataset "gnomad_r3" has no unexpected changes 1`] = `
       className="VariantPage__Section-sc-hd87ur-0 CMQAN"
     >
       <h2>
-        Genetic ancestry group Frequencies 
+        Genetic Ancestry Group Frequencies 
         <button
           className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
           onClick={[Function]}
@@ -652,7 +652,7 @@ exports[`VariantPage with dataset "gnomad_r3" has no unexpected changes 1`] = `
                         onClick={[Function]}
                         type="button"
                       >
-                        Genetic ancestry group
+                        Genetic Ancestry Group
                       </button>
                     </th>
                     <th
@@ -9203,7 +9203,7 @@ exports[`VariantPage with dataset "gnomad_r3_controls_and_biobanks" has no unexp
       className="VariantPage__Section-sc-hd87ur-0 CMQAN"
     >
       <h2>
-        Genetic ancestry group Frequencies 
+        Genetic Ancestry Group Frequencies 
         <button
           className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
           onClick={[Function]}
@@ -9337,7 +9337,7 @@ exports[`VariantPage with dataset "gnomad_r3_controls_and_biobanks" has no unexp
                         onClick={[Function]}
                         type="button"
                       >
-                        Genetic ancestry group
+                        Genetic Ancestry Group
                       </button>
                     </th>
                     <th
@@ -17891,7 +17891,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_cancer" has no unexpected chang
       className="VariantPage__Section-sc-hd87ur-0 CMQAN"
     >
       <h2>
-        Genetic ancestry group Frequencies 
+        Genetic Ancestry Group Frequencies 
         <button
           className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
           onClick={[Function]}
@@ -18025,7 +18025,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_cancer" has no unexpected chang
                         onClick={[Function]}
                         type="button"
                       >
-                        Genetic ancestry group
+                        Genetic Ancestry Group
                       </button>
                     </th>
                     <th
@@ -26579,7 +26579,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_neuro" has no unexpected change
       className="VariantPage__Section-sc-hd87ur-0 CMQAN"
     >
       <h2>
-        Genetic ancestry group Frequencies 
+        Genetic Ancestry Group Frequencies 
         <button
           className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
           onClick={[Function]}
@@ -26713,7 +26713,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_neuro" has no unexpected change
                         onClick={[Function]}
                         type="button"
                       >
-                        Genetic ancestry group
+                        Genetic Ancestry Group
                       </button>
                     </th>
                     <th
@@ -35267,7 +35267,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_topmed" has no unexpected chang
       className="VariantPage__Section-sc-hd87ur-0 CMQAN"
     >
       <h2>
-        Genetic ancestry group Frequencies 
+        Genetic Ancestry Group Frequencies 
         <button
           className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
           onClick={[Function]}
@@ -35401,7 +35401,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_topmed" has no unexpected chang
                         onClick={[Function]}
                         type="button"
                       >
-                        Genetic ancestry group
+                        Genetic Ancestry Group
                       </button>
                     </th>
                     <th
@@ -43955,7 +43955,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_v2" has no unexpected changes 1
       className="VariantPage__Section-sc-hd87ur-0 CMQAN"
     >
       <h2>
-        Genetic ancestry group Frequencies 
+        Genetic Ancestry Group Frequencies 
         <button
           className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
           onClick={[Function]}
@@ -44089,7 +44089,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_v2" has no unexpected changes 1
                         onClick={[Function]}
                         type="button"
                       >
-                        Genetic ancestry group
+                        Genetic Ancestry Group
                       </button>
                     </th>
                     <th
@@ -52580,7 +52580,7 @@ exports[`VariantPage with dataset exac has no unexpected changes 1`] = `
       className="VariantPage__Section-sc-hd87ur-0 CMQAN"
     >
       <h2>
-        Genetic ancestry group Frequencies 
+        Genetic Ancestry Group Frequencies 
         <button
           className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
           onClick={[Function]}
@@ -52627,7 +52627,7 @@ exports[`VariantPage with dataset exac has no unexpected changes 1`] = `
                   onClick={[Function]}
                   type="button"
                 >
-                  Genetic ancestry group
+                  Genetic Ancestry Group
                 </button>
               </th>
               <th
@@ -59710,7 +59710,7 @@ exports[`VariantPage with dataset gnomad_r2_1 has no unexpected changes 1`] = `
       className="VariantPage__Section-sc-hd87ur-0 CMQAN"
     >
       <h2>
-        Genetic ancestry group Frequencies 
+        Genetic Ancestry Group Frequencies 
         <button
           className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
           onClick={[Function]}
@@ -59757,7 +59757,7 @@ exports[`VariantPage with dataset gnomad_r2_1 has no unexpected changes 1`] = `
                   onClick={[Function]}
                   type="button"
                 >
-                  Genetic ancestry group
+                  Genetic Ancestry Group
                 </button>
               </th>
               <th
@@ -68448,7 +68448,7 @@ exports[`VariantPage with dataset gnomad_r2_1_controls has no unexpected changes
       className="VariantPage__Section-sc-hd87ur-0 CMQAN"
     >
       <h2>
-        Genetic ancestry group Frequencies 
+        Genetic Ancestry Group Frequencies 
         <button
           className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
           onClick={[Function]}
@@ -68495,7 +68495,7 @@ exports[`VariantPage with dataset gnomad_r2_1_controls has no unexpected changes
                   onClick={[Function]}
                   type="button"
                 >
-                  Genetic ancestry group
+                  Genetic Ancestry Group
                 </button>
               </th>
               <th
@@ -77186,7 +77186,7 @@ exports[`VariantPage with dataset gnomad_r2_1_non_cancer has no unexpected chang
       className="VariantPage__Section-sc-hd87ur-0 CMQAN"
     >
       <h2>
-        Genetic ancestry group Frequencies 
+        Genetic Ancestry Group Frequencies 
         <button
           className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
           onClick={[Function]}
@@ -77233,7 +77233,7 @@ exports[`VariantPage with dataset gnomad_r2_1_non_cancer has no unexpected chang
                   onClick={[Function]}
                   type="button"
                 >
-                  Genetic ancestry group
+                  Genetic Ancestry Group
                 </button>
               </th>
               <th
@@ -85924,7 +85924,7 @@ exports[`VariantPage with dataset gnomad_r2_1_non_neuro has no unexpected change
       className="VariantPage__Section-sc-hd87ur-0 CMQAN"
     >
       <h2>
-        Genetic ancestry group Frequencies 
+        Genetic Ancestry Group Frequencies 
         <button
           className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
           onClick={[Function]}
@@ -85971,7 +85971,7 @@ exports[`VariantPage with dataset gnomad_r2_1_non_neuro has no unexpected change
                   onClick={[Function]}
                   type="button"
                 >
-                  Genetic ancestry group
+                  Genetic Ancestry Group
                 </button>
               </th>
               <th
@@ -94662,7 +94662,7 @@ exports[`VariantPage with dataset gnomad_r2_1_non_topmed has no unexpected chang
       className="VariantPage__Section-sc-hd87ur-0 CMQAN"
     >
       <h2>
-        Genetic ancestry group Frequencies 
+        Genetic Ancestry Group Frequencies 
         <button
           className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
           onClick={[Function]}
@@ -94709,7 +94709,7 @@ exports[`VariantPage with dataset gnomad_r2_1_non_topmed has no unexpected chang
                   onClick={[Function]}
                   type="button"
                 >
-                  Genetic ancestry group
+                  Genetic Ancestry Group
                 </button>
               </th>
               <th

--- a/browser/src/VariantPage/__snapshots__/VariantPage.spec.tsx.snap
+++ b/browser/src/VariantPage/__snapshots__/VariantPage.spec.tsx.snap
@@ -379,7 +379,7 @@ exports[`VariantPage with dataset "gnomad_r3" has no unexpected changes 1`] = `
                   <span
                     className="VariantOccurrenceTable__NoWrap-sc-8b13g7-1 kmxNQ"
                   >
-                    Popmax Filtering AF 
+                    Grpmax Filtering AF 
                     <button
                       className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
                       onClick={[Function]}
@@ -9064,7 +9064,7 @@ exports[`VariantPage with dataset "gnomad_r3_controls_and_biobanks" has no unexp
                   <span
                     className="VariantOccurrenceTable__NoWrap-sc-8b13g7-1 kmxNQ"
                   >
-                    Popmax Filtering AF 
+                    Grpmax Filtering AF 
                     <button
                       className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
                       onClick={[Function]}
@@ -17752,7 +17752,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_cancer" has no unexpected chang
                   <span
                     className="VariantOccurrenceTable__NoWrap-sc-8b13g7-1 kmxNQ"
                   >
-                    Popmax Filtering AF 
+                    Grpmax Filtering AF 
                     <button
                       className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
                       onClick={[Function]}
@@ -26440,7 +26440,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_neuro" has no unexpected change
                   <span
                     className="VariantOccurrenceTable__NoWrap-sc-8b13g7-1 kmxNQ"
                   >
-                    Popmax Filtering AF 
+                    Grpmax Filtering AF 
                     <button
                       className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
                       onClick={[Function]}
@@ -35128,7 +35128,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_topmed" has no unexpected chang
                   <span
                     className="VariantOccurrenceTable__NoWrap-sc-8b13g7-1 kmxNQ"
                   >
-                    Popmax Filtering AF 
+                    Grpmax Filtering AF 
                     <button
                       className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
                       onClick={[Function]}
@@ -43816,7 +43816,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_v2" has no unexpected changes 1
                   <span
                     className="VariantOccurrenceTable__NoWrap-sc-8b13g7-1 kmxNQ"
                   >
-                    Popmax Filtering AF 
+                    Grpmax Filtering AF 
                     <button
                       className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
                       onClick={[Function]}
@@ -59573,7 +59573,7 @@ exports[`VariantPage with dataset gnomad_r2_1 has no unexpected changes 1`] = `
                   <span
                     className="VariantOccurrenceTable__NoWrap-sc-8b13g7-1 kmxNQ"
                   >
-                    Popmax Filtering AF 
+                    Grpmax Filtering AF 
                     <button
                       className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
                       onClick={[Function]}
@@ -68311,7 +68311,7 @@ exports[`VariantPage with dataset gnomad_r2_1_controls has no unexpected changes
                   <span
                     className="VariantOccurrenceTable__NoWrap-sc-8b13g7-1 kmxNQ"
                   >
-                    Popmax Filtering AF 
+                    Grpmax Filtering AF 
                     <button
                       className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
                       onClick={[Function]}
@@ -77049,7 +77049,7 @@ exports[`VariantPage with dataset gnomad_r2_1_non_cancer has no unexpected chang
                   <span
                     className="VariantOccurrenceTable__NoWrap-sc-8b13g7-1 kmxNQ"
                   >
-                    Popmax Filtering AF 
+                    Grpmax Filtering AF 
                     <button
                       className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
                       onClick={[Function]}
@@ -85787,7 +85787,7 @@ exports[`VariantPage with dataset gnomad_r2_1_non_neuro has no unexpected change
                   <span
                     className="VariantOccurrenceTable__NoWrap-sc-8b13g7-1 kmxNQ"
                   >
-                    Popmax Filtering AF 
+                    Grpmax Filtering AF 
                     <button
                       className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
                       onClick={[Function]}
@@ -94525,7 +94525,7 @@ exports[`VariantPage with dataset gnomad_r2_1_non_topmed has no unexpected chang
                   <span
                     className="VariantOccurrenceTable__NoWrap-sc-8b13g7-1 kmxNQ"
                   >
-                    Popmax Filtering AF 
+                    Grpmax Filtering AF 
                     <button
                       className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
                       onClick={[Function]}

--- a/dataset-metadata/gnomadPopulations.ts
+++ b/dataset-metadata/gnomadPopulations.ts
@@ -6,9 +6,10 @@ export const GNOMAD_POPULATION_NAMES = {
   amr: 'Admixed American',
   asj: 'Ashkenazi Jewish',
   eas: 'East Asian',
-  fin: 'European (Finnish)',
   mid: 'Middle Eastern',
+  eur: 'European',
   nfe: 'European (non-Finnish)',
+  fin: 'European (Finnish)',
   oth: 'Remaining individuals',
   sas: 'South Asian',
 
@@ -29,4 +30,4 @@ export const GNOMAD_POPULATION_NAMES = {
 export type PopulationId = keyof typeof GNOMAD_POPULATION_NAMES
 
 export const populationName = (populationId: string) =>
-  textOrMissingTextWarning('population name', GNOMAD_POPULATION_NAMES, populationId)
+  textOrMissingTextWarning('genetic ancestry group name', GNOMAD_POPULATION_NAMES, populationId)


### PR DESCRIPTION
Resolves #1051 

Updates 

- the term "Population" to "Genetic ancestry group", 
- the term "popmax" to "grpmax" 

throughout the user facing text of browser.

---

Changing the term usage in the API, and possibly local variable names if we want, is a task for later.

