### PR TITLE
Add v4 launch banner

### DIFF
--- a/browser/src/App.tsx
+++ b/browser/src/App.tsx
@@ -3,6 +3,8 @@ import { hot } from 'react-hot-loader/root'
 import { BrowserRouter as Router, Route, useLocation } from 'react-router-dom'
 import styled from 'styled-components'
 
+import { ExternalLink } from '@gnomad/ui'
+
 import Delayed from './Delayed'
 import ErrorBoundary from './ErrorBoundary'
 
@@ -65,11 +67,20 @@ const Banner = styled.div`
   text-align: center;
 
   a {
-    color: #fff !important;
+    color: #8ac8f4 !important;
+    text-decoration: underline;
   }
 `
 
-const BANNER_CONTENT = null
+const BANNER_CONTENT = (
+  <>
+    gnomAD v4 is here! Read our {/* @ts-expect-error */}
+    <ExternalLink href="https://gnomad.broadinstitute.org/news/2023-11-gnomad-v4-0">
+      blog post
+    </ExternalLink>{' '}
+    for more details
+  </>
+)
 
 const App = () => {
   const [isLoading, setIsLoading] = useState(true)


### PR DESCRIPTION
Resolves #1165 

Corresponding Blog PR: https://github.com/broadinstitute/gnomad-blog/pull/134

Adds a banner to the gnomAD Browser to better publicize the launch of gnomAD v4.

![Screenshot 2023-10-30 at 17 08 03](https://github.com/broadinstitute/gnomad-browser/assets/59549713/0dc8db60-d961-40dc-a237-e54b601e584a)
