### PR TITLE
Update Total Values Genetic Ancestry Group Table (CNVs)

### DIFF
--- a/browser/src/CopyNumberVariantPage/CNVPopulationsTable.tsx
+++ b/browser/src/CopyNumberVariantPage/CNVPopulationsTable.tsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import styled from 'styled-components'
 
 import { BaseTable, TextButton, TooltipAnchor, TooltipHint } from '@gnomad/ui'
+import { CopyNumberVariant } from './CopyNumberVariantPage'
 
 const Table = styled(BaseTable)`
   min-width: 100%;
@@ -80,6 +81,7 @@ type OwnPopulationsTableProps = {
     }[]
   }[]
   initiallyExpandRows?: boolean
+  variant: CopyNumberVariant
 }
 
 type CNVPopulationsTableState = any
@@ -87,15 +89,16 @@ type CNVPopulationsTableState = any
 type CNVPopulationsTableProps = OwnPopulationsTableProps & typeof CNVPopulationsTable.defaultProps
 
 export class CNVPopulationsTable extends Component<
-  CNVPopulationsTableProps,
+  CNVPopulationsTableProps & { variant: CopyNumberVariant},
   CNVPopulationsTableState
 > {
   static defaultProps = {
     columnLabels: {},
     initiallyExpandRows: false,
+    variant: {}
   }
 
-  constructor(props: CNVPopulationsTableProps) {
+  constructor(props: CNVPopulationsTableProps ) {
     super(props)
 
     this.state = {
@@ -173,7 +176,7 @@ export class CNVPopulationsTable extends Component<
   }
 
   render() {
-    const { columnLabels, populations } = this.props
+    const { columnLabels, populations, variant } = this.props
     const { expandedPopulations, sortAscending, sortBy } = this.state
 
     const renderedPopulations = populations
@@ -232,14 +235,8 @@ export class CNVPopulationsTable extends Component<
       })
 
     // XX/XY numbers are included in the ancestry populations.
-    const totalSC = renderedPopulations
-      .filter((pop) => !isSexSpecificPopulation(pop))
-      .map((pop) => pop.sc)
-      .reduce((acc, n) => acc + n, 0)
-    const totalSN = renderedPopulations
-      .filter((pop) => !isSexSpecificPopulation(pop))
-      .map((pop) => pop.sn)
-      .reduce((acc, n) => acc + n, 0)
+    const totalSC = variant.sc
+    const totalSN = variant.sn
     const totalSF = totalSN !== 0 ? totalSC / totalSN : 0
 
     return (

--- a/browser/src/CopyNumberVariantPage/CopyNumberVariantPopulationsTable.tsx
+++ b/browser/src/CopyNumberVariantPage/CopyNumberVariantPopulationsTable.tsx
@@ -72,7 +72,7 @@ const CopyNumberVariantPopulationsTable = ({ variant }: CopyNumberVariantPopulat
     sf: 'Site Frequency',
   }
 
-  return <CNVPopulationsTable columnLabels={columnLabels} populations={populations} />
+  return <CNVPopulationsTable columnLabels={columnLabels} populations={populations} variant={variant} />
 }
 
 export default CopyNumberVariantPopulationsTable

--- a/browser/src/CopyNumberVariantPage/__snapshots__/CopyNumberVariantPage.spec.tsx.snap
+++ b/browser/src/CopyNumberVariantPage/__snapshots__/CopyNumberVariantPage.spec.tsx.snap
@@ -415,17 +415,17 @@ exports[`CopyNumberVariantPage with dataset gnomad_cnv_r4 with variant of type D
           <td
             className="right-align"
           >
-            0
+            123
           </td>
           <td
             className="right-align"
           >
-            0
+            345
           </td>
           <td
             className="right-align"
           >
-            0.000
+            0.3565
           </td>
         </tr>
       </tfoot>
@@ -867,17 +867,17 @@ exports[`CopyNumberVariantPage with dataset gnomad_cnv_r4 with variant of type D
           <td
             className="right-align"
           >
-            0
+            123
           </td>
           <td
             className="right-align"
           >
-            0
+            345
           </td>
           <td
             className="right-align"
           >
-            0.000
+            0.3565
           </td>
         </tr>
       </tfoot>


### PR DESCRIPTION
Currently, the total `Site Count` `Site Number`, and `Site Frequency` values in the Genetic Ancestry Group Frequency table do not match the totals provided. This PR updates the `total` row in the table with the `Site Count` and `Site Number` provided to derive the correct `Site Frequency` value.