### PR TITLE
Update default structural dataset to SVs v4

### DIFF
--- a/browser/src/DatasetSelector.tsx
+++ b/browser/src/DatasetSelector.tsx
@@ -591,15 +591,15 @@ const DatasetSelector = withRouter(({ datasetOptions, history, selectedDataset }
   if (includeStructuralVariants || includeCopyNumberVariants) {
     const topLevelStructuralVariantDataset = hasStructuralVariants(selectedDataset)
       ? selectedDataset
-      : 'gnomad_sv_r2_1'
+      : 'gnomad_sv_r4'
 
     const topLevelCopyNumberVariantDataset = hasCopyNumberVariants(selectedDataset)
       ? selectedDataset
       : 'gnomad_cnv_r4'
 
-    const currentDataset = hasStructuralVariants(selectedDataset)
-      ? topLevelStructuralVariantDataset
-      : topLevelCopyNumberVariantDataset
+    const currentDataset = hasCopyNumberVariants(selectedDataset)
+      ? topLevelCopyNumberVariantDataset
+      : topLevelStructuralVariantDataset
 
     datasets.push(
       {

--- a/browser/src/DatasetSelector.tsx
+++ b/browser/src/DatasetSelector.tsx
@@ -6,7 +6,7 @@ import queryString from 'query-string'
 import React, { Component } from 'react'
 import { Link, withRouter } from 'react-router-dom'
 import styled from 'styled-components'
-
+import { isV2 } from '@gnomad/dataset-metadata/metadata'
 import sampleCounts from '@gnomad/dataset-metadata/sampleCounts'
 
 import {
@@ -457,14 +457,14 @@ const DatasetSelector = withRouter(({ datasetOptions, history, selectedDataset }
     const shortVariantDatasets = [
       {
         id: 'current_short_variant',
-        isActive: hasShortVariants(selectedDataset) && !hasCopyNumberVariants(selectedDataset),
+        isActive: hasShortVariants(selectedDataset),
         label: labelForDataset(topLevelShortVariantDataset),
         url: datasetLink(topLevelShortVariantDataset),
         childReferenceGenome: referenceGenome(topLevelShortVariantDataset),
       },
       {
         id: 'other_short_variant',
-        isActive: hasShortVariants(selectedDataset) && !hasCopyNumberVariants(selectedDataset),
+        isActive: hasShortVariants(selectedDataset),
         label: 'More datasets',
         children: [] as ChildDataset[],
       },
@@ -482,6 +482,7 @@ const DatasetSelector = withRouter(({ datasetOptions, history, selectedDataset }
       })
     }
 
+
     if (includeGnomad3) {
       shortVariantDatasets[1].children.push({
         id: 'gnomad_r3',
@@ -491,6 +492,8 @@ const DatasetSelector = withRouter(({ datasetOptions, history, selectedDataset }
         childReferenceGenome: referenceGenome('gnomad_r3'),
       })
     }
+
+
 
     if (includeGnomad3 && includeGnomad3Subsets) {
       shortVariantDatasets[1].children.push(
@@ -589,7 +592,9 @@ const DatasetSelector = withRouter(({ datasetOptions, history, selectedDataset }
   }
 
   if (includeStructuralVariants || includeCopyNumberVariants) {
-    const topLevelStructuralVariantDataset = hasStructuralVariants(selectedDataset)
+    const topLevelStructuralVariantDataset = isV2(selectedDataset)
+      ? 'gnomad_sv_r2_1'
+      : hasStructuralVariants(selectedDataset)
       ? selectedDataset
       : 'gnomad_sv_r4'
 

--- a/browser/src/DatasetSelector.tsx
+++ b/browser/src/DatasetSelector.tsx
@@ -6,7 +6,6 @@ import queryString from 'query-string'
 import React, { Component } from 'react'
 import { Link, withRouter } from 'react-router-dom'
 import styled from 'styled-components'
-import { isV2 } from '@gnomad/dataset-metadata/metadata'
 import sampleCounts from '@gnomad/dataset-metadata/sampleCounts'
 
 import {
@@ -16,6 +15,7 @@ import {
   referenceGenome,
   hasCopyNumberVariants,
   shortVariantDatasetId,
+  isV2,
 } from '@gnomad/dataset-metadata/metadata'
 
 const NavigationMenuWrapper = styled.ul`
@@ -482,7 +482,6 @@ const DatasetSelector = withRouter(({ datasetOptions, history, selectedDataset }
       })
     }
 
-
     if (includeGnomad3) {
       shortVariantDatasets[1].children.push({
         id: 'gnomad_r3',
@@ -492,8 +491,6 @@ const DatasetSelector = withRouter(({ datasetOptions, history, selectedDataset }
         childReferenceGenome: referenceGenome('gnomad_r3'),
       })
     }
-
-
 
     if (includeGnomad3 && includeGnomad3Subsets) {
       shortVariantDatasets[1].children.push(
@@ -592,11 +589,17 @@ const DatasetSelector = withRouter(({ datasetOptions, history, selectedDataset }
   }
 
   if (includeStructuralVariants || includeCopyNumberVariants) {
-    const topLevelStructuralVariantDataset = isV2(selectedDataset)
-      ? 'gnomad_sv_r2_1'
-      : hasStructuralVariants(selectedDataset)
-      ? selectedDataset
-      : 'gnomad_sv_r4'
+    const topLevelStructuralVariantDataset: any = (() => {
+      if (isV2(selectedDataset)) {
+        return 'gnomad_sv_r2_1'
+      }
+
+      if (hasStructuralVariants(selectedDataset)) {
+        return selectedDataset
+      }
+
+      return 'gnomad_sv_r4'
+    })()
 
     const topLevelCopyNumberVariantDataset = hasCopyNumberVariants(selectedDataset)
       ? selectedDataset

--- a/browser/src/GenePage/__snapshots__/GenePage.spec.tsx.snap
+++ b/browser/src/GenePage/__snapshots__/GenePage.spec.tsx.snap
@@ -10621,12 +10621,12 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1" has no unexpected changes 1`
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_sv_r4"
+              href="/?dataset=gnomad_sv_r2_1"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD SVs v4.0
+              gnomAD SVs v2.1
             </a>
           </li>
           <li
@@ -12209,12 +12209,12 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_controls" has no unexpected c
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_sv_r4"
+              href="/?dataset=gnomad_sv_r2_1"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD SVs v4.0
+              gnomAD SVs v2.1
             </a>
           </li>
           <li
@@ -13797,12 +13797,12 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_non_cancer" has no unexpected
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_sv_r4"
+              href="/?dataset=gnomad_sv_r2_1"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD SVs v4.0
+              gnomAD SVs v2.1
             </a>
           </li>
           <li
@@ -15385,12 +15385,12 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_non_neuro" has no unexpected 
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_sv_r4"
+              href="/?dataset=gnomad_sv_r2_1"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD SVs v4.0
+              gnomAD SVs v2.1
             </a>
           </li>
           <li
@@ -16973,12 +16973,12 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_non_topmed" has no unexpected
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_sv_r4"
+              href="/?dataset=gnomad_sv_r2_1"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD SVs v4.0
+              gnomAD SVs v2.1
             </a>
           </li>
           <li

--- a/browser/src/GenePage/__snapshots__/GenePage.spec.tsx.snap
+++ b/browser/src/GenePage/__snapshots__/GenePage.spec.tsx.snap
@@ -7647,12 +7647,12 @@ exports[`GenePage with non-SV dataset "exac" has no unexpected changes 1`] = `
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_cnv_r4"
+              href="/?dataset=gnomad_sv_r4"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD CNVs v4.0
+              gnomAD SVs v4.0
             </a>
           </li>
           <li
@@ -10621,12 +10621,12 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1" has no unexpected changes 1`
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_cnv_r4"
+              href="/?dataset=gnomad_sv_r4"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD CNVs v4.0
+              gnomAD SVs v4.0
             </a>
           </li>
           <li
@@ -12209,12 +12209,12 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_controls" has no unexpected c
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_cnv_r4"
+              href="/?dataset=gnomad_sv_r4"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD CNVs v4.0
+              gnomAD SVs v4.0
             </a>
           </li>
           <li
@@ -13797,12 +13797,12 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_non_cancer" has no unexpected
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_cnv_r4"
+              href="/?dataset=gnomad_sv_r4"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD CNVs v4.0
+              gnomAD SVs v4.0
             </a>
           </li>
           <li
@@ -15385,12 +15385,12 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_non_neuro" has no unexpected 
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_cnv_r4"
+              href="/?dataset=gnomad_sv_r4"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD CNVs v4.0
+              gnomAD SVs v4.0
             </a>
           </li>
           <li
@@ -16973,12 +16973,12 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_non_topmed" has no unexpected
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_cnv_r4"
+              href="/?dataset=gnomad_sv_r4"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD CNVs v4.0
+              gnomAD SVs v4.0
             </a>
           </li>
           <li
@@ -18561,12 +18561,12 @@ exports[`GenePage with non-SV dataset "gnomad_r3" has no unexpected changes 1`] 
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_cnv_r4"
+              href="/?dataset=gnomad_sv_r4"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD CNVs v4.0
+              gnomAD SVs v4.0
             </a>
           </li>
           <li
@@ -20065,12 +20065,12 @@ exports[`GenePage with non-SV dataset "gnomad_r3_controls_and_biobanks" has no u
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_cnv_r4"
+              href="/?dataset=gnomad_sv_r4"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD CNVs v4.0
+              gnomAD SVs v4.0
             </a>
           </li>
           <li
@@ -21569,12 +21569,12 @@ exports[`GenePage with non-SV dataset "gnomad_r3_non_cancer" has no unexpected c
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_cnv_r4"
+              href="/?dataset=gnomad_sv_r4"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD CNVs v4.0
+              gnomAD SVs v4.0
             </a>
           </li>
           <li
@@ -23073,12 +23073,12 @@ exports[`GenePage with non-SV dataset "gnomad_r3_non_neuro" has no unexpected ch
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_cnv_r4"
+              href="/?dataset=gnomad_sv_r4"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD CNVs v4.0
+              gnomAD SVs v4.0
             </a>
           </li>
           <li
@@ -24577,12 +24577,12 @@ exports[`GenePage with non-SV dataset "gnomad_r3_non_topmed" has no unexpected c
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_cnv_r4"
+              href="/?dataset=gnomad_sv_r4"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD CNVs v4.0
+              gnomAD SVs v4.0
             </a>
           </li>
           <li
@@ -26081,12 +26081,12 @@ exports[`GenePage with non-SV dataset "gnomad_r3_non_v2" has no unexpected chang
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_cnv_r4"
+              href="/?dataset=gnomad_sv_r4"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD CNVs v4.0
+              gnomAD SVs v4.0
             </a>
           </li>
           <li
@@ -27585,12 +27585,12 @@ exports[`GenePage with non-SV dataset "gnomad_r4" has no unexpected changes 1`] 
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_cnv_r4"
+              href="/?dataset=gnomad_sv_r4"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD CNVs v4.0
+              gnomAD SVs v4.0
             </a>
           </li>
           <li

--- a/browser/src/MitochondrialVariantPage/__snapshots__/MitochondrialVariantPage.spec.tsx.snap
+++ b/browser/src/MitochondrialVariantPage/__snapshots__/MitochondrialVariantPage.spec.tsx.snap
@@ -8454,12 +8454,12 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3 has no unexpected chang
           <a
             className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
             data-item="current_sv_dataset"
-            href="/?dataset=gnomad_cnv_r4"
+            href="/?dataset=gnomad_sv_r4"
             onBlur={[Function]}
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            gnomAD CNVs v4.0
+            gnomAD SVs v4.0
           </a>
         </li>
         <li
@@ -16675,12 +16675,12 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_controls_and_biobanks h
           <a
             className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
             data-item="current_sv_dataset"
-            href="/?dataset=gnomad_cnv_r4"
+            href="/?dataset=gnomad_sv_r4"
             onBlur={[Function]}
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            gnomAD CNVs v4.0
+            gnomAD SVs v4.0
           </a>
         </li>
         <li
@@ -24896,12 +24896,12 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_non_cancer has no unexp
           <a
             className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
             data-item="current_sv_dataset"
-            href="/?dataset=gnomad_cnv_r4"
+            href="/?dataset=gnomad_sv_r4"
             onBlur={[Function]}
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            gnomAD CNVs v4.0
+            gnomAD SVs v4.0
           </a>
         </li>
         <li
@@ -33117,12 +33117,12 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_non_neuro has no unexpe
           <a
             className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
             data-item="current_sv_dataset"
-            href="/?dataset=gnomad_cnv_r4"
+            href="/?dataset=gnomad_sv_r4"
             onBlur={[Function]}
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            gnomAD CNVs v4.0
+            gnomAD SVs v4.0
           </a>
         </li>
         <li
@@ -41338,12 +41338,12 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_non_topmed has no unexp
           <a
             className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
             data-item="current_sv_dataset"
-            href="/?dataset=gnomad_cnv_r4"
+            href="/?dataset=gnomad_sv_r4"
             onBlur={[Function]}
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            gnomAD CNVs v4.0
+            gnomAD SVs v4.0
           </a>
         </li>
         <li
@@ -49559,12 +49559,12 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_non_v2 has no unexpecte
           <a
             className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
             data-item="current_sv_dataset"
-            href="/?dataset=gnomad_cnv_r4"
+            href="/?dataset=gnomad_sv_r4"
             onBlur={[Function]}
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            gnomAD CNVs v4.0
+            gnomAD SVs v4.0
           </a>
         </li>
         <li
@@ -57780,12 +57780,12 @@ exports[`MitochondrialVariantPage with dataset gnomad_r4 has no unexpected chang
           <a
             className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
             data-item="current_sv_dataset"
-            href="/?dataset=gnomad_cnv_r4"
+            href="/?dataset=gnomad_sv_r4"
             onBlur={[Function]}
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            gnomAD CNVs v4.0
+            gnomAD SVs v4.0
           </a>
         </li>
         <li

--- a/browser/src/TranscriptPage/__snapshots__/TranscriptPage.spec.tsx.snap
+++ b/browser/src/TranscriptPage/__snapshots__/TranscriptPage.spec.tsx.snap
@@ -318,12 +318,12 @@ exports[`TranscriptPage with dataset "exac" has no unexpected changes 1`] = `
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_cnv_r4"
+              href="/?dataset=gnomad_sv_r4"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD CNVs v4.0
+              gnomAD SVs v4.0
             </a>
           </li>
           <li
@@ -1945,12 +1945,12 @@ exports[`TranscriptPage with dataset "gnomad_r2_1" has no unexpected changes 1`]
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_cnv_r4"
+              href="/?dataset=gnomad_sv_r4"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD CNVs v4.0
+              gnomAD SVs v4.0
             </a>
           </li>
           <li
@@ -2753,12 +2753,12 @@ exports[`TranscriptPage with dataset "gnomad_r2_1_controls" has no unexpected ch
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_cnv_r4"
+              href="/?dataset=gnomad_sv_r4"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD CNVs v4.0
+              gnomAD SVs v4.0
             </a>
           </li>
           <li
@@ -3561,12 +3561,12 @@ exports[`TranscriptPage with dataset "gnomad_r2_1_non_cancer" has no unexpected 
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_cnv_r4"
+              href="/?dataset=gnomad_sv_r4"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD CNVs v4.0
+              gnomAD SVs v4.0
             </a>
           </li>
           <li
@@ -4369,12 +4369,12 @@ exports[`TranscriptPage with dataset "gnomad_r2_1_non_neuro" has no unexpected c
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_cnv_r4"
+              href="/?dataset=gnomad_sv_r4"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD CNVs v4.0
+              gnomAD SVs v4.0
             </a>
           </li>
           <li
@@ -5177,12 +5177,12 @@ exports[`TranscriptPage with dataset "gnomad_r2_1_non_topmed" has no unexpected 
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_cnv_r4"
+              href="/?dataset=gnomad_sv_r4"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD CNVs v4.0
+              gnomAD SVs v4.0
             </a>
           </li>
           <li
@@ -5985,12 +5985,12 @@ exports[`TranscriptPage with dataset "gnomad_r3" has no unexpected changes 1`] =
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_cnv_r4"
+              href="/?dataset=gnomad_sv_r4"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD CNVs v4.0
+              gnomAD SVs v4.0
             </a>
           </li>
           <li
@@ -6804,12 +6804,12 @@ exports[`TranscriptPage with dataset "gnomad_r3_controls_and_biobanks" has no un
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_cnv_r4"
+              href="/?dataset=gnomad_sv_r4"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD CNVs v4.0
+              gnomAD SVs v4.0
             </a>
           </li>
           <li
@@ -7623,12 +7623,12 @@ exports[`TranscriptPage with dataset "gnomad_r3_non_cancer" has no unexpected ch
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_cnv_r4"
+              href="/?dataset=gnomad_sv_r4"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD CNVs v4.0
+              gnomAD SVs v4.0
             </a>
           </li>
           <li
@@ -8442,12 +8442,12 @@ exports[`TranscriptPage with dataset "gnomad_r3_non_neuro" has no unexpected cha
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_cnv_r4"
+              href="/?dataset=gnomad_sv_r4"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD CNVs v4.0
+              gnomAD SVs v4.0
             </a>
           </li>
           <li
@@ -9261,12 +9261,12 @@ exports[`TranscriptPage with dataset "gnomad_r3_non_topmed" has no unexpected ch
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_cnv_r4"
+              href="/?dataset=gnomad_sv_r4"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD CNVs v4.0
+              gnomAD SVs v4.0
             </a>
           </li>
           <li
@@ -10080,12 +10080,12 @@ exports[`TranscriptPage with dataset "gnomad_r3_non_v2" has no unexpected change
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_cnv_r4"
+              href="/?dataset=gnomad_sv_r4"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD CNVs v4.0
+              gnomAD SVs v4.0
             </a>
           </li>
           <li
@@ -10899,12 +10899,12 @@ exports[`TranscriptPage with dataset "gnomad_r4" has no unexpected changes 1`] =
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_cnv_r4"
+              href="/?dataset=gnomad_sv_r4"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD CNVs v4.0
+              gnomAD SVs v4.0
             </a>
           </li>
           <li

--- a/browser/src/TranscriptPage/__snapshots__/TranscriptPage.spec.tsx.snap
+++ b/browser/src/TranscriptPage/__snapshots__/TranscriptPage.spec.tsx.snap
@@ -1945,12 +1945,12 @@ exports[`TranscriptPage with dataset "gnomad_r2_1" has no unexpected changes 1`]
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_sv_r4"
+              href="/?dataset=gnomad_sv_r2_1"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD SVs v4.0
+              gnomAD SVs v2.1
             </a>
           </li>
           <li
@@ -2753,12 +2753,12 @@ exports[`TranscriptPage with dataset "gnomad_r2_1_controls" has no unexpected ch
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_sv_r4"
+              href="/?dataset=gnomad_sv_r2_1"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD SVs v4.0
+              gnomAD SVs v2.1
             </a>
           </li>
           <li
@@ -3561,12 +3561,12 @@ exports[`TranscriptPage with dataset "gnomad_r2_1_non_cancer" has no unexpected 
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_sv_r4"
+              href="/?dataset=gnomad_sv_r2_1"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD SVs v4.0
+              gnomAD SVs v2.1
             </a>
           </li>
           <li
@@ -4369,12 +4369,12 @@ exports[`TranscriptPage with dataset "gnomad_r2_1_non_neuro" has no unexpected c
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_sv_r4"
+              href="/?dataset=gnomad_sv_r2_1"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD SVs v4.0
+              gnomAD SVs v2.1
             </a>
           </li>
           <li
@@ -5177,12 +5177,12 @@ exports[`TranscriptPage with dataset "gnomad_r2_1_non_topmed" has no unexpected 
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_sv_r4"
+              href="/?dataset=gnomad_sv_r2_1"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD SVs v4.0
+              gnomAD SVs v2.1
             </a>
           </li>
           <li

--- a/browser/src/TranscriptPage/__snapshots__/TranscriptPageContainer.spec.tsx.snap
+++ b/browser/src/TranscriptPage/__snapshots__/TranscriptPageContainer.spec.tsx.snap
@@ -318,12 +318,12 @@ exports[`TranscriptPageContainer with dataset exac has no unexpected changes 1`]
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_cnv_r4"
+              href="/?dataset=gnomad_sv_r4"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD CNVs v4.0
+              gnomAD SVs v4.0
             </a>
           </li>
           <li
@@ -3143,12 +3143,12 @@ exports[`TranscriptPageContainer with dataset gnomad_r2_1 has no unexpected chan
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_cnv_r4"
+              href="/?dataset=gnomad_sv_r4"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD CNVs v4.0
+              gnomAD SVs v4.0
             </a>
           </li>
           <li
@@ -4550,12 +4550,12 @@ exports[`TranscriptPageContainer with dataset gnomad_r2_1_controls has no unexpe
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_cnv_r4"
+              href="/?dataset=gnomad_sv_r4"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD CNVs v4.0
+              gnomAD SVs v4.0
             </a>
           </li>
           <li
@@ -5957,12 +5957,12 @@ exports[`TranscriptPageContainer with dataset gnomad_r2_1_non_cancer has no unex
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_cnv_r4"
+              href="/?dataset=gnomad_sv_r4"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD CNVs v4.0
+              gnomAD SVs v4.0
             </a>
           </li>
           <li
@@ -7364,12 +7364,12 @@ exports[`TranscriptPageContainer with dataset gnomad_r2_1_non_neuro has no unexp
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_cnv_r4"
+              href="/?dataset=gnomad_sv_r4"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD CNVs v4.0
+              gnomAD SVs v4.0
             </a>
           </li>
           <li
@@ -8771,12 +8771,12 @@ exports[`TranscriptPageContainer with dataset gnomad_r2_1_non_topmed has no unex
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_cnv_r4"
+              href="/?dataset=gnomad_sv_r4"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD CNVs v4.0
+              gnomAD SVs v4.0
             </a>
           </li>
           <li
@@ -10178,12 +10178,12 @@ exports[`TranscriptPageContainer with dataset gnomad_r3 has no unexpected change
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_cnv_r4"
+              href="/?dataset=gnomad_sv_r4"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD CNVs v4.0
+              gnomAD SVs v4.0
             </a>
           </li>
           <li
@@ -11596,12 +11596,12 @@ exports[`TranscriptPageContainer with dataset gnomad_r3_controls_and_biobanks ha
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_cnv_r4"
+              href="/?dataset=gnomad_sv_r4"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD CNVs v4.0
+              gnomAD SVs v4.0
             </a>
           </li>
           <li
@@ -13014,12 +13014,12 @@ exports[`TranscriptPageContainer with dataset gnomad_r3_non_cancer has no unexpe
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_cnv_r4"
+              href="/?dataset=gnomad_sv_r4"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD CNVs v4.0
+              gnomAD SVs v4.0
             </a>
           </li>
           <li
@@ -14432,12 +14432,12 @@ exports[`TranscriptPageContainer with dataset gnomad_r3_non_neuro has no unexpec
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_cnv_r4"
+              href="/?dataset=gnomad_sv_r4"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD CNVs v4.0
+              gnomAD SVs v4.0
             </a>
           </li>
           <li
@@ -15850,12 +15850,12 @@ exports[`TranscriptPageContainer with dataset gnomad_r3_non_topmed has no unexpe
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_cnv_r4"
+              href="/?dataset=gnomad_sv_r4"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD CNVs v4.0
+              gnomAD SVs v4.0
             </a>
           </li>
           <li
@@ -17268,12 +17268,12 @@ exports[`TranscriptPageContainer with dataset gnomad_r3_non_v2 has no unexpected
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_cnv_r4"
+              href="/?dataset=gnomad_sv_r4"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD CNVs v4.0
+              gnomAD SVs v4.0
             </a>
           </li>
           <li
@@ -18686,12 +18686,12 @@ exports[`TranscriptPageContainer with dataset gnomad_r4 has no unexpected change
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/gene/dummy_gene?dataset=gnomad_cnv_r4"
+              href="/gene/dummy_gene?dataset=gnomad_sv_r4"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD CNVs v4.0
+              gnomAD SVs v4.0
             </a>
           </li>
           <li

--- a/browser/src/TranscriptPage/__snapshots__/TranscriptPageContainer.spec.tsx.snap
+++ b/browser/src/TranscriptPage/__snapshots__/TranscriptPageContainer.spec.tsx.snap
@@ -3143,12 +3143,12 @@ exports[`TranscriptPageContainer with dataset gnomad_r2_1 has no unexpected chan
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_sv_r4"
+              href="/?dataset=gnomad_sv_r2_1"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD SVs v4.0
+              gnomAD SVs v2.1
             </a>
           </li>
           <li
@@ -4550,12 +4550,12 @@ exports[`TranscriptPageContainer with dataset gnomad_r2_1_controls has no unexpe
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_sv_r4"
+              href="/?dataset=gnomad_sv_r2_1"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD SVs v4.0
+              gnomAD SVs v2.1
             </a>
           </li>
           <li
@@ -5957,12 +5957,12 @@ exports[`TranscriptPageContainer with dataset gnomad_r2_1_non_cancer has no unex
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_sv_r4"
+              href="/?dataset=gnomad_sv_r2_1"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD SVs v4.0
+              gnomAD SVs v2.1
             </a>
           </li>
           <li
@@ -7364,12 +7364,12 @@ exports[`TranscriptPageContainer with dataset gnomad_r2_1_non_neuro has no unexp
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_sv_r4"
+              href="/?dataset=gnomad_sv_r2_1"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD SVs v4.0
+              gnomAD SVs v2.1
             </a>
           </li>
           <li
@@ -8771,12 +8771,12 @@ exports[`TranscriptPageContainer with dataset gnomad_r2_1_non_topmed has no unex
             <a
               className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
               data-item="current_sv_dataset"
-              href="/?dataset=gnomad_sv_r4"
+              href="/?dataset=gnomad_sv_r2_1"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD SVs v4.0
+              gnomAD SVs v2.1
             </a>
           </li>
           <li

--- a/browser/src/__snapshots__/DatasetSelector.spec.tsx.snap
+++ b/browser/src/__snapshots__/DatasetSelector.spec.tsx.snap
@@ -452,12 +452,12 @@ exports[`DataSelector with "exac" dataset selected has no unexpected changes 1`]
     <a
       className="c2 c3"
       data-item="current_sv_dataset"
-      href="/?dataset=gnomad_cnv_r4"
+      href="/?dataset=gnomad_sv_r4"
       onBlur={[Function]}
       onClick={[Function]}
       onKeyDown={[Function]}
     >
-      gnomAD CNVs v4.0
+      gnomAD SVs v4.0
     </a>
   </li>
   <li
@@ -1044,12 +1044,12 @@ exports[`DataSelector with "exac" dataset selected has no unexpected changes whe
     <a
       className="c2 c3"
       data-item="current_sv_dataset"
-      href="/?dataset=gnomad_cnv_r4"
+      href="/?dataset=gnomad_sv_r4"
       onBlur={[Function]}
       onClick={[Function]}
       onKeyDown={[Function]}
     >
-      gnomAD CNVs v4.0
+      gnomAD SVs v4.0
     </a>
   </li>
   <li
@@ -2820,12 +2820,12 @@ exports[`DataSelector with "gnomad_r2_1" dataset selected has no unexpected chan
     <a
       className="c2 c3"
       data-item="current_sv_dataset"
-      href="/?dataset=gnomad_cnv_r4"
+      href="/?dataset=gnomad_sv_r4"
       onBlur={[Function]}
       onClick={[Function]}
       onKeyDown={[Function]}
     >
-      gnomAD CNVs v4.0
+      gnomAD SVs v4.0
     </a>
   </li>
   <li
@@ -3412,12 +3412,12 @@ exports[`DataSelector with "gnomad_r2_1" dataset selected has no unexpected chan
     <a
       className="c2 c3"
       data-item="current_sv_dataset"
-      href="/?dataset=gnomad_cnv_r4"
+      href="/?dataset=gnomad_sv_r4"
       onBlur={[Function]}
       onClick={[Function]}
       onKeyDown={[Function]}
     >
-      gnomAD CNVs v4.0
+      gnomAD SVs v4.0
     </a>
   </li>
   <li
@@ -4004,12 +4004,12 @@ exports[`DataSelector with "gnomad_r2_1_controls" dataset selected has no unexpe
     <a
       className="c2 c3"
       data-item="current_sv_dataset"
-      href="/?dataset=gnomad_cnv_r4"
+      href="/?dataset=gnomad_sv_r4"
       onBlur={[Function]}
       onClick={[Function]}
       onKeyDown={[Function]}
     >
-      gnomAD CNVs v4.0
+      gnomAD SVs v4.0
     </a>
   </li>
   <li
@@ -4596,12 +4596,12 @@ exports[`DataSelector with "gnomad_r2_1_controls" dataset selected has no unexpe
     <a
       className="c2 c3"
       data-item="current_sv_dataset"
-      href="/?dataset=gnomad_cnv_r4"
+      href="/?dataset=gnomad_sv_r4"
       onBlur={[Function]}
       onClick={[Function]}
       onKeyDown={[Function]}
     >
-      gnomAD CNVs v4.0
+      gnomAD SVs v4.0
     </a>
   </li>
   <li
@@ -5188,12 +5188,12 @@ exports[`DataSelector with "gnomad_r2_1_non_cancer" dataset selected has no unex
     <a
       className="c2 c3"
       data-item="current_sv_dataset"
-      href="/?dataset=gnomad_cnv_r4"
+      href="/?dataset=gnomad_sv_r4"
       onBlur={[Function]}
       onClick={[Function]}
       onKeyDown={[Function]}
     >
-      gnomAD CNVs v4.0
+      gnomAD SVs v4.0
     </a>
   </li>
   <li
@@ -5780,12 +5780,12 @@ exports[`DataSelector with "gnomad_r2_1_non_cancer" dataset selected has no unex
     <a
       className="c2 c3"
       data-item="current_sv_dataset"
-      href="/?dataset=gnomad_cnv_r4"
+      href="/?dataset=gnomad_sv_r4"
       onBlur={[Function]}
       onClick={[Function]}
       onKeyDown={[Function]}
     >
-      gnomAD CNVs v4.0
+      gnomAD SVs v4.0
     </a>
   </li>
   <li
@@ -6372,12 +6372,12 @@ exports[`DataSelector with "gnomad_r2_1_non_neuro" dataset selected has no unexp
     <a
       className="c2 c3"
       data-item="current_sv_dataset"
-      href="/?dataset=gnomad_cnv_r4"
+      href="/?dataset=gnomad_sv_r4"
       onBlur={[Function]}
       onClick={[Function]}
       onKeyDown={[Function]}
     >
-      gnomAD CNVs v4.0
+      gnomAD SVs v4.0
     </a>
   </li>
   <li
@@ -6964,12 +6964,12 @@ exports[`DataSelector with "gnomad_r2_1_non_neuro" dataset selected has no unexp
     <a
       className="c2 c3"
       data-item="current_sv_dataset"
-      href="/?dataset=gnomad_cnv_r4"
+      href="/?dataset=gnomad_sv_r4"
       onBlur={[Function]}
       onClick={[Function]}
       onKeyDown={[Function]}
     >
-      gnomAD CNVs v4.0
+      gnomAD SVs v4.0
     </a>
   </li>
   <li
@@ -7556,12 +7556,12 @@ exports[`DataSelector with "gnomad_r2_1_non_topmed" dataset selected has no unex
     <a
       className="c2 c3"
       data-item="current_sv_dataset"
-      href="/?dataset=gnomad_cnv_r4"
+      href="/?dataset=gnomad_sv_r4"
       onBlur={[Function]}
       onClick={[Function]}
       onKeyDown={[Function]}
     >
-      gnomAD CNVs v4.0
+      gnomAD SVs v4.0
     </a>
   </li>
   <li
@@ -8148,12 +8148,12 @@ exports[`DataSelector with "gnomad_r2_1_non_topmed" dataset selected has no unex
     <a
       className="c2 c3"
       data-item="current_sv_dataset"
-      href="/?dataset=gnomad_cnv_r4"
+      href="/?dataset=gnomad_sv_r4"
       onBlur={[Function]}
       onClick={[Function]}
       onKeyDown={[Function]}
     >
-      gnomAD CNVs v4.0
+      gnomAD SVs v4.0
     </a>
   </li>
   <li
@@ -8740,12 +8740,12 @@ exports[`DataSelector with "gnomad_r3" dataset selected has no unexpected change
     <a
       className="c2 c3"
       data-item="current_sv_dataset"
-      href="/?dataset=gnomad_cnv_r4"
+      href="/?dataset=gnomad_sv_r4"
       onBlur={[Function]}
       onClick={[Function]}
       onKeyDown={[Function]}
     >
-      gnomAD CNVs v4.0
+      gnomAD SVs v4.0
     </a>
   </li>
   <li
@@ -9332,12 +9332,12 @@ exports[`DataSelector with "gnomad_r3" dataset selected has no unexpected change
     <a
       className="c2 c3"
       data-item="current_sv_dataset"
-      href="/?dataset=gnomad_cnv_r4"
+      href="/?dataset=gnomad_sv_r4"
       onBlur={[Function]}
       onClick={[Function]}
       onKeyDown={[Function]}
     >
-      gnomAD CNVs v4.0
+      gnomAD SVs v4.0
     </a>
   </li>
   <li
@@ -9924,12 +9924,12 @@ exports[`DataSelector with "gnomad_r3_controls_and_biobanks" dataset selected ha
     <a
       className="c2 c3"
       data-item="current_sv_dataset"
-      href="/?dataset=gnomad_cnv_r4"
+      href="/?dataset=gnomad_sv_r4"
       onBlur={[Function]}
       onClick={[Function]}
       onKeyDown={[Function]}
     >
-      gnomAD CNVs v4.0
+      gnomAD SVs v4.0
     </a>
   </li>
   <li
@@ -10516,12 +10516,12 @@ exports[`DataSelector with "gnomad_r3_controls_and_biobanks" dataset selected ha
     <a
       className="c2 c3"
       data-item="current_sv_dataset"
-      href="/?dataset=gnomad_cnv_r4"
+      href="/?dataset=gnomad_sv_r4"
       onBlur={[Function]}
       onClick={[Function]}
       onKeyDown={[Function]}
     >
-      gnomAD CNVs v4.0
+      gnomAD SVs v4.0
     </a>
   </li>
   <li
@@ -11108,12 +11108,12 @@ exports[`DataSelector with "gnomad_r3_non_cancer" dataset selected has no unexpe
     <a
       className="c2 c3"
       data-item="current_sv_dataset"
-      href="/?dataset=gnomad_cnv_r4"
+      href="/?dataset=gnomad_sv_r4"
       onBlur={[Function]}
       onClick={[Function]}
       onKeyDown={[Function]}
     >
-      gnomAD CNVs v4.0
+      gnomAD SVs v4.0
     </a>
   </li>
   <li
@@ -11700,12 +11700,12 @@ exports[`DataSelector with "gnomad_r3_non_cancer" dataset selected has no unexpe
     <a
       className="c2 c3"
       data-item="current_sv_dataset"
-      href="/?dataset=gnomad_cnv_r4"
+      href="/?dataset=gnomad_sv_r4"
       onBlur={[Function]}
       onClick={[Function]}
       onKeyDown={[Function]}
     >
-      gnomAD CNVs v4.0
+      gnomAD SVs v4.0
     </a>
   </li>
   <li
@@ -12292,12 +12292,12 @@ exports[`DataSelector with "gnomad_r3_non_neuro" dataset selected has no unexpec
     <a
       className="c2 c3"
       data-item="current_sv_dataset"
-      href="/?dataset=gnomad_cnv_r4"
+      href="/?dataset=gnomad_sv_r4"
       onBlur={[Function]}
       onClick={[Function]}
       onKeyDown={[Function]}
     >
-      gnomAD CNVs v4.0
+      gnomAD SVs v4.0
     </a>
   </li>
   <li
@@ -12884,12 +12884,12 @@ exports[`DataSelector with "gnomad_r3_non_neuro" dataset selected has no unexpec
     <a
       className="c2 c3"
       data-item="current_sv_dataset"
-      href="/?dataset=gnomad_cnv_r4"
+      href="/?dataset=gnomad_sv_r4"
       onBlur={[Function]}
       onClick={[Function]}
       onKeyDown={[Function]}
     >
-      gnomAD CNVs v4.0
+      gnomAD SVs v4.0
     </a>
   </li>
   <li
@@ -13476,12 +13476,12 @@ exports[`DataSelector with "gnomad_r3_non_topmed" dataset selected has no unexpe
     <a
       className="c2 c3"
       data-item="current_sv_dataset"
-      href="/?dataset=gnomad_cnv_r4"
+      href="/?dataset=gnomad_sv_r4"
       onBlur={[Function]}
       onClick={[Function]}
       onKeyDown={[Function]}
     >
-      gnomAD CNVs v4.0
+      gnomAD SVs v4.0
     </a>
   </li>
   <li
@@ -14068,12 +14068,12 @@ exports[`DataSelector with "gnomad_r3_non_topmed" dataset selected has no unexpe
     <a
       className="c2 c3"
       data-item="current_sv_dataset"
-      href="/?dataset=gnomad_cnv_r4"
+      href="/?dataset=gnomad_sv_r4"
       onBlur={[Function]}
       onClick={[Function]}
       onKeyDown={[Function]}
     >
-      gnomAD CNVs v4.0
+      gnomAD SVs v4.0
     </a>
   </li>
   <li
@@ -14660,12 +14660,12 @@ exports[`DataSelector with "gnomad_r3_non_v2" dataset selected has no unexpected
     <a
       className="c2 c3"
       data-item="current_sv_dataset"
-      href="/?dataset=gnomad_cnv_r4"
+      href="/?dataset=gnomad_sv_r4"
       onBlur={[Function]}
       onClick={[Function]}
       onKeyDown={[Function]}
     >
-      gnomAD CNVs v4.0
+      gnomAD SVs v4.0
     </a>
   </li>
   <li
@@ -15252,12 +15252,12 @@ exports[`DataSelector with "gnomad_r3_non_v2" dataset selected has no unexpected
     <a
       className="c2 c3"
       data-item="current_sv_dataset"
-      href="/?dataset=gnomad_cnv_r4"
+      href="/?dataset=gnomad_sv_r4"
       onBlur={[Function]}
       onClick={[Function]}
       onKeyDown={[Function]}
     >
-      gnomAD CNVs v4.0
+      gnomAD SVs v4.0
     </a>
   </li>
   <li
@@ -15844,12 +15844,12 @@ exports[`DataSelector with "gnomad_r4" dataset selected has no unexpected change
     <a
       className="c2 c3"
       data-item="current_sv_dataset"
-      href="/?dataset=gnomad_cnv_r4"
+      href="/?dataset=gnomad_sv_r4"
       onBlur={[Function]}
       onClick={[Function]}
       onKeyDown={[Function]}
     >
-      gnomAD CNVs v4.0
+      gnomAD SVs v4.0
     </a>
   </li>
   <li
@@ -16436,12 +16436,12 @@ exports[`DataSelector with "gnomad_r4" dataset selected has no unexpected change
     <a
       className="c2 c3"
       data-item="current_sv_dataset"
-      href="/?dataset=gnomad_cnv_r4"
+      href="/?dataset=gnomad_sv_r4"
       onBlur={[Function]}
       onClick={[Function]}
       onKeyDown={[Function]}
     >
-      gnomAD CNVs v4.0
+      gnomAD SVs v4.0
     </a>
   </li>
   <li

--- a/browser/src/__snapshots__/DatasetSelector.spec.tsx.snap
+++ b/browser/src/__snapshots__/DatasetSelector.spec.tsx.snap
@@ -2820,12 +2820,12 @@ exports[`DataSelector with "gnomad_r2_1" dataset selected has no unexpected chan
     <a
       className="c2 c3"
       data-item="current_sv_dataset"
-      href="/?dataset=gnomad_sv_r4"
+      href="/?dataset=gnomad_sv_r2_1"
       onBlur={[Function]}
       onClick={[Function]}
       onKeyDown={[Function]}
     >
-      gnomAD SVs v4.0
+      gnomAD SVs v2.1
     </a>
   </li>
   <li
@@ -3412,12 +3412,12 @@ exports[`DataSelector with "gnomad_r2_1" dataset selected has no unexpected chan
     <a
       className="c2 c3"
       data-item="current_sv_dataset"
-      href="/?dataset=gnomad_sv_r4"
+      href="/?dataset=gnomad_sv_r2_1"
       onBlur={[Function]}
       onClick={[Function]}
       onKeyDown={[Function]}
     >
-      gnomAD SVs v4.0
+      gnomAD SVs v2.1
     </a>
   </li>
   <li
@@ -4004,12 +4004,12 @@ exports[`DataSelector with "gnomad_r2_1_controls" dataset selected has no unexpe
     <a
       className="c2 c3"
       data-item="current_sv_dataset"
-      href="/?dataset=gnomad_sv_r4"
+      href="/?dataset=gnomad_sv_r2_1"
       onBlur={[Function]}
       onClick={[Function]}
       onKeyDown={[Function]}
     >
-      gnomAD SVs v4.0
+      gnomAD SVs v2.1
     </a>
   </li>
   <li
@@ -4596,12 +4596,12 @@ exports[`DataSelector with "gnomad_r2_1_controls" dataset selected has no unexpe
     <a
       className="c2 c3"
       data-item="current_sv_dataset"
-      href="/?dataset=gnomad_sv_r4"
+      href="/?dataset=gnomad_sv_r2_1"
       onBlur={[Function]}
       onClick={[Function]}
       onKeyDown={[Function]}
     >
-      gnomAD SVs v4.0
+      gnomAD SVs v2.1
     </a>
   </li>
   <li
@@ -5188,12 +5188,12 @@ exports[`DataSelector with "gnomad_r2_1_non_cancer" dataset selected has no unex
     <a
       className="c2 c3"
       data-item="current_sv_dataset"
-      href="/?dataset=gnomad_sv_r4"
+      href="/?dataset=gnomad_sv_r2_1"
       onBlur={[Function]}
       onClick={[Function]}
       onKeyDown={[Function]}
     >
-      gnomAD SVs v4.0
+      gnomAD SVs v2.1
     </a>
   </li>
   <li
@@ -5780,12 +5780,12 @@ exports[`DataSelector with "gnomad_r2_1_non_cancer" dataset selected has no unex
     <a
       className="c2 c3"
       data-item="current_sv_dataset"
-      href="/?dataset=gnomad_sv_r4"
+      href="/?dataset=gnomad_sv_r2_1"
       onBlur={[Function]}
       onClick={[Function]}
       onKeyDown={[Function]}
     >
-      gnomAD SVs v4.0
+      gnomAD SVs v2.1
     </a>
   </li>
   <li
@@ -6372,12 +6372,12 @@ exports[`DataSelector with "gnomad_r2_1_non_neuro" dataset selected has no unexp
     <a
       className="c2 c3"
       data-item="current_sv_dataset"
-      href="/?dataset=gnomad_sv_r4"
+      href="/?dataset=gnomad_sv_r2_1"
       onBlur={[Function]}
       onClick={[Function]}
       onKeyDown={[Function]}
     >
-      gnomAD SVs v4.0
+      gnomAD SVs v2.1
     </a>
   </li>
   <li
@@ -6964,12 +6964,12 @@ exports[`DataSelector with "gnomad_r2_1_non_neuro" dataset selected has no unexp
     <a
       className="c2 c3"
       data-item="current_sv_dataset"
-      href="/?dataset=gnomad_sv_r4"
+      href="/?dataset=gnomad_sv_r2_1"
       onBlur={[Function]}
       onClick={[Function]}
       onKeyDown={[Function]}
     >
-      gnomAD SVs v4.0
+      gnomAD SVs v2.1
     </a>
   </li>
   <li
@@ -7556,12 +7556,12 @@ exports[`DataSelector with "gnomad_r2_1_non_topmed" dataset selected has no unex
     <a
       className="c2 c3"
       data-item="current_sv_dataset"
-      href="/?dataset=gnomad_sv_r4"
+      href="/?dataset=gnomad_sv_r2_1"
       onBlur={[Function]}
       onClick={[Function]}
       onKeyDown={[Function]}
     >
-      gnomAD SVs v4.0
+      gnomAD SVs v2.1
     </a>
   </li>
   <li
@@ -8148,12 +8148,12 @@ exports[`DataSelector with "gnomad_r2_1_non_topmed" dataset selected has no unex
     <a
       className="c2 c3"
       data-item="current_sv_dataset"
-      href="/?dataset=gnomad_sv_r4"
+      href="/?dataset=gnomad_sv_r2_1"
       onBlur={[Function]}
       onClick={[Function]}
       onKeyDown={[Function]}
     >
-      gnomAD SVs v4.0
+      gnomAD SVs v2.1
     </a>
   </li>
   <li


### PR DESCRIPTION
Currently, the default structural dataset in the `DatasetSelector` is the v4 CNVs. This PR changes that to the v4 SVs. 

Fixes #1252 