### PR TITLE
Fix export variants to csv button

### DIFF
--- a/browser/src/VariantList/ExportVariantsButton.tsx
+++ b/browser/src/VariantList/ExportVariantsButton.tsx
@@ -122,22 +122,25 @@ const exportVariantsToCsv = (variants: Variant[], datasetId: any, baseFileName: 
     populationColumns = populationColumns.concat([
       {
         label: `Allele Count ${popName}`,
-        getValue: (variant: any) => JSON.stringify(variant.populations[popIndex].ac),
+        getValue: (variant: any) =>
+          variant.populations[popIndex] ? JSON.stringify(variant.populations[popIndex].ac) : '',
       },
       {
         label: `Allele Number ${popName}`,
-        getValue: (variant: any) => JSON.stringify(variant.populations[popIndex].an),
+        getValue: (variant: any) =>
+          variant.populations[popIndex] ? JSON.stringify(variant.populations[popIndex].an) : '',
       },
       {
         label: `Homozygote Count ${popName}`,
-        getValue: (variant: any) => JSON.stringify(variant.populations[popIndex].ac_hom),
+        getValue: (variant: any) =>
+          variant.populations[popIndex] ? JSON.stringify(variant.populations[popIndex].ac_hom) : '',
       },
       {
         label: `Hemizygote Count ${popName}`,
         getValue: (variant: any) =>
-          variant.populations[popIndex].ac_hemi === null
-            ? ''
-            : JSON.stringify(variant.populations[popIndex].ac_hemi),
+          variant.populations[popIndex]
+            ? JSON.stringify(variant.populations[popIndex].ac_hemi)
+            : '',
       },
     ])
   })


### PR DESCRIPTION
Resolves https://atgu.slack.com/archives/CNL7NA6H2/p1699389268749339

Fixes a bug in which certain variants that didn't have counts for all populations would cause the "export to csv" button for the variant list to silently fail - printing an error to the console but nothing else.

This adds a simple check to see if the value exists, and if not enters a blank value in the csv.