### PR TITLE
Fix RSID search for exome variants 

### DIFF
--- a/graphql-api/src/queries/variant-datasets/gnomad-v4-variant-queries.ts
+++ b/graphql-api/src/queries/variant-datasets/gnomad-v4-variant-queries.ts
@@ -536,7 +536,7 @@ const fetchMatchingVariants = async (
     index: GNOMAD_V4_VARIANT_INDEX,
     type: '_doc',
     size: 100,
-    _source: [`value.genome.freq.${subset}`, 'value.variant_id'],
+    _source: [`value.genome.freq.${subset}`, `value.exome.freq.${subset}`, 'value.variant_id'],
     body: {
       query: {
         bool: {


### PR DESCRIPTION
Currently RSID searching for variants found only in exomes will yield an error, for example:

https://gnomad.broadinstitute.org/variant/rs1225046798?dataset=gnomad_r4

This is because the Elasticsearch was not returning the relevant variant frequency data. This PR resolves this.

May be related to #1266