### PR TITLE
Update constraint tooltips for v4

### DIFF
--- a/browser/src/ConstraintTable/ConstraintTable.tsx
+++ b/browser/src/ConstraintTable/ConstraintTable.tsx
@@ -110,7 +110,7 @@ const ConstraintTable = ({ datasetId, geneOrTranscript }: Props) => {
       {['controls', 'non_neuro', 'non_cancer', 'non_topmed'].some((subset) =>
         datasetId.includes(subset)
       ) && <p>Constraint is based on the full gnomAD dataset, not the selected subset.</p>}
-      <GnomadConstraintTable constraint={gnomadConstraint} />
+      <GnomadConstraintTable constraint={gnomadConstraint} datasetId={datasetId} />
       {isGene(geneOrTranscript) && (
         <p style={{ marginBottom: 0 }}>
           Constraint metrics based on {transcriptDescription} transcript (

--- a/browser/src/ConstraintTable/GnomadConstraintTable.tsx
+++ b/browser/src/ConstraintTable/GnomadConstraintTable.tsx
@@ -5,6 +5,7 @@ import { Badge, BaseTable, TooltipAnchor, TooltipHint } from '@gnomad/ui'
 
 import Link from '../Link'
 import { renderRoundedNumber } from './constraintMetrics'
+import { DatasetId, isV4 } from '@gnomad/dataset-metadata/metadata'
 
 const Table = styled(BaseTable)`
   @media (max-width: 600px) {
@@ -161,9 +162,10 @@ type OEMetricField =
 
 type GnomadConstraintTableProps = {
   constraint: GnomadConstraint
+  datasetId: DatasetId
 }
 
-const GnomadConstraintTable = ({ constraint }: GnomadConstraintTableProps) => {
+const GnomadConstraintTable = ({ constraint, datasetId }: GnomadConstraintTableProps) => {
   let lofHighlightColor = null
   if (constraint.oe_lof_upper !== null) {
     if (constraint.oe_lof_upper < 0.33) {
@@ -184,15 +186,31 @@ const GnomadConstraintTable = ({ constraint }: GnomadConstraintTableProps) => {
           <tr>
             <th scope="col">Category</th>
             <th scope="col">
-              {/* @ts-expect-error TS(2322) FIXME: Type '{ children: Element; tooltip: string; }' is ... Remove this comment to see the full error message */}
-              <TooltipAnchor tooltip="Expected variant counts were predicted using a depth corrected probability of mutation for each gene. More details can be found in the gnomAD flagship paper. Note that the expected variant counts for bases with a median depth <1 were removed from the totals.">
+              <TooltipAnchor
+                // TODO: abstract this away from being just v4 when we're not time pressured
+                // @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message
+                tooltip={
+                  isV4(datasetId)
+                    ? 'Expected variant counts were predicted using a depth corrected probability of mutation for each gene. More details can be found in the gnomAD flagship paper. Note that the expected variant counts for bases with a median depth < 30 were removed from the totals.'
+                    : 'Expected variant counts were predicted using a depth corrected probability of mutation for each gene. More details can be found in the gnomAD flagship paper. Note that the expected variant counts for bases with a median depth <1 were removed from the totals.'
+                }
+              >
                 {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
                 <TooltipHint>Expected SNVs</TooltipHint>
               </TooltipAnchor>
             </th>
+
+            {/* Includes single nucleotide changes that occurred in the canonical transcript that were found at a frequency of <0.1%, passed all filters, and at sites with a median depth ≥1. The counts represent the number of unique variants and not the allele count of these variants. */}
             <th scope="col">
-              {/* @ts-expect-error TS(2322) FIXME: Type '{ children: Element; tooltip: string; }' is ... Remove this comment to see the full error message */}
-              <TooltipAnchor tooltip="Includes single nucleotide changes that occurred in the canonical transcript that were found at a frequency of <0.1%, passed all filters, and at sites with a median depth ≥1. The counts represent the number of unique variants and not the allele count of these variants.">
+              <TooltipAnchor
+                /// TODO: abstract this away from being just v4 when we're not time pressured
+                // @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message
+                tooltip={
+                  isV4(datasetId)
+                    ? 'Includes single nucleotide changes that occurred in the canonical transcript that were found at a frequency of <0.1%, passed all filters, and at sites with a median depth ≥ 30. The counts represent the number of unique variants and not the allele count of these variants.'
+                    : 'Expected variant counts were predicted using a depth corrected probability of mutation for each gene. More details can be found in the gnomAD flagship paper. Note that the expected variant counts for bases with a median depth <1 were removed from the totals.'
+                }
+              >
                 {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
                 <TooltipHint>Observed SNVs</TooltipHint>
               </TooltipAnchor>


### PR DESCRIPTION
Updates tooltips for constraint on the gene page per a comment on the internal demo.