### PR TITLE
Fix region, transcript, and gene page crashes for certain datasets

### DIFF
--- a/browser/src/GenePage/MitochondrialGeneCoverageTrack.tsx
+++ b/browser/src/GenePage/MitochondrialGeneCoverageTrack.tsx
@@ -68,6 +68,7 @@ const MitochondrialGeneCoverageTrack = ({ datasetId, geneId }: Props) => {
             filenameForExport={() => `${geneId}_coverage`}
             height={190}
             maxCoverage={3000}
+            datasetId={datasetId}
           />
         )
       }}

--- a/browser/src/RegionPage/CopyNumberVariantsRegionCoverageTrack.tsx
+++ b/browser/src/RegionPage/CopyNumberVariantsRegionCoverageTrack.tsx
@@ -68,6 +68,7 @@ const CopyNumberVariantsRegionCoverageTrack = ({ datasetId, chrom, start, stop }
             filenameForExport={() => `${chrom}-${start}-${stop}_coverage`}
             height={190}
             maxCoverage={3000}
+            datasetId={datasetId}
           />
         )
       }}

--- a/browser/src/RegionPage/MitochondrialRegionCoverageTrack.tsx
+++ b/browser/src/RegionPage/MitochondrialRegionCoverageTrack.tsx
@@ -70,6 +70,7 @@ const MitochondrialRegionCoverageTrack = ({ datasetId, start, stop }: Props) => 
             filenameForExport={() => `M-${start}-${stop}_coverage`}
             height={190}
             maxCoverage={3000}
+            datasetId={datasetId}
           />
         )
       }}

--- a/browser/src/TranscriptPage/MitochondrialTranscriptCoverageTrack.tsx
+++ b/browser/src/TranscriptPage/MitochondrialTranscriptCoverageTrack.tsx
@@ -67,6 +67,7 @@ const MitochondrialTranscriptCoverageTrack = ({ datasetId, transcriptId }: Props
             filenameForExport={() => `${transcriptId}_coverage`}
             height={190}
             maxCoverage={3000}
+            datasetId={datasetId}
           />
         )
       }}


### PR DESCRIPTION
Resolves #1256 

Passes `datasetId` to all remaining occurrences of `<CoverageTrack>` to prevent a crash on certain datasets (Mitochondrial v3) and to set the default v4 coverage track consistently to fraction > 20.

The coverage track was updated to check datasetId as part of the v4 release, that way v4 can display its default coverage metric as fraction > 20, while the rest can remain with mean as the default metric.

