### PR TITLE
Update default coverage metric for v4 dataset to fraction > 20

### DIFF
--- a/browser/src/CoverageTrack.tsx
+++ b/browser/src/CoverageTrack.tsx
@@ -107,7 +107,7 @@ class CoverageTrack extends Component<CoverageTrackProps, CoverageTrackState> {
   plotElement: any
 
   state = {
-    selectedMetric: isV4(this.props.datasetId) ? 'over_30' : 'mean',
+    selectedMetric: isV4(this.props.datasetId) ? 'over_20' : 'mean',
   }
 
   plotRef = (el: any) => {

--- a/browser/src/GenePage/__snapshots__/GenePage.spec.tsx.snap
+++ b/browser/src/GenePage/__snapshots__/GenePage.spec.tsx.snap
@@ -28035,7 +28035,7 @@ exports[`GenePage with non-SV dataset "gnomad_r4" has no unexpected changes 1`] 
                 className="Select-sc-1lkyg9e-0 ivadCR"
                 id="coverage-metric"
                 onChange={[Function]}
-                value="over_30"
+                value="over_20"
               >
                 <optgroup
                   label="Per-base depth of coverage"
@@ -28139,7 +28139,7 @@ exports[`GenePage with non-SV dataset "gnomad_r4" has no unexpected changes 1`] 
             <div
               className="CoverageTrack__TitlePanel-sc-1kumbsx-4 bwGOoh"
             >
-              Fraction of individuals with coverage over 30
+              Fraction of individuals with coverage over 20
             </div>
           </div>
           <div

--- a/browser/src/TranscriptPage/__snapshots__/TranscriptPageContainer.spec.tsx.snap
+++ b/browser/src/TranscriptPage/__snapshots__/TranscriptPageContainer.spec.tsx.snap
@@ -19057,7 +19057,7 @@ exports[`TranscriptPageContainer with dataset gnomad_r4 has no unexpected change
                 className="Select-sc-1lkyg9e-0 ivadCR"
                 id="coverage-metric"
                 onChange={[Function]}
-                value="over_30"
+                value="over_20"
               >
                 <optgroup
                   label="Per-base depth of coverage"
@@ -19161,7 +19161,7 @@ exports[`TranscriptPageContainer with dataset gnomad_r4 has no unexpected change
             <div
               className="CoverageTrack__TitlePanel-sc-1kumbsx-4 bwGOoh"
             >
-              Fraction of individuals with coverage over 30
+              Fraction of individuals with coverage over 20
             </div>
           </div>
           <div

--- a/browser/src/VariantPage/VariantOccurrenceTable.tsx
+++ b/browser/src/VariantPage/VariantOccurrenceTable.tsx
@@ -222,11 +222,11 @@ export const GnomadVariantOccurrenceTable = ({
 
   const exomeCoverage = {
     mean: (variant.coverage.exome || { mean: null }).mean,
-    over30: (variant.coverage.exome || { over_30: null }).over_30,
+    over20: (variant.coverage.exome || { over_20: null }).over_20,
   }
   const genomeCoverage = {
     mean: (variant.coverage.genome || { mean: null }).mean,
-    over30: (variant.coverage.genome || { over_30: null }).over_30,
+    over20: (variant.coverage.genome || { over_20: null }).over_20,
   }
 
   // Display a warning if a variant's AN is < 50% of the max AN for exomes/genomes.
@@ -439,19 +439,19 @@ export const GnomadVariantOccurrenceTable = ({
             <tr>
               <th scope="row">
                 {/* @ts-expect-error TS(2322) FIXME: Type '{ children: Element; tooltip: string; }' is ... Remove this comment to see the full error message */}
-                <TooltipAnchor tooltip="Fraction of individuals with >30x coverage at this variant's locus">
+                <TooltipAnchor tooltip="Fraction of individuals with >20x coverage at this variant's locus">
                   {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
-                  <TooltipHint>Fraction of individuals with &gt;30x coverage</TooltipHint>
+                  <TooltipHint>Fraction of individuals with &gt;20x coverage</TooltipHint>
                 </TooltipAnchor>
               </th>
               {/* TODO: this logic can be extracted into a helper, and cleaned for clarity, todo after V4 mvp launch */}
               {variant.exome ? (
-                <td>{exomeCoverage.over30 !== null ? exomeCoverage.over30.toFixed(1) : '–'}</td>
+                <td>{exomeCoverage.over20 !== null ? exomeCoverage.over20.toFixed(1) : '–'}</td>
               ) : (
                 <td />
               )}
               {variant.genome ? (
-                <td>{genomeCoverage.over30 !== null ? genomeCoverage.over30.toFixed(1) : '–'}</td>
+                <td>{genomeCoverage.over20 !== null ? genomeCoverage.over20.toFixed(1) : '–'}</td>
               ) : (
                 <td />
               )}

--- a/browser/src/VariantPage/VariantPage.tsx
+++ b/browser/src/VariantPage/VariantPage.tsx
@@ -460,11 +460,11 @@ query ${operationName}($variantId: String!, $datasetId: DatasetId!, $referenceGe
     coverage {
       exome {
         mean
-        over_30
+        over_20
       }
       genome {
         mean
-        over_30
+        over_20
       }
     }
     multi_nucleotide_variants {

--- a/browser/src/VariantPage/VariantPage.tsx
+++ b/browser/src/VariantPage/VariantPage.tsx
@@ -460,9 +460,11 @@ query ${operationName}($variantId: String!, $datasetId: DatasetId!, $referenceGe
     coverage {
       exome {
         mean
+        over_30
       }
       genome {
         mean
+        over_30
       }
     }
     multi_nucleotide_variants {


### PR DESCRIPTION
All changes entirely in frontend (doesn't touch API / mess with cache warming at all).

- Updates variant page to display fraction > number instead of mean coverage
- Updates the default coverage metric on coverage tracks to >20 re: Heidi comment in [this google doc](https://docs.google.com/document/d/1lso44_Bpx5oIWPRRzYadeqJrr9AKRqwf3v5aEvLTtoA/edit) (tldr vote seemed to be in favor of >20)

---

- ![Screenshot 2023-11-01 at 10 47 23](https://github.com/broadinstitute/gnomad-browser/assets/59549713/66263067-7155-4fe5-9ad0-02910f15afc8)

- ![Screenshot 2023-11-01 at 10 47 31](https://github.com/broadinstitute/gnomad-browser/assets/59549713/6e431781-258b-4cc9-aba7-41c198fb50f5)

- <img src="https://github.com/broadinstitute/gnomad-browser/assets/59549713/d91bb602-46d4-4419-80ce-771301aab77f" width="275" />
