### PR TITLE
disables the poorly performing replication

### DIFF
--- a/deploy/manifests/browser/base/api.deployment.yaml
+++ b/deploy/manifests/browser/base/api.deployment.yaml
@@ -34,9 +34,7 @@ spec:
             - name: REDIS_HOST
               value: 'redis'
             - name: REDIS_PORT
-              value: '26379'
-            - name: REDIS_USE_SENTINEL
-              value: 'true'
+              value: '6379'
             - name: TRUST_PROXY
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
Sadly, redis replication fell over immediately and couldn't start back up, so we're back to single node redis.