### PR TITLE
use Persistent http cache

### DIFF
--- a/deploy/manifests/browser/base/api.deployment.yaml
+++ b/deploy/manifests/browser/base/api.deployment.yaml
@@ -44,16 +44,16 @@ spec:
                   key: ips
             # Global rate limiting
             - name: MAX_CONCURRENT_ES_REQUESTS
-              value: '10'
-            - name: MAX_QUEUED_ES_REQUESTS
               value: '100'
+            - name: MAX_QUEUED_ES_REQUESTS
+              value: '1000'
             # Individual rate limiting
             - name: MAX_REQUESTS_PER_MINUTE
-              value: '30'
-            - name: MAX_QUERY_COST
-              value: '25'
-            - name: MAX_QUERY_COST_PER_MINUTE
               value: '300'
+            - name: MAX_QUERY_COST
+              value: '2500'
+            - name: MAX_QUERY_COST_PER_MINUTE
+              value: '30000'
           ports:
             - name: http
               containerPort: 8000

--- a/deploy/manifests/browser/base/browser.deployment.yaml
+++ b/deploy/manifests/browser/base/browser.deployment.yaml
@@ -17,8 +17,8 @@ spec:
     spec:
       volumes:
         - name: nginx-cache
-          emptyDir:
-            sizeLimit: 20Gi
+          persistentVolumeClaim:
+            claimName: browsercache
       containers:
         - name: web
           image: gnomad-browser

--- a/deploy/manifests/browser/base/browser.pvc.yaml
+++ b/deploy/manifests/browser/base/browser.pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: browsercache
+spec:
+  resources:
+    requests:
+      storage: 100Gi
+  accessModes:
+    - ReadWriteMany
+  storageClassName: premium-rwo


### PR DESCRIPTION
As an insurance policy to let us restart the browser during the launch without losing the cache