### PR TITLE
Fix variant site quality metrics

### DIFF
--- a/browser/src/VariantPage/VariantSiteQualityMetrics.tsx
+++ b/browser/src/VariantPage/VariantSiteQualityMetrics.tsx
@@ -31,6 +31,8 @@ const qualityMetricDescriptions = {
   FS: "Phred-scaled p-value of Fisher's exact test for strand bias.",
   InbreedingCoeff:
     'Inbreeding coefficient as estimated from the genotype likelihoods per-sample when compared against the Hardy-Weinberg expectation.',
+  inbreeding_coeff:
+    'Inbreeding coefficient as estimated from the genotype likelihoods per-sample when compared against the Hardy-Weinberg expectation.',
   MQ: 'Root mean square of the mapping quality of reads across all samples.',
   MQRankSum:
     'Z-score from Wilcoxon rank sum test of alternate vs. reference read mapping qualities.',
@@ -150,6 +152,15 @@ const getMetricDataForSequencingType = ({
         }.`
       // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       key = `${metric === 'SiteQuality' ? 'QUALapprox' : metric}-binned_${afBin.key}`
+    }
+  } else if (metric === 'inbreeding_coeff') {
+    const af = an === 0 ? 0 : ac / an
+    if (af < 0.0005) {
+      key = `inbreeding_coeff-under_0.0005`
+      description = 'inbreeding_coeff for all variants with AF < 0.0005.'
+    } else {
+      key = 'inbreeding_coeff-over_0.0005'
+      description = 'inbreeding_coeff for all variants with AF >= 0.0005.'
     }
   } else if (metric === 'InbreedingCoeff') {
     const af = an === 0 ? 0 : ac / an

--- a/browser/src/VariantPage/VariantSiteQualityMetrics.tsx
+++ b/browser/src/VariantPage/VariantSiteQualityMetrics.tsx
@@ -73,7 +73,7 @@ interface MetricDistribution {
 interface SequencingTypeMetrics {
   binEdges: number[]
   binValues: number[]
-  metricValue: number
+  metricValue: number | null | undefined
   description: string
 }
 
@@ -82,7 +82,7 @@ const getMetricDataForSequencingType = ({
   genomeOrExome,
   metricDistributions,
 }: {
-  metric: string
+  metric: string | undefined | null
   genomeOrExome: SequencingType
   metricDistributions: MetricDistribution[]
 }): SequencingTypeMetrics | null => {
@@ -92,24 +92,19 @@ const getMetricDataForSequencingType = ({
   const genomeOrExomeMetric = genomeOrExome.quality_metrics.site_quality_metrics.find(
     (m: any) => m.metric === metric
   )
-  const metricValue = genomeOrExomeMetric && genomeOrExomeMetric.value
 
-  if (!metricValue) {
-    throw new Error(`Could not determine metric value ${metricValue}`)
-  }
+  const metricValue = genomeOrExomeMetric && genomeOrExomeMetric.value
 
   const { ac, an } = genomeOrExome
   if (metric === 'SiteQuality' || metric === 'AS_QUALapprox') {
     if (ac === 1) {
       key = `${metric === 'SiteQuality' ? 'QUALapprox' : metric}-binned_singleton`
-      description = `${
-        metric === 'SiteQuality' ? 'Site quality' : 'Allele-specific variant qual'
-      } approximation for all singleton variants.`
+      description = `${metric === 'SiteQuality' ? 'Site quality' : 'Allele-specific variant qual'
+        } approximation for all singleton variants.`
     } else if (ac === 2) {
       key = `${metric === 'SiteQuality' ? 'QUALapprox' : metric}-binned_doubleton`
-      description = `${
-        metric === 'SiteQuality' ? 'Site quality' : 'Allele-specific variant qual'
-      } approximation for all doubleton variants.`
+      description = `${metric === 'SiteQuality' ? 'Site quality' : 'Allele-specific variant qual'
+        } approximation for all doubleton variants.`
     } else {
       const afBins = [
         { min: 0, max: 0.00005, key: '0.00005' },
@@ -131,25 +126,23 @@ const getMetricDataForSequencingType = ({
       const afBin = afBins.find((bin: any) => bin.min <= af && af < bin.max)
       // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       if (afBin.max === Infinity) {
-        description = `${
-          metric === 'SiteQuality' ? 'Site quality' : 'Allele-specific variant qual'
-        } approximation for all variants with AF >= ${
+        description = `${metric === 'SiteQuality' ? 'Site quality' : 'Allele-specific variant qual'
+          } approximation for all variants with AF >= ${
           // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           afBin.min
-        }.`
+          }.`
       } else
-        description = `${
-          metric === 'SiteQuality' ? 'Site quality' : 'Allele-specific variant qual'
-        } approximation for all variants with ${
+        description = `${metric === 'SiteQuality' ? 'Site quality' : 'Allele-specific variant qual'
+          } approximation for all variants with ${
           // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           afBin.min
-        } <= AF ${
+          } <= AF ${
           // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           afBin.max === 1 ? '<=' : '<'
-        } ${
+          } ${
           // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           afBin.max
-        }.`
+          }.`
       // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       key = `${metric === 'SiteQuality' ? 'QUALapprox' : metric}-binned_${afBin.key}`
     }
@@ -173,7 +166,7 @@ const getMetricDataForSequencingType = ({
     }
   } else {
     key = metric
-    if (metric.startsWith('AS_')) {
+    if (metric && metric.startsWith('AS_')) {
       // @ts-expect-error TS(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
       const baseDescription = qualityMetricDescriptions[metric.slice(3)]
       if (baseDescription) {
@@ -204,8 +197,8 @@ const getMetricDataForSequencingType = ({
 }
 
 const prepareDataGnomadV4 = ({ metric, variant }: { metric: string; variant: Variant }) => {
-  let exomeMetrics: SequencingTypeMetrics | null = null
-  let genomeMetrics: SequencingTypeMetrics | null = null
+  let exomeMetrics: SequencingTypeMetrics | null | undefined = null
+  let genomeMetrics: SequencingTypeMetrics | null | undefined = null
   let binEdges: number[] | undefined
   let description: string | undefined
 
@@ -303,9 +296,8 @@ const prepareDataGnomadV2 = ({ metric, variant }: any) => {
           (bin: any) => bin.min_af <= af && (af < bin.max_af || (af === 1 && af <= bin.max_af))
         )
         afBinHistogram = afBin.histogram
-        afBinLabel = `${sequencingType} variants with ${afBin.min_af} <= AF ${
-          afBin.max_af === 1 ? '<=' : '<'
-        } ${afBin.max_af}`
+        afBinLabel = `${sequencingType} variants with ${afBin.min_af} <= AF ${afBin.max_af === 1 ? '<=' : '<'
+          } ${afBin.max_af}`
       }
       return { histogram: afBinHistogram, label: afBinLabel }
     }
@@ -338,10 +330,10 @@ const prepareDataGnomadV2 = ({ metric, variant }: any) => {
       : null
     genomeBinValues = genomeBin
       ? [
-          genomeBin.histogram.n_smaller,
-          ...genomeBin.histogram.bin_freq,
-          genomeBin.histogram.n_larger,
-        ]
+        genomeBin.histogram.n_smaller,
+        ...genomeBin.histogram.bin_freq,
+        genomeBin.histogram.n_larger,
+      ]
       : null
 
     if (variant.exome && variant.genome) {
@@ -351,7 +343,7 @@ const prepareDataGnomadV2 = ({ metric, variant }: any) => {
       description = `This is the site quality distribution for all ${
         // @ts-expect-error TS(2531) FIXME: Object is possibly 'null'.
         (exomeBin || genomeBin).label
-      }.`
+        }.`
     }
   } else {
     // @ts-expect-error
@@ -424,7 +416,7 @@ const prepareDataExac = ({ metric, variant }: any) => {
         // @ts-expect-error
         afBin.min_af
         // @ts-expect-error
-      } <= AF ${afBin.max_af === 1 ? '<=' : '<'} ${afBin.max_af}.`
+        } <= AF ${afBin.max_af === 1 ? '<=' : '<'} ${afBin.max_af}.`
     }
     binEdges = histogram.bin_edges.map((edge: any) => Math.log10(edge))
   } else {
@@ -436,7 +428,7 @@ const prepareDataExac = ({ metric, variant }: any) => {
       metric === 'DP'
         ? histogram.bin_edges.map((edge: any) => Math.log10(edge))
         : // @ts-expect-error
-          histogram.binEdges
+        histogram.binEdges
     // @ts-expect-error TS(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
     description = qualityMetricDescriptions[metric]
   }
@@ -478,7 +470,8 @@ const getAvailableMetrics = (datasetId: any) => {
   if (isV4(datasetId)) {
     return [
       'SiteQuality',
-      'InbreedingCoeff',
+      'inbreeding_coeff',
+      // 'InbreedingCoeff',
       'AS_FS',
       'AS_MQ',
       'AS_MQRankSum',
@@ -574,8 +567,11 @@ const yTickFormat = (n: any) => {
 }
 
 const formatMetricValue = (value: any, metric: any) => {
+  if (value === 0) {
+    return '0'
+  }
   if (!value) {
-    return '-'
+    return 'No value for this metric'
   }
   if (
     metric === 'SiteQuality' ||
@@ -691,11 +687,11 @@ const SiteQualityMetricsHistogram = ({
 
   const primaryYScale = primaryYDomain
     ? // @ts-expect-error TS(2345) FIXME: Argument of type '(string | number)[]' is not assi... Remove this comment to see the full error message
-      scaleLinear().domain(primaryYDomain).range([plotHeight, 0])
+    scaleLinear().domain(primaryYDomain).range([plotHeight, 0])
     : null
   const secondaryYScale = secondaryYDomain
     ? // @ts-expect-error TS(2345) FIXME: Argument of type '(string | number)[]' is not assi... Remove this comment to see the full error message
-      scaleLinear().domain(secondaryYDomain).range([plotHeight, 0])
+    scaleLinear().domain(secondaryYDomain).range([plotHeight, 0])
     : null
 
   const halfBandWidth = bandWidth / 2
@@ -703,49 +699,49 @@ const SiteQualityMetricsHistogram = ({
   const renderBars =
     exomeBinValues && genomeBinValues
       ? (binIndex: any) => {
-          // @ts-expect-error TS(2531) FIXME: Object is possibly 'null'.
-          const primaryY = primaryYScale(primaryValues[binIndex])
-          // @ts-expect-error TS(2531) FIXME: Object is possibly 'null'.
-          const secondaryY = secondaryYScale(secondaryValues[binIndex])
-          return (
-            <React.Fragment key={binIndex}>
-              <rect
-                x={0}
-                y={primaryY}
-                height={plotHeight - primaryY}
-                width={halfBandWidth}
-                fill={primaryBarColor}
-                stroke="#333"
-                strokeWidth={0.5}
-              />
-              <rect
-                x={halfBandWidth}
-                y={secondaryY}
-                height={plotHeight - secondaryY}
-                width={halfBandWidth}
-                fill={secondaryBarColor}
-                stroke="#333"
-                strokeWidth={0.5}
-              />
-            </React.Fragment>
-          )
-        }
-      : (binIndex: any) => {
-          // @ts-expect-error TS(2531) FIXME: Object is possibly 'null'.
-          const y = primaryYScale(primaryValues[binIndex])
-          return (
+        // @ts-expect-error TS(2531) FIXME: Object is possibly 'null'.
+        const primaryY = primaryYScale(primaryValues[binIndex])
+        // @ts-expect-error TS(2531) FIXME: Object is possibly 'null'.
+        const secondaryY = secondaryYScale(secondaryValues[binIndex])
+        return (
+          <React.Fragment key={binIndex}>
             <rect
-              key={binIndex}
               x={0}
-              y={y}
-              height={plotHeight - y}
-              width={bandWidth}
+              y={primaryY}
+              height={plotHeight - primaryY}
+              width={halfBandWidth}
               fill={primaryBarColor}
               stroke="#333"
-              strokeWidth={1}
+              strokeWidth={0.5}
             />
-          )
-        }
+            <rect
+              x={halfBandWidth}
+              y={secondaryY}
+              height={plotHeight - secondaryY}
+              width={halfBandWidth}
+              fill={secondaryBarColor}
+              stroke="#333"
+              strokeWidth={0.5}
+            />
+          </React.Fragment>
+        )
+      }
+      : (binIndex: any) => {
+        // @ts-expect-error TS(2531) FIXME: Object is possibly 'null'.
+        const y = primaryYScale(primaryValues[binIndex])
+        return (
+          <rect
+            key={binIndex}
+            x={0}
+            y={y}
+            height={plotHeight - y}
+            width={bandWidth}
+            fill={primaryBarColor}
+            stroke="#333"
+            strokeWidth={1}
+          />
+        )
+      }
 
   const getMetricValueX = (metricValue: any) => {
     const scaledValue = isLogScale ? Math.log10(metricValue) : metricValue
@@ -1013,19 +1009,15 @@ const VariantSiteQualityMetricsDistribution = ({
 
   let values
   if (variant.exome && variant.genome) {
-    values = `${
-      exomeMetricValue === null ? '–' : formatMetricValue(exomeMetricValue, selectedMetric)
-    } (exome samples), ${
-      genomeMetricValue === null ? '–' : formatMetricValue(genomeMetricValue, selectedMetric)
-    } (genome samples)`
+    values = `${exomeMetricValue === null ? '–' : formatMetricValue(exomeMetricValue, selectedMetric)
+      } (exome samples), ${genomeMetricValue === null ? '–' : formatMetricValue(genomeMetricValue, selectedMetric)
+      } (genome samples)`
   } else if (variant.exome) {
-    values = `${
-      exomeMetricValue === null ? '–' : formatMetricValue(exomeMetricValue, selectedMetric)
-    } (exome samples)`
+    values = `${exomeMetricValue === null ? '–' : formatMetricValue(exomeMetricValue, selectedMetric)
+      } (exome samples)`
   } else {
-    values = `${
-      genomeMetricValue === null ? '–' : formatMetricValue(genomeMetricValue, selectedMetric)
-    } (genome samples)`
+    values = `${genomeMetricValue === null ? '–' : formatMetricValue(genomeMetricValue, selectedMetric)
+      } (genome samples)`
   }
 
   return (
@@ -1150,21 +1142,21 @@ const VariantSiteQualityMetricsTable = ({
 
   const exomeMetricValues: Record<string, number> | null = variant.exome
     ? variant.exome.quality_metrics.site_quality_metrics.reduce(
-        (acc, m) => ({
-          ...acc,
-          [m.metric]: m.value,
-        }),
-        {}
-      )
+      (acc, m) => ({
+        ...acc,
+        [m.metric]: m.value,
+      }),
+      {}
+    )
     : null
   const genomeMetricValues: Record<string, number> | null = variant.genome
     ? variant.genome.quality_metrics.site_quality_metrics.reduce(
-        (acc, m) => ({
-          ...acc,
-          [m.metric]: m.value,
-        }),
-        {}
-      )
+      (acc, m) => ({
+        ...acc,
+        [m.metric]: m.value,
+      }),
+      {}
+    )
     : null
 
   const availableMetrics = getAvailableMetrics(datasetId)

--- a/browser/src/VariantPage/VariantSiteQualityMetrics.tsx
+++ b/browser/src/VariantPage/VariantSiteQualityMetrics.tsx
@@ -471,7 +471,6 @@ const getAvailableMetrics = (datasetId: any) => {
     return [
       'SiteQuality',
       'inbreeding_coeff',
-      // 'InbreedingCoeff',
       'AS_FS',
       'AS_MQ',
       'AS_MQRankSum',


### PR DESCRIPTION
Currently, the variant site quality plot breaks when metrics such as `AF_FS` or `InbreedingCoeff` are selected.

In the first case, this was because an a new error was added that breaks the page in the event of an undefined quality metric value. This PR allows undefined metrics, and if so, displays "No value for this metric" in the text.

![image](https://github.com/broadinstitute/gnomad-browser/assets/8867295/3fca6a42-682a-4a47-8391-5434b83bcf75)

Note other quality metrics might be null, so this will hopefully prevent errors with those as well.

See: https://github.com/broadinstitute/gnomad-browser/blob/5ef4ccd65b10afa741c425c779fcb0cbb5f6d214/data-pipeline/src/data_pipeline/datasets/gnomad_v4/types/initial_variant.py#L63

The issue with `InbreedingCoeff` is separate in that this field was renamed to `inbreeding_coeff` by methods team. This PR also includes changes to support the new field.