### PR TITLE
Update Downloads page for v4

### DIFF
--- a/browser/src/DownloadsPage/DownloadsPage.tsx
+++ b/browser/src/DownloadsPage/DownloadsPage.tsx
@@ -1,7 +1,9 @@
 import React from 'react'
 import styled from 'styled-components'
 
-import { ExternalLink, PageHeading, Link } from '@gnomad/ui'
+import { ExternalLink, PageHeading } from '@gnomad/ui'
+
+import Link from '../Link'
 
 import DocumentTitle from '../DocumentTitle'
 import InfoPage from '../InfoPage'
@@ -13,14 +15,14 @@ import DownloadsPageTableOfContents from './TableOfContents'
 // @ts-expect-error
 import styles from './DownloadsPage.module.css'
 
+import GnomadV4Downloads from './GnomadV4Downloads'
+import GnomadV3Downloads from './GnomadV3Downloads'
 import GnomadV2Downloads from './GnomadV2Downloads'
 import GnomadV2LiftoverDownloads from './GnomadV2LiftoverDownloads'
-import GnomadV3Downloads from './GnomadV3Downloads'
 import ExacDownloads from './ExacDownloads'
 
 const CodeBlock = styled.code`
   display: inline-block;
-  overflow-x: scroll;
   box-sizing: border-box;
   max-width: 100%;
   padding: 0.5em 1em;
@@ -195,9 +197,9 @@ const DownloadsPage = () => {
 
           <h3>Downloads</h3>
           <StyledParagraph>
-            See {/* @ts-expect-error */}
+            See{' '}
             <Link to="/help/whats-the-difference-between-the-different-versions-of-gnomad">
-              &ldquo;What&apos;s the difference between gnomAD v2 and v3?&rdquo;
+              &ldquo;What&apos;s the difference between different versions of gnomad?&rdquo;
             </Link>{' '}
             to decide which version is right for you.
           </StyledParagraph>
@@ -221,12 +223,16 @@ const DownloadsPage = () => {
 
         <hr />
 
-        <GnomadV2Downloads />
-        <GnomadV2LiftoverDownloads />
+        <GnomadV4Downloads />
+
         <GnomadV3Downloads />
+
+        <GnomadV2LiftoverDownloads />
+
+        <GnomadV2Downloads />
+
         <ExacDownloads />
 
-        {/* TODO:(rgrant) I put these here as a spacer so you can highlight the last items successfully */}
         <BottomSpacer />
       </TextSection>
     </InfoPage>

--- a/browser/src/DownloadsPage/GnomadV2Downloads.tsx
+++ b/browser/src/DownloadsPage/GnomadV2Downloads.tsx
@@ -397,6 +397,44 @@ const GnomadV2Downloads = () => {
       </DownloadsSection>
 
       <DownloadsSection>
+        <SectionTitle id="v2-regional-missense-constraint">
+          Regional Missense Constraint
+        </SectionTitle>
+        <FileList>
+          {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+          <ListItem>
+            <GenericDownloadLinks
+              label="Regional missense constraint Hail Table"
+              // TODO: check after sync
+              path="/release/2.1.1/regional_missense_constraint/gnomad_v2.1.1_rmc.ht"
+              includeAWS={false}
+              includeAzure={false}
+            />
+          </ListItem>
+          {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+          <ListItem>
+            <GenericDownloadLinks
+              label="Regional missense constraint TSV (transcripts with RMC)"
+              // TODO: check after sync
+              path="/release/2.1.1/regional_missense_constraint/gnomAD_v2.1.1_transcripts_with_rmc.tsv"
+              includeAWS={false}
+              includeAzure={false}
+            />
+          </ListItem>
+          {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+          <ListItem>
+            <GenericDownloadLinks
+              label="Regional missense constraint TSV (transcripts without RMC)"
+              // TODO: check after sync
+              path="/release/2.1.1/regional_missense_constraint/gnomAD_v2.1.1_transcripts_without_rmc.tsv"
+              includeAWS={false}
+              includeAzure={false}
+            />
+          </ListItem>
+        </FileList>
+      </DownloadsSection>
+
+      <DownloadsSection>
         <SectionTitle id="v2-resources">Resources</SectionTitle>
         <FileList>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}

--- a/browser/src/DownloadsPage/GnomadV4Downloads.tsx
+++ b/browser/src/DownloadsPage/GnomadV4Downloads.tsx
@@ -1,0 +1,391 @@
+import React from 'react'
+
+import { ExternalLink, ListItem } from '@gnomad/ui'
+
+import {
+  Column,
+  ColumnsWrapper,
+  DownloadsSection,
+  FileList,
+  GenericDownloadLinks,
+  GetUrlButtons,
+  IndexedFileDownloadLinks,
+  SectionTitle,
+  StyledParagraph,
+} from './downloadsPageStyles'
+import Link from '../Link'
+
+// TODO:
+const exomeChromosomeVcfs = [
+  { chrom: '1', size: '_ GiB', md5: '_' },
+  { chrom: '2', size: '_ GiB', md5: '_' },
+  { chrom: '3', size: '_ GiB', md5: '_' },
+  { chrom: '4', size: '_ GiB', md5: '_' },
+  { chrom: '5', size: '_ GiB', md5: '_' },
+  { chrom: '6', size: '_ GiB', md5: '_' },
+  { chrom: '7', size: '_ GiB', md5: '_' },
+  { chrom: '8', size: '_ GiB', md5: '_' },
+  { chrom: '9', size: '_ GiB', md5: '_' },
+  { chrom: '10', size: '_ GiB', md5: '_' },
+  { chrom: '11', size: '_ GiB', md5: '_' },
+  { chrom: '12', size: '- GiB', md5: '_' },
+  { chrom: '13', size: '_ MiB', md5: '_' },
+  { chrom: '14', size: '_ GiB', md5: '_' },
+  { chrom: '15', size: '_ GiB', md5: '_' },
+  { chrom: '16', size: '_ GiB', md5: '_' },
+  { chrom: '17', size: '_ GiB', md5: '_' },
+  { chrom: '18', size: '_ MiB', md5: '_' },
+  { chrom: '19', size: '_ GiB', md5: '_' },
+  { chrom: '20', size: '_ GiB', md5: '_' },
+  { chrom: '21', size: '_ MiB', md5: '_' },
+  { chrom: '22', size: '_ GiB', md5: '_' },
+  { chrom: 'X', size: '_ GiB', md5: '_' },
+  { chrom: 'Y', size: '_ MiB', md5: '_' },
+]
+
+// TODO:
+const genomeChromosomeVcfs = [
+  { chrom: '1', size: '_ GiB', md5: '_' },
+  { chrom: '2', size: '_ GiB', md5: '_' },
+  { chrom: '3', size: '_ GiB', md5: '_' },
+  { chrom: '4', size: '_ GiB', md5: '_' },
+  { chrom: '5', size: '_ GiB', md5: '_' },
+  { chrom: '6', size: '_ GiB', md5: '_' },
+  { chrom: '7', size: '_ GiB', md5: '_' },
+  { chrom: '8', size: '_ GiB', md5: '_' },
+  { chrom: '9', size: '_ GiB', md5: '_' },
+  { chrom: '10', size: '_ GiB', md5: '_' },
+  { chrom: '11', size: '_ GiB', md5: '_' },
+  { chrom: '12', size: '_ GiB', md5: '_' },
+  { chrom: '13', size: '_ GiB', md5: '_' },
+  { chrom: '14', size: '_ GiB', md5: '_' },
+  { chrom: '15', size: '_ GiB', md5: '_' },
+  { chrom: '16', size: '_ GiB', md5: '_' },
+  { chrom: '17', size: '_ GiB', md5: '_' },
+  { chrom: '18', size: '_ GiB', md5: '_' },
+  { chrom: '19', size: '_ GiB', md5: '_' },
+  { chrom: '20', size: '_ GiB', md5: '_' },
+  { chrom: '21', size: '_ GiB', md5: '_' },
+  { chrom: '22', size: '_ GiB', md5: '_' },
+  { chrom: 'X', size: '_ GiB', md5: '_' },
+]
+
+// TODO:
+const svChromosomeVcfs = [
+  { chrom: '1', size: '_ GiB', md5: '_' },
+  { chrom: '2', size: '_ GiB', md5: '_' },
+  { chrom: '3', size: '_ GiB', md5: '_' },
+  { chrom: '4', size: '_ GiB', md5: '_' },
+  { chrom: '5', size: '_ GiB', md5: '_' },
+  { chrom: '6', size: '_ GiB', md5: '_' },
+  { chrom: '7', size: '_ GiB', md5: '_' },
+  { chrom: '8', size: '_ GiB', md5: '_' },
+  { chrom: '9', size: '_ GiB', md5: '_' },
+  { chrom: '10', size: '_ GiB', md5: '_' },
+  { chrom: '11', size: '_ GiB', md5: '_' },
+  { chrom: '12', size: '- GiB', md5: '_' },
+  { chrom: '13', size: '_ MiB', md5: '_' },
+  { chrom: '14', size: '_ GiB', md5: '_' },
+  { chrom: '15', size: '_ GiB', md5: '_' },
+  { chrom: '16', size: '_ GiB', md5: '_' },
+  { chrom: '17', size: '_ GiB', md5: '_' },
+  { chrom: '18', size: '_ MiB', md5: '_' },
+  { chrom: '19', size: '_ GiB', md5: '_' },
+  { chrom: '20', size: '_ GiB', md5: '_' },
+  { chrom: '21', size: '_ MiB', md5: '_' },
+  { chrom: '22', size: '_ GiB', md5: '_' },
+  { chrom: 'X', size: '_ GiB', md5: '_' },
+  { chrom: 'Y', size: '_ MiB', md5: '_' },
+]
+
+const GnomadV4Downloads = () => {
+  return (
+    <>
+      <SectionTitle id="v4" theme={{ type: 'release' }}>
+        v4 Downloads
+      </SectionTitle>
+      <StyledParagraph>
+        The gnomAD v4.0.0 data set contains data from 730,947 exomes and 76,215 whole genomes, all
+        mapped to the GRCh38 reference sequence.
+      </StyledParagraph>
+
+      <SectionTitle id="v4-core-dataset" theme={{ type: 'datasets' }}>
+        Core Dataset
+      </SectionTitle>
+      <StyledParagraph>
+        gnomAD database and features created and maintained by the gnomAD production team.
+      </StyledParagraph>
+
+      <DownloadsSection>
+        <SectionTitle id="v4-variants">Variants</SectionTitle>
+        <p>
+          For more information, read the{' '}
+          {/* @ts-expect-error TS(2786) FIXME: 'ExternalLink' cannot be used as a JSX component. */}
+          <ExternalLink href="https://gnomad.broadinstitute.org/news/2023-11-gnomad-v4-0">
+            v4 blog post
+          </ExternalLink>
+          , and the{' '}
+          {/* @ts-expect-error TS(2786) FIXME: 'ExternalLink' cannot be used as a JSX component. */}
+          <ExternalLink href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/README.txt">
+            gnomAD v4.0.0 README
+          </ExternalLink>
+          .
+        </p>
+        <ColumnsWrapper>
+          <Column>
+            <h3>Exomes</h3>
+            <FileList>
+              {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+              <ListItem>
+                <GetUrlButtons
+                  label="Sites Hail Table"
+                  // TODO: check after sync
+                  path="/release/4.0/ht/exomes/gnomad.exomes.v4.0.sites.ht"
+                  includeAWS={false}
+                  includeAzure={false}
+                />
+              </ListItem>
+              {exomeChromosomeVcfs.map(({ chrom, size, md5 }) => (
+                // @ts-expect-error TS(2769) FIXME: No overload matches this call.
+                <ListItem key={chrom}>
+                  <IndexedFileDownloadLinks
+                    label={`chr${chrom} sites VCF`}
+                    // TODO: check after sync
+                    path={`/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr${chrom}.vcf.bgz`}
+                    size={size}
+                    md5={md5}
+                    includeAWS={false}
+                    includeAzure={false}
+                  />
+                </ListItem>
+              ))}
+            </FileList>
+          </Column>
+
+          <Column>
+            <h3>Genomes</h3>
+            <FileList>
+              {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+              <ListItem>
+                <GetUrlButtons
+                  label="Sites Hail Table"
+                  // TODO: check after sync
+                  path="/release/4.0/ht/genomes/gnomad.genomes.v4.0.sites.ht"
+                  includeAWS={false}
+                  includeAzure={false}
+                />
+              </ListItem>
+              {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+              <ListItem>
+                <IndexedFileDownloadLinks
+                  label="Exome calling intervals VCF"
+                  // TODO: check after sync
+                  path="/release/4.0/vcf/genomes/gnomad.genomes.r4.0.exome_calling_intervals.sites.vcf.bgz"
+                  size="_ GiB"
+                  md5="_"
+                  includeAWS={false}
+                  includeAzure={false}
+                />
+              </ListItem>
+              {genomeChromosomeVcfs.map(({ chrom, size, md5 }) => (
+                // @ts-expect-error TS(2769) FIXME: No overload matches this call.
+                <ListItem key={chrom}>
+                  <IndexedFileDownloadLinks
+                    label={`chr${chrom} sites VCF`}
+                    // TODO: check after sync
+                    path={`/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr${chrom}.vcf.bgz`}
+                    size={size}
+                    md5={md5}
+                    includeAWS={false}
+                    includeAzure={false}
+                  />
+                </ListItem>
+              ))}
+            </FileList>
+          </Column>
+        </ColumnsWrapper>
+      </DownloadsSection>
+
+      <DownloadsSection>
+        <SectionTitle id="v4-coverage">Coverage</SectionTitle>
+        <FileList>
+          {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+          <ListItem>
+            <GetUrlButtons
+              label="Exome coverage Hail Table"
+              // TODO: double check this after sync
+              path="/release/4.0/coverage/exomes/gnomad.exomes.v4.0.coverage.ht"
+              includeAWS={false}
+              includeAzure={false}
+            />
+          </ListItem>
+          {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+          <ListItem>
+            <GenericDownloadLinks
+              label="Exome coverage summary TSV"
+              // TODO: double check this after sync
+              path="/release/4.0/coverage/exomes/gnomad.exomes.v4.0.coverage.tsv.bgz"
+              size="_ GiB"
+              md5="_"
+              includeAWS={false}
+              includeAzure={false}
+            />
+          </ListItem>
+          {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+          <ListItem>
+            <GetUrlButtons
+              label="Genome coverage Hail Table"
+              // TODO: double check this after sync
+              path="/release/4.0/coverage/genomes/gnomad.genomes.v4.0.coverage.ht"
+              includeAWS={false}
+              includeAzure={false}
+            />
+          </ListItem>
+          {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+          <ListItem>
+            <GenericDownloadLinks
+              label="Genome coverage summary TSV"
+              // TODO: double check this after sync
+              path="/release/4.0/coverage/genomes/gnomad.genomes.v4.0.coverage.tsv.bgz"
+              size="_ GiB"
+              md5="_"
+              includeAWS={false}
+              includeAzure={false}
+            />
+          </ListItem>
+        </FileList>
+      </DownloadsSection>
+
+      <DownloadsSection>
+        <SectionTitle id="v4-constraint">Constraint</SectionTitle>
+        <p>
+          For information on constraint, see our <Link to="/help/constraint">help text</Link>
+        </p>
+        <FileList>
+          {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+          <ListItem>
+            <GetUrlButtons
+              label="Constraint metrics Hail Table"
+              // TODO: double check this after sync
+              path="/release/4.0/constraint/metrics/gnomad.v4.0.constraint_metrics.ht"
+              includeAWS={false}
+              includeAzure={false}
+            />
+          </ListItem>
+          {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+          <ListItem>
+            <GenericDownloadLinks
+              label="Constraint metrics TSV"
+              // TODO: double check this after sync
+              path="/release/4.0/constraint/metrics/gnomad.v4.0.constraint_metrics.tsv.bgz"
+              includeAWS={false}
+              includeAzure={false}
+            />
+          </ListItem>
+        </FileList>
+      </DownloadsSection>
+
+      <DownloadsSection>
+        <SectionTitle id="v4-structural-variants">Structural variants</SectionTitle>
+        <p>
+          For information on structural variants, see our{' '}
+          <Link to="/help/sv-overview">help text</Link>
+        </p>
+        <FileList>
+          {svChromosomeVcfs.map(({ chrom, size, md5 }) => (
+            // @ts-expect-error TS(2769) FIXME: No overload matches this call.
+            <ListItem key={chrom}>
+              <IndexedFileDownloadLinks
+                label={`chr${chrom} VCF`}
+                // TODO: check after sync
+                path={`/release/4.0/genome_sv/gnomad.v4.0.sv.chr${chrom}.vcf.gz`}
+                size={size}
+                md5={md5}
+                includeAWS={false}
+                includeAzure={false}
+              />
+            </ListItem>
+          ))}
+        </FileList>
+      </DownloadsSection>
+
+      <DownloadsSection>
+        <SectionTitle id="v4-copy-number-variants">Copy number variants</SectionTitle>
+        <p>
+          For information on copy number variants, see our{' '}
+          <Link to="/help/sv-overview">help text</Link>
+        </p>
+        <FileList>
+          {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+          <ListItem>
+            <GenericDownloadLinks
+              label="Exome CNV VCF"
+              // TODO: double check this after sync
+              path="/release/4.0/exome_cnv/gnomad.v4.0.cnv.all.vcf.gz"
+              includeAWS={false}
+              includeAzure={false}
+            />
+          </ListItem>
+          {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+          <ListItem>
+            <GenericDownloadLinks
+              label="Exome CNV non neuro VCF"
+              // TODO: double check this after sync
+              path="/release/4.0/exome_cnv/gnomad.v4.0.cnv.non_neuro.vcf.gz"
+              includeAWS={false}
+              includeAzure={false}
+            />
+          </ListItem>
+          {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+          <ListItem>
+            <GenericDownloadLinks
+              label="Exome CNV non-neuro controls VCF"
+              // TODO: double check this after sync
+              path="/release/4.0/exome_cnv/gnomad.v4.0.cnv.non_neuro_controls.vcf.gz"
+              includeAWS={false}
+              includeAzure={false}
+            />
+          </ListItem>
+        </FileList>
+      </DownloadsSection>
+
+      <DownloadsSection>
+        <SectionTitle id="v4-resources">Resources</SectionTitle>
+        <FileList>
+          {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+          <ListItem>
+            <GenericDownloadLinks
+              label="Exome sex ploidy cutoffs TSV"
+              // TODO: double check this after sync
+              path="/release/4.0/sex_inference/gnomad.exomes.v4.0.sample_qc.sex_inference.ploidy_cutoffs.tsv"
+              includeAWS={false}
+              includeAzure={false}
+            />
+          </ListItem>
+          {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+          <ListItem>
+            <GetUrlButtons
+              label="Exome calling intervals Hail Table"
+              // TODO: double check this after sync
+              path="/resources/grch38/intervals/ukb.pad50.broad.pad50.union.interval_list.ht"
+              includeAWS={false}
+              includeAzure={false}
+            />
+          </ListItem>
+          {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+          <ListItem>
+            <GenericDownloadLinks
+              label="Exome calling intervals flat file"
+              // TODO: double check this after sync
+              path="/resources/grch38/intervals/ukb.pad50.broad.pad50.union.intervals"
+              includeAWS={false}
+              includeAzure={false}
+            />
+          </ListItem>
+        </FileList>
+      </DownloadsSection>
+    </>
+  )
+}
+
+export default GnomadV4Downloads

--- a/browser/src/DownloadsPage/TableOfContents.tsx
+++ b/browser/src/DownloadsPage/TableOfContents.tsx
@@ -57,6 +57,8 @@ const DownloadsPageTableOfContents = () => {
       setActiveSection('v2-liftover')
     } else if (activeId.indexOf('v2') > -1) {
       setActiveSection('v2')
+    } else if (activeId.indexOf('v4') > -1) {
+      setActiveSection('v4')
     } else if (activeId.indexOf('v3') > -1) {
       setActiveSection('v3')
     } else if (activeId.indexOf('exac') > -1) {
@@ -88,9 +90,9 @@ const DownloadsPageTableOfContents = () => {
   }
 
   type ContentItem = {
-    link: string,
-    indent: string,
-    text: string,
+    link: string
+    indent: string
+    text: string
   }
 
   return (

--- a/browser/src/DownloadsPage/__snapshots__/DownloadsPage.spec.tsx.snap
+++ b/browser/src/DownloadsPage/__snapshots__/DownloadsPage.spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Downloads Page has no unexpected changes 1`] = `
-.c22 {
+.c21 {
   padding: 0;
   border: none;
   background: none;
@@ -15,22 +15,22 @@ exports[`Downloads Page has no unexpected changes 1`] = `
   user-select: none;
 }
 
-.c22:active,
-.c22:hover {
+.c21:active,
+.c21:hover {
   color: #be4248;
 }
 
-.c22:disabled {
+.c21:disabled {
   color: rgba(66,139,202,0.5);
   cursor: not-allowed;
 }
 
-.c22:focus {
+.c21:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c17 {
+.c22 {
   position: relative;
   top: -0.1em;
   display: inline-block;
@@ -44,19 +44,19 @@ exports[`Downloads Page has no unexpected changes 1`] = `
   line-height: 1;
 }
 
-.c13 {
+.c23 {
   color: #1173bb;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c13:visited,
-.c13:active {
+.c23:visited,
+.c23:active {
   color: #1173bb;
 }
 
-.c13:focus,
-.c13:hover {
+.c23:focus,
+.c23:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
@@ -78,7 +78,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
   text-decoration: underline;
 }
 
-.c21 {
+.c20 {
   margin-bottom: 0.5em;
 }
 
@@ -104,7 +104,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
   margin: 0;
 }
 
-.c23 {
+.c24 {
   height: calc(2em + 2px);
   padding: 0.375em 1.5em 0.375em 0.75em;
   border: 1px solid #6c757d;
@@ -119,10 +119,27 @@ exports[`Downloads Page has no unexpected changes 1`] = `
   line-height: 1.25;
 }
 
-.c23:focus {
+.c24:focus {
   outline: none;
   border-color: rgb(70,130,180);
   box-shadow: 0 0 0 0.2em rgba(70,130,180,0.5);
+}
+
+.c13 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c13:visited,
+.c13:active {
+  color: #1173bb;
+}
+
+.c13:focus,
+.c13:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
 }
 
 .c0 {
@@ -167,13 +184,13 @@ exports[`Downloads Page has no unexpected changes 1`] = `
   visibility: visible;
 }
 
-.c20 {
+.c19 {
   padding-left: 20px;
   list-style-type: disc;
   margin-bottom: 1em;
 }
 
-.c20 li {
+.c19 li {
   line-height: 1.25;
 }
 
@@ -193,7 +210,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
   padding-bottom: 1rem;
 }
 
-.c18 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -207,13 +224,13 @@ exports[`Downloads Page has no unexpected changes 1`] = `
   justify-content: space-between;
 }
 
-.c19 {
+.c18 {
   -webkit-flex-basis: calc(50% - 25px);
   -ms-flex-preferred-size: calc(50% - 25px);
   flex-basis: calc(50% - 25px);
 }
 
-.c19 > h3 {
+.c18 > h3 {
   margin-top: 0;
 }
 
@@ -225,26 +242,8 @@ exports[`Downloads Page has no unexpected changes 1`] = `
   margin-left: 1rem;
 }
 
-.c24 {
-  color: #1173bb;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c24:visited,
-.c24:active {
-  color: #1173bb;
-}
-
-.c24:focus,
-.c24:hover {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
 .c12 {
   display: inline-block;
-  overflow-x: scroll;
   box-sizing: border-box;
   max-width: 100%;
   padding: 0.5em 1em;
@@ -312,7 +311,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
 }
 
 @media (max-width:900px) {
-  .c19 {
+  .c18 {
     -webkit-flex-basis: 100%;
     -ms-flex-preferred-size: 100%;
     flex-basis: 100%;
@@ -581,12 +580,14 @@ exports[`Downloads Page has no unexpected changes 1`] = `
       <p
         className="c11"
       >
-        See 
+        See
+         
         <a
-          className="c13"
-          to="/help/whats-the-difference-between-the-different-versions-of-gnomad"
+          className="-Link c13"
+          href="/help/whats-the-difference-between-the-different-versions-of-gnomad"
+          onClick={[Function]}
         >
-          “What's the difference between gnomAD v2 and v3?”
+          “What's the difference between different versions of gnomad?”
         </a>
          
         to decide which version is right for you.
@@ -620,6 +621,14074 @@ exports[`Downloads Page has no unexpected changes 1`] = `
       </p>
     </div>
     <hr />
+    <span
+      className="c6"
+    >
+      <h2
+        className="c14"
+      >
+        <a
+          aria-hidden="true"
+          className="c8 c9"
+          href="#v4"
+          id="v4"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        v4 Downloads
+      </h2>
+    </span>
+    <p
+      className="c11"
+    >
+      The gnomAD v4.0.0 data set contains data from 730,947 exomes and 76,215 whole genomes, all mapped to the GRCh38 reference sequence.
+    </p>
+    <span
+      className="c6"
+    >
+      <h2
+        className="c7"
+      >
+        <a
+          aria-hidden="true"
+          className="c8 c9"
+          href="#v4-core-dataset"
+          id="v4-core-dataset"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Core Dataset
+      </h2>
+    </span>
+    <p
+      className="c11"
+    >
+      gnomAD database and features created and maintained by the gnomAD production team.
+    </p>
+    <section
+      className="c15"
+    >
+      <span
+        className="c6"
+      >
+        <h2
+          className="c16"
+        >
+          <a
+            aria-hidden="true"
+            className="c8 c9"
+            href="#v4-variants"
+            id="v4-variants"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Variants
+        </h2>
+      </span>
+      <p>
+        For more information, read the
+         
+        <a
+          className="c10"
+          href="https://gnomad.broadinstitute.org/news/2023-11-gnomad-v4-0"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          v4 blog post
+        </a>
+        , and the
+         
+        <a
+          className="c10"
+          href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/README.txt"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          gnomAD v4.0.0 README
+        </a>
+        .
+      </p>
+      <div
+        className="c17"
+      >
+        <div
+          className="c18"
+        >
+          <h3>
+            Exomes
+          </h3>
+          <ul
+            className="c19"
+          >
+            <li
+              className="c20"
+            >
+              <span>
+                Sites Hail Table
+              </span>
+              <br />
+              Show URL for
+               
+              <button
+                aria-label="Show Google URL for Sites Hail Table"
+                className="c21"
+                onClick={[Function]}
+                type="button"
+              >
+                Google
+              </button>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr1 sites VCF
+              </span>
+              <br />
+              <span>
+                _ GiB
+                , MD5: 
+                _
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr1 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr1.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr1 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr1.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr2 sites VCF
+              </span>
+              <br />
+              <span>
+                _ GiB
+                , MD5: 
+                _
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr2 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr2.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr2 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr2.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr3 sites VCF
+              </span>
+              <br />
+              <span>
+                _ GiB
+                , MD5: 
+                _
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr3 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr3.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr3 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr3.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr4 sites VCF
+              </span>
+              <br />
+              <span>
+                _ GiB
+                , MD5: 
+                _
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr4 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr4.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr4 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr4.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr5 sites VCF
+              </span>
+              <br />
+              <span>
+                _ GiB
+                , MD5: 
+                _
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr5 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr5.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr5 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr5.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr6 sites VCF
+              </span>
+              <br />
+              <span>
+                _ GiB
+                , MD5: 
+                _
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr6 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr6.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr6 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr6.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr7 sites VCF
+              </span>
+              <br />
+              <span>
+                _ GiB
+                , MD5: 
+                _
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr7 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr7.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr7 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr7.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr8 sites VCF
+              </span>
+              <br />
+              <span>
+                _ GiB
+                , MD5: 
+                _
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr8 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr8.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr8 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr8.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr9 sites VCF
+              </span>
+              <br />
+              <span>
+                _ GiB
+                , MD5: 
+                _
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr9 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr9.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr9 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr9.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr10 sites VCF
+              </span>
+              <br />
+              <span>
+                _ GiB
+                , MD5: 
+                _
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr10 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr10.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr10 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr10.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr11 sites VCF
+              </span>
+              <br />
+              <span>
+                _ GiB
+                , MD5: 
+                _
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr11 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr11.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr11 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr11.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr12 sites VCF
+              </span>
+              <br />
+              <span>
+                - GiB
+                , MD5: 
+                _
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr12 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr12.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr12 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr12.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr13 sites VCF
+              </span>
+              <br />
+              <span>
+                _ MiB
+                , MD5: 
+                _
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr13 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr13.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr13 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr13.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr14 sites VCF
+              </span>
+              <br />
+              <span>
+                _ GiB
+                , MD5: 
+                _
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr14 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr14.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr14 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr14.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr15 sites VCF
+              </span>
+              <br />
+              <span>
+                _ GiB
+                , MD5: 
+                _
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr15 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr15.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr15 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr15.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr16 sites VCF
+              </span>
+              <br />
+              <span>
+                _ GiB
+                , MD5: 
+                _
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr16 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr16.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr16 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr16.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr17 sites VCF
+              </span>
+              <br />
+              <span>
+                _ GiB
+                , MD5: 
+                _
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr17 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr17.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr17 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr17.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr18 sites VCF
+              </span>
+              <br />
+              <span>
+                _ MiB
+                , MD5: 
+                _
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr18 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr18.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr18 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr18.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr19 sites VCF
+              </span>
+              <br />
+              <span>
+                _ GiB
+                , MD5: 
+                _
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr19 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr19.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr19 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr19.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr20 sites VCF
+              </span>
+              <br />
+              <span>
+                _ GiB
+                , MD5: 
+                _
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr20 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr20.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr20 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr20.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr21 sites VCF
+              </span>
+              <br />
+              <span>
+                _ MiB
+                , MD5: 
+                _
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr21 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr21.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr21 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr21.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr22 sites VCF
+              </span>
+              <br />
+              <span>
+                _ GiB
+                , MD5: 
+                _
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr22 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr22.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr22 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr22.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chrX sites VCF
+              </span>
+              <br />
+              <span>
+                _ GiB
+                , MD5: 
+                _
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chrX sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chrX.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chrX sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chrX.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chrY sites VCF
+              </span>
+              <br />
+              <span>
+                _ MiB
+                , MD5: 
+                _
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chrY sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chrY.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chrY sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chrY.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+            </li>
+          </ul>
+        </div>
+        <div
+          className="c18"
+        >
+          <h3>
+            Genomes
+          </h3>
+          <ul
+            className="c19"
+          >
+            <li
+              className="c20"
+            >
+              <span>
+                Sites Hail Table
+              </span>
+              <br />
+              Show URL for
+               
+              <button
+                aria-label="Show Google URL for Sites Hail Table"
+                className="c21"
+                onClick={[Function]}
+                type="button"
+              >
+                Google
+              </button>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                Exome calling intervals VCF
+              </span>
+              <br />
+              <span>
+                _ GiB
+                , MD5: 
+                _
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download Exome calling intervals VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.r4.0.exome_calling_intervals.sites.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for Exome calling intervals VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.r4.0.exome_calling_intervals.sites.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr1 sites VCF
+              </span>
+              <br />
+              <span>
+                _ GiB
+                , MD5: 
+                _
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr1 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr1.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr1 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr1.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr2 sites VCF
+              </span>
+              <br />
+              <span>
+                _ GiB
+                , MD5: 
+                _
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr2 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr2.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr2 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr2.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr3 sites VCF
+              </span>
+              <br />
+              <span>
+                _ GiB
+                , MD5: 
+                _
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr3 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr3.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr3 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr3.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr4 sites VCF
+              </span>
+              <br />
+              <span>
+                _ GiB
+                , MD5: 
+                _
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr4 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr4.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr4 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr4.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr5 sites VCF
+              </span>
+              <br />
+              <span>
+                _ GiB
+                , MD5: 
+                _
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr5 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr5.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr5 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr5.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr6 sites VCF
+              </span>
+              <br />
+              <span>
+                _ GiB
+                , MD5: 
+                _
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr6 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr6.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr6 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr6.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr7 sites VCF
+              </span>
+              <br />
+              <span>
+                _ GiB
+                , MD5: 
+                _
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr7 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr7.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr7 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr7.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr8 sites VCF
+              </span>
+              <br />
+              <span>
+                _ GiB
+                , MD5: 
+                _
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr8 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr8.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr8 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr8.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr9 sites VCF
+              </span>
+              <br />
+              <span>
+                _ GiB
+                , MD5: 
+                _
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr9 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr9.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr9 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr9.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr10 sites VCF
+              </span>
+              <br />
+              <span>
+                _ GiB
+                , MD5: 
+                _
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr10 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr10.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr10 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr10.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr11 sites VCF
+              </span>
+              <br />
+              <span>
+                _ GiB
+                , MD5: 
+                _
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr11 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr11.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr11 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr11.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr12 sites VCF
+              </span>
+              <br />
+              <span>
+                _ GiB
+                , MD5: 
+                _
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr12 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr12.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr12 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr12.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr13 sites VCF
+              </span>
+              <br />
+              <span>
+                _ GiB
+                , MD5: 
+                _
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr13 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr13.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr13 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr13.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr14 sites VCF
+              </span>
+              <br />
+              <span>
+                _ GiB
+                , MD5: 
+                _
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr14 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr14.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr14 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr14.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr15 sites VCF
+              </span>
+              <br />
+              <span>
+                _ GiB
+                , MD5: 
+                _
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr15 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr15.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr15 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr15.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr16 sites VCF
+              </span>
+              <br />
+              <span>
+                _ GiB
+                , MD5: 
+                _
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr16 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr16.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr16 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr16.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr17 sites VCF
+              </span>
+              <br />
+              <span>
+                _ GiB
+                , MD5: 
+                _
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr17 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr17.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr17 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr17.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr18 sites VCF
+              </span>
+              <br />
+              <span>
+                _ GiB
+                , MD5: 
+                _
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr18 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr18.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr18 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr18.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr19 sites VCF
+              </span>
+              <br />
+              <span>
+                _ GiB
+                , MD5: 
+                _
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr19 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr19.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr19 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr19.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr20 sites VCF
+              </span>
+              <br />
+              <span>
+                _ GiB
+                , MD5: 
+                _
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr20 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr20.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr20 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr20.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr21 sites VCF
+              </span>
+              <br />
+              <span>
+                _ GiB
+                , MD5: 
+                _
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr21 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr21.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr21 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr21.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr22 sites VCF
+              </span>
+              <br />
+              <span>
+                _ GiB
+                , MD5: 
+                _
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr22 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr22.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr22 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr22.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chrX sites VCF
+              </span>
+              <br />
+              <span>
+                _ GiB
+                , MD5: 
+                _
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chrX sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chrX.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chrX sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chrX.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+              </span>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </section>
+    <section
+      className="c15"
+    >
+      <span
+        className="c6"
+      >
+        <h2
+          className="c16"
+        >
+          <a
+            aria-hidden="true"
+            className="c8 c9"
+            href="#v4-coverage"
+            id="v4-coverage"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Coverage
+        </h2>
+      </span>
+      <ul
+        className="c19"
+      >
+        <li
+          className="c20"
+        >
+          <span>
+            Exome coverage Hail Table
+          </span>
+          <br />
+          Show URL for
+           
+          <button
+            aria-label="Show Google URL for Exome coverage Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Google
+          </button>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            Exome coverage summary TSV
+          </span>
+          <br />
+          <span>
+            _ GiB
+            , MD5: 
+            _
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download Exome coverage summary TSV from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/coverage/exomes/gnomad.exomes.v4.0.coverage.tsv.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            Genome coverage Hail Table
+          </span>
+          <br />
+          Show URL for
+           
+          <button
+            aria-label="Show Google URL for Genome coverage Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Google
+          </button>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            Genome coverage summary TSV
+          </span>
+          <br />
+          <span>
+            _ GiB
+            , MD5: 
+            _
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download Genome coverage summary TSV from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/coverage/genomes/gnomad.genomes.v4.0.coverage.tsv.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+        </li>
+      </ul>
+    </section>
+    <section
+      className="c15"
+    >
+      <span
+        className="c6"
+      >
+        <h2
+          className="c16"
+        >
+          <a
+            aria-hidden="true"
+            className="c8 c9"
+            href="#v4-constraint"
+            id="v4-constraint"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Constraint
+        </h2>
+      </span>
+      <p>
+        For information on constraint, see our 
+        <a
+          className="-Link c13"
+          href="/help/constraint"
+          onClick={[Function]}
+        >
+          help text
+        </a>
+      </p>
+      <ul
+        className="c19"
+      >
+        <li
+          className="c20"
+        >
+          <span>
+            Constraint metrics Hail Table
+          </span>
+          <br />
+          Show URL for
+           
+          <button
+            aria-label="Show Google URL for Constraint metrics Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Google
+          </button>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            Constraint metrics TSV
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download Constraint metrics TSV from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/constraint/metrics/gnomad.v4.0.constraint_metrics.tsv.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+        </li>
+      </ul>
+    </section>
+    <section
+      className="c15"
+    >
+      <span
+        className="c6"
+      >
+        <h2
+          className="c16"
+        >
+          <a
+            aria-hidden="true"
+            className="c8 c9"
+            href="#v4-structural-variants"
+            id="v4-structural-variants"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Structural variants
+        </h2>
+      </span>
+      <p>
+        For information on structural variants, see our
+         
+        <a
+          className="-Link c13"
+          href="/help/sv-overview"
+          onClick={[Function]}
+        >
+          help text
+        </a>
+      </p>
+      <ul
+        className="c19"
+      >
+        <li
+          className="c20"
+        >
+          <span>
+            chr1 VCF
+          </span>
+          <br />
+          <span>
+            _ GiB
+            , MD5: 
+            _
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr1 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr1.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr1 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr1.vcf.gz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr2 VCF
+          </span>
+          <br />
+          <span>
+            _ GiB
+            , MD5: 
+            _
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr2 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr2.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr2 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr2.vcf.gz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr3 VCF
+          </span>
+          <br />
+          <span>
+            _ GiB
+            , MD5: 
+            _
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr3 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr3.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr3 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr3.vcf.gz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr4 VCF
+          </span>
+          <br />
+          <span>
+            _ GiB
+            , MD5: 
+            _
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr4 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr4.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr4 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr4.vcf.gz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr5 VCF
+          </span>
+          <br />
+          <span>
+            _ GiB
+            , MD5: 
+            _
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr5 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr5.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr5 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr5.vcf.gz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr6 VCF
+          </span>
+          <br />
+          <span>
+            _ GiB
+            , MD5: 
+            _
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr6 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr6.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr6 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr6.vcf.gz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr7 VCF
+          </span>
+          <br />
+          <span>
+            _ GiB
+            , MD5: 
+            _
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr7 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr7.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr7 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr7.vcf.gz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr8 VCF
+          </span>
+          <br />
+          <span>
+            _ GiB
+            , MD5: 
+            _
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr8 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr8.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr8 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr8.vcf.gz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr9 VCF
+          </span>
+          <br />
+          <span>
+            _ GiB
+            , MD5: 
+            _
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr9 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr9.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr9 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr9.vcf.gz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr10 VCF
+          </span>
+          <br />
+          <span>
+            _ GiB
+            , MD5: 
+            _
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr10 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr10.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr10 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr10.vcf.gz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr11 VCF
+          </span>
+          <br />
+          <span>
+            _ GiB
+            , MD5: 
+            _
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr11 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr11.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr11 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr11.vcf.gz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr12 VCF
+          </span>
+          <br />
+          <span>
+            - GiB
+            , MD5: 
+            _
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr12 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr12.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr12 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr12.vcf.gz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr13 VCF
+          </span>
+          <br />
+          <span>
+            _ MiB
+            , MD5: 
+            _
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr13 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr13.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr13 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr13.vcf.gz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr14 VCF
+          </span>
+          <br />
+          <span>
+            _ GiB
+            , MD5: 
+            _
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr14 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr14.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr14 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr14.vcf.gz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr15 VCF
+          </span>
+          <br />
+          <span>
+            _ GiB
+            , MD5: 
+            _
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr15 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr15.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr15 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr15.vcf.gz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr16 VCF
+          </span>
+          <br />
+          <span>
+            _ GiB
+            , MD5: 
+            _
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr16 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr16.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr16 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr16.vcf.gz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr17 VCF
+          </span>
+          <br />
+          <span>
+            _ GiB
+            , MD5: 
+            _
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr17 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr17.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr17 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr17.vcf.gz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr18 VCF
+          </span>
+          <br />
+          <span>
+            _ MiB
+            , MD5: 
+            _
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr18 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr18.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr18 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr18.vcf.gz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr19 VCF
+          </span>
+          <br />
+          <span>
+            _ GiB
+            , MD5: 
+            _
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr19 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr19.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr19 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr19.vcf.gz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr20 VCF
+          </span>
+          <br />
+          <span>
+            _ GiB
+            , MD5: 
+            _
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr20 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr20.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr20 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr20.vcf.gz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr21 VCF
+          </span>
+          <br />
+          <span>
+            _ MiB
+            , MD5: 
+            _
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr21 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr21.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr21 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr21.vcf.gz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr22 VCF
+          </span>
+          <br />
+          <span>
+            _ GiB
+            , MD5: 
+            _
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr22 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr22.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr22 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr22.vcf.gz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chrX VCF
+          </span>
+          <br />
+          <span>
+            _ GiB
+            , MD5: 
+            _
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chrX VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chrX.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chrX VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chrX.vcf.gz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chrY VCF
+          </span>
+          <br />
+          <span>
+            _ MiB
+            , MD5: 
+            _
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chrY VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chrY.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chrY VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chrY.vcf.gz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+        </li>
+      </ul>
+    </section>
+    <section
+      className="c15"
+    >
+      <span
+        className="c6"
+      >
+        <h2
+          className="c16"
+        >
+          <a
+            aria-hidden="true"
+            className="c8 c9"
+            href="#v4-copy-number-variants"
+            id="v4-copy-number-variants"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Copy number variants
+        </h2>
+      </span>
+      <p>
+        For information on copy number variants, see our
+         
+        <a
+          className="-Link c13"
+          href="/help/sv-overview"
+          onClick={[Function]}
+        >
+          help text
+        </a>
+      </p>
+      <ul
+        className="c19"
+      >
+        <li
+          className="c20"
+        >
+          <span>
+            Exome CNV VCF
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download Exome CNV VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/exome_cnv/gnomad.v4.0.cnv.all.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            Exome CNV non neuro VCF
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download Exome CNV non neuro VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/exome_cnv/gnomad.v4.0.cnv.non_neuro.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            Exome CNV non-neuro controls VCF
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download Exome CNV non-neuro controls VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/exome_cnv/gnomad.v4.0.cnv.non_neuro_controls.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+        </li>
+      </ul>
+    </section>
+    <section
+      className="c15"
+    >
+      <span
+        className="c6"
+      >
+        <h2
+          className="c16"
+        >
+          <a
+            aria-hidden="true"
+            className="c8 c9"
+            href="#v4-resources"
+            id="v4-resources"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Resources
+        </h2>
+      </span>
+      <ul
+        className="c19"
+      >
+        <li
+          className="c20"
+        >
+          <span>
+            Exome sex ploidy cutoffs TSV
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download Exome sex ploidy cutoffs TSV from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/sex_inference/gnomad.exomes.v4.0.sample_qc.sex_inference.ploidy_cutoffs.tsv"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            Exome calling intervals Hail Table
+          </span>
+          <br />
+          Show URL for
+           
+          <button
+            aria-label="Show Google URL for Exome calling intervals Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Google
+          </button>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            Exome calling intervals flat file
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download Exome calling intervals flat file from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/resources/grch38/intervals/ukb.pad50.broad.pad50.union.intervals"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+        </li>
+      </ul>
+    </section>
+    <span
+      className="c6"
+    >
+      <h2
+        className="c14"
+      >
+        <a
+          aria-hidden="true"
+          className="c8 c9"
+          href="#v3"
+          id="v3"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        v3 Downloads
+      </h2>
+    </span>
+    <p
+      className="c11"
+    >
+      The gnomAD v3.1.2 data set contains 76,156 whole genomes (and no exomes), all mapped to the GRCh38 reference sequence.
+    </p>
+    <span
+      className="c6"
+    >
+      <h2
+        className="c7"
+      >
+        <a
+          aria-hidden="true"
+          className="c8 c9"
+          href="#v3-core-dataset"
+          id="v3-core-dataset"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Core Dataset
+      </h2>
+    </span>
+    <p
+      className="c11"
+    >
+      gnomAD database and features created and maintained by the gnomAD production team.
+    </p>
+    <section
+      className="c15"
+    >
+      <span
+        className="c6"
+      >
+        <h2
+          className="c16"
+        >
+          <a
+            aria-hidden="true"
+            className="c8 c9"
+            href="#v3-variants"
+            id="v3-variants"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Variants
+        </h2>
+      </span>
+      <p>
+        <span
+          className="c22"
+        >
+          Note
+        </span>
+         Find out what changed in the latest release in the
+         
+        <a
+          className="c10"
+          href="https://gnomad.broadinstitute.org/news/2021-10-gnomad-v3-1-2-minor-release/"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          gnomAD v3.1.2 blog post
+        </a>
+        .
+      </p>
+      <p>
+        The variant dataset files below contain all subsets (non-cancer, non-neuro, non-v2, non-TOPMed, controls/biobanks, 1KG, and HGDP).
+      </p>
+      <h3>
+        Genomes
+      </h3>
+      <ul
+        className="c19"
+      >
+        <li
+          className="c20"
+        >
+          <span>
+            Sites Hail Table
+          </span>
+          <br />
+          Show URL for
+           
+          <button
+            aria-label="Show Google URL for Sites Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Google
+          </button>
+           / 
+          <button
+            aria-label="Show Amazon URL for Sites Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Amazon
+          </button>
+           / 
+          <button
+            aria-label="Show Microsoft URL for Sites Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Microsoft
+          </button>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr1 sites VCF
+          </span>
+          <br />
+          <span>
+            182.01 GiB
+            , MD5: 
+            65b21b95252786012721de95458a90e3
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr1 sites VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr1.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download chr1 sites VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr1.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download chr1 sites VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr1.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr1 sites VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr1.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr1 sites VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr1.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr1 sites VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr1.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr2 sites VCF
+          </span>
+          <br />
+          <span>
+            193.31 GiB
+            , MD5: 
+            6ad213299e21959d7b91787928d6f8b5
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr2 sites VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr2.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download chr2 sites VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr2.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download chr2 sites VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr2.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr2 sites VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr2.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr2 sites VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr2.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr2 sites VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr2.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr3 sites VCF
+          </span>
+          <br />
+          <span>
+            158.78 GiB
+            , MD5: 
+            13e380299b1cb61d2d18a45a522e8810
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr3 sites VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr3.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download chr3 sites VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr3.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download chr3 sites VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr3.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr3 sites VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr3.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr3 sites VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr3.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr3 sites VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr3.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr4 sites VCF
+          </span>
+          <br />
+          <span>
+            152.11 GiB
+            , MD5: 
+            90021c65fa7dabfed1a404b713db503f
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr4 sites VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr4.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download chr4 sites VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr4.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download chr4 sites VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr4.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr4 sites VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr4.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr4 sites VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr4.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr4 sites VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr4.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr5 sites VCF
+          </span>
+          <br />
+          <span>
+            140.43 GiB
+            , MD5: 
+            fc17883bc83787524b7872ba3002a05f
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr5 sites VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr5.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download chr5 sites VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr5.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download chr5 sites VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr5.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr5 sites VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr5.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr5 sites VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr5.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr5 sites VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr5.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr6 sites VCF
+          </span>
+          <br />
+          <span>
+            133.43 GiB
+            , MD5: 
+            3f1a3910c97e3625fe12962d2ed69a9a
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr6 sites VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr6.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download chr6 sites VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr6.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download chr6 sites VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr6.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr6 sites VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr6.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr6 sites VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr6.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr6 sites VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr6.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr7 sites VCF
+          </span>
+          <br />
+          <span>
+            130.4 GiB
+            , MD5: 
+            98fa44053cf0f907b9ae52ac461bb717
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr7 sites VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr7.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download chr7 sites VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr7.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download chr7 sites VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr7.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr7 sites VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr7.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr7 sites VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr7.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr7 sites VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr7.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr8 sites VCF
+          </span>
+          <br />
+          <span>
+            122.3 GiB
+            , MD5: 
+            5ac0337761d358832aa4adb041d1c3b7
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr8 sites VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr8.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download chr8 sites VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr8.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download chr8 sites VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr8.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr8 sites VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr8.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr8 sites VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr8.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr8 sites VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr8.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr9 sites VCF
+          </span>
+          <br />
+          <span>
+            103.13 GiB
+            , MD5: 
+            1a6fcfc564cd1d8e58db3e330b743303
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr9 sites VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr9.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download chr9 sites VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr9.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download chr9 sites VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr9.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr9 sites VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr9.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr9 sites VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr9.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr9 sites VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr9.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr10 sites VCF
+          </span>
+          <br />
+          <span>
+            109.82 GiB
+            , MD5: 
+            f84d74e58e9eb568bdfe349e6daa2645
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr10 sites VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr10.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download chr10 sites VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr10.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download chr10 sites VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr10.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr10 sites VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr10.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr10 sites VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr10.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr10 sites VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr10.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr11 sites VCF
+          </span>
+          <br />
+          <span>
+            108.34 GiB
+            , MD5: 
+            843ec265623593200dd64d56a5a045b3
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr11 sites VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr11.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download chr11 sites VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr11.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download chr11 sites VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr11.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr11 sites VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr11.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr11 sites VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr11.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr11 sites VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr11.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr12 sites VCF
+          </span>
+          <br />
+          <span>
+            106.21 GiB
+            , MD5: 
+            31f76395874ec62a7998e9fb3b2850a1
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr12 sites VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr12.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download chr12 sites VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr12.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download chr12 sites VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr12.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr12 sites VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr12.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr12 sites VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr12.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr12 sites VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr12.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr13 sites VCF
+          </span>
+          <br />
+          <span>
+            74.87 GiB
+            , MD5: 
+            78a27d411d3512dbbc6eb4b120391cb8
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr13 sites VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr13.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download chr13 sites VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr13.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download chr13 sites VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr13.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr13 sites VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr13.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr13 sites VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr13.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr13 sites VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr13.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr14 sites VCF
+          </span>
+          <br />
+          <span>
+            73.11 GiB
+            , MD5: 
+            e8273eef9760aac6ad9f799a52082d5d
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr14 sites VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr14.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download chr14 sites VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr14.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download chr14 sites VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr14.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr14 sites VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr14.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr14 sites VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr14.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr14 sites VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr14.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr15 sites VCF
+          </span>
+          <br />
+          <span>
+            68.73 GiB
+            , MD5: 
+            89d6cd19e5c7621f627fab6577cd0e87
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr15 sites VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr15.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download chr15 sites VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr15.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download chr15 sites VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr15.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr15 sites VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr15.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr15 sites VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr15.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr15 sites VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr15.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr16 sites VCF
+          </span>
+          <br />
+          <span>
+            76.75 GiB
+            , MD5: 
+            33ef1541b49d0347d6141609a287bdc7
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr16 sites VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr16.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download chr16 sites VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr16.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download chr16 sites VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr16.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr16 sites VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr16.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr16 sites VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr16.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr16 sites VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr16.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr17 sites VCF
+          </span>
+          <br />
+          <span>
+            68.76 GiB
+            , MD5: 
+            d13b9287a89e11d8119a93bc0f094c77
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr17 sites VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr17.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download chr17 sites VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr17.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download chr17 sites VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr17.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr17 sites VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr17.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr17 sites VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr17.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr17 sites VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr17.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr18 sites VCF
+          </span>
+          <br />
+          <span>
+            59.86 GiB
+            , MD5: 
+            e95595ca7a90edc528a09b209ea9bc4c
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr18 sites VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr18.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download chr18 sites VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr18.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download chr18 sites VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr18.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr18 sites VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr18.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr18 sites VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr18.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr18 sites VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr18.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr19 sites VCF
+          </span>
+          <br />
+          <span>
+            54.47 GiB
+            , MD5: 
+            32308281570563a5bc71a815ac11154f
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr19 sites VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr19.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download chr19 sites VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr19.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download chr19 sites VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr19.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr19 sites VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr19.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr19 sites VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr19.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr19 sites VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr19.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr20 sites VCF
+          </span>
+          <br />
+          <span>
+            49.63 GiB
+            , MD5: 
+            5cb14ed936340875c8ef664dbe6e772d
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr20 sites VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr20.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download chr20 sites VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr20.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download chr20 sites VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr20.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr20 sites VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr20.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr20 sites VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr20.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr20 sites VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr20.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr21 sites VCF
+          </span>
+          <br />
+          <span>
+            32.92 GiB
+            , MD5: 
+            92c4b4f1bd63a7bd64ac8378d88d86e2
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr21 sites VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr21.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download chr21 sites VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr21.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download chr21 sites VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr21.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr21 sites VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr21.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr21 sites VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr21.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr21 sites VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr21.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr22 sites VCF
+          </span>
+          <br />
+          <span>
+            35.77 GiB
+            , MD5: 
+            35f4d25b924ab2e9520c725dd9699ee5
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr22 sites VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr22.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download chr22 sites VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr22.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download chr22 sites VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr22.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr22 sites VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr22.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr22 sites VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr22.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr22 sites VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr22.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chrX sites VCF
+          </span>
+          <br />
+          <span>
+            95.6 GiB
+            , MD5: 
+            040080a18046533728fa60800eedcf4b
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chrX sites VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chrX.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download chrX sites VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chrX.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download chrX sites VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chrX.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chrX sites VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chrX.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chrX sites VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chrX.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chrX sites VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chrX.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chrY sites VCF
+          </span>
+          <br />
+          <span>
+            2.29 GiB
+            , MD5: 
+            112ed724f8d1cf13b031006def03f55e
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chrY sites VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chrY.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download chrY sites VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chrY.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download chrY sites VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chrY.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chrY sites VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chrY.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chrY sites VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chrY.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chrY sites VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chrY.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+      </ul>
+    </section>
+    <section
+      className="c15"
+    >
+      <span
+        className="c6"
+      >
+        <h2
+          className="c16"
+        >
+          <a
+            aria-hidden="true"
+            className="c8 c9"
+            href="#v3-coverage"
+            id="v3-coverage"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Coverage
+        </h2>
+      </span>
+      <ul
+        className="c19"
+      >
+        <li
+          className="c20"
+        >
+          <span>
+            Genome coverage Hail Table
+          </span>
+          <br />
+          Show URL for
+           
+          <button
+            aria-label="Show Google URL for Genome coverage Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Google
+          </button>
+           / 
+          <button
+            aria-label="Show Amazon URL for Genome coverage Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Amazon
+          </button>
+           / 
+          <button
+            aria-label="Show Microsoft URL for Genome coverage Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Microsoft
+          </button>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            Genome coverage summary TSV
+          </span>
+          <br />
+          <span>
+            75.38 GiB
+            , MD5: 
+            6c809627ff7922dcfc8d2c67bba017ff
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download Genome coverage summary TSV from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.0.1/coverage/genomes/gnomad.genomes.r3.0.1.coverage.summary.tsv.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download Genome coverage summary TSV from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.0.1/coverage/genomes/gnomad.genomes.r3.0.1.coverage.summary.tsv.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download Genome coverage summary TSV from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.0.1/coverage/genomes/gnomad.genomes.r3.0.1.coverage.summary.tsv.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+      </ul>
+    </section>
+    <section
+      className="c15"
+    >
+      <span
+        className="c6"
+      >
+        <h2
+          className="c16"
+        >
+          <a
+            aria-hidden="true"
+            className="c8 c9"
+            href="#v3-hgdp-1kg"
+            id="v3-hgdp-1kg"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          HGDP + 1KG callset
+        </h2>
+      </span>
+      <p>
+        These files contain individual genotypes for all samples in the HGDP and 1KG subsets. For more information, see the
+         
+        <a
+          className="c10"
+          href="https://gnomad.broadinstitute.org/news/2021-10-gnomad-v3-1-2-minor-release/"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          gnomAD v3.1.2 blog post
+        </a>
+         
+        and the
+         
+        <a
+          className="-Link c13"
+          href="/help/hgdp-1kg-annotations"
+          onClick={[Function]}
+        >
+          HGDP + 1KG dense MatrixTable annotation descriptions
+        </a>
+        .
+      </p>
+      <h3>
+        Genomes
+      </h3>
+      <ul
+        className="c19"
+      >
+        <li
+          className="c20"
+        >
+          <span>
+            Dense Hail MatrixTable
+          </span>
+          <br />
+          Show URL for
+           
+          <button
+            aria-label="Show Google URL for Dense Hail MatrixTable"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Google
+          </button>
+           / 
+          <button
+            aria-label="Show Amazon URL for Dense Hail MatrixTable"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Amazon
+          </button>
+           / 
+          <button
+            aria-label="Show Microsoft URL for Dense Hail MatrixTable"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Microsoft
+          </button>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            Sparse Hail MatrixTable
+          </span>
+          <br />
+          Show URL for
+           
+          <button
+            aria-label="Show Google URL for Sparse Hail MatrixTable"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Google
+          </button>
+           / 
+          <button
+            aria-label="Show Amazon URL for Sparse Hail MatrixTable"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Amazon
+          </button>
+           / 
+          <button
+            aria-label="Show Microsoft URL for Sparse Hail MatrixTable"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Microsoft
+          </button>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            Variant annotations Hail Table
+          </span>
+          <br />
+          Show URL for
+           
+          <button
+            aria-label="Show Google URL for Variant annotations Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Google
+          </button>
+           / 
+          <button
+            aria-label="Show Amazon URL for Variant annotations Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Amazon
+          </button>
+           / 
+          <button
+            aria-label="Show Microsoft URL for Variant annotations Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Microsoft
+          </button>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            Sample metadata Hail Table
+          </span>
+          <br />
+          Show URL for
+           
+          <button
+            aria-label="Show Google URL for Sample metadata Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Google
+          </button>
+           / 
+          <button
+            aria-label="Show Amazon URL for Sample metadata Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Amazon
+          </button>
+           / 
+          <button
+            aria-label="Show Microsoft URL for Sample metadata Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Microsoft
+          </button>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            Sample metadata TSV
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download Sample metadata TSV from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_1kg_subset_sample_meta.tsv.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download Sample metadata TSV from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_1kg_subset_sample_meta.tsv.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download Sample metadata TSV from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_1kg_subset_sample_meta.tsv.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr1 VCF
+          </span>
+          <br />
+          <span>
+            260.95 GiB
+            , MD5: 
+            66b515f3bc2f54ec01c974b359f93686
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr1 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr1.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download chr1 VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr1.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download chr1 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr1.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr1 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr1.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr1 VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr1.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr1 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr1.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr2 VCF
+          </span>
+          <br />
+          <span>
+            274.93 GiB
+            , MD5: 
+            3dcfa0a6eaf1b322422620c35e302ab0
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr2 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr2.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download chr2 VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr2.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download chr2 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr2.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr2 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr2.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr2 VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr2.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr2 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr2.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr3 VCF
+          </span>
+          <br />
+          <span>
+            224.56 GiB
+            , MD5: 
+            f7911776bef12fae38c2c7ff477893be
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr3 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr3.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download chr3 VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr3.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download chr3 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr3.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr3 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr3.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr3 VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr3.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr3 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr3.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr4 VCF
+          </span>
+          <br />
+          <span>
+            222.16 GiB
+            , MD5: 
+            26d97a4da3b7b0ffce4f42c37ede10fd
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr4 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr4.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download chr4 VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr4.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download chr4 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr4.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr4 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr4.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr4 VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr4.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr4 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr4.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr5 VCF
+          </span>
+          <br />
+          <span>
+            202.47 GiB
+            , MD5: 
+            4b1e3553262b8077b50940c953c8e00f
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr5 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr5.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download chr5 VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr5.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download chr5 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr5.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr5 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr5.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr5 VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr5.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr5 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr5.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr6 VCF
+          </span>
+          <br />
+          <span>
+            193.78 GiB
+            , MD5: 
+            eb9b309051b2f059500056cec856b220
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr6 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr6.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download chr6 VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr6.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download chr6 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr6.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr6 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr6.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr6 VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr6.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr6 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr6.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr7 VCF
+          </span>
+          <br />
+          <span>
+            189.71 GiB
+            , MD5: 
+            e18af68af38a91c523d1de6b4e390579
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr7 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr7.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download chr7 VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr7.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download chr7 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr7.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr7 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr7.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr7 VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr7.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr7 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr7.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr8 VCF
+          </span>
+          <br />
+          <span>
+            175.21 GiB
+            , MD5: 
+            35fbd4be95c70ab4683005ef58734535
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr8 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr8.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download chr8 VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr8.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download chr8 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr8.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr8 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr8.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr8 VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr8.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr8 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr8.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr9 VCF
+          </span>
+          <br />
+          <span>
+            148.36 GiB
+            , MD5: 
+            26d0842911a0a42d470e766a9d44741a
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr9 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr9.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download chr9 VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr9.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download chr9 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr9.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr9 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr9.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr9 VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr9.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr9 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr9.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr10 VCF
+          </span>
+          <br />
+          <span>
+            160.43 GiB
+            , MD5: 
+            f8d79f3ac86d8b50c89a330e1b3f7989
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr10 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr10.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download chr10 VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr10.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download chr10 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr10.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr10 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr10.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr10 VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr10.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr10 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr10.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr11 VCF
+          </span>
+          <br />
+          <span>
+            154.64 GiB
+            , MD5: 
+            fbbe9b8042105e791e5906c69af5166d
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr11 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr11.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download chr11 VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr11.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download chr11 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr11.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr11 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr11.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr11 VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr11.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr11 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr11.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr12 VCF
+          </span>
+          <br />
+          <span>
+            152.53 GiB
+            , MD5: 
+            52f20182eeb07782663bd2615789c55c
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr12 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr12.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download chr12 VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr12.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download chr12 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr12.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr12 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr12.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr12 VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr12.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr12 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr12.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr13 VCF
+          </span>
+          <br />
+          <span>
+            110.43 GiB
+            , MD5: 
+            3c69f708ffcf7e44927ff4c08d4c66f7
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr13 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr13.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download chr13 VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr13.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download chr13 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr13.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr13 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr13.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr13 VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr13.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr13 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr13.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr14 VCF
+          </span>
+          <br />
+          <span>
+            106.29 GiB
+            , MD5: 
+            d493751b424c20a0a2a298ba369b1e96
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr14 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr14.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download chr14 VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr14.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download chr14 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr14.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr14 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr14.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr14 VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr14.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr14 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr14.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr15 VCF
+          </span>
+          <br />
+          <span>
+            98.83 GiB
+            , MD5: 
+            ff2e043db7bb1643dfafd0a21a41ec59
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr15 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr15.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download chr15 VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr15.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download chr15 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr15.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr15 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr15.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr15 VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr15.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr15 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr15.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr16 VCF
+          </span>
+          <br />
+          <span>
+            110.94 GiB
+            , MD5: 
+            9bc8a00d6faf1c349992e34c22168a2d
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr16 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr16.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download chr16 VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr16.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download chr16 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr16.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr16 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr16.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr16 VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr16.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr16 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr16.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr17 VCF
+          </span>
+          <br />
+          <span>
+            100.7 GiB
+            , MD5: 
+            840b73079d2de44bf3f0b0f03c84c173
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr17 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr17.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download chr17 VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr17.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download chr17 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr17.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr17 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr17.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr17 VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr17.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr17 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr17.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr18 VCF
+          </span>
+          <br />
+          <span>
+            86.69 GiB
+            , MD5: 
+            55010a092c0246295eefed8a5c275b62
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr18 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr18.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download chr18 VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr18.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download chr18 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr18.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr18 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr18.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr18 VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr18.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr18 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr18.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr19 VCF
+          </span>
+          <br />
+          <span>
+            82.66 GiB
+            , MD5: 
+            a807d07199e3218bc5a330ad13beebd2
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr19 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr19.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download chr19 VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr19.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download chr19 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr19.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr19 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr19.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr19 VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr19.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr19 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr19.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr20 VCF
+          </span>
+          <br />
+          <span>
+            74.09 GiB
+            , MD5: 
+            7b4bedc5cbeaea2271ebda41a290350b
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr20 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr20.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download chr20 VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr20.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download chr20 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr20.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr20 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr20.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr20 VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr20.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr20 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr20.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr21 VCF
+          </span>
+          <br />
+          <span>
+            51.26 GiB
+            , MD5: 
+            13f97437754916a293a0900c4993e358
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr21 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr21.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download chr21 VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr21.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download chr21 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr21.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr21 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr21.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr21 VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr21.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr21 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr21.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chr22 VCF
+          </span>
+          <br />
+          <span>
+            55.38 GiB
+            , MD5: 
+            eb04c341491a1553cb020bb0d2a4cf36
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chr22 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr22.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download chr22 VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr22.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download chr22 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr22.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chr22 VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr22.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr22 VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr22.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr22 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr22.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chrX VCF
+          </span>
+          <br />
+          <span>
+            136.42 GiB
+            , MD5: 
+            b20924dca26a6ab12a3d7ee61e88ad92
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chrX VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chrX.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download chrX VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chrX.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download chrX VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chrX.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chrX VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chrX.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chrX VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chrX.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chrX VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chrX.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chrY VCF
+          </span>
+          <br />
+          <span>
+            8.42 GiB
+            , MD5: 
+            407654bf8a3914582ee472762e0d2d11
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chrY VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chrY.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download chrY VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chrY.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download chrY VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chrY.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chrY VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chrY.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chrY VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chrY.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chrY VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chrY.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+      </ul>
+    </section>
+    <section
+      className="c15"
+    >
+      <span
+        className="c6"
+      >
+        <h2
+          className="c16"
+        >
+          <a
+            aria-hidden="true"
+            className="c8 c9"
+            href="#v3-mitochondrial-dna"
+            id="v3-mitochondrial-dna"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Mitochondrial DNA (mtDNA)
+        </h2>
+      </span>
+      <p>
+        For details about these files, see the
+         
+        <a
+          className="c10"
+          href="https://gnomad.broadinstitute.org/news/2020-11-gnomad-v3-1-mitochondrial-dna-variants/"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          gnomAD v3.1 Mitochondrial DNA Variants blog post
+        </a>
+        .
+      </p>
+      <ul
+        className="c19"
+      >
+        <li
+          className="c20"
+        >
+          <span>
+            chrM sites Hail Table
+          </span>
+          <br />
+          Show URL for
+           
+          <button
+            aria-label="Show Google URL for chrM sites Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Google
+          </button>
+           / 
+          <button
+            aria-label="Show Amazon URL for chrM sites Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Amazon
+          </button>
+           / 
+          <button
+            aria-label="Show Microsoft URL for chrM sites Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Microsoft
+          </button>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chrM sites VCF
+          </span>
+          <br />
+          <span>
+            4.77 MiB
+            , MD5: 
+            d0ef2bd882ae44236897d743cb5528cf
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chrM sites VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/vcf/genomes/gnomad.genomes.v3.1.sites.chrM.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download chrM sites VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/vcf/genomes/gnomad.genomes.v3.1.sites.chrM.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download chrM sites VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/vcf/genomes/gnomad.genomes.v3.1.sites.chrM.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download TBI from
+             
+            <a
+              aria-label="Download TBI file for chrM sites VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/vcf/genomes/gnomad.genomes.v3.1.sites.chrM.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chrM sites VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/vcf/genomes/gnomad.genomes.v3.1.sites.chrM.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chrM sites VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/vcf/genomes/gnomad.genomes.v3.1.sites.chrM.vcf.bgz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chrM coverage Hail Table
+          </span>
+          <br />
+          Show URL for
+           
+          <button
+            aria-label="Show Google URL for chrM coverage Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Google
+          </button>
+           / 
+          <button
+            aria-label="Show Amazon URL for chrM coverage Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Amazon
+          </button>
+           / 
+          <button
+            aria-label="Show Microsoft URL for chrM coverage Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Microsoft
+          </button>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            chrM sites TSV (reduced annotations)
+          </span>
+          <br />
+          <span>
+            1 MiB
+            , MD5: 
+            45a91b22ddc3c1176c103d4afee080f5
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download chrM sites TSV (reduced annotations) from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/vcf/genomes/gnomad.genomes.v3.1.sites.chrM.reduced_annotations.tsv"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download chrM sites TSV (reduced annotations) from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/vcf/genomes/gnomad.genomes.v3.1.sites.chrM.reduced_annotations.tsv"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download chrM sites TSV (reduced annotations) from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/vcf/genomes/gnomad.genomes.v3.1.sites.chrM.reduced_annotations.tsv"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+      </ul>
+    </section>
+    <section
+      className="c15"
+    >
+      <span
+        className="c6"
+      >
+        <h2
+          className="c16"
+        >
+          <a
+            aria-hidden="true"
+            className="c8 c9"
+            href="#v3-ancestry-classification"
+            id="v3-ancestry-classification"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Ancestry classification
+        </h2>
+      </span>
+      <p>
+        For more information about these files, see our blog post on
+         
+        <a
+          className="c10"
+          href="https://gnomad.broadinstitute.org/news/2021-09-using-the-gnomad-ancestry-principal-components-analysis-loadings-and-random-forest-classifier-on-your-dataset/"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          using the gnomAD ancestry principal components analysis loadings and random forest classifier on your dataset
+        </a>
+        .
+      </p>
+      <ul
+        className="c19"
+      >
+        <li
+          className="c20"
+        >
+          <span>
+            Principal component analysis (PCA) variant loadings
+          </span>
+          <br />
+          Show URL for
+           
+          <button
+            aria-label="Show Google URL for Principal component analysis (PCA) variant loadings"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Google
+          </button>
+           / 
+          <button
+            aria-label="Show Amazon URL for Principal component analysis (PCA) variant loadings"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Amazon
+          </button>
+           / 
+          <button
+            aria-label="Show Microsoft URL for Principal component analysis (PCA) variant loadings"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Microsoft
+          </button>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            Random forest (RF) model
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download Random forest (RF) model from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/pca/gnomad.v3.1.RF_fit.onnx"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download Random forest (RF) model from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/pca/gnomad.v3.1.RF_fit.onnx"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download Random forest (RF) model from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/pca/gnomad.v3.1.RF_fit.onnx"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+      </ul>
+    </section>
+    <section
+      className="c15"
+    >
+      <span
+        className="c6"
+      >
+        <h2
+          className="c16"
+        >
+          <a
+            aria-hidden="true"
+            className="c8 c9"
+            href="#v3-local-ancestry"
+            id="v3-local-ancestry"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Local ancestry
+        </h2>
+      </span>
+      <p>
+        For more information about these files, see our blog post on
+         
+        <a
+          className="c10"
+          href="https://gnomad.broadinstitute.org/news/2021-12-local-ancestry-inference-for-latino-admixed-american-samples-in-gnomad/"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          local ancestry inference for Latino/Admixed American samples in gnomAD
+        </a>
+        .
+      </p>
+      <ul
+        className="c19"
+      >
+        <li
+          className="c20"
+        >
+          <span>
+            Sites VCF
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download Sites VCF from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/local_ancestry/genomes/gnomad.genomes.v3.1.local_ancestry.amr.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download Sites VCF from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/local_ancestry/genomes/gnomad.genomes.v3.1.local_ancestry.amr.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download Sites VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/local_ancestry/genomes/gnomad.genomes.v3.1.local_ancestry.amr.vcf.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+      </ul>
+    </section>
+    <section
+      className="c15"
+    >
+      <span
+        className="c6"
+      >
+        <h2
+          className="c16"
+        >
+          <a
+            aria-hidden="true"
+            className="c8 c9"
+            href="#v3-short-tandem-repeats"
+            id="v3-short-tandem-repeats"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Short tandem repeats
+        </h2>
+      </span>
+      <p>
+        For more information about these files, see our blog post on
+         
+        <a
+          className="c10"
+          href="https://gnomad.broadinstitute.org/news/2022-01-the-addition-of-short-tandem-repeat-calls-to-gnomad/"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          the addition of short tandem repeat calls to gnomAD
+        </a>
+        .
+      </p>
+      <ul
+        className="c19"
+      >
+        <li
+          className="c20"
+        >
+          <span>
+            README
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download README from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.3/tsv/README.txt"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download README from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.3/tsv/README.txt"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download README from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.3/tsv/README.txt"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            Genotypes (TSV)
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download Genotypes (TSV) from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.3/tsv/gnomAD_STR_genotypes__2022_01_20.tsv.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download Genotypes (TSV) from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.3/tsv/gnomAD_STR_genotypes__2022_01_20.tsv.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download Genotypes (TSV) from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.3/tsv/gnomAD_STR_genotypes__2022_01_20.tsv.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            Distributions (JSON)
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download Distributions (JSON) from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.3/json/gnomAD_STR_distributions__2022_01_20.json.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download Distributions (JSON) from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.3/json/gnomAD_STR_distributions__2022_01_20.json.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download Distributions (JSON) from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.3/json/gnomAD_STR_distributions__2022_01_20.json.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+      </ul>
+    </section>
+    <span
+      className="c6"
+    >
+      <h2
+        className="c7"
+      >
+        <a
+          aria-hidden="true"
+          className="c8 c9"
+          href="#v3-secondary-analyses"
+          id="v3-secondary-analyses"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Secondary Analyses
+      </h2>
+    </span>
+    <p
+      className="c11"
+    >
+      Additional research analyses created using the core gnomAD releases in collaboration with members of the gnomAD steering committee.
+    </p>
+    <section
+      className="c15"
+    >
+      <span
+        className="c6"
+      >
+        <h2
+          className="c16"
+        >
+          <a
+            aria-hidden="true"
+            className="c8 c9"
+            href="#v3-genomic-constraint"
+            id="v3-genomic-constraint"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Genomic constraint
+        </h2>
+      </span>
+      <p>
+        For more information about these files, see the README included in the download.
+      </p>
+      <ul
+        className="c19"
+      >
+        <li
+          className="c20"
+        >
+          <span>
+            README
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download README from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/secondary_analyses/genomic_constraint/nc_constraint_gnomad_v31_README.docx"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download README from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/secondary_analyses/genomic_constraint/nc_constraint_gnomad_v31_README.docx"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download README from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/secondary_analyses/genomic_constraint/nc_constraint_gnomad_v31_README.docx"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            Raw genomic constraint by 1kb regions
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download Raw genomic constraint by 1kb regions from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/secondary_analyses/genomic_constraint/constraint_z_genome_1kb.raw.download.txt.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download Raw genomic constraint by 1kb regions from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/secondary_analyses/genomic_constraint/constraint_z_genome_1kb.raw.download.txt.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download Raw genomic constraint by 1kb regions from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/secondary_analyses/genomic_constraint/constraint_z_genome_1kb.raw.download.txt.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            QCed genomic constraint by 1kb regions
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download QCed genomic constraint by 1kb regions from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/secondary_analyses/genomic_constraint/constraint_z_genome_1kb.qc.download.txt.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download QCed genomic constraint by 1kb regions from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/secondary_analyses/genomic_constraint/constraint_z_genome_1kb.qc.download.txt.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download QCed genomic constraint by 1kb regions from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/secondary_analyses/genomic_constraint/constraint_z_genome_1kb.qc.download.txt.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            Non-coding constraint for gene tissue enhancers
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download Non-coding constraint for gene tissue enhancers from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/secondary_analyses/genomic_constraint/constraint_z_enh_gene_roadmaplinks.all.download.txt.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download Non-coding constraint for gene tissue enhancers from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/secondary_analyses/genomic_constraint/constraint_z_enh_gene_roadmaplinks.all.download.txt.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download Non-coding constraint for gene tissue enhancers from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/secondary_analyses/genomic_constraint/constraint_z_enh_gene_roadmaplinks.all.download.txt.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+      </ul>
+    </section>
+    <section
+      className="c15"
+    >
+      <span
+        className="c6"
+      >
+        <h2
+          className="c16"
+        >
+          <a
+            aria-hidden="true"
+            className="c8 c9"
+            href="#v3-hgdp-1kg-tutorials"
+            id="v3-hgdp-1kg-tutorials"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          HGDP + 1KG tutorials
+        </h2>
+      </span>
+      <p>
+        For more information about these files, see the 
+        <a
+          className="c10"
+          href="https://docs.google.com/document/d/16W0KyrpRGRKHaOwahxtogtepbHe181BoOrSpTQVSVHc/edit?usp=sharing"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          README
+        </a>
+         
+        and the 
+        <a
+          className="c10"
+          href="https://docs.google.com/spreadsheets/d/179I6AUPOQ09jdsFbKcwcDQugFt4pmL-NNOD_3_rsidA/edit?usp=sharing"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          File Descriptions.
+        </a>
+      </p>
+      <p>
+        <b>
+          Please note:
+        </b>
+         while these files were generated from the
+        <a
+          className="c23"
+          href="/downloads#v3-hgdp-1kg"
+        >
+           HGDP + 1KG callset
+        </a>
+         files above, the quality control steps may differ slightly. This would lead to minor differences in sample counts. See the tutorials for details.
+      </p>
+      <ul
+        className="c19"
+      >
+        <li
+          className="c20"
+        >
+          <a
+            className="c10"
+            href="https://docs.google.com/document/d/16W0KyrpRGRKHaOwahxtogtepbHe181BoOrSpTQVSVHc/edit?usp=sharing"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            README
+          </a>
+        </li>
+        <li
+          className="c20"
+        >
+          <a
+            className="c10"
+            href="https://docs.google.com/spreadsheets/d/179I6AUPOQ09jdsFbKcwcDQugFt4pmL-NNOD_3_rsidA/edit?usp=sharing"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            File Descriptions
+          </a>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            Dense Hail MatrixTable
+          </span>
+          <br />
+          Show URL for
+           
+          <button
+            aria-label="Show Google URL for Dense Hail MatrixTable"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Google
+          </button>
+           / 
+          <button
+            aria-label="Show Amazon URL for Dense Hail MatrixTable"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Amazon
+          </button>
+           / 
+          <button
+            aria-label="Show Microsoft URL for Dense Hail MatrixTable"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Microsoft
+          </button>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            Sample metadata TSV
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download Sample metadata TSV from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/secondary_analyses/hgdp_1kg/metadata_and_qc/gnomad_meta_v1.tsv"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download Sample metadata TSV from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/secondary_analyses/hgdp_1kg/metadata_and_qc/gnomad_meta_v1.tsv"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download Sample metadata TSV from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/secondary_analyses/hgdp_1kg/metadata_and_qc/gnomad_meta_v1.tsv"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            Subset of the HGDP+1KG callset MatrixTable
+          </span>
+          <br />
+          Show URL for
+           
+          <button
+            aria-label="Show Google URL for Subset of the HGDP+1KG callset MatrixTable"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Google
+          </button>
+           / 
+          <button
+            aria-label="Show Amazon URL for Subset of the HGDP+1KG callset MatrixTable"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Amazon
+          </button>
+           / 
+          <button
+            aria-label="Show Microsoft URL for Subset of the HGDP+1KG callset MatrixTable"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Microsoft
+          </button>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            Related sample IDs Hail Table
+          </span>
+          <br />
+          Show URL for
+           
+          <button
+            aria-label="Show Google URL for Related sample IDs Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Google
+          </button>
+           / 
+          <button
+            aria-label="Show Amazon URL for Related sample IDs Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Amazon
+          </button>
+           / 
+          <button
+            aria-label="Show Microsoft URL for Related sample IDs Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Microsoft
+          </button>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            Principal component analysis (PCA) PC score tables GCS Bucket
+          </span>
+          <br />
+          Show URL for
+           
+          <button
+            aria-label="Show Google URL for Principal component analysis (PCA) PC score tables GCS Bucket"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Google
+          </button>
+           / 
+          <button
+            aria-label="Show Amazon URL for Principal component analysis (PCA) PC score tables GCS Bucket"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Amazon
+          </button>
+           / 
+          <button
+            aria-label="Show Microsoft URL for Principal component analysis (PCA) PC score tables GCS Bucket"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Microsoft
+          </button>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            PCA outliers table
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download PCA outliers table from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/secondary_analyses/hgdp_1kg/pca/pca_outliers.txt"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download PCA outliers table from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/secondary_analyses/hgdp_1kg/pca/pca_outliers.txt"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download PCA outliers table from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/secondary_analyses/hgdp_1kg/pca/pca_outliers.txt"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            PCA PC score tables without outliers GCS Buckets
+          </span>
+          <br />
+          Show URL for
+           
+          <button
+            aria-label="Show Google URL for PCA PC score tables without outliers GCS Buckets"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Google
+          </button>
+           / 
+          <button
+            aria-label="Show Amazon URL for PCA PC score tables without outliers GCS Buckets"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Amazon
+          </button>
+           / 
+          <button
+            aria-label="Show Microsoft URL for PCA PC score tables without outliers GCS Buckets"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Microsoft
+          </button>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            Variants and unrelated samples MatrixTable
+          </span>
+          <br />
+          Show URL for
+           
+          <button
+            aria-label="Show Google URL for Variants and unrelated samples MatrixTable"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Google
+          </button>
+           / 
+          <button
+            aria-label="Show Amazon URL for Variants and unrelated samples MatrixTable"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Amazon
+          </button>
+           / 
+          <button
+            aria-label="Show Microsoft URL for Variants and unrelated samples MatrixTable"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Microsoft
+          </button>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            Variants and related samples MatrixTable
+          </span>
+          <br />
+          Show URL for
+           
+          <button
+            aria-label="Show Google URL for Variants and related samples MatrixTable"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Google
+          </button>
+           / 
+          <button
+            aria-label="Show Amazon URL for Variants and related samples MatrixTable"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Amazon
+          </button>
+           / 
+          <button
+            aria-label="Show Microsoft URL for Variants and related samples MatrixTable"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Microsoft
+          </button>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            Population-level statistical summary TSV
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download Population-level statistical summary TSV from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/secondary_analyses/hgdp_1kg/metadata_and_qc/post_qc_summary.tsv"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download Population-level statistical summary TSV from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/secondary_analyses/hgdp_1kg/metadata_and_qc/post_qc_summary.tsv"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download Population-level statistical summary TSV from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/secondary_analyses/hgdp_1kg/metadata_and_qc/post_qc_summary.tsv"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            Doubleton counts CSV
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download Doubleton counts CSV from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/secondary_analyses/hgdp_1kg/f2_fst/doubleton_count.csv"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download Doubleton counts CSV from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/secondary_analyses/hgdp_1kg/f2_fst/doubleton_count.csv"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download Doubleton counts CSV from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/secondary_analyses/hgdp_1kg/f2_fst/doubleton_count.csv"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            Variants and unrelated sample PLINK files
+          </span>
+          <br />
+          Show URL for
+           
+          <button
+            aria-label="Show Google URL for Variants and unrelated sample PLINK files"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Google
+          </button>
+           / 
+          <button
+            aria-label="Show Amazon URL for Variants and unrelated sample PLINK files"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Amazon
+          </button>
+           / 
+          <button
+            aria-label="Show Microsoft URL for Variants and unrelated sample PLINK files"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Microsoft
+          </button>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            Population-level mean fixation index table
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download Population-level mean fixation index table from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/secondary_analyses/hgdp_1kg/f2_fst/mean_fst.txt"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download Population-level mean fixation index table from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/secondary_analyses/hgdp_1kg/f2_fst/mean_fst.txt"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download Population-level mean fixation index table from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/secondary_analyses/hgdp_1kg/f2_fst/mean_fst.txt"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            Gambian Genome Variation Project MatrixTable
+          </span>
+          <br />
+          Show URL for
+           
+          <button
+            aria-label="Show Google URL for Gambian Genome Variation Project MatrixTable"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Google
+          </button>
+           / 
+          <button
+            aria-label="Show Amazon URL for Gambian Genome Variation Project MatrixTable"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Amazon
+          </button>
+           / 
+          <button
+            aria-label="Show Microsoft URL for Gambian Genome Variation Project MatrixTable"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Microsoft
+          </button>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            Principal component analysis (PCA) variant loadings Hail Table
+          </span>
+          <br />
+          Show URL for
+           
+          <button
+            aria-label="Show Google URL for Principal component analysis (PCA) variant loadings Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Google
+          </button>
+           / 
+          <button
+            aria-label="Show Amazon URL for Principal component analysis (PCA) variant loadings Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Amazon
+          </button>
+           / 
+          <button
+            aria-label="Show Microsoft URL for Principal component analysis (PCA) variant loadings Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Microsoft
+          </button>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            Random forest (RF) model PKL
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download Random forest (RF) model PKL from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/pca/gnomad.v3.1.RF_fit.pkl"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download Random forest (RF) model PKL from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/pca/gnomad.v3.1.RF_fit.pkl"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download Random forest (RF) model PKL from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/pca/gnomad.v3.1.RF_fit.pkl"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            HGDP+1KG and GVV intersection Matrix Table
+          </span>
+          <br />
+          Show URL for
+           
+          <button
+            aria-label="Show Google URL for HGDP+1KG and GVV intersection Matrix Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Google
+          </button>
+           / 
+          <button
+            aria-label="Show Amazon URL for HGDP+1KG and GVV intersection Matrix Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Amazon
+          </button>
+           / 
+          <button
+            aria-label="Show Microsoft URL for HGDP+1KG and GVV intersection Matrix Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Microsoft
+          </button>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            Super population labels TSV
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download Super population labels TSV from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/secondary_analyses/hgdp_1kg/data_intersection/hgdp_1kg_sample_info.unrelateds.pca_outliers_removed.with_project.tsv"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download Super population labels TSV from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/secondary_analyses/hgdp_1kg/data_intersection/hgdp_1kg_sample_info.unrelateds.pca_outliers_removed.with_project.tsv"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download Super population labels TSV from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/secondary_analyses/hgdp_1kg/data_intersection/hgdp_1kg_sample_info.unrelateds.pca_outliers_removed.with_project.tsv"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            Phased haplotypes of HGDP+1KG dataset GCS Bucket
+          </span>
+          <br />
+          Show URL for
+           
+          <button
+            aria-label="Show Google URL for Phased haplotypes of HGDP+1KG dataset GCS Bucket"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Google
+          </button>
+           / 
+          <button
+            aria-label="Show Amazon URL for Phased haplotypes of HGDP+1KG dataset GCS Bucket"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Amazon
+          </button>
+           / 
+          <button
+            aria-label="Show Microsoft URL for Phased haplotypes of HGDP+1KG dataset GCS Bucket"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Microsoft
+          </button>
+        </li>
+        <h3>
+          Pre-QC plotting tables
+        </h3>
+        <li
+          className="c20"
+        >
+          <span>
+            Pre-QC column fields Hail Table
+          </span>
+          <br />
+          Show URL for
+           
+          <button
+            aria-label="Show Google URL for Pre-QC column fields Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Google
+          </button>
+           / 
+          <button
+            aria-label="Show Amazon URL for Pre-QC column fields Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Amazon
+          </button>
+           / 
+          <button
+            aria-label="Show Microsoft URL for Pre-QC column fields Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Microsoft
+          </button>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            Pre-QC expected heterozygosity Hail Table
+          </span>
+          <br />
+          Show URL for
+           
+          <button
+            aria-label="Show Google URL for Pre-QC expected heterozygosity Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Google
+          </button>
+           / 
+          <button
+            aria-label="Show Amazon URL for Pre-QC expected heterozygosity Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Amazon
+          </button>
+           / 
+          <button
+            aria-label="Show Microsoft URL for Pre-QC expected heterozygosity Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Microsoft
+          </button>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            Pre-QC actual heterozygosity Hail Table
+          </span>
+          <br />
+          Show URL for
+           
+          <button
+            aria-label="Show Google URL for Pre-QC actual heterozygosity Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Google
+          </button>
+           / 
+          <button
+            aria-label="Show Amazon URL for Pre-QC actual heterozygosity Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Amazon
+          </button>
+           / 
+          <button
+            aria-label="Show Microsoft URL for Pre-QC actual heterozygosity Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Microsoft
+          </button>
+        </li>
+        <h3>
+          Post-QC plotting tables
+        </h3>
+        <li
+          className="c20"
+        >
+          <span>
+            Post-QC column fields Hail Table
+          </span>
+          <br />
+          Show URL for
+           
+          <button
+            aria-label="Show Google URL for Post-QC column fields Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Google
+          </button>
+           / 
+          <button
+            aria-label="Show Amazon URL for Post-QC column fields Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Amazon
+          </button>
+           / 
+          <button
+            aria-label="Show Microsoft URL for Post-QC column fields Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Microsoft
+          </button>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            Post-QC expected heterozygosity Hail Table
+          </span>
+          <br />
+          Show URL for
+           
+          <button
+            aria-label="Show Google URL for Post-QC expected heterozygosity Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Google
+          </button>
+           / 
+          <button
+            aria-label="Show Amazon URL for Post-QC expected heterozygosity Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Amazon
+          </button>
+           / 
+          <button
+            aria-label="Show Microsoft URL for Post-QC expected heterozygosity Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Microsoft
+          </button>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            Post-QC actual heterozygosity Hail Table
+          </span>
+          <br />
+          Show URL for
+           
+          <button
+            aria-label="Show Google URL for Post-QC actual heterozygosity Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Google
+          </button>
+           / 
+          <button
+            aria-label="Show Amazon URL for Post-QC actual heterozygosity Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Amazon
+          </button>
+           / 
+          <button
+            aria-label="Show Microsoft URL for Post-QC actual heterozygosity Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Microsoft
+          </button>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            Post-QC site frequency spectrum table
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download Post-QC site frequency spectrum table from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/secondary_analyses/hgdp_1kg/plot_datasets/sfs_post_qc.txt"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download Post-QC site frequency spectrum table from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/secondary_analyses/hgdp_1kg/plot_datasets/sfs_post_qc.txt"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download Post-QC site frequency spectrum table from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/secondary_analyses/hgdp_1kg/plot_datasets/sfs_post_qc.txt"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+      </ul>
+    </section>
+    <span
+      className="c6"
+    >
+      <h2
+        className="c14"
+      >
+        <a
+          aria-hidden="true"
+          className="c8 c9"
+          href="#v2-liftover"
+          id="v2-liftover"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        v2 Liftover Downloads
+      </h2>
+    </span>
+    <p
+      className="c11"
+    >
+      The gnomAD v2.1.1 liftover data set contains data from 125,748 exomes and 15,708 whole genomes, lifted over from the GRCh37 to the GRCh38 reference sequence.
+    </p>
+    <span
+      className="c6"
+    >
+      <h2
+        className="c7"
+      >
+        <a
+          aria-hidden="true"
+          className="c8 c9"
+          href="#v2-liftover-core-dataset"
+          id="v2-liftover-core-dataset"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Core Dataset
+      </h2>
+    </span>
+    <p
+      className="c11"
+    >
+      gnomAD database and features created and maintained by the gnomAD production team.
+    </p>
+    <section
+      className="c15"
+    >
+      <span
+        className="c6"
+      >
+        <h2
+          className="c16"
+        >
+          <a
+            aria-hidden="true"
+            className="c8 c9"
+            href="#v2-liftover-variants"
+            id="v2-liftover-variants"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Variants (GRCh38 liftover)
+        </h2>
+      </span>
+      <p>
+        The variant dataset files below contain all subsets (non-neuro, non-cancer, controls-only, and non-TOPMed).
+      </p>
+      <div
+        className="c17"
+      >
+        <div
+          className="c18"
+        >
+          <h3>
+            Exomes
+          </h3>
+          <ul
+            className="c19"
+          >
+            <li
+              className="c20"
+            >
+              <span>
+                Sites Hail Table
+              </span>
+              <br />
+              Show URL for
+               
+              <button
+                aria-label="Show Google URL for Sites Hail Table"
+                className="c21"
+                onClick={[Function]}
+                type="button"
+              >
+                Google
+              </button>
+               / 
+              <button
+                aria-label="Show Amazon URL for Sites Hail Table"
+                className="c21"
+                onClick={[Function]}
+                type="button"
+              >
+                Amazon
+              </button>
+               / 
+              <button
+                aria-label="Show Microsoft URL for Sites Hail Table"
+                className="c21"
+                onClick={[Function]}
+                type="button"
+              >
+                Microsoft
+              </button>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                All chromosomes VCF
+              </span>
+              <br />
+              <span>
+                85.31 GiB
+                , MD5: 
+                cff8d0cfed50adc9211d1feaed2d4ca7
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download All chromosomes VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download All chromosomes VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download All chromosomes VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for All chromosomes VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for All chromosomes VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for All chromosomes VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr1 sites VCF
+              </span>
+              <br />
+              <span>
+                5.3 GiB
+                , MD5: 
+                6afa2df088f1627eb649c6d24d8784e8
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr1 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.1.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr1 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.1.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr1 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.1.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr1 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.1.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr1 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.1.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr1 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.1.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr2 sites VCF
+              </span>
+              <br />
+              <span>
+                3.85 GiB
+                , MD5: 
+                570b5aee023938c7b5ab660f28a79651
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr2 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.2.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr2 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.2.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr2 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.2.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr2 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.2.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr2 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.2.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr2 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.2.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr3 sites VCF
+              </span>
+              <br />
+              <span>
+                3.02 GiB
+                , MD5: 
+                29dd5e955afe7cc9c8342aa1ee88e099
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr3 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.3.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr3 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.3.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr3 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.3.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr3 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.3.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr3 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.3.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr3 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.3.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr4 sites VCF
+              </span>
+              <br />
+              <span>
+                1.99 GiB
+                , MD5: 
+                560e0fb2c514411ea35638fb2b2a35bf
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr4 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.4.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr4 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.4.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr4 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.4.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr4 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.4.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr4 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.4.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr4 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.4.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr5 sites VCF
+              </span>
+              <br />
+              <span>
+                2.31 GiB
+                , MD5: 
+                5e777b38fe2437b56b32b455de80015c
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr5 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.5.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr5 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.5.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr5 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.5.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr5 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.5.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr5 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.5.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr5 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.5.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr6 sites VCF
+              </span>
+              <br />
+              <span>
+                2.6 GiB
+                , MD5: 
+                8815cd575bd71504d8dd243136995d16
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr6 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.6.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr6 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.6.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr6 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.6.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr6 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.6.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr6 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.6.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr6 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.6.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr7 sites VCF
+              </span>
+              <br />
+              <span>
+                2.62 GiB
+                , MD5: 
+                70d4fbaf888017ab0a12e3c0dced5700
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr7 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.7.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr7 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.7.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr7 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.7.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr7 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.7.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr7 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.7.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr7 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.7.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr8 sites VCF
+              </span>
+              <br />
+              <span>
+                1.95 GiB
+                , MD5: 
+                39017f2660ac88916a6a9470f0192eda
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr8 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.8.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr8 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.8.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr8 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.8.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr8 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.8.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr8 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.8.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr8 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.8.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr9 sites VCF
+              </span>
+              <br />
+              <span>
+                2.2 GiB
+                , MD5: 
+                9c683f3b8a17e2aee1eac8b5ad860edf
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr9 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.9.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr9 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.9.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr9 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.9.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr9 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.9.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr9 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.9.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr9 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.9.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr10 sites VCF
+              </span>
+              <br />
+              <span>
+                2.04 GiB
+                , MD5: 
+                72073e8257316017f5356b986b779dd2
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr10 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.10.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr10 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.10.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr10 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.10.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr10 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.10.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr10 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.10.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr10 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.10.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr11 sites VCF
+              </span>
+              <br />
+              <span>
+                3.32 GiB
+                , MD5: 
+                89bf2840850664fad81d2f1277bd0d7a
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr11 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.11.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr11 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.11.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr11 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.11.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr11 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.11.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr11 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.11.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr11 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.11.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr12 sites VCF
+              </span>
+              <br />
+              <span>
+                2.82 GiB
+                , MD5: 
+                50b5cb95f9d7125e385ee3153992fea1
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr12 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.12.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr12 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.12.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr12 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.12.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr12 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.12.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr12 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.12.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr12 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.12.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr13 sites VCF
+              </span>
+              <br />
+              <span>
+                892.17 MiB
+                , MD5: 
+                8bf51379fa45b205461eb27a8664f2c2
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr13 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.13.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr13 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.13.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr13 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.13.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr13 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.13.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr13 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.13.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr13 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.13.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr14 sites VCF
+              </span>
+              <br />
+              <span>
+                1.85 GiB
+                , MD5: 
+                75bdaaea3b2ace57cd1165799b29fbd5
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr14 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.14.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr14 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.14.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr14 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.14.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr14 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.14.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr14 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.14.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr14 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.14.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr15 sites VCF
+              </span>
+              <br />
+              <span>
+                1.91 GiB
+                , MD5: 
+                30f244130bf6ac58006463cd87d56272
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr15 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.15.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr15 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.15.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr15 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.15.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr15 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.15.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr15 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.15.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr15 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.15.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr16 sites VCF
+              </span>
+              <br />
+              <span>
+                2.81 GiB
+                , MD5: 
+                1ac5e4d7d6ee3255ceedd652691b6cd0
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr16 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.16.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr16 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.16.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr16 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.16.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr16 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.16.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr16 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.16.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr16 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.16.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr17 sites VCF
+              </span>
+              <br />
+              <span>
+                3.33 GiB
+                , MD5: 
+                947b32de25fe137a8cc95948b852e757
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr17 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.17.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr17 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.17.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr17 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.17.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr17 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.17.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr17 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.17.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr17 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.17.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr18 sites VCF
+              </span>
+              <br />
+              <span>
+                810.06 MiB
+                , MD5: 
+                6bf85f4d674917346d3b658646b4fdbf
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr18 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.18.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr18 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.18.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr18 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.18.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr18 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.18.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr18 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.18.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr18 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.18.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr19 sites VCF
+              </span>
+              <br />
+              <span>
+                3.94 GiB
+                , MD5: 
+                f882913ec97cdbbbf195b777ca4be732
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr19 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.19.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr19 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.19.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr19 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.19.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr19 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.19.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr19 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.19.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr19 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.19.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr20 sites VCF
+              </span>
+              <br />
+              <span>
+                1.32 GiB
+                , MD5: 
+                9167cd594f30321fec62f31ade758c2c
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr20 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.20.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr20 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.20.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr20 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.20.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr20 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.20.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr20 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.20.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr20 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.20.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr21 sites VCF
+              </span>
+              <br />
+              <span>
+                599.31 MiB
+                , MD5: 
+                113d7a5d058b617c60db768ce527a96f
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr21 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.21.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr21 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.21.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr21 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.21.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr21 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.21.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr21 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.21.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr21 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.21.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr22 sites VCF
+              </span>
+              <br />
+              <span>
+                1.31 GiB
+                , MD5: 
+                394dc422f48914496646f33e92eacd27
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr22 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.22.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr22 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.22.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr22 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.22.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr22 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.22.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr22 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.22.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr22 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.22.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chrX sites VCF
+              </span>
+              <br />
+              <span>
+                1.19 GiB
+                , MD5: 
+                047145d2b7fb416b516566201e1bc694
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chrX sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.X.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download chrX sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.X.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download chrX sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.X.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chrX sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.X.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chrX sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.X.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chrX sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.X.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chrY sites VCF
+              </span>
+              <br />
+              <span>
+                14.18 MiB
+                , MD5: 
+                4b8cfe3f9051050c94948dab4871c9ce
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chrY sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.Y.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download chrY sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.Y.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download chrY sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.Y.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chrY sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.Y.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chrY sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.Y.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chrY sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.Y.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+            </li>
+          </ul>
+        </div>
+        <div
+          className="c18"
+        >
+          <h3>
+            Genomes
+          </h3>
+          <ul
+            className="c19"
+          >
+            <li
+              className="c20"
+            >
+              <span>
+                Sites Hail Table
+              </span>
+              <br />
+              Show URL for
+               
+              <button
+                aria-label="Show Google URL for Sites Hail Table"
+                className="c21"
+                onClick={[Function]}
+                type="button"
+              >
+                Google
+              </button>
+               / 
+              <button
+                aria-label="Show Amazon URL for Sites Hail Table"
+                className="c21"
+                onClick={[Function]}
+                type="button"
+              >
+                Amazon
+              </button>
+               / 
+              <button
+                aria-label="Show Microsoft URL for Sites Hail Table"
+                className="c21"
+                onClick={[Function]}
+                type="button"
+              >
+                Microsoft
+              </button>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                All chromosomes VCF
+              </span>
+              <br />
+              <span>
+                743.06 GiB
+                , MD5: 
+                83de3d5b52669f714e810d4fcf047c18
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download All chromosomes VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download All chromosomes VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download All chromosomes VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for All chromosomes VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for All chromosomes VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for All chromosomes VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr1 sites VCF
+              </span>
+              <br />
+              <span>
+                33.37 GiB
+                , MD5: 
+                49a18c485dbf68fa6bc92312c4a646eb
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr1 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.1.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr1 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.1.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr1 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.1.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr1 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.1.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr1 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.1.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr1 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.1.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr2 sites VCF
+              </span>
+              <br />
+              <span>
+                35.88 GiB
+                , MD5: 
+                c5f5ec623377b1d2dbc30502cd31d086
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr2 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.2.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr2 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.2.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr2 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.2.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr2 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.2.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr2 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.2.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr2 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.2.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr3 sites VCF
+              </span>
+              <br />
+              <span>
+                29.47 GiB
+                , MD5: 
+                0ad77689edb3bc731c71d6d140dfaacd
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr3 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.3.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr3 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.3.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr3 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.3.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr3 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.3.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr3 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.3.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr3 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.3.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr4 sites VCF
+              </span>
+              <br />
+              <span>
+                28.47 GiB
+                , MD5: 
+                e0b1dc365600bc31cb48debb6b03c561
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr4 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.4.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr4 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.4.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr4 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.4.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr4 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.4.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr4 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.4.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr4 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.4.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr5 sites VCF
+              </span>
+              <br />
+              <span>
+                26.56 GiB
+                , MD5: 
+                ea53a6e364cade4f6ed5504d5cd14d62
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr5 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.5.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr5 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.5.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr5 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.5.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr5 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.5.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr5 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.5.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr5 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.5.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr6 sites VCF
+              </span>
+              <br />
+              <span>
+                24.88 GiB
+                , MD5: 
+                b717eb2c2154740558ca3f62adf30a4a
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr6 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.6.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr6 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.6.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr6 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.6.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr6 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.6.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr6 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.6.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr6 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.6.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr7 sites VCF
+              </span>
+              <br />
+              <span>
+                24.37 GiB
+                , MD5: 
+                5b97c8c80b9b8404f611d5725d4f563d
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr7 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.7.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr7 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.7.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr7 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.7.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr7 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.7.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr7 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.7.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr7 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.7.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr8 sites VCF
+              </span>
+              <br />
+              <span>
+                22.99 GiB
+                , MD5: 
+                f502012b3b6fd771e1f97878d4c89831
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr8 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.8.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr8 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.8.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr8 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.8.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr8 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.8.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr8 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.8.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr8 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.8.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr9 sites VCF
+              </span>
+              <br />
+              <span>
+                18.76 GiB
+                , MD5: 
+                d9cb3ac24eb9cdd891bbeaf554b7f701
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr9 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.9.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr9 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.9.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr9 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.9.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr9 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.9.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr9 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.9.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr9 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.9.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr10 sites VCF
+              </span>
+              <br />
+              <span>
+                19.93 GiB
+                , MD5: 
+                8b4573aee1f13efcaa822a736cea3be3
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr10 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.10.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr10 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.10.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr10 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.10.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr10 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.10.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr10 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.10.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr10 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.10.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr11 sites VCF
+              </span>
+              <br />
+              <span>
+                20.53 GiB
+                , MD5: 
+                340101c9092be9a2e408c82c78f860fc
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr11 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.11.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr11 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.11.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr11 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.11.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr11 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.11.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr11 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.11.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr11 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.11.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr12 sites VCF
+              </span>
+              <br />
+              <span>
+                19.97 GiB
+                , MD5: 
+                e7612e7a222cbf7077f3766eb793f75b
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr12 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.12.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr12 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.12.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr12 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.12.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr12 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.12.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr12 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.12.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr12 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.12.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr13 sites VCF
+              </span>
+              <br />
+              <span>
+                13.99 GiB
+                , MD5: 
+                e8146ed73263cfc6c733bcb9e942a05f
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr13 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.13.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr13 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.13.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr13 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.13.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr13 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.13.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr13 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.13.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr13 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.13.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr14 sites VCF
+              </span>
+              <br />
+              <span>
+                13.71 GiB
+                , MD5: 
+                3b437d953f169a299df69ab51726117a
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr14 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.14.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr14 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.14.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr14 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.14.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr14 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.14.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr14 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.14.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr14 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.14.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr15 sites VCF
+              </span>
+              <br />
+              <span>
+                12.92 GiB
+                , MD5: 
+                d03e682c7271dac3d333da2aab17b486
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr15 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.15.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr15 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.15.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr15 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.15.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr15 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.15.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr15 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.15.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr15 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.15.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr16 sites VCF
+              </span>
+              <br />
+              <span>
+                14.51 GiB
+                , MD5: 
+                f38fe23fe7bdc3debf5f43945f160383
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr16 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.16.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr16 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.16.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr16 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.16.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr16 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.16.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr16 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.16.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr16 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.16.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr17 sites VCF
+              </span>
+              <br />
+              <span>
+                12.67 GiB
+                , MD5: 
+                732e899517000c1505898ca918a38267
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr17 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.17.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr17 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.17.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr17 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.17.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr17 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.17.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr17 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.17.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr17 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.17.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr18 sites VCF
+              </span>
+              <br />
+              <span>
+                11.34 GiB
+                , MD5: 
+                de2e98425c57ba805145dea4f2483867
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr18 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.18.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr18 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.18.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr18 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.18.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr18 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.18.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr18 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.18.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr18 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.18.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr19 sites VCF
+              </span>
+              <br />
+              <span>
+                10.48 GiB
+                , MD5: 
+                60f5d011e1684f6db81b3d052ae75bc0
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr19 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.19.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr19 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.19.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr19 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.19.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr19 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.19.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr19 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.19.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr19 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.19.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr20 sites VCF
+              </span>
+              <br />
+              <span>
+                9.04 GiB
+                , MD5: 
+                1da4057634c7143a0f33f61f49ebbe5f
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr20 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.20.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr20 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.20.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr20 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.20.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr20 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.20.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr20 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.20.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr20 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.20.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr21 sites VCF
+              </span>
+              <br />
+              <span>
+                5.77 GiB
+                , MD5: 
+                be37bea3ac95097021e8c130291d45de
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr21 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.21.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr21 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.21.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr21 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.21.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr21 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.21.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr21 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.21.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr21 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.21.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chr22 sites VCF
+              </span>
+              <br />
+              <span>
+                6.07 GiB
+                , MD5: 
+                0f5703d8373516eb3753bcf89a547621
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chr22 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.22.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr22 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.22.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download chr22 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.22.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chr22 sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.22.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr22 sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.22.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr22 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.22.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                chrX sites VCF
+              </span>
+              <br />
+              <span>
+                16.41 GiB
+                , MD5: 
+                898a122480632cfdc58450bbbb3554c1
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download chrX sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.X.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download chrX sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.X.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download chrX sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.X.liftover_grch38.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+              <br />
+              <span>
+                Download TBI from
+                 
+                <a
+                  aria-label="Download TBI file for chrX sites VCF from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.X.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chrX sites VCF from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.X.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chrX sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.X.liftover_grch38.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </section>
+    <section
+      className="c15"
+    >
+      <span
+        className="c6"
+      >
+        <h2
+          className="c16"
+        >
+          <a
+            aria-hidden="true"
+            className="c8 c9"
+            href="#v2-liftover-structural-variants"
+            id="v2-liftover-structural-variants"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Structural variants (GRCh38 liftover)
+        </h2>
+      </span>
+      <p>
+        <span
+          className="c22"
+        >
+          Note
+        </span>
+         The lifted over structural variant dataset was created by dbVar and has not been assessed by the gnomAD production team.
+      </p>
+      <ul
+        className="c19"
+      >
+        <li
+          className="c20"
+        >
+          <a
+            className="c10"
+            href="https://www.ncbi.nlm.nih.gov/sites/dbvarapp/studies/nstd166/"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            nstd166 (gnomAD Structural Variants)
+          </a>
+        </li>
+      </ul>
+    </section>
     <span
       className="c6"
     >
@@ -704,7 +14773,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
       </span>
       <p>
         <span
-          className="c17"
+          className="c22"
         >
           Note
         </span>
@@ -724,19 +14793,19 @@ exports[`Downloads Page has no unexpected changes 1`] = `
         The variant dataset files below contain all subsets (non-neuro, non-cancer, controls-only, and non-TOPMed).
       </p>
       <div
-        className="c18"
+        className="c17"
       >
         <div
-          className="c19"
+          className="c18"
         >
           <h3>
             Exomes
           </h3>
           <ul
-            className="c20"
+            className="c19"
           >
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 Sites Hail Table
@@ -746,7 +14815,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                
               <button
                 aria-label="Show Google URL for Sites Hail Table"
-                className="c22"
+                className="c21"
                 onClick={[Function]}
                 type="button"
               >
@@ -755,7 +14824,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                / 
               <button
                 aria-label="Show Amazon URL for Sites Hail Table"
-                className="c22"
+                className="c21"
                 onClick={[Function]}
                 type="button"
               >
@@ -764,7 +14833,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                / 
               <button
                 aria-label="Show Microsoft URL for Sites Hail Table"
-                className="c22"
+                className="c21"
                 onClick={[Function]}
                 type="button"
               >
@@ -772,7 +14841,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </button>
             </li>
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 All chromosomes sites VCF
@@ -853,7 +14922,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
             </li>
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 chr1 sites VCF
@@ -934,7 +15003,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
             </li>
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 chr2 sites VCF
@@ -1015,7 +15084,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
             </li>
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 chr3 sites VCF
@@ -1096,7 +15165,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
             </li>
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 chr4 sites VCF
@@ -1177,7 +15246,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
             </li>
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 chr5 sites VCF
@@ -1258,7 +15327,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
             </li>
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 chr6 sites VCF
@@ -1339,7 +15408,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
             </li>
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 chr7 sites VCF
@@ -1420,7 +15489,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
             </li>
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 chr8 sites VCF
@@ -1501,7 +15570,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
             </li>
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 chr9 sites VCF
@@ -1582,7 +15651,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
             </li>
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 chr10 sites VCF
@@ -1663,7 +15732,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
             </li>
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 chr11 sites VCF
@@ -1744,7 +15813,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
             </li>
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 chr12 sites VCF
@@ -1825,7 +15894,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
             </li>
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 chr13 sites VCF
@@ -1906,7 +15975,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
             </li>
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 chr14 sites VCF
@@ -1987,7 +16056,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
             </li>
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 chr15 sites VCF
@@ -2068,7 +16137,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
             </li>
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 chr16 sites VCF
@@ -2149,7 +16218,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
             </li>
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 chr17 sites VCF
@@ -2230,7 +16299,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
             </li>
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 chr18 sites VCF
@@ -2311,7 +16380,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
             </li>
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 chr19 sites VCF
@@ -2392,7 +16461,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
             </li>
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 chr20 sites VCF
@@ -2473,7 +16542,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
             </li>
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 chr21 sites VCF
@@ -2554,7 +16623,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
             </li>
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 chr22 sites VCF
@@ -2635,7 +16704,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
             </li>
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 chrX sites VCF
@@ -2716,7 +16785,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
             </li>
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 chrY sites VCF
@@ -2799,16 +16868,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </ul>
         </div>
         <div
-          className="c19"
+          className="c18"
         >
           <h3>
             Genomes
           </h3>
           <ul
-            className="c20"
+            className="c19"
           >
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 Sites Hail Table
@@ -2818,7 +16887,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                
               <button
                 aria-label="Show Google URL for Sites Hail Table"
-                className="c22"
+                className="c21"
                 onClick={[Function]}
                 type="button"
               >
@@ -2827,7 +16896,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                / 
               <button
                 aria-label="Show Amazon URL for Sites Hail Table"
-                className="c22"
+                className="c21"
                 onClick={[Function]}
                 type="button"
               >
@@ -2836,7 +16905,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                / 
               <button
                 aria-label="Show Microsoft URL for Sites Hail Table"
-                className="c22"
+                className="c21"
                 onClick={[Function]}
                 type="button"
               >
@@ -2844,7 +16913,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </button>
             </li>
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 All chromosomes sites VCF
@@ -2925,7 +16994,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
             </li>
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 Exome calling intervals VCF
@@ -3006,7 +17075,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
             </li>
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 chr1 sites VCF
@@ -3087,7 +17156,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
             </li>
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 chr2 sites VCF
@@ -3168,7 +17237,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
             </li>
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 chr3 sites VCF
@@ -3249,7 +17318,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
             </li>
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 chr4 sites VCF
@@ -3330,7 +17399,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
             </li>
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 chr5 sites VCF
@@ -3411,7 +17480,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
             </li>
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 chr6 sites VCF
@@ -3492,7 +17561,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
             </li>
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 chr7 sites VCF
@@ -3573,7 +17642,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
             </li>
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 chr8 sites VCF
@@ -3654,7 +17723,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
             </li>
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 chr9 sites VCF
@@ -3735,7 +17804,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
             </li>
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 chr10 sites VCF
@@ -3816,7 +17885,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
             </li>
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 chr11 sites VCF
@@ -3897,7 +17966,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
             </li>
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 chr12 sites VCF
@@ -3978,7 +18047,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
             </li>
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 chr13 sites VCF
@@ -4059,7 +18128,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
             </li>
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 chr14 sites VCF
@@ -4140,7 +18209,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
             </li>
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 chr15 sites VCF
@@ -4221,7 +18290,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
             </li>
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 chr16 sites VCF
@@ -4302,7 +18371,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
             </li>
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 chr17 sites VCF
@@ -4383,7 +18452,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
             </li>
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 chr18 sites VCF
@@ -4464,7 +18533,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
             </li>
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 chr19 sites VCF
@@ -4545,7 +18614,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
             </li>
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 chr20 sites VCF
@@ -4626,7 +18695,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
             </li>
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 chr21 sites VCF
@@ -4707,7 +18776,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
             </li>
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 chr22 sites VCF
@@ -4788,7 +18857,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
             </li>
             <li
-              className="c21"
+              className="c20"
             >
               <span>
                 chrX sites VCF
@@ -4899,10 +18968,10 @@ exports[`Downloads Page has no unexpected changes 1`] = `
         </h2>
       </span>
       <ul
-        className="c20"
+        className="c19"
       >
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             Exome coverage Hail Table
@@ -4912,7 +18981,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            
           <button
             aria-label="Show Google URL for Exome coverage Hail Table"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -4921,7 +18990,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            / 
           <button
             aria-label="Show Amazon URL for Exome coverage Hail Table"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -4930,7 +18999,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            / 
           <button
             aria-label="Show Microsoft URL for Exome coverage Hail Table"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -4938,7 +19007,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </button>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             Exome coverage summary TSV
@@ -4985,7 +19054,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             Genome coverage Hail Table
@@ -4995,7 +19064,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            
           <button
             aria-label="Show Google URL for Genome coverage Hail Table"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -5004,7 +19073,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            / 
           <button
             aria-label="Show Amazon URL for Genome coverage Hail Table"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -5013,7 +19082,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            / 
           <button
             aria-label="Show Microsoft URL for Genome coverage Hail Table"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -5021,7 +19090,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </button>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             Genome coverage summary TSV
@@ -5111,10 +19180,10 @@ exports[`Downloads Page has no unexpected changes 1`] = `
         </a>
       </p>
       <ul
-        className="c20"
+        className="c19"
       >
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             SV 2.1 sites VCF
@@ -5189,7 +19258,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             SV 2.1 sites BED
@@ -5264,7 +19333,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             SV 2.1 (controls) sites VCF
@@ -5339,7 +19408,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             SV 2.1 (controls) sites BED
@@ -5414,7 +19483,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             SV 2.1 (non-neuro) sites VCF
@@ -5489,7 +19558,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             SV 2.1 (non-neuro) sites BED
@@ -5597,7 +19666,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
         >
           Population 
           <select
-            className="c23"
+            className="c24"
             id="ld-files-population"
             onChange={[Function]}
             value="afr"
@@ -5655,10 +19724,10 @@ exports[`Downloads Page has no unexpected changes 1`] = `
         </label>
       </p>
       <ul
-        className="c20"
+        className="c19"
       >
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             LD matrix Hail BlockMatrix for African/African American population
@@ -5668,7 +19737,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            
           <button
             aria-label="Show Google URL for LD matrix Hail BlockMatrix for African/African American population"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -5677,7 +19746,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            / 
           <button
             aria-label="Show Amazon URL for LD matrix Hail BlockMatrix for African/African American population"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -5686,7 +19755,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            / 
           <button
             aria-label="Show Microsoft URL for LD matrix Hail BlockMatrix for African/African American population"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -5694,7 +19763,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </button>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             Variant indices Hail Table for African/African American population
@@ -5704,7 +19773,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            
           <button
             aria-label="Show Google URL for Variant indices Hail Table for African/African American population"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -5713,7 +19782,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            / 
           <button
             aria-label="Show Amazon URL for Variant indices Hail Table for African/African American population"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -5722,7 +19791,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            / 
           <button
             aria-label="Show Microsoft URL for Variant indices Hail Table for African/African American population"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -5730,7 +19799,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </button>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             LD scores Hail Table for African/African American population
@@ -5740,7 +19809,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            
           <button
             aria-label="Show Google URL for LD scores Hail Table for African/African American population"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -5749,7 +19818,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            / 
           <button
             aria-label="Show Amazon URL for LD scores Hail Table for African/African American population"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -5758,7 +19827,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            / 
           <button
             aria-label="Show Microsoft URL for LD scores Hail Table for African/African American population"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -5766,7 +19835,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </button>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             LDSC .ldscore.bgz file for African/African American population
@@ -5807,7 +19876,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             LDSC .M file for African/African American population
@@ -5848,7 +19917,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             LDSC .M_5_50 file for African/African American population
@@ -5930,10 +19999,10 @@ exports[`Downloads Page has no unexpected changes 1`] = `
         .
       </p>
       <ul
-        className="c20"
+        className="c19"
       >
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             Principal component analysis (PCA) variant loadings
@@ -5943,7 +20012,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            
           <button
             aria-label="Show Google URL for Principal component analysis (PCA) variant loadings"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -5952,7 +20021,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            / 
           <button
             aria-label="Show Amazon URL for Principal component analysis (PCA) variant loadings"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -5961,7 +20030,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            / 
           <button
             aria-label="Show Microsoft URL for Principal component analysis (PCA) variant loadings"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -5969,7 +20038,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </button>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             Random forest (RF) model
@@ -6023,6 +20092,100 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           <a
             aria-hidden="true"
             className="c8 c9"
+            href="#v2-regional-missense-constraint"
+            id="v2-regional-missense-constraint"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Regional Missense Constraint
+        </h2>
+      </span>
+      <ul
+        className="c19"
+      >
+        <li
+          className="c20"
+        >
+          <span>
+            Regional missense constraint Hail Table
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download Regional missense constraint Hail Table from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/regional_missense_constraint/gnomad_v2.1.1_rmc.ht"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            Regional missense constraint TSV (transcripts with RMC)
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download Regional missense constraint TSV (transcripts with RMC) from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/regional_missense_constraint/gnomAD_v2.1.1_transcripts_with_rmc.tsv"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            Regional missense constraint TSV (transcripts without RMC)
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download Regional missense constraint TSV (transcripts without RMC) from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/regional_missense_constraint/gnomAD_v2.1.1_transcripts_without_rmc.tsv"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+          </span>
+        </li>
+      </ul>
+    </section>
+    <section
+      className="c15"
+    >
+      <span
+        className="c6"
+      >
+        <h2
+          className="c16"
+        >
+          <a
+            aria-hidden="true"
+            className="c8 c9"
             href="#v2-resources"
             id="v2-resources"
           >
@@ -6038,10 +20201,10 @@ exports[`Downloads Page has no unexpected changes 1`] = `
         </h2>
       </span>
       <ul
-        className="c20"
+        className="c19"
       >
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             Exome calling regions
@@ -6082,7 +20245,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             Genome calling regions
@@ -6123,7 +20286,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             All pLoF variants
@@ -6248,10 +20411,10 @@ exports[`Downloads Page has no unexpected changes 1`] = `
         .
       </p>
       <ul
-        className="c20"
+        className="c19"
       >
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             pLoF Metrics by Transcript Hail Table
@@ -6261,7 +20424,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            
           <button
             aria-label="Show Google URL for pLoF Metrics by Transcript Hail Table"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -6270,7 +20433,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            / 
           <button
             aria-label="Show Amazon URL for pLoF Metrics by Transcript Hail Table"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -6279,7 +20442,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            / 
           <button
             aria-label="Show Microsoft URL for pLoF Metrics by Transcript Hail Table"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -6287,7 +20450,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </button>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             pLoF Metrics by Transcript TSV
@@ -6328,7 +20491,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             pLoF Metrics by Gene TSV
@@ -6369,7 +20532,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             pLoF Metrics Downsamplings TSV
@@ -6454,10 +20617,10 @@ exports[`Downloads Page has no unexpected changes 1`] = `
         </a>
       </p>
       <ul
-        className="c20"
+        className="c19"
       >
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             README
@@ -6498,7 +20661,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             Coding MNVs TSV
@@ -6539,7 +20702,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             Coding MNVs consisting of 3 SNVs TSV
@@ -6584,10 +20747,10 @@ exports[`Downloads Page has no unexpected changes 1`] = `
         MNVs genome wide
       </h3>
       <ul
-        className="c20"
+        className="c19"
       >
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             Distance = 1 Hail Table
@@ -6597,7 +20760,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            
           <button
             aria-label="Show Google URL for Distance = 1 Hail Table"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -6606,7 +20769,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            / 
           <button
             aria-label="Show Amazon URL for Distance = 1 Hail Table"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -6615,7 +20778,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            / 
           <button
             aria-label="Show Microsoft URL for Distance = 1 Hail Table"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -6623,7 +20786,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </button>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             Distance = 1 TSV
@@ -6664,7 +20827,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             Distance = 2 Hail Table
@@ -6674,7 +20837,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            
           <button
             aria-label="Show Google URL for Distance = 2 Hail Table"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -6683,7 +20846,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            / 
           <button
             aria-label="Show Amazon URL for Distance = 2 Hail Table"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -6692,7 +20855,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            / 
           <button
             aria-label="Show Microsoft URL for Distance = 2 Hail Table"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -6700,7 +20863,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </button>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             Distance = 2 TSV
@@ -6741,7 +20904,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             Distance = 3 Hail Table
@@ -6751,7 +20914,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            
           <button
             aria-label="Show Google URL for Distance = 3 Hail Table"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -6760,7 +20923,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            / 
           <button
             aria-label="Show Amazon URL for Distance = 3 Hail Table"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -6769,7 +20932,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            / 
           <button
             aria-label="Show Microsoft URL for Distance = 3 Hail Table"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -6777,7 +20940,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </button>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             Distance = 3 TSV
@@ -6818,7 +20981,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             Distance = 4 Hail Table
@@ -6828,7 +20991,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            
           <button
             aria-label="Show Google URL for Distance = 4 Hail Table"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -6837,7 +21000,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            / 
           <button
             aria-label="Show Amazon URL for Distance = 4 Hail Table"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -6846,7 +21009,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            / 
           <button
             aria-label="Show Microsoft URL for Distance = 4 Hail Table"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -6854,7 +21017,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </button>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             Distance = 4 TSV
@@ -6895,7 +21058,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             Distance = 5 Hail Table
@@ -6905,7 +21068,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            
           <button
             aria-label="Show Google URL for Distance = 5 Hail Table"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -6914,7 +21077,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            / 
           <button
             aria-label="Show Amazon URL for Distance = 5 Hail Table"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -6923,7 +21086,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            / 
           <button
             aria-label="Show Microsoft URL for Distance = 5 Hail Table"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -6931,7 +21094,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </button>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             Distance = 5 TSV
@@ -6972,7 +21135,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             Distance = 6 Hail Table
@@ -6982,7 +21145,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            
           <button
             aria-label="Show Google URL for Distance = 6 Hail Table"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -6991,7 +21154,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            / 
           <button
             aria-label="Show Amazon URL for Distance = 6 Hail Table"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -7000,7 +21163,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            / 
           <button
             aria-label="Show Microsoft URL for Distance = 6 Hail Table"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -7008,7 +21171,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </button>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             Distance = 6 TSV
@@ -7049,7 +21212,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             Distance = 7 Hail Table
@@ -7059,7 +21222,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            
           <button
             aria-label="Show Google URL for Distance = 7 Hail Table"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -7068,7 +21231,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            / 
           <button
             aria-label="Show Amazon URL for Distance = 7 Hail Table"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -7077,7 +21240,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            / 
           <button
             aria-label="Show Microsoft URL for Distance = 7 Hail Table"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -7085,7 +21248,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </button>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             Distance = 7 TSV
@@ -7126,7 +21289,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             Distance = 8 Hail Table
@@ -7136,7 +21299,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            
           <button
             aria-label="Show Google URL for Distance = 8 Hail Table"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -7145,7 +21308,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            / 
           <button
             aria-label="Show Amazon URL for Distance = 8 Hail Table"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -7154,7 +21317,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            / 
           <button
             aria-label="Show Microsoft URL for Distance = 8 Hail Table"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -7162,7 +21325,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </button>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             Distance = 8 TSV
@@ -7203,7 +21366,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             Distance = 9 Hail Table
@@ -7213,7 +21376,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            
           <button
             aria-label="Show Google URL for Distance = 9 Hail Table"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -7222,7 +21385,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            / 
           <button
             aria-label="Show Amazon URL for Distance = 9 Hail Table"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -7231,7 +21394,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            / 
           <button
             aria-label="Show Microsoft URL for Distance = 9 Hail Table"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -7239,7 +21402,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </button>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             Distance = 9 TSV
@@ -7280,7 +21443,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             Distance = 10 Hail Table
@@ -7290,7 +21453,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            
           <button
             aria-label="Show Google URL for Distance = 10 Hail Table"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -7299,7 +21462,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            / 
           <button
             aria-label="Show Amazon URL for Distance = 10 Hail Table"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -7308,7 +21471,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            / 
           <button
             aria-label="Show Microsoft URL for Distance = 10 Hail Table"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -7316,7 +21479,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </button>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             Distance = 10 TSV
@@ -7401,10 +21564,10 @@ exports[`Downloads Page has no unexpected changes 1`] = `
         </a>
       </p>
       <ul
-        className="c20"
+        className="c19"
       >
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             Annotation-level pext for all possible SNVs Hail table
@@ -7414,7 +21577,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            
           <button
             aria-label="Show Google URL for Annotation-level pext for all possible SNVs Hail table"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -7423,7 +21586,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            / 
           <button
             aria-label="Show Amazon URL for Annotation-level pext for all possible SNVs Hail table"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -7432,7 +21595,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            / 
           <button
             aria-label="Show Microsoft URL for Annotation-level pext for all possible SNVs Hail table"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -7440,7 +21603,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </button>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             Annotation-level pext for all possible SNVs TSV
@@ -7481,7 +21644,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             Base-level pext Hail table
@@ -7491,7 +21654,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            
           <button
             aria-label="Show Google URL for Base-level pext Hail table"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -7500,7 +21663,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            / 
           <button
             aria-label="Show Amazon URL for Base-level pext Hail table"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -7509,7 +21672,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            / 
           <button
             aria-label="Show Microsoft URL for Base-level pext Hail table"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -7517,7 +21680,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </button>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             Base-level pext TSV
@@ -7586,10 +21749,10 @@ exports[`Downloads Page has no unexpected changes 1`] = `
         </h2>
       </span>
       <ul
-        className="c20"
+        className="c19"
       >
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             README
@@ -7630,7 +21793,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             Variant co-occurrence Hail Table
@@ -7640,7 +21803,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            
           <button
             aria-label="Show Google URL for Variant co-occurrence Hail Table"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -7649,7 +21812,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            / 
           <button
             aria-label="Show Amazon URL for Variant co-occurrence Hail Table"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -7658,7 +21821,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            / 
           <button
             aria-label="Show Microsoft URL for Variant co-occurrence Hail Table"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -7666,7 +21829,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </button>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             Variant co-occurrence by gene (homozygous rare variants)
@@ -7676,7 +21839,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            
           <button
             aria-label="Show Google URL for Variant co-occurrence by gene (homozygous rare variants)"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -7685,7 +21848,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            / 
           <button
             aria-label="Show Amazon URL for Variant co-occurrence by gene (homozygous rare variants)"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -7694,7 +21857,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            / 
           <button
             aria-label="Show Microsoft URL for Variant co-occurrence by gene (homozygous rare variants)"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -7702,7 +21865,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </button>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             Variant co-occurrence by gene (two heterozygous rare variants)
@@ -7712,7 +21875,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            
           <button
             aria-label="Show Google URL for Variant co-occurrence by gene (two heterozygous rare variants)"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -7721,7 +21884,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            / 
           <button
             aria-label="Show Amazon URL for Variant co-occurrence by gene (two heterozygous rare variants)"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -7730,7 +21893,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            / 
           <button
             aria-label="Show Microsoft URL for Variant co-occurrence by gene (two heterozygous rare variants)"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -7799,10 +21962,10 @@ exports[`Downloads Page has no unexpected changes 1`] = `
         (haploinsufficient genes LoF curation results).
       </p>
       <ul
-        className="c20"
+        className="c19"
       >
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             All homozygous LoF curation results
@@ -7843,7 +22006,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             Lysosomal storage disease genes LoF curation results
@@ -7884,7 +22047,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             AP4 LoF curation results
@@ -7925,7 +22088,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             FIG4 LoF curation results
@@ -7966,7 +22129,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             MCOLN1 LoF curation results
@@ -8007,7 +22170,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             Haploinsufficient genes LoF curation results
@@ -8048,7 +22211,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             Metabolic conditions genes LoF curation results
@@ -8089,7 +22252,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             gnomAD addendum LoF curation results
@@ -8130,7 +22293,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             NSD1 LoF curation results
@@ -8163,10515 +22326,6 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               aria-label="Download NSD1 LoF curation results from Microsoft"
               className="c10"
               href="https://datasetgnomad.blob.core.windows.net/dataset/truth-sets/source/lof-curation/NSD1_curation_results.csv"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-      </ul>
-    </section>
-    <span
-      className="c6"
-    >
-      <h2
-        className="c14"
-      >
-        <a
-          aria-hidden="true"
-          className="c8 c9"
-          href="#v2-liftover"
-          id="v2-liftover"
-        >
-          <img
-            alt=""
-            aria-hidden="true"
-            height={12}
-            src="test-file-stub"
-            width={12}
-          />
-        </a>
-        v2 Liftover Downloads
-      </h2>
-    </span>
-    <p
-      className="c11"
-    >
-      The gnomAD v2.1.1 liftover data set contains data from 125,748 exomes and 15,708 whole genomes, lifted over from the GRCh37 to the GRCh38 reference sequence.
-    </p>
-    <span
-      className="c6"
-    >
-      <h2
-        className="c7"
-      >
-        <a
-          aria-hidden="true"
-          className="c8 c9"
-          href="#v2-liftover-core-dataset"
-          id="v2-liftover-core-dataset"
-        >
-          <img
-            alt=""
-            aria-hidden="true"
-            height={12}
-            src="test-file-stub"
-            width={12}
-          />
-        </a>
-        Core Dataset
-      </h2>
-    </span>
-    <p
-      className="c11"
-    >
-      gnomAD database and features created and maintained by the gnomAD production team.
-    </p>
-    <section
-      className="c15"
-    >
-      <span
-        className="c6"
-      >
-        <h2
-          className="c16"
-        >
-          <a
-            aria-hidden="true"
-            className="c8 c9"
-            href="#v2-liftover-variants"
-            id="v2-liftover-variants"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Variants (GRCh38 liftover)
-        </h2>
-      </span>
-      <p>
-        The variant dataset files below contain all subsets (non-neuro, non-cancer, controls-only, and non-TOPMed).
-      </p>
-      <div
-        className="c18"
-      >
-        <div
-          className="c19"
-        >
-          <h3>
-            Exomes
-          </h3>
-          <ul
-            className="c20"
-          >
-            <li
-              className="c21"
-            >
-              <span>
-                Sites Hail Table
-              </span>
-              <br />
-              Show URL for
-               
-              <button
-                aria-label="Show Google URL for Sites Hail Table"
-                className="c22"
-                onClick={[Function]}
-                type="button"
-              >
-                Google
-              </button>
-               / 
-              <button
-                aria-label="Show Amazon URL for Sites Hail Table"
-                className="c22"
-                onClick={[Function]}
-                type="button"
-              >
-                Amazon
-              </button>
-               / 
-              <button
-                aria-label="Show Microsoft URL for Sites Hail Table"
-                className="c22"
-                onClick={[Function]}
-                type="button"
-              >
-                Microsoft
-              </button>
-            </li>
-            <li
-              className="c21"
-            >
-              <span>
-                All chromosomes VCF
-              </span>
-              <br />
-              <span>
-                85.31 GiB
-                , MD5: 
-                cff8d0cfed50adc9211d1feaed2d4ca7
-              </span>
-              <br />
-              <span>
-                Download from
-                 
-                <a
-                  aria-label="Download All chromosomes VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download All chromosomes VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download All chromosomes VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-              <br />
-              <span>
-                Download TBI from
-                 
-                <a
-                  aria-label="Download TBI file for All chromosomes VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for All chromosomes VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for All chromosomes VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-            </li>
-            <li
-              className="c21"
-            >
-              <span>
-                chr1 sites VCF
-              </span>
-              <br />
-              <span>
-                5.3 GiB
-                , MD5: 
-                6afa2df088f1627eb649c6d24d8784e8
-              </span>
-              <br />
-              <span>
-                Download from
-                 
-                <a
-                  aria-label="Download chr1 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.1.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr1 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.1.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr1 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.1.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-              <br />
-              <span>
-                Download TBI from
-                 
-                <a
-                  aria-label="Download TBI file for chr1 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.1.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr1 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.1.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr1 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.1.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-            </li>
-            <li
-              className="c21"
-            >
-              <span>
-                chr2 sites VCF
-              </span>
-              <br />
-              <span>
-                3.85 GiB
-                , MD5: 
-                570b5aee023938c7b5ab660f28a79651
-              </span>
-              <br />
-              <span>
-                Download from
-                 
-                <a
-                  aria-label="Download chr2 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.2.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr2 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.2.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr2 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.2.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-              <br />
-              <span>
-                Download TBI from
-                 
-                <a
-                  aria-label="Download TBI file for chr2 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.2.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr2 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.2.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr2 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.2.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-            </li>
-            <li
-              className="c21"
-            >
-              <span>
-                chr3 sites VCF
-              </span>
-              <br />
-              <span>
-                3.02 GiB
-                , MD5: 
-                29dd5e955afe7cc9c8342aa1ee88e099
-              </span>
-              <br />
-              <span>
-                Download from
-                 
-                <a
-                  aria-label="Download chr3 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.3.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr3 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.3.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr3 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.3.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-              <br />
-              <span>
-                Download TBI from
-                 
-                <a
-                  aria-label="Download TBI file for chr3 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.3.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr3 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.3.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr3 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.3.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-            </li>
-            <li
-              className="c21"
-            >
-              <span>
-                chr4 sites VCF
-              </span>
-              <br />
-              <span>
-                1.99 GiB
-                , MD5: 
-                560e0fb2c514411ea35638fb2b2a35bf
-              </span>
-              <br />
-              <span>
-                Download from
-                 
-                <a
-                  aria-label="Download chr4 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.4.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr4 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.4.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr4 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.4.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-              <br />
-              <span>
-                Download TBI from
-                 
-                <a
-                  aria-label="Download TBI file for chr4 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.4.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr4 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.4.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr4 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.4.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-            </li>
-            <li
-              className="c21"
-            >
-              <span>
-                chr5 sites VCF
-              </span>
-              <br />
-              <span>
-                2.31 GiB
-                , MD5: 
-                5e777b38fe2437b56b32b455de80015c
-              </span>
-              <br />
-              <span>
-                Download from
-                 
-                <a
-                  aria-label="Download chr5 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.5.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr5 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.5.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr5 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.5.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-              <br />
-              <span>
-                Download TBI from
-                 
-                <a
-                  aria-label="Download TBI file for chr5 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.5.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr5 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.5.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr5 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.5.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-            </li>
-            <li
-              className="c21"
-            >
-              <span>
-                chr6 sites VCF
-              </span>
-              <br />
-              <span>
-                2.6 GiB
-                , MD5: 
-                8815cd575bd71504d8dd243136995d16
-              </span>
-              <br />
-              <span>
-                Download from
-                 
-                <a
-                  aria-label="Download chr6 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.6.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr6 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.6.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr6 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.6.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-              <br />
-              <span>
-                Download TBI from
-                 
-                <a
-                  aria-label="Download TBI file for chr6 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.6.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr6 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.6.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr6 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.6.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-            </li>
-            <li
-              className="c21"
-            >
-              <span>
-                chr7 sites VCF
-              </span>
-              <br />
-              <span>
-                2.62 GiB
-                , MD5: 
-                70d4fbaf888017ab0a12e3c0dced5700
-              </span>
-              <br />
-              <span>
-                Download from
-                 
-                <a
-                  aria-label="Download chr7 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.7.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr7 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.7.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr7 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.7.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-              <br />
-              <span>
-                Download TBI from
-                 
-                <a
-                  aria-label="Download TBI file for chr7 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.7.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr7 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.7.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr7 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.7.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-            </li>
-            <li
-              className="c21"
-            >
-              <span>
-                chr8 sites VCF
-              </span>
-              <br />
-              <span>
-                1.95 GiB
-                , MD5: 
-                39017f2660ac88916a6a9470f0192eda
-              </span>
-              <br />
-              <span>
-                Download from
-                 
-                <a
-                  aria-label="Download chr8 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.8.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr8 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.8.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr8 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.8.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-              <br />
-              <span>
-                Download TBI from
-                 
-                <a
-                  aria-label="Download TBI file for chr8 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.8.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr8 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.8.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr8 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.8.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-            </li>
-            <li
-              className="c21"
-            >
-              <span>
-                chr9 sites VCF
-              </span>
-              <br />
-              <span>
-                2.2 GiB
-                , MD5: 
-                9c683f3b8a17e2aee1eac8b5ad860edf
-              </span>
-              <br />
-              <span>
-                Download from
-                 
-                <a
-                  aria-label="Download chr9 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.9.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr9 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.9.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr9 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.9.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-              <br />
-              <span>
-                Download TBI from
-                 
-                <a
-                  aria-label="Download TBI file for chr9 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.9.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr9 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.9.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr9 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.9.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-            </li>
-            <li
-              className="c21"
-            >
-              <span>
-                chr10 sites VCF
-              </span>
-              <br />
-              <span>
-                2.04 GiB
-                , MD5: 
-                72073e8257316017f5356b986b779dd2
-              </span>
-              <br />
-              <span>
-                Download from
-                 
-                <a
-                  aria-label="Download chr10 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.10.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr10 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.10.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr10 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.10.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-              <br />
-              <span>
-                Download TBI from
-                 
-                <a
-                  aria-label="Download TBI file for chr10 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.10.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr10 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.10.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr10 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.10.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-            </li>
-            <li
-              className="c21"
-            >
-              <span>
-                chr11 sites VCF
-              </span>
-              <br />
-              <span>
-                3.32 GiB
-                , MD5: 
-                89bf2840850664fad81d2f1277bd0d7a
-              </span>
-              <br />
-              <span>
-                Download from
-                 
-                <a
-                  aria-label="Download chr11 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.11.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr11 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.11.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr11 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.11.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-              <br />
-              <span>
-                Download TBI from
-                 
-                <a
-                  aria-label="Download TBI file for chr11 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.11.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr11 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.11.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr11 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.11.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-            </li>
-            <li
-              className="c21"
-            >
-              <span>
-                chr12 sites VCF
-              </span>
-              <br />
-              <span>
-                2.82 GiB
-                , MD5: 
-                50b5cb95f9d7125e385ee3153992fea1
-              </span>
-              <br />
-              <span>
-                Download from
-                 
-                <a
-                  aria-label="Download chr12 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.12.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr12 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.12.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr12 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.12.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-              <br />
-              <span>
-                Download TBI from
-                 
-                <a
-                  aria-label="Download TBI file for chr12 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.12.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr12 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.12.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr12 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.12.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-            </li>
-            <li
-              className="c21"
-            >
-              <span>
-                chr13 sites VCF
-              </span>
-              <br />
-              <span>
-                892.17 MiB
-                , MD5: 
-                8bf51379fa45b205461eb27a8664f2c2
-              </span>
-              <br />
-              <span>
-                Download from
-                 
-                <a
-                  aria-label="Download chr13 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.13.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr13 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.13.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr13 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.13.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-              <br />
-              <span>
-                Download TBI from
-                 
-                <a
-                  aria-label="Download TBI file for chr13 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.13.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr13 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.13.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr13 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.13.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-            </li>
-            <li
-              className="c21"
-            >
-              <span>
-                chr14 sites VCF
-              </span>
-              <br />
-              <span>
-                1.85 GiB
-                , MD5: 
-                75bdaaea3b2ace57cd1165799b29fbd5
-              </span>
-              <br />
-              <span>
-                Download from
-                 
-                <a
-                  aria-label="Download chr14 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.14.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr14 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.14.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr14 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.14.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-              <br />
-              <span>
-                Download TBI from
-                 
-                <a
-                  aria-label="Download TBI file for chr14 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.14.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr14 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.14.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr14 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.14.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-            </li>
-            <li
-              className="c21"
-            >
-              <span>
-                chr15 sites VCF
-              </span>
-              <br />
-              <span>
-                1.91 GiB
-                , MD5: 
-                30f244130bf6ac58006463cd87d56272
-              </span>
-              <br />
-              <span>
-                Download from
-                 
-                <a
-                  aria-label="Download chr15 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.15.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr15 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.15.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr15 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.15.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-              <br />
-              <span>
-                Download TBI from
-                 
-                <a
-                  aria-label="Download TBI file for chr15 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.15.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr15 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.15.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr15 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.15.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-            </li>
-            <li
-              className="c21"
-            >
-              <span>
-                chr16 sites VCF
-              </span>
-              <br />
-              <span>
-                2.81 GiB
-                , MD5: 
-                1ac5e4d7d6ee3255ceedd652691b6cd0
-              </span>
-              <br />
-              <span>
-                Download from
-                 
-                <a
-                  aria-label="Download chr16 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.16.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr16 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.16.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr16 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.16.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-              <br />
-              <span>
-                Download TBI from
-                 
-                <a
-                  aria-label="Download TBI file for chr16 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.16.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr16 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.16.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr16 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.16.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-            </li>
-            <li
-              className="c21"
-            >
-              <span>
-                chr17 sites VCF
-              </span>
-              <br />
-              <span>
-                3.33 GiB
-                , MD5: 
-                947b32de25fe137a8cc95948b852e757
-              </span>
-              <br />
-              <span>
-                Download from
-                 
-                <a
-                  aria-label="Download chr17 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.17.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr17 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.17.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr17 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.17.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-              <br />
-              <span>
-                Download TBI from
-                 
-                <a
-                  aria-label="Download TBI file for chr17 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.17.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr17 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.17.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr17 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.17.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-            </li>
-            <li
-              className="c21"
-            >
-              <span>
-                chr18 sites VCF
-              </span>
-              <br />
-              <span>
-                810.06 MiB
-                , MD5: 
-                6bf85f4d674917346d3b658646b4fdbf
-              </span>
-              <br />
-              <span>
-                Download from
-                 
-                <a
-                  aria-label="Download chr18 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.18.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr18 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.18.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr18 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.18.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-              <br />
-              <span>
-                Download TBI from
-                 
-                <a
-                  aria-label="Download TBI file for chr18 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.18.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr18 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.18.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr18 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.18.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-            </li>
-            <li
-              className="c21"
-            >
-              <span>
-                chr19 sites VCF
-              </span>
-              <br />
-              <span>
-                3.94 GiB
-                , MD5: 
-                f882913ec97cdbbbf195b777ca4be732
-              </span>
-              <br />
-              <span>
-                Download from
-                 
-                <a
-                  aria-label="Download chr19 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.19.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr19 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.19.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr19 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.19.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-              <br />
-              <span>
-                Download TBI from
-                 
-                <a
-                  aria-label="Download TBI file for chr19 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.19.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr19 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.19.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr19 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.19.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-            </li>
-            <li
-              className="c21"
-            >
-              <span>
-                chr20 sites VCF
-              </span>
-              <br />
-              <span>
-                1.32 GiB
-                , MD5: 
-                9167cd594f30321fec62f31ade758c2c
-              </span>
-              <br />
-              <span>
-                Download from
-                 
-                <a
-                  aria-label="Download chr20 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.20.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr20 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.20.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr20 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.20.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-              <br />
-              <span>
-                Download TBI from
-                 
-                <a
-                  aria-label="Download TBI file for chr20 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.20.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr20 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.20.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr20 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.20.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-            </li>
-            <li
-              className="c21"
-            >
-              <span>
-                chr21 sites VCF
-              </span>
-              <br />
-              <span>
-                599.31 MiB
-                , MD5: 
-                113d7a5d058b617c60db768ce527a96f
-              </span>
-              <br />
-              <span>
-                Download from
-                 
-                <a
-                  aria-label="Download chr21 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.21.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr21 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.21.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr21 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.21.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-              <br />
-              <span>
-                Download TBI from
-                 
-                <a
-                  aria-label="Download TBI file for chr21 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.21.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr21 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.21.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr21 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.21.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-            </li>
-            <li
-              className="c21"
-            >
-              <span>
-                chr22 sites VCF
-              </span>
-              <br />
-              <span>
-                1.31 GiB
-                , MD5: 
-                394dc422f48914496646f33e92eacd27
-              </span>
-              <br />
-              <span>
-                Download from
-                 
-                <a
-                  aria-label="Download chr22 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.22.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr22 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.22.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr22 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.22.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-              <br />
-              <span>
-                Download TBI from
-                 
-                <a
-                  aria-label="Download TBI file for chr22 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.22.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr22 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.22.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr22 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.22.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-            </li>
-            <li
-              className="c21"
-            >
-              <span>
-                chrX sites VCF
-              </span>
-              <br />
-              <span>
-                1.19 GiB
-                , MD5: 
-                047145d2b7fb416b516566201e1bc694
-              </span>
-              <br />
-              <span>
-                Download from
-                 
-                <a
-                  aria-label="Download chrX sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.X.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download chrX sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.X.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download chrX sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.X.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-              <br />
-              <span>
-                Download TBI from
-                 
-                <a
-                  aria-label="Download TBI file for chrX sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.X.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chrX sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.X.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chrX sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.X.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-            </li>
-            <li
-              className="c21"
-            >
-              <span>
-                chrY sites VCF
-              </span>
-              <br />
-              <span>
-                14.18 MiB
-                , MD5: 
-                4b8cfe3f9051050c94948dab4871c9ce
-              </span>
-              <br />
-              <span>
-                Download from
-                 
-                <a
-                  aria-label="Download chrY sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.Y.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download chrY sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.Y.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download chrY sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.Y.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-              <br />
-              <span>
-                Download TBI from
-                 
-                <a
-                  aria-label="Download TBI file for chrY sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.Y.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chrY sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.Y.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chrY sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.Y.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-            </li>
-          </ul>
-        </div>
-        <div
-          className="c19"
-        >
-          <h3>
-            Genomes
-          </h3>
-          <ul
-            className="c20"
-          >
-            <li
-              className="c21"
-            >
-              <span>
-                Sites Hail Table
-              </span>
-              <br />
-              Show URL for
-               
-              <button
-                aria-label="Show Google URL for Sites Hail Table"
-                className="c22"
-                onClick={[Function]}
-                type="button"
-              >
-                Google
-              </button>
-               / 
-              <button
-                aria-label="Show Amazon URL for Sites Hail Table"
-                className="c22"
-                onClick={[Function]}
-                type="button"
-              >
-                Amazon
-              </button>
-               / 
-              <button
-                aria-label="Show Microsoft URL for Sites Hail Table"
-                className="c22"
-                onClick={[Function]}
-                type="button"
-              >
-                Microsoft
-              </button>
-            </li>
-            <li
-              className="c21"
-            >
-              <span>
-                All chromosomes VCF
-              </span>
-              <br />
-              <span>
-                743.06 GiB
-                , MD5: 
-                83de3d5b52669f714e810d4fcf047c18
-              </span>
-              <br />
-              <span>
-                Download from
-                 
-                <a
-                  aria-label="Download All chromosomes VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download All chromosomes VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download All chromosomes VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-              <br />
-              <span>
-                Download TBI from
-                 
-                <a
-                  aria-label="Download TBI file for All chromosomes VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for All chromosomes VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for All chromosomes VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-            </li>
-            <li
-              className="c21"
-            >
-              <span>
-                chr1 sites VCF
-              </span>
-              <br />
-              <span>
-                33.37 GiB
-                , MD5: 
-                49a18c485dbf68fa6bc92312c4a646eb
-              </span>
-              <br />
-              <span>
-                Download from
-                 
-                <a
-                  aria-label="Download chr1 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.1.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr1 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.1.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr1 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.1.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-              <br />
-              <span>
-                Download TBI from
-                 
-                <a
-                  aria-label="Download TBI file for chr1 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.1.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr1 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.1.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr1 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.1.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-            </li>
-            <li
-              className="c21"
-            >
-              <span>
-                chr2 sites VCF
-              </span>
-              <br />
-              <span>
-                35.88 GiB
-                , MD5: 
-                c5f5ec623377b1d2dbc30502cd31d086
-              </span>
-              <br />
-              <span>
-                Download from
-                 
-                <a
-                  aria-label="Download chr2 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.2.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr2 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.2.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr2 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.2.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-              <br />
-              <span>
-                Download TBI from
-                 
-                <a
-                  aria-label="Download TBI file for chr2 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.2.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr2 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.2.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr2 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.2.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-            </li>
-            <li
-              className="c21"
-            >
-              <span>
-                chr3 sites VCF
-              </span>
-              <br />
-              <span>
-                29.47 GiB
-                , MD5: 
-                0ad77689edb3bc731c71d6d140dfaacd
-              </span>
-              <br />
-              <span>
-                Download from
-                 
-                <a
-                  aria-label="Download chr3 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.3.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr3 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.3.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr3 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.3.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-              <br />
-              <span>
-                Download TBI from
-                 
-                <a
-                  aria-label="Download TBI file for chr3 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.3.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr3 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.3.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr3 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.3.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-            </li>
-            <li
-              className="c21"
-            >
-              <span>
-                chr4 sites VCF
-              </span>
-              <br />
-              <span>
-                28.47 GiB
-                , MD5: 
-                e0b1dc365600bc31cb48debb6b03c561
-              </span>
-              <br />
-              <span>
-                Download from
-                 
-                <a
-                  aria-label="Download chr4 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.4.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr4 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.4.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr4 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.4.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-              <br />
-              <span>
-                Download TBI from
-                 
-                <a
-                  aria-label="Download TBI file for chr4 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.4.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr4 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.4.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr4 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.4.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-            </li>
-            <li
-              className="c21"
-            >
-              <span>
-                chr5 sites VCF
-              </span>
-              <br />
-              <span>
-                26.56 GiB
-                , MD5: 
-                ea53a6e364cade4f6ed5504d5cd14d62
-              </span>
-              <br />
-              <span>
-                Download from
-                 
-                <a
-                  aria-label="Download chr5 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.5.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr5 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.5.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr5 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.5.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-              <br />
-              <span>
-                Download TBI from
-                 
-                <a
-                  aria-label="Download TBI file for chr5 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.5.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr5 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.5.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr5 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.5.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-            </li>
-            <li
-              className="c21"
-            >
-              <span>
-                chr6 sites VCF
-              </span>
-              <br />
-              <span>
-                24.88 GiB
-                , MD5: 
-                b717eb2c2154740558ca3f62adf30a4a
-              </span>
-              <br />
-              <span>
-                Download from
-                 
-                <a
-                  aria-label="Download chr6 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.6.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr6 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.6.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr6 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.6.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-              <br />
-              <span>
-                Download TBI from
-                 
-                <a
-                  aria-label="Download TBI file for chr6 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.6.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr6 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.6.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr6 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.6.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-            </li>
-            <li
-              className="c21"
-            >
-              <span>
-                chr7 sites VCF
-              </span>
-              <br />
-              <span>
-                24.37 GiB
-                , MD5: 
-                5b97c8c80b9b8404f611d5725d4f563d
-              </span>
-              <br />
-              <span>
-                Download from
-                 
-                <a
-                  aria-label="Download chr7 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.7.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr7 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.7.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr7 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.7.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-              <br />
-              <span>
-                Download TBI from
-                 
-                <a
-                  aria-label="Download TBI file for chr7 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.7.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr7 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.7.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr7 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.7.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-            </li>
-            <li
-              className="c21"
-            >
-              <span>
-                chr8 sites VCF
-              </span>
-              <br />
-              <span>
-                22.99 GiB
-                , MD5: 
-                f502012b3b6fd771e1f97878d4c89831
-              </span>
-              <br />
-              <span>
-                Download from
-                 
-                <a
-                  aria-label="Download chr8 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.8.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr8 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.8.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr8 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.8.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-              <br />
-              <span>
-                Download TBI from
-                 
-                <a
-                  aria-label="Download TBI file for chr8 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.8.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr8 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.8.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr8 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.8.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-            </li>
-            <li
-              className="c21"
-            >
-              <span>
-                chr9 sites VCF
-              </span>
-              <br />
-              <span>
-                18.76 GiB
-                , MD5: 
-                d9cb3ac24eb9cdd891bbeaf554b7f701
-              </span>
-              <br />
-              <span>
-                Download from
-                 
-                <a
-                  aria-label="Download chr9 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.9.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr9 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.9.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr9 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.9.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-              <br />
-              <span>
-                Download TBI from
-                 
-                <a
-                  aria-label="Download TBI file for chr9 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.9.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr9 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.9.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr9 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.9.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-            </li>
-            <li
-              className="c21"
-            >
-              <span>
-                chr10 sites VCF
-              </span>
-              <br />
-              <span>
-                19.93 GiB
-                , MD5: 
-                8b4573aee1f13efcaa822a736cea3be3
-              </span>
-              <br />
-              <span>
-                Download from
-                 
-                <a
-                  aria-label="Download chr10 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.10.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr10 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.10.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr10 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.10.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-              <br />
-              <span>
-                Download TBI from
-                 
-                <a
-                  aria-label="Download TBI file for chr10 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.10.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr10 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.10.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr10 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.10.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-            </li>
-            <li
-              className="c21"
-            >
-              <span>
-                chr11 sites VCF
-              </span>
-              <br />
-              <span>
-                20.53 GiB
-                , MD5: 
-                340101c9092be9a2e408c82c78f860fc
-              </span>
-              <br />
-              <span>
-                Download from
-                 
-                <a
-                  aria-label="Download chr11 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.11.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr11 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.11.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr11 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.11.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-              <br />
-              <span>
-                Download TBI from
-                 
-                <a
-                  aria-label="Download TBI file for chr11 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.11.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr11 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.11.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr11 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.11.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-            </li>
-            <li
-              className="c21"
-            >
-              <span>
-                chr12 sites VCF
-              </span>
-              <br />
-              <span>
-                19.97 GiB
-                , MD5: 
-                e7612e7a222cbf7077f3766eb793f75b
-              </span>
-              <br />
-              <span>
-                Download from
-                 
-                <a
-                  aria-label="Download chr12 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.12.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr12 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.12.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr12 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.12.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-              <br />
-              <span>
-                Download TBI from
-                 
-                <a
-                  aria-label="Download TBI file for chr12 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.12.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr12 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.12.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr12 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.12.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-            </li>
-            <li
-              className="c21"
-            >
-              <span>
-                chr13 sites VCF
-              </span>
-              <br />
-              <span>
-                13.99 GiB
-                , MD5: 
-                e8146ed73263cfc6c733bcb9e942a05f
-              </span>
-              <br />
-              <span>
-                Download from
-                 
-                <a
-                  aria-label="Download chr13 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.13.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr13 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.13.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr13 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.13.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-              <br />
-              <span>
-                Download TBI from
-                 
-                <a
-                  aria-label="Download TBI file for chr13 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.13.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr13 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.13.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr13 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.13.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-            </li>
-            <li
-              className="c21"
-            >
-              <span>
-                chr14 sites VCF
-              </span>
-              <br />
-              <span>
-                13.71 GiB
-                , MD5: 
-                3b437d953f169a299df69ab51726117a
-              </span>
-              <br />
-              <span>
-                Download from
-                 
-                <a
-                  aria-label="Download chr14 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.14.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr14 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.14.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr14 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.14.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-              <br />
-              <span>
-                Download TBI from
-                 
-                <a
-                  aria-label="Download TBI file for chr14 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.14.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr14 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.14.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr14 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.14.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-            </li>
-            <li
-              className="c21"
-            >
-              <span>
-                chr15 sites VCF
-              </span>
-              <br />
-              <span>
-                12.92 GiB
-                , MD5: 
-                d03e682c7271dac3d333da2aab17b486
-              </span>
-              <br />
-              <span>
-                Download from
-                 
-                <a
-                  aria-label="Download chr15 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.15.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr15 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.15.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr15 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.15.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-              <br />
-              <span>
-                Download TBI from
-                 
-                <a
-                  aria-label="Download TBI file for chr15 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.15.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr15 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.15.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr15 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.15.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-            </li>
-            <li
-              className="c21"
-            >
-              <span>
-                chr16 sites VCF
-              </span>
-              <br />
-              <span>
-                14.51 GiB
-                , MD5: 
-                f38fe23fe7bdc3debf5f43945f160383
-              </span>
-              <br />
-              <span>
-                Download from
-                 
-                <a
-                  aria-label="Download chr16 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.16.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr16 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.16.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr16 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.16.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-              <br />
-              <span>
-                Download TBI from
-                 
-                <a
-                  aria-label="Download TBI file for chr16 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.16.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr16 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.16.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr16 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.16.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-            </li>
-            <li
-              className="c21"
-            >
-              <span>
-                chr17 sites VCF
-              </span>
-              <br />
-              <span>
-                12.67 GiB
-                , MD5: 
-                732e899517000c1505898ca918a38267
-              </span>
-              <br />
-              <span>
-                Download from
-                 
-                <a
-                  aria-label="Download chr17 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.17.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr17 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.17.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr17 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.17.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-              <br />
-              <span>
-                Download TBI from
-                 
-                <a
-                  aria-label="Download TBI file for chr17 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.17.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr17 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.17.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr17 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.17.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-            </li>
-            <li
-              className="c21"
-            >
-              <span>
-                chr18 sites VCF
-              </span>
-              <br />
-              <span>
-                11.34 GiB
-                , MD5: 
-                de2e98425c57ba805145dea4f2483867
-              </span>
-              <br />
-              <span>
-                Download from
-                 
-                <a
-                  aria-label="Download chr18 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.18.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr18 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.18.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr18 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.18.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-              <br />
-              <span>
-                Download TBI from
-                 
-                <a
-                  aria-label="Download TBI file for chr18 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.18.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr18 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.18.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr18 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.18.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-            </li>
-            <li
-              className="c21"
-            >
-              <span>
-                chr19 sites VCF
-              </span>
-              <br />
-              <span>
-                10.48 GiB
-                , MD5: 
-                60f5d011e1684f6db81b3d052ae75bc0
-              </span>
-              <br />
-              <span>
-                Download from
-                 
-                <a
-                  aria-label="Download chr19 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.19.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr19 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.19.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr19 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.19.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-              <br />
-              <span>
-                Download TBI from
-                 
-                <a
-                  aria-label="Download TBI file for chr19 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.19.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr19 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.19.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr19 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.19.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-            </li>
-            <li
-              className="c21"
-            >
-              <span>
-                chr20 sites VCF
-              </span>
-              <br />
-              <span>
-                9.04 GiB
-                , MD5: 
-                1da4057634c7143a0f33f61f49ebbe5f
-              </span>
-              <br />
-              <span>
-                Download from
-                 
-                <a
-                  aria-label="Download chr20 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.20.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr20 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.20.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr20 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.20.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-              <br />
-              <span>
-                Download TBI from
-                 
-                <a
-                  aria-label="Download TBI file for chr20 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.20.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr20 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.20.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr20 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.20.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-            </li>
-            <li
-              className="c21"
-            >
-              <span>
-                chr21 sites VCF
-              </span>
-              <br />
-              <span>
-                5.77 GiB
-                , MD5: 
-                be37bea3ac95097021e8c130291d45de
-              </span>
-              <br />
-              <span>
-                Download from
-                 
-                <a
-                  aria-label="Download chr21 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.21.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr21 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.21.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr21 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.21.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-              <br />
-              <span>
-                Download TBI from
-                 
-                <a
-                  aria-label="Download TBI file for chr21 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.21.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr21 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.21.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr21 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.21.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-            </li>
-            <li
-              className="c21"
-            >
-              <span>
-                chr22 sites VCF
-              </span>
-              <br />
-              <span>
-                6.07 GiB
-                , MD5: 
-                0f5703d8373516eb3753bcf89a547621
-              </span>
-              <br />
-              <span>
-                Download from
-                 
-                <a
-                  aria-label="Download chr22 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.22.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr22 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.22.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download chr22 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.22.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-              <br />
-              <span>
-                Download TBI from
-                 
-                <a
-                  aria-label="Download TBI file for chr22 sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.22.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr22 sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.22.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chr22 sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.22.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-            </li>
-            <li
-              className="c21"
-            >
-              <span>
-                chrX sites VCF
-              </span>
-              <br />
-              <span>
-                16.41 GiB
-                , MD5: 
-                898a122480632cfdc58450bbbb3554c1
-              </span>
-              <br />
-              <span>
-                Download from
-                 
-                <a
-                  aria-label="Download chrX sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.X.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download chrX sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.X.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download chrX sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.X.liftover_grch38.vcf.bgz"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-              <br />
-              <span>
-                Download TBI from
-                 
-                <a
-                  aria-label="Download TBI file for chrX sites VCF from Google"
-                  className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.X.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Google
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chrX sites VCF from Amazon"
-                  className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.X.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Amazon
-                </a>
-                 / 
-                <a
-                  aria-label="Download TBI file for chrX sites VCF from Microsoft"
-                  className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.X.liftover_grch38.vcf.bgz.tbi"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Microsoft
-                </a>
-              </span>
-            </li>
-          </ul>
-        </div>
-      </div>
-    </section>
-    <section
-      className="c15"
-    >
-      <span
-        className="c6"
-      >
-        <h2
-          className="c16"
-        >
-          <a
-            aria-hidden="true"
-            className="c8 c9"
-            href="#v2-liftover-structural-variants"
-            id="v2-liftover-structural-variants"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Structural variants (GRCh38 liftover)
-        </h2>
-      </span>
-      <p>
-        <span
-          className="c17"
-        >
-          Note
-        </span>
-         The lifted over structural variant dataset was created by dbVar and has not been assessed by the gnomAD production team.
-      </p>
-      <ul
-        className="c20"
-      >
-        <li
-          className="c21"
-        >
-          <a
-            className="c10"
-            href="https://www.ncbi.nlm.nih.gov/sites/dbvarapp/studies/nstd166/"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            nstd166 (gnomAD Structural Variants)
-          </a>
-        </li>
-      </ul>
-    </section>
-    <span
-      className="c6"
-    >
-      <h2
-        className="c14"
-      >
-        <a
-          aria-hidden="true"
-          className="c8 c9"
-          href="#v3"
-          id="v3"
-        >
-          <img
-            alt=""
-            aria-hidden="true"
-            height={12}
-            src="test-file-stub"
-            width={12}
-          />
-        </a>
-        v3 Downloads
-      </h2>
-    </span>
-    <p
-      className="c11"
-    >
-      The gnomAD v3.1.2 data set contains 76,156 whole genomes (and no exomes), all mapped to the GRCh38 reference sequence.
-    </p>
-    <span
-      className="c6"
-    >
-      <h2
-        className="c7"
-      >
-        <a
-          aria-hidden="true"
-          className="c8 c9"
-          href="#v3-core-dataset"
-          id="v3-core-dataset"
-        >
-          <img
-            alt=""
-            aria-hidden="true"
-            height={12}
-            src="test-file-stub"
-            width={12}
-          />
-        </a>
-        Core Dataset
-      </h2>
-    </span>
-    <p
-      className="c11"
-    >
-      gnomAD database and features created and maintained by the gnomAD production team.
-    </p>
-    <section
-      className="c15"
-    >
-      <span
-        className="c6"
-      >
-        <h2
-          className="c16"
-        >
-          <a
-            aria-hidden="true"
-            className="c8 c9"
-            href="#v3-variants"
-            id="v3-variants"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Variants
-        </h2>
-      </span>
-      <p>
-        <span
-          className="c17"
-        >
-          Note
-        </span>
-         Find out what changed in the latest release in the
-         
-        <a
-          className="c10"
-          href="https://gnomad.broadinstitute.org/news/2021-10-gnomad-v3-1-2-minor-release/"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          gnomAD v3.1.2 blog post
-        </a>
-        .
-      </p>
-      <p>
-        The variant dataset files below contain all subsets (non-cancer, non-neuro, non-v2, non-TOPMed, controls/biobanks, 1KG, and HGDP).
-      </p>
-      <h3>
-        Genomes
-      </h3>
-      <ul
-        className="c20"
-      >
-        <li
-          className="c21"
-        >
-          <span>
-            Sites Hail Table
-          </span>
-          <br />
-          Show URL for
-           
-          <button
-            aria-label="Show Google URL for Sites Hail Table"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Google
-          </button>
-           / 
-          <button
-            aria-label="Show Amazon URL for Sites Hail Table"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Amazon
-          </button>
-           / 
-          <button
-            aria-label="Show Microsoft URL for Sites Hail Table"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Microsoft
-          </button>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            chr1 sites VCF
-          </span>
-          <br />
-          <span>
-            182.01 GiB
-            , MD5: 
-            65b21b95252786012721de95458a90e3
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr1 sites VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr1.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr1 sites VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr1.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr1 sites VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr1.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr1 sites VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr1.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr1 sites VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr1.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr1 sites VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr1.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            chr2 sites VCF
-          </span>
-          <br />
-          <span>
-            193.31 GiB
-            , MD5: 
-            6ad213299e21959d7b91787928d6f8b5
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr2 sites VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr2.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr2 sites VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr2.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr2 sites VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr2.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr2 sites VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr2.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr2 sites VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr2.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr2 sites VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr2.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            chr3 sites VCF
-          </span>
-          <br />
-          <span>
-            158.78 GiB
-            , MD5: 
-            13e380299b1cb61d2d18a45a522e8810
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr3 sites VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr3.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr3 sites VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr3.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr3 sites VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr3.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr3 sites VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr3.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr3 sites VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr3.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr3 sites VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr3.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            chr4 sites VCF
-          </span>
-          <br />
-          <span>
-            152.11 GiB
-            , MD5: 
-            90021c65fa7dabfed1a404b713db503f
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr4 sites VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr4.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr4 sites VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr4.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr4 sites VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr4.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr4 sites VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr4.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr4 sites VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr4.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr4 sites VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr4.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            chr5 sites VCF
-          </span>
-          <br />
-          <span>
-            140.43 GiB
-            , MD5: 
-            fc17883bc83787524b7872ba3002a05f
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr5 sites VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr5.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr5 sites VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr5.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr5 sites VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr5.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr5 sites VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr5.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr5 sites VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr5.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr5 sites VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr5.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            chr6 sites VCF
-          </span>
-          <br />
-          <span>
-            133.43 GiB
-            , MD5: 
-            3f1a3910c97e3625fe12962d2ed69a9a
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr6 sites VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr6.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr6 sites VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr6.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr6 sites VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr6.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr6 sites VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr6.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr6 sites VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr6.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr6 sites VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr6.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            chr7 sites VCF
-          </span>
-          <br />
-          <span>
-            130.4 GiB
-            , MD5: 
-            98fa44053cf0f907b9ae52ac461bb717
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr7 sites VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr7.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr7 sites VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr7.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr7 sites VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr7.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr7 sites VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr7.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr7 sites VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr7.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr7 sites VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr7.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            chr8 sites VCF
-          </span>
-          <br />
-          <span>
-            122.3 GiB
-            , MD5: 
-            5ac0337761d358832aa4adb041d1c3b7
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr8 sites VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr8.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr8 sites VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr8.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr8 sites VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr8.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr8 sites VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr8.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr8 sites VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr8.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr8 sites VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr8.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            chr9 sites VCF
-          </span>
-          <br />
-          <span>
-            103.13 GiB
-            , MD5: 
-            1a6fcfc564cd1d8e58db3e330b743303
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr9 sites VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr9.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr9 sites VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr9.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr9 sites VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr9.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr9 sites VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr9.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr9 sites VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr9.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr9 sites VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr9.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            chr10 sites VCF
-          </span>
-          <br />
-          <span>
-            109.82 GiB
-            , MD5: 
-            f84d74e58e9eb568bdfe349e6daa2645
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr10 sites VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr10.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr10 sites VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr10.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr10 sites VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr10.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr10 sites VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr10.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr10 sites VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr10.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr10 sites VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr10.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            chr11 sites VCF
-          </span>
-          <br />
-          <span>
-            108.34 GiB
-            , MD5: 
-            843ec265623593200dd64d56a5a045b3
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr11 sites VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr11.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr11 sites VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr11.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr11 sites VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr11.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr11 sites VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr11.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr11 sites VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr11.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr11 sites VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr11.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            chr12 sites VCF
-          </span>
-          <br />
-          <span>
-            106.21 GiB
-            , MD5: 
-            31f76395874ec62a7998e9fb3b2850a1
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr12 sites VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr12.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr12 sites VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr12.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr12 sites VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr12.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr12 sites VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr12.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr12 sites VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr12.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr12 sites VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr12.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            chr13 sites VCF
-          </span>
-          <br />
-          <span>
-            74.87 GiB
-            , MD5: 
-            78a27d411d3512dbbc6eb4b120391cb8
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr13 sites VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr13.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr13 sites VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr13.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr13 sites VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr13.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr13 sites VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr13.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr13 sites VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr13.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr13 sites VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr13.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            chr14 sites VCF
-          </span>
-          <br />
-          <span>
-            73.11 GiB
-            , MD5: 
-            e8273eef9760aac6ad9f799a52082d5d
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr14 sites VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr14.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr14 sites VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr14.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr14 sites VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr14.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr14 sites VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr14.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr14 sites VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr14.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr14 sites VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr14.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            chr15 sites VCF
-          </span>
-          <br />
-          <span>
-            68.73 GiB
-            , MD5: 
-            89d6cd19e5c7621f627fab6577cd0e87
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr15 sites VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr15.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr15 sites VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr15.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr15 sites VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr15.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr15 sites VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr15.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr15 sites VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr15.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr15 sites VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr15.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            chr16 sites VCF
-          </span>
-          <br />
-          <span>
-            76.75 GiB
-            , MD5: 
-            33ef1541b49d0347d6141609a287bdc7
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr16 sites VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr16.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr16 sites VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr16.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr16 sites VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr16.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr16 sites VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr16.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr16 sites VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr16.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr16 sites VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr16.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            chr17 sites VCF
-          </span>
-          <br />
-          <span>
-            68.76 GiB
-            , MD5: 
-            d13b9287a89e11d8119a93bc0f094c77
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr17 sites VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr17.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr17 sites VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr17.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr17 sites VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr17.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr17 sites VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr17.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr17 sites VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr17.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr17 sites VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr17.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            chr18 sites VCF
-          </span>
-          <br />
-          <span>
-            59.86 GiB
-            , MD5: 
-            e95595ca7a90edc528a09b209ea9bc4c
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr18 sites VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr18.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr18 sites VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr18.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr18 sites VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr18.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr18 sites VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr18.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr18 sites VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr18.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr18 sites VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr18.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            chr19 sites VCF
-          </span>
-          <br />
-          <span>
-            54.47 GiB
-            , MD5: 
-            32308281570563a5bc71a815ac11154f
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr19 sites VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr19.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr19 sites VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr19.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr19 sites VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr19.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr19 sites VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr19.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr19 sites VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr19.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr19 sites VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr19.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            chr20 sites VCF
-          </span>
-          <br />
-          <span>
-            49.63 GiB
-            , MD5: 
-            5cb14ed936340875c8ef664dbe6e772d
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr20 sites VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr20.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr20 sites VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr20.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr20 sites VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr20.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr20 sites VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr20.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr20 sites VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr20.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr20 sites VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr20.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            chr21 sites VCF
-          </span>
-          <br />
-          <span>
-            32.92 GiB
-            , MD5: 
-            92c4b4f1bd63a7bd64ac8378d88d86e2
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr21 sites VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr21.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr21 sites VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr21.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr21 sites VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr21.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr21 sites VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr21.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr21 sites VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr21.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr21 sites VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr21.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            chr22 sites VCF
-          </span>
-          <br />
-          <span>
-            35.77 GiB
-            , MD5: 
-            35f4d25b924ab2e9520c725dd9699ee5
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr22 sites VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr22.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr22 sites VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr22.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr22 sites VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr22.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr22 sites VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr22.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr22 sites VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr22.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr22 sites VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr22.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            chrX sites VCF
-          </span>
-          <br />
-          <span>
-            95.6 GiB
-            , MD5: 
-            040080a18046533728fa60800eedcf4b
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chrX sites VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chrX.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chrX sites VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chrX.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chrX sites VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chrX.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chrX sites VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chrX.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chrX sites VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chrX.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chrX sites VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chrX.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            chrY sites VCF
-          </span>
-          <br />
-          <span>
-            2.29 GiB
-            , MD5: 
-            112ed724f8d1cf13b031006def03f55e
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chrY sites VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chrY.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chrY sites VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chrY.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chrY sites VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chrY.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chrY sites VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chrY.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chrY sites VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chrY.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chrY sites VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chrY.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-      </ul>
-    </section>
-    <section
-      className="c15"
-    >
-      <span
-        className="c6"
-      >
-        <h2
-          className="c16"
-        >
-          <a
-            aria-hidden="true"
-            className="c8 c9"
-            href="#v3-coverage"
-            id="v3-coverage"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Coverage
-        </h2>
-      </span>
-      <ul
-        className="c20"
-      >
-        <li
-          className="c21"
-        >
-          <span>
-            Genome coverage Hail Table
-          </span>
-          <br />
-          Show URL for
-           
-          <button
-            aria-label="Show Google URL for Genome coverage Hail Table"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Google
-          </button>
-           / 
-          <button
-            aria-label="Show Amazon URL for Genome coverage Hail Table"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Amazon
-          </button>
-           / 
-          <button
-            aria-label="Show Microsoft URL for Genome coverage Hail Table"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Microsoft
-          </button>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            Genome coverage summary TSV
-          </span>
-          <br />
-          <span>
-            75.38 GiB
-            , MD5: 
-            6c809627ff7922dcfc8d2c67bba017ff
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download Genome coverage summary TSV from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.0.1/coverage/genomes/gnomad.genomes.r3.0.1.coverage.summary.tsv.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download Genome coverage summary TSV from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.0.1/coverage/genomes/gnomad.genomes.r3.0.1.coverage.summary.tsv.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download Genome coverage summary TSV from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.0.1/coverage/genomes/gnomad.genomes.r3.0.1.coverage.summary.tsv.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-      </ul>
-    </section>
-    <section
-      className="c15"
-    >
-      <span
-        className="c6"
-      >
-        <h2
-          className="c16"
-        >
-          <a
-            aria-hidden="true"
-            className="c8 c9"
-            href="#v3-hgdp-1kg"
-            id="v3-hgdp-1kg"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          HGDP + 1KG callset
-        </h2>
-      </span>
-      <p>
-        These files contain individual genotypes for all samples in the HGDP and 1KG subsets. For more information, see the
-         
-        <a
-          className="c10"
-          href="https://gnomad.broadinstitute.org/news/2021-10-gnomad-v3-1-2-minor-release/"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          gnomAD v3.1.2 blog post
-        </a>
-         
-        and the
-         
-        <a
-          className="-Link c24"
-          href="/help/hgdp-1kg-annotations"
-          onClick={[Function]}
-        >
-          HGDP + 1KG dense MatrixTable annotation descriptions
-        </a>
-        .
-      </p>
-      <h3>
-        Genomes
-      </h3>
-      <ul
-        className="c20"
-      >
-        <li
-          className="c21"
-        >
-          <span>
-            Dense Hail MatrixTable
-          </span>
-          <br />
-          Show URL for
-           
-          <button
-            aria-label="Show Google URL for Dense Hail MatrixTable"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Google
-          </button>
-           / 
-          <button
-            aria-label="Show Amazon URL for Dense Hail MatrixTable"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Amazon
-          </button>
-           / 
-          <button
-            aria-label="Show Microsoft URL for Dense Hail MatrixTable"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Microsoft
-          </button>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            Sparse Hail MatrixTable
-          </span>
-          <br />
-          Show URL for
-           
-          <button
-            aria-label="Show Google URL for Sparse Hail MatrixTable"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Google
-          </button>
-           / 
-          <button
-            aria-label="Show Amazon URL for Sparse Hail MatrixTable"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Amazon
-          </button>
-           / 
-          <button
-            aria-label="Show Microsoft URL for Sparse Hail MatrixTable"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Microsoft
-          </button>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            Variant annotations Hail Table
-          </span>
-          <br />
-          Show URL for
-           
-          <button
-            aria-label="Show Google URL for Variant annotations Hail Table"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Google
-          </button>
-           / 
-          <button
-            aria-label="Show Amazon URL for Variant annotations Hail Table"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Amazon
-          </button>
-           / 
-          <button
-            aria-label="Show Microsoft URL for Variant annotations Hail Table"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Microsoft
-          </button>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            Sample metadata Hail Table
-          </span>
-          <br />
-          Show URL for
-           
-          <button
-            aria-label="Show Google URL for Sample metadata Hail Table"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Google
-          </button>
-           / 
-          <button
-            aria-label="Show Amazon URL for Sample metadata Hail Table"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Amazon
-          </button>
-           / 
-          <button
-            aria-label="Show Microsoft URL for Sample metadata Hail Table"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Microsoft
-          </button>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            Sample metadata TSV
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download Sample metadata TSV from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_1kg_subset_sample_meta.tsv.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download Sample metadata TSV from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_1kg_subset_sample_meta.tsv.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download Sample metadata TSV from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_1kg_subset_sample_meta.tsv.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            chr1 VCF
-          </span>
-          <br />
-          <span>
-            260.95 GiB
-            , MD5: 
-            66b515f3bc2f54ec01c974b359f93686
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr1 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr1.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr1 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr1.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr1 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr1.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr1 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr1.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr1 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr1.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr1 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr1.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            chr2 VCF
-          </span>
-          <br />
-          <span>
-            274.93 GiB
-            , MD5: 
-            3dcfa0a6eaf1b322422620c35e302ab0
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr2 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr2.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr2 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr2.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr2 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr2.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr2 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr2.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr2 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr2.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr2 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr2.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            chr3 VCF
-          </span>
-          <br />
-          <span>
-            224.56 GiB
-            , MD5: 
-            f7911776bef12fae38c2c7ff477893be
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr3 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr3.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr3 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr3.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr3 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr3.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr3 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr3.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr3 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr3.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr3 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr3.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            chr4 VCF
-          </span>
-          <br />
-          <span>
-            222.16 GiB
-            , MD5: 
-            26d97a4da3b7b0ffce4f42c37ede10fd
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr4 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr4.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr4 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr4.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr4 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr4.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr4 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr4.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr4 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr4.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr4 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr4.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            chr5 VCF
-          </span>
-          <br />
-          <span>
-            202.47 GiB
-            , MD5: 
-            4b1e3553262b8077b50940c953c8e00f
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr5 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr5.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr5 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr5.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr5 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr5.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr5 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr5.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr5 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr5.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr5 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr5.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            chr6 VCF
-          </span>
-          <br />
-          <span>
-            193.78 GiB
-            , MD5: 
-            eb9b309051b2f059500056cec856b220
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr6 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr6.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr6 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr6.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr6 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr6.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr6 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr6.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr6 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr6.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr6 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr6.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            chr7 VCF
-          </span>
-          <br />
-          <span>
-            189.71 GiB
-            , MD5: 
-            e18af68af38a91c523d1de6b4e390579
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr7 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr7.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr7 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr7.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr7 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr7.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr7 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr7.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr7 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr7.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr7 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr7.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            chr8 VCF
-          </span>
-          <br />
-          <span>
-            175.21 GiB
-            , MD5: 
-            35fbd4be95c70ab4683005ef58734535
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr8 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr8.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr8 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr8.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr8 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr8.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr8 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr8.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr8 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr8.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr8 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr8.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            chr9 VCF
-          </span>
-          <br />
-          <span>
-            148.36 GiB
-            , MD5: 
-            26d0842911a0a42d470e766a9d44741a
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr9 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr9.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr9 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr9.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr9 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr9.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr9 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr9.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr9 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr9.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr9 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr9.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            chr10 VCF
-          </span>
-          <br />
-          <span>
-            160.43 GiB
-            , MD5: 
-            f8d79f3ac86d8b50c89a330e1b3f7989
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr10 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr10.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr10 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr10.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr10 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr10.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr10 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr10.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr10 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr10.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr10 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr10.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            chr11 VCF
-          </span>
-          <br />
-          <span>
-            154.64 GiB
-            , MD5: 
-            fbbe9b8042105e791e5906c69af5166d
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr11 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr11.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr11 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr11.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr11 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr11.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr11 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr11.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr11 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr11.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr11 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr11.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            chr12 VCF
-          </span>
-          <br />
-          <span>
-            152.53 GiB
-            , MD5: 
-            52f20182eeb07782663bd2615789c55c
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr12 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr12.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr12 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr12.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr12 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr12.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr12 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr12.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr12 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr12.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr12 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr12.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            chr13 VCF
-          </span>
-          <br />
-          <span>
-            110.43 GiB
-            , MD5: 
-            3c69f708ffcf7e44927ff4c08d4c66f7
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr13 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr13.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr13 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr13.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr13 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr13.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr13 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr13.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr13 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr13.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr13 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr13.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            chr14 VCF
-          </span>
-          <br />
-          <span>
-            106.29 GiB
-            , MD5: 
-            d493751b424c20a0a2a298ba369b1e96
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr14 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr14.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr14 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr14.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr14 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr14.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr14 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr14.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr14 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr14.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr14 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr14.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            chr15 VCF
-          </span>
-          <br />
-          <span>
-            98.83 GiB
-            , MD5: 
-            ff2e043db7bb1643dfafd0a21a41ec59
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr15 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr15.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr15 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr15.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr15 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr15.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr15 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr15.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr15 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr15.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr15 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr15.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            chr16 VCF
-          </span>
-          <br />
-          <span>
-            110.94 GiB
-            , MD5: 
-            9bc8a00d6faf1c349992e34c22168a2d
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr16 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr16.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr16 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr16.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr16 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr16.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr16 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr16.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr16 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr16.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr16 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr16.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            chr17 VCF
-          </span>
-          <br />
-          <span>
-            100.7 GiB
-            , MD5: 
-            840b73079d2de44bf3f0b0f03c84c173
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr17 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr17.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr17 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr17.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr17 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr17.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr17 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr17.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr17 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr17.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr17 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr17.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            chr18 VCF
-          </span>
-          <br />
-          <span>
-            86.69 GiB
-            , MD5: 
-            55010a092c0246295eefed8a5c275b62
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr18 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr18.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr18 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr18.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr18 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr18.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr18 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr18.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr18 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr18.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr18 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr18.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            chr19 VCF
-          </span>
-          <br />
-          <span>
-            82.66 GiB
-            , MD5: 
-            a807d07199e3218bc5a330ad13beebd2
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr19 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr19.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr19 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr19.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr19 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr19.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr19 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr19.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr19 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr19.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr19 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr19.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            chr20 VCF
-          </span>
-          <br />
-          <span>
-            74.09 GiB
-            , MD5: 
-            7b4bedc5cbeaea2271ebda41a290350b
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr20 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr20.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr20 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr20.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr20 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr20.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr20 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr20.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr20 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr20.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr20 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr20.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            chr21 VCF
-          </span>
-          <br />
-          <span>
-            51.26 GiB
-            , MD5: 
-            13f97437754916a293a0900c4993e358
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr21 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr21.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr21 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr21.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr21 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr21.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr21 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr21.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr21 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr21.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr21 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr21.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            chr22 VCF
-          </span>
-          <br />
-          <span>
-            55.38 GiB
-            , MD5: 
-            eb04c341491a1553cb020bb0d2a4cf36
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr22 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr22.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr22 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr22.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr22 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr22.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr22 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr22.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr22 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr22.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr22 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr22.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            chrX VCF
-          </span>
-          <br />
-          <span>
-            136.42 GiB
-            , MD5: 
-            b20924dca26a6ab12a3d7ee61e88ad92
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chrX VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chrX.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chrX VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chrX.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chrX VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chrX.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chrX VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chrX.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chrX VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chrX.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chrX VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chrX.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            chrY VCF
-          </span>
-          <br />
-          <span>
-            8.42 GiB
-            , MD5: 
-            407654bf8a3914582ee472762e0d2d11
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chrY VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chrY.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chrY VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chrY.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chrY VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chrY.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chrY VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chrY.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chrY VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chrY.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chrY VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chrY.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-      </ul>
-    </section>
-    <section
-      className="c15"
-    >
-      <span
-        className="c6"
-      >
-        <h2
-          className="c16"
-        >
-          <a
-            aria-hidden="true"
-            className="c8 c9"
-            href="#v3-mitochondrial-dna"
-            id="v3-mitochondrial-dna"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Mitochondrial DNA (mtDNA)
-        </h2>
-      </span>
-      <p>
-        For details about these files, see the
-         
-        <a
-          className="c10"
-          href="https://gnomad.broadinstitute.org/news/2020-11-gnomad-v3-1-mitochondrial-dna-variants/"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          gnomAD v3.1 Mitochondrial DNA Variants blog post
-        </a>
-        .
-      </p>
-      <ul
-        className="c20"
-      >
-        <li
-          className="c21"
-        >
-          <span>
-            chrM sites Hail Table
-          </span>
-          <br />
-          Show URL for
-           
-          <button
-            aria-label="Show Google URL for chrM sites Hail Table"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Google
-          </button>
-           / 
-          <button
-            aria-label="Show Amazon URL for chrM sites Hail Table"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Amazon
-          </button>
-           / 
-          <button
-            aria-label="Show Microsoft URL for chrM sites Hail Table"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Microsoft
-          </button>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            chrM sites VCF
-          </span>
-          <br />
-          <span>
-            4.77 MiB
-            , MD5: 
-            d0ef2bd882ae44236897d743cb5528cf
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chrM sites VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/vcf/genomes/gnomad.genomes.v3.1.sites.chrM.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chrM sites VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/vcf/genomes/gnomad.genomes.v3.1.sites.chrM.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chrM sites VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/vcf/genomes/gnomad.genomes.v3.1.sites.chrM.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chrM sites VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/vcf/genomes/gnomad.genomes.v3.1.sites.chrM.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chrM sites VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/vcf/genomes/gnomad.genomes.v3.1.sites.chrM.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chrM sites VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/vcf/genomes/gnomad.genomes.v3.1.sites.chrM.vcf.bgz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            chrM coverage Hail Table
-          </span>
-          <br />
-          Show URL for
-           
-          <button
-            aria-label="Show Google URL for chrM coverage Hail Table"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Google
-          </button>
-           / 
-          <button
-            aria-label="Show Amazon URL for chrM coverage Hail Table"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Amazon
-          </button>
-           / 
-          <button
-            aria-label="Show Microsoft URL for chrM coverage Hail Table"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Microsoft
-          </button>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            chrM sites TSV (reduced annotations)
-          </span>
-          <br />
-          <span>
-            1 MiB
-            , MD5: 
-            45a91b22ddc3c1176c103d4afee080f5
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chrM sites TSV (reduced annotations) from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/vcf/genomes/gnomad.genomes.v3.1.sites.chrM.reduced_annotations.tsv"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chrM sites TSV (reduced annotations) from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/vcf/genomes/gnomad.genomes.v3.1.sites.chrM.reduced_annotations.tsv"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chrM sites TSV (reduced annotations) from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/vcf/genomes/gnomad.genomes.v3.1.sites.chrM.reduced_annotations.tsv"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-      </ul>
-    </section>
-    <section
-      className="c15"
-    >
-      <span
-        className="c6"
-      >
-        <h2
-          className="c16"
-        >
-          <a
-            aria-hidden="true"
-            className="c8 c9"
-            href="#v3-ancestry-classification"
-            id="v3-ancestry-classification"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Ancestry classification
-        </h2>
-      </span>
-      <p>
-        For more information about these files, see our blog post on
-         
-        <a
-          className="c10"
-          href="https://gnomad.broadinstitute.org/news/2021-09-using-the-gnomad-ancestry-principal-components-analysis-loadings-and-random-forest-classifier-on-your-dataset/"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          using the gnomAD ancestry principal components analysis loadings and random forest classifier on your dataset
-        </a>
-        .
-      </p>
-      <ul
-        className="c20"
-      >
-        <li
-          className="c21"
-        >
-          <span>
-            Principal component analysis (PCA) variant loadings
-          </span>
-          <br />
-          Show URL for
-           
-          <button
-            aria-label="Show Google URL for Principal component analysis (PCA) variant loadings"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Google
-          </button>
-           / 
-          <button
-            aria-label="Show Amazon URL for Principal component analysis (PCA) variant loadings"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Amazon
-          </button>
-           / 
-          <button
-            aria-label="Show Microsoft URL for Principal component analysis (PCA) variant loadings"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Microsoft
-          </button>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            Random forest (RF) model
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download Random forest (RF) model from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/pca/gnomad.v3.1.RF_fit.onnx"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download Random forest (RF) model from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/pca/gnomad.v3.1.RF_fit.onnx"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download Random forest (RF) model from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/pca/gnomad.v3.1.RF_fit.onnx"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-      </ul>
-    </section>
-    <section
-      className="c15"
-    >
-      <span
-        className="c6"
-      >
-        <h2
-          className="c16"
-        >
-          <a
-            aria-hidden="true"
-            className="c8 c9"
-            href="#v3-local-ancestry"
-            id="v3-local-ancestry"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Local ancestry
-        </h2>
-      </span>
-      <p>
-        For more information about these files, see our blog post on
-         
-        <a
-          className="c10"
-          href="https://gnomad.broadinstitute.org/news/2021-12-local-ancestry-inference-for-latino-admixed-american-samples-in-gnomad/"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          local ancestry inference for Latino/Admixed American samples in gnomAD
-        </a>
-        .
-      </p>
-      <ul
-        className="c20"
-      >
-        <li
-          className="c21"
-        >
-          <span>
-            Sites VCF
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download Sites VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/local_ancestry/genomes/gnomad.genomes.v3.1.local_ancestry.amr.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download Sites VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/local_ancestry/genomes/gnomad.genomes.v3.1.local_ancestry.amr.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download Sites VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/local_ancestry/genomes/gnomad.genomes.v3.1.local_ancestry.amr.vcf.bgz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-      </ul>
-    </section>
-    <section
-      className="c15"
-    >
-      <span
-        className="c6"
-      >
-        <h2
-          className="c16"
-        >
-          <a
-            aria-hidden="true"
-            className="c8 c9"
-            href="#v3-short-tandem-repeats"
-            id="v3-short-tandem-repeats"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Short tandem repeats
-        </h2>
-      </span>
-      <p>
-        For more information about these files, see our blog post on
-         
-        <a
-          className="c10"
-          href="https://gnomad.broadinstitute.org/news/2022-01-the-addition-of-short-tandem-repeat-calls-to-gnomad/"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          the addition of short tandem repeat calls to gnomAD
-        </a>
-        .
-      </p>
-      <ul
-        className="c20"
-      >
-        <li
-          className="c21"
-        >
-          <span>
-            README
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download README from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.3/tsv/README.txt"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download README from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.3/tsv/README.txt"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download README from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.3/tsv/README.txt"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            Genotypes (TSV)
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download Genotypes (TSV) from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.3/tsv/gnomAD_STR_genotypes__2022_01_20.tsv.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download Genotypes (TSV) from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.3/tsv/gnomAD_STR_genotypes__2022_01_20.tsv.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download Genotypes (TSV) from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.3/tsv/gnomAD_STR_genotypes__2022_01_20.tsv.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            Distributions (JSON)
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download Distributions (JSON) from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.3/json/gnomAD_STR_distributions__2022_01_20.json.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download Distributions (JSON) from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.3/json/gnomAD_STR_distributions__2022_01_20.json.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download Distributions (JSON) from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.3/json/gnomAD_STR_distributions__2022_01_20.json.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-      </ul>
-    </section>
-    <span
-      className="c6"
-    >
-      <h2
-        className="c7"
-      >
-        <a
-          aria-hidden="true"
-          className="c8 c9"
-          href="#v3-secondary-analyses"
-          id="v3-secondary-analyses"
-        >
-          <img
-            alt=""
-            aria-hidden="true"
-            height={12}
-            src="test-file-stub"
-            width={12}
-          />
-        </a>
-        Secondary Analyses
-      </h2>
-    </span>
-    <p
-      className="c11"
-    >
-      Additional research analyses created using the core gnomAD releases in collaboration with members of the gnomAD steering committee.
-    </p>
-    <section
-      className="c15"
-    >
-      <span
-        className="c6"
-      >
-        <h2
-          className="c16"
-        >
-          <a
-            aria-hidden="true"
-            className="c8 c9"
-            href="#v3-genomic-constraint"
-            id="v3-genomic-constraint"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Genomic constraint
-        </h2>
-      </span>
-      <p>
-        For more information about these files, see the README included in the download.
-      </p>
-      <ul
-        className="c20"
-      >
-        <li
-          className="c21"
-        >
-          <span>
-            README
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download README from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/secondary_analyses/genomic_constraint/nc_constraint_gnomad_v31_README.docx"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download README from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/secondary_analyses/genomic_constraint/nc_constraint_gnomad_v31_README.docx"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download README from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/secondary_analyses/genomic_constraint/nc_constraint_gnomad_v31_README.docx"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            Raw genomic constraint by 1kb regions
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download Raw genomic constraint by 1kb regions from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/secondary_analyses/genomic_constraint/constraint_z_genome_1kb.raw.download.txt.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download Raw genomic constraint by 1kb regions from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/secondary_analyses/genomic_constraint/constraint_z_genome_1kb.raw.download.txt.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download Raw genomic constraint by 1kb regions from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/secondary_analyses/genomic_constraint/constraint_z_genome_1kb.raw.download.txt.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            QCed genomic constraint by 1kb regions
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download QCed genomic constraint by 1kb regions from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/secondary_analyses/genomic_constraint/constraint_z_genome_1kb.qc.download.txt.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download QCed genomic constraint by 1kb regions from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/secondary_analyses/genomic_constraint/constraint_z_genome_1kb.qc.download.txt.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download QCed genomic constraint by 1kb regions from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/secondary_analyses/genomic_constraint/constraint_z_genome_1kb.qc.download.txt.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            Non-coding constraint for gene tissue enhancers
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download Non-coding constraint for gene tissue enhancers from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/secondary_analyses/genomic_constraint/constraint_z_enh_gene_roadmaplinks.all.download.txt.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download Non-coding constraint for gene tissue enhancers from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/secondary_analyses/genomic_constraint/constraint_z_enh_gene_roadmaplinks.all.download.txt.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download Non-coding constraint for gene tissue enhancers from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/secondary_analyses/genomic_constraint/constraint_z_enh_gene_roadmaplinks.all.download.txt.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-      </ul>
-    </section>
-    <section
-      className="c15"
-    >
-      <span
-        className="c6"
-      >
-        <h2
-          className="c16"
-        >
-          <a
-            aria-hidden="true"
-            className="c8 c9"
-            href="#v3-hgdp-1kg-tutorials"
-            id="v3-hgdp-1kg-tutorials"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          HGDP + 1KG tutorials
-        </h2>
-      </span>
-      <p>
-        For more information about these files, see the 
-        <a
-          className="c10"
-          href="https://docs.google.com/document/d/16W0KyrpRGRKHaOwahxtogtepbHe181BoOrSpTQVSVHc/edit?usp=sharing"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          README
-        </a>
-         
-        and the 
-        <a
-          className="c10"
-          href="https://docs.google.com/spreadsheets/d/179I6AUPOQ09jdsFbKcwcDQugFt4pmL-NNOD_3_rsidA/edit?usp=sharing"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          File Descriptions.
-        </a>
-      </p>
-      <p>
-        <b>
-          Please note:
-        </b>
-         while these files were generated from the
-        <a
-          className="c13"
-          href="/downloads#v3-hgdp-1kg"
-        >
-           HGDP + 1KG callset
-        </a>
-         files above, the quality control steps may differ slightly. This would lead to minor differences in sample counts. See the tutorials for details.
-      </p>
-      <ul
-        className="c20"
-      >
-        <li
-          className="c21"
-        >
-          <a
-            className="c10"
-            href="https://docs.google.com/document/d/16W0KyrpRGRKHaOwahxtogtepbHe181BoOrSpTQVSVHc/edit?usp=sharing"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            README
-          </a>
-        </li>
-        <li
-          className="c21"
-        >
-          <a
-            className="c10"
-            href="https://docs.google.com/spreadsheets/d/179I6AUPOQ09jdsFbKcwcDQugFt4pmL-NNOD_3_rsidA/edit?usp=sharing"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            File Descriptions
-          </a>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            Dense Hail MatrixTable
-          </span>
-          <br />
-          Show URL for
-           
-          <button
-            aria-label="Show Google URL for Dense Hail MatrixTable"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Google
-          </button>
-           / 
-          <button
-            aria-label="Show Amazon URL for Dense Hail MatrixTable"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Amazon
-          </button>
-           / 
-          <button
-            aria-label="Show Microsoft URL for Dense Hail MatrixTable"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Microsoft
-          </button>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            Sample metadata TSV
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download Sample metadata TSV from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/secondary_analyses/hgdp_1kg/metadata_and_qc/gnomad_meta_v1.tsv"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download Sample metadata TSV from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/secondary_analyses/hgdp_1kg/metadata_and_qc/gnomad_meta_v1.tsv"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download Sample metadata TSV from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/secondary_analyses/hgdp_1kg/metadata_and_qc/gnomad_meta_v1.tsv"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            Subset of the HGDP+1KG callset MatrixTable
-          </span>
-          <br />
-          Show URL for
-           
-          <button
-            aria-label="Show Google URL for Subset of the HGDP+1KG callset MatrixTable"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Google
-          </button>
-           / 
-          <button
-            aria-label="Show Amazon URL for Subset of the HGDP+1KG callset MatrixTable"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Amazon
-          </button>
-           / 
-          <button
-            aria-label="Show Microsoft URL for Subset of the HGDP+1KG callset MatrixTable"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Microsoft
-          </button>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            Related sample IDs Hail Table
-          </span>
-          <br />
-          Show URL for
-           
-          <button
-            aria-label="Show Google URL for Related sample IDs Hail Table"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Google
-          </button>
-           / 
-          <button
-            aria-label="Show Amazon URL for Related sample IDs Hail Table"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Amazon
-          </button>
-           / 
-          <button
-            aria-label="Show Microsoft URL for Related sample IDs Hail Table"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Microsoft
-          </button>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            Principal component analysis (PCA) PC score tables GCS Bucket
-          </span>
-          <br />
-          Show URL for
-           
-          <button
-            aria-label="Show Google URL for Principal component analysis (PCA) PC score tables GCS Bucket"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Google
-          </button>
-           / 
-          <button
-            aria-label="Show Amazon URL for Principal component analysis (PCA) PC score tables GCS Bucket"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Amazon
-          </button>
-           / 
-          <button
-            aria-label="Show Microsoft URL for Principal component analysis (PCA) PC score tables GCS Bucket"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Microsoft
-          </button>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            PCA outliers table
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download PCA outliers table from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/secondary_analyses/hgdp_1kg/pca/pca_outliers.txt"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download PCA outliers table from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/secondary_analyses/hgdp_1kg/pca/pca_outliers.txt"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download PCA outliers table from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/secondary_analyses/hgdp_1kg/pca/pca_outliers.txt"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            PCA PC score tables without outliers GCS Buckets
-          </span>
-          <br />
-          Show URL for
-           
-          <button
-            aria-label="Show Google URL for PCA PC score tables without outliers GCS Buckets"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Google
-          </button>
-           / 
-          <button
-            aria-label="Show Amazon URL for PCA PC score tables without outliers GCS Buckets"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Amazon
-          </button>
-           / 
-          <button
-            aria-label="Show Microsoft URL for PCA PC score tables without outliers GCS Buckets"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Microsoft
-          </button>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            Variants and unrelated samples MatrixTable
-          </span>
-          <br />
-          Show URL for
-           
-          <button
-            aria-label="Show Google URL for Variants and unrelated samples MatrixTable"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Google
-          </button>
-           / 
-          <button
-            aria-label="Show Amazon URL for Variants and unrelated samples MatrixTable"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Amazon
-          </button>
-           / 
-          <button
-            aria-label="Show Microsoft URL for Variants and unrelated samples MatrixTable"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Microsoft
-          </button>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            Variants and related samples MatrixTable
-          </span>
-          <br />
-          Show URL for
-           
-          <button
-            aria-label="Show Google URL for Variants and related samples MatrixTable"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Google
-          </button>
-           / 
-          <button
-            aria-label="Show Amazon URL for Variants and related samples MatrixTable"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Amazon
-          </button>
-           / 
-          <button
-            aria-label="Show Microsoft URL for Variants and related samples MatrixTable"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Microsoft
-          </button>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            Population-level statistical summary TSV
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download Population-level statistical summary TSV from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/secondary_analyses/hgdp_1kg/metadata_and_qc/post_qc_summary.tsv"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download Population-level statistical summary TSV from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/secondary_analyses/hgdp_1kg/metadata_and_qc/post_qc_summary.tsv"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download Population-level statistical summary TSV from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/secondary_analyses/hgdp_1kg/metadata_and_qc/post_qc_summary.tsv"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            Doubleton counts CSV
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download Doubleton counts CSV from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/secondary_analyses/hgdp_1kg/f2_fst/doubleton_count.csv"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download Doubleton counts CSV from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/secondary_analyses/hgdp_1kg/f2_fst/doubleton_count.csv"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download Doubleton counts CSV from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/secondary_analyses/hgdp_1kg/f2_fst/doubleton_count.csv"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            Variants and unrelated sample PLINK files
-          </span>
-          <br />
-          Show URL for
-           
-          <button
-            aria-label="Show Google URL for Variants and unrelated sample PLINK files"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Google
-          </button>
-           / 
-          <button
-            aria-label="Show Amazon URL for Variants and unrelated sample PLINK files"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Amazon
-          </button>
-           / 
-          <button
-            aria-label="Show Microsoft URL for Variants and unrelated sample PLINK files"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Microsoft
-          </button>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            Population-level mean fixation index table
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download Population-level mean fixation index table from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/secondary_analyses/hgdp_1kg/f2_fst/mean_fst.txt"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download Population-level mean fixation index table from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/secondary_analyses/hgdp_1kg/f2_fst/mean_fst.txt"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download Population-level mean fixation index table from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/secondary_analyses/hgdp_1kg/f2_fst/mean_fst.txt"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            Gambian Genome Variation Project MatrixTable
-          </span>
-          <br />
-          Show URL for
-           
-          <button
-            aria-label="Show Google URL for Gambian Genome Variation Project MatrixTable"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Google
-          </button>
-           / 
-          <button
-            aria-label="Show Amazon URL for Gambian Genome Variation Project MatrixTable"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Amazon
-          </button>
-           / 
-          <button
-            aria-label="Show Microsoft URL for Gambian Genome Variation Project MatrixTable"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Microsoft
-          </button>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            Principal component analysis (PCA) variant loadings Hail Table
-          </span>
-          <br />
-          Show URL for
-           
-          <button
-            aria-label="Show Google URL for Principal component analysis (PCA) variant loadings Hail Table"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Google
-          </button>
-           / 
-          <button
-            aria-label="Show Amazon URL for Principal component analysis (PCA) variant loadings Hail Table"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Amazon
-          </button>
-           / 
-          <button
-            aria-label="Show Microsoft URL for Principal component analysis (PCA) variant loadings Hail Table"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Microsoft
-          </button>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            Random forest (RF) model PKL
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download Random forest (RF) model PKL from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/pca/gnomad.v3.1.RF_fit.pkl"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download Random forest (RF) model PKL from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/pca/gnomad.v3.1.RF_fit.pkl"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download Random forest (RF) model PKL from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/pca/gnomad.v3.1.RF_fit.pkl"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            HGDP+1KG and GVV intersection Matrix Table
-          </span>
-          <br />
-          Show URL for
-           
-          <button
-            aria-label="Show Google URL for HGDP+1KG and GVV intersection Matrix Table"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Google
-          </button>
-           / 
-          <button
-            aria-label="Show Amazon URL for HGDP+1KG and GVV intersection Matrix Table"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Amazon
-          </button>
-           / 
-          <button
-            aria-label="Show Microsoft URL for HGDP+1KG and GVV intersection Matrix Table"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Microsoft
-          </button>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            Super population labels TSV
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download Super population labels TSV from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/secondary_analyses/hgdp_1kg/data_intersection/hgdp_1kg_sample_info.unrelateds.pca_outliers_removed.with_project.tsv"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download Super population labels TSV from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/secondary_analyses/hgdp_1kg/data_intersection/hgdp_1kg_sample_info.unrelateds.pca_outliers_removed.with_project.tsv"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download Super population labels TSV from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/secondary_analyses/hgdp_1kg/data_intersection/hgdp_1kg_sample_info.unrelateds.pca_outliers_removed.with_project.tsv"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            Phased haplotypes of HGDP+1KG dataset GCS Bucket
-          </span>
-          <br />
-          Show URL for
-           
-          <button
-            aria-label="Show Google URL for Phased haplotypes of HGDP+1KG dataset GCS Bucket"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Google
-          </button>
-           / 
-          <button
-            aria-label="Show Amazon URL for Phased haplotypes of HGDP+1KG dataset GCS Bucket"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Amazon
-          </button>
-           / 
-          <button
-            aria-label="Show Microsoft URL for Phased haplotypes of HGDP+1KG dataset GCS Bucket"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Microsoft
-          </button>
-        </li>
-        <h3>
-          Pre-QC plotting tables
-        </h3>
-        <li
-          className="c21"
-        >
-          <span>
-            Pre-QC column fields Hail Table
-          </span>
-          <br />
-          Show URL for
-           
-          <button
-            aria-label="Show Google URL for Pre-QC column fields Hail Table"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Google
-          </button>
-           / 
-          <button
-            aria-label="Show Amazon URL for Pre-QC column fields Hail Table"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Amazon
-          </button>
-           / 
-          <button
-            aria-label="Show Microsoft URL for Pre-QC column fields Hail Table"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Microsoft
-          </button>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            Pre-QC expected heterozygosity Hail Table
-          </span>
-          <br />
-          Show URL for
-           
-          <button
-            aria-label="Show Google URL for Pre-QC expected heterozygosity Hail Table"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Google
-          </button>
-           / 
-          <button
-            aria-label="Show Amazon URL for Pre-QC expected heterozygosity Hail Table"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Amazon
-          </button>
-           / 
-          <button
-            aria-label="Show Microsoft URL for Pre-QC expected heterozygosity Hail Table"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Microsoft
-          </button>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            Pre-QC actual heterozygosity Hail Table
-          </span>
-          <br />
-          Show URL for
-           
-          <button
-            aria-label="Show Google URL for Pre-QC actual heterozygosity Hail Table"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Google
-          </button>
-           / 
-          <button
-            aria-label="Show Amazon URL for Pre-QC actual heterozygosity Hail Table"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Amazon
-          </button>
-           / 
-          <button
-            aria-label="Show Microsoft URL for Pre-QC actual heterozygosity Hail Table"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Microsoft
-          </button>
-        </li>
-        <h3>
-          Post-QC plotting tables
-        </h3>
-        <li
-          className="c21"
-        >
-          <span>
-            Post-QC column fields Hail Table
-          </span>
-          <br />
-          Show URL for
-           
-          <button
-            aria-label="Show Google URL for Post-QC column fields Hail Table"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Google
-          </button>
-           / 
-          <button
-            aria-label="Show Amazon URL for Post-QC column fields Hail Table"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Amazon
-          </button>
-           / 
-          <button
-            aria-label="Show Microsoft URL for Post-QC column fields Hail Table"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Microsoft
-          </button>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            Post-QC expected heterozygosity Hail Table
-          </span>
-          <br />
-          Show URL for
-           
-          <button
-            aria-label="Show Google URL for Post-QC expected heterozygosity Hail Table"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Google
-          </button>
-           / 
-          <button
-            aria-label="Show Amazon URL for Post-QC expected heterozygosity Hail Table"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Amazon
-          </button>
-           / 
-          <button
-            aria-label="Show Microsoft URL for Post-QC expected heterozygosity Hail Table"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Microsoft
-          </button>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            Post-QC actual heterozygosity Hail Table
-          </span>
-          <br />
-          Show URL for
-           
-          <button
-            aria-label="Show Google URL for Post-QC actual heterozygosity Hail Table"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Google
-          </button>
-           / 
-          <button
-            aria-label="Show Amazon URL for Post-QC actual heterozygosity Hail Table"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Amazon
-          </button>
-           / 
-          <button
-            aria-label="Show Microsoft URL for Post-QC actual heterozygosity Hail Table"
-            className="c22"
-            onClick={[Function]}
-            type="button"
-          >
-            Microsoft
-          </button>
-        </li>
-        <li
-          className="c21"
-        >
-          <span>
-            Post-QC site frequency spectrum table
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download Post-QC site frequency spectrum table from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/secondary_analyses/hgdp_1kg/plot_datasets/sfs_post_qc.txt"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download Post-QC site frequency spectrum table from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/secondary_analyses/hgdp_1kg/plot_datasets/sfs_post_qc.txt"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download Post-QC site frequency spectrum table from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/secondary_analyses/hgdp_1kg/plot_datasets/sfs_post_qc.txt"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -18767,10 +22421,10 @@ exports[`Downloads Page has no unexpected changes 1`] = `
         Exomes
       </h3>
       <ul
-        className="c20"
+        className="c19"
       >
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             All chromosomes VCF
@@ -18879,10 +22533,10 @@ exports[`Downloads Page has no unexpected changes 1`] = `
         </h2>
       </span>
       <ul
-        className="c20"
+        className="c19"
       >
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             chr1 exome coverage summary TSV
@@ -18929,7 +22583,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             chr2 exome coverage summary TSV
@@ -18976,7 +22630,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             chr3 exome coverage summary TSV
@@ -19023,7 +22677,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             chr4 exome coverage summary TSV
@@ -19070,7 +22724,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             chr5 exome coverage summary TSV
@@ -19117,7 +22771,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             chr6 exome coverage summary TSV
@@ -19164,7 +22818,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             chr7 exome coverage summary TSV
@@ -19211,7 +22865,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             chr8 exome coverage summary TSV
@@ -19258,7 +22912,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             chr9 exome coverage summary TSV
@@ -19305,7 +22959,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             chr10 exome coverage summary TSV
@@ -19352,7 +23006,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             chr11 exome coverage summary TSV
@@ -19399,7 +23053,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             chr12 exome coverage summary TSV
@@ -19446,7 +23100,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             chr13 exome coverage summary TSV
@@ -19493,7 +23147,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             chr14 exome coverage summary TSV
@@ -19540,7 +23194,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             chr15 exome coverage summary TSV
@@ -19587,7 +23241,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             chr16 exome coverage summary TSV
@@ -19634,7 +23288,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             chr17 exome coverage summary TSV
@@ -19681,7 +23335,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             chr18 exome coverage summary TSV
@@ -19728,7 +23382,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             chr19 exome coverage summary TSV
@@ -19775,7 +23429,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             chr20 exome coverage summary TSV
@@ -19822,7 +23476,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             chr21 exome coverage summary TSV
@@ -19869,7 +23523,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             chr22 exome coverage summary TSV
@@ -19916,7 +23570,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             chrX exome coverage summary TSV
@@ -19963,7 +23617,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             chrY exome coverage summary TSV
@@ -20038,10 +23692,10 @@ exports[`Downloads Page has no unexpected changes 1`] = `
         </h2>
       </span>
       <ul
-        className="c20"
+        className="c19"
       >
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             Gene constraint scores TSV
@@ -20110,10 +23764,10 @@ exports[`Downloads Page has no unexpected changes 1`] = `
         </h2>
       </span>
       <ul
-        className="c20"
+        className="c19"
       >
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             Regional missense constraint TSV
@@ -20182,10 +23836,10 @@ exports[`Downloads Page has no unexpected changes 1`] = `
         </h2>
       </span>
       <ul
-        className="c20"
+        className="c19"
       >
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             Exome calling regions
@@ -20252,10 +23906,10 @@ exports[`Downloads Page has no unexpected changes 1`] = `
         </h2>
       </span>
       <ul
-        className="c20"
+        className="c19"
       >
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             Manuscript data
@@ -20265,7 +23919,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            
           <button
             aria-label="Show Google URL for Manuscript data"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -20274,7 +23928,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            / 
           <button
             aria-label="Show Amazon URL for Manuscript data"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -20283,7 +23937,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            / 
           <button
             aria-label="Show Microsoft URL for Manuscript data"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -20291,7 +23945,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </button>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             Subset VCFs (non-TCGA and non-psych)
@@ -20301,7 +23955,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            
           <button
             aria-label="Show Google URL for Subset VCFs (non-TCGA and non-psych)"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -20310,7 +23964,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            / 
           <button
             aria-label="Show Amazon URL for Subset VCFs (non-TCGA and non-psych)"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -20319,7 +23973,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            / 
           <button
             aria-label="Show Microsoft URL for Subset VCFs (non-TCGA and non-psych)"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -20327,7 +23981,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </button>
         </li>
         <li
-          className="c21"
+          className="c20"
         >
           <span>
             CNV counts and intolerance scores
@@ -20337,7 +23991,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            
           <button
             aria-label="Show Google URL for CNV counts and intolerance scores"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -20346,7 +24000,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            / 
           <button
             aria-label="Show Amazon URL for CNV counts and intolerance scores"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >
@@ -20355,7 +24009,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
            / 
           <button
             aria-label="Show Microsoft URL for CNV counts and intolerance scores"
-            className="c22"
+            className="c21"
             onClick={[Function]}
             type="button"
           >


### PR DESCRIPTION
Updates the downloads page to include v4 links

For launch, only GCP is guaranteed to have synced. AWS and Azure will be added to the downloads links after they have synced.

Mostly waiting on this for the v4 release files to start syncing to GCP. Until that happens, there's not much of a point to updating the Downloads page
