### PR TITLE
Correct UCSC links for v4 SVs

### DIFF
--- a/browser/src/StructuralVariantPage/SVReferenceList.spec.tsx
+++ b/browser/src/StructuralVariantPage/SVReferenceList.spec.tsx
@@ -1,0 +1,20 @@
+import { describe, expect, test } from '@jest/globals'
+import 'jest-styled-components'
+
+import React from 'react'
+import renderer from 'react-test-renderer'
+
+import { forAllDatasets } from '../../../tests/__helpers__/datasets'
+import SVReferenceList from './SVReferenceList'
+import structuralVariantFactory from '../__factories__/StructuralVariant'
+import { svTypes } from '../StructuralVariantList/structuralVariantTypes'
+
+forAllDatasets('SVReferenceList with dataset %s selected', (datasetId) => {
+  describe.each(svTypes)('for SV of type %s', (variantType: string) => {
+    test('has no unexpected changes', () => {
+      const sv = structuralVariantFactory.build({ type: variantType })
+      const tree = renderer.create(<SVReferenceList variant={sv} datasetId={datasetId} />)
+      expect(tree).toMatchSnapshot()
+    })
+  })
+})

--- a/browser/src/StructuralVariantPage/SVReferenceList.tsx
+++ b/browser/src/StructuralVariantPage/SVReferenceList.tsx
@@ -3,15 +3,19 @@ import React from 'react'
 import { ExternalLink, List, ListItem } from '@gnomad/ui'
 
 import { StructuralVariant } from './StructuralVariantPage'
+import { DatasetId, usesGrch37 } from '@gnomad/dataset-metadata/metadata'
 
-const ucscUrl = (chrom: any, pos: any, end: any) =>
-  `https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr${chrom}%3A${pos}-${end}`
 
 type SVUCSCLinksProps = {
   variant: StructuralVariant
+  datasetId: DatasetId
 }
 
-const SVUCSCLinks = ({ variant }: SVUCSCLinksProps) => {
+const SVUCSCLinks = ({ variant, datasetId }: SVUCSCLinksProps) => {
+  const ucscReferenceGenomeId = usesGrch37(datasetId) ? 'hg19' : 'hg38'
+  const ucscUrl = (chrom: string, pos: number, end: number, ) =>
+  `https://genome.ucsc.edu/cgi-bin/hgTracks?db=${ucscReferenceGenomeId}&position=chr${chrom}%3A${pos}-${end}`
+
   if (variant.type === 'INS') {
     return (
       // @ts-expect-error TS(2786) FIXME: 'ExternalLink' cannot be used as a JSX component.
@@ -50,14 +54,15 @@ const SVUCSCLinks = ({ variant }: SVUCSCLinksProps) => {
 
 type SVReferenceListProps = {
   variant: StructuralVariant
+  datasetId: DatasetId
 }
 
-const SVReferenceList = ({ variant }: SVReferenceListProps) => (
+export const SVReferenceList = ({ variant, datasetId }: SVReferenceListProps) => (
   // @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message
   <List>
     {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
     <ListItem>
-      <SVUCSCLinks variant={variant} />
+      <SVUCSCLinks variant={variant} datasetId={datasetId} />
     </ListItem>
   </List>
 )

--- a/browser/src/StructuralVariantPage/StructuralVariantPage.tsx
+++ b/browser/src/StructuralVariantPage/StructuralVariantPage.tsx
@@ -95,7 +95,7 @@ const StructuralVariantPage = ({ datasetId, variant }: StructuralVariantPageProp
       </ResponsiveSection>
       <ResponsiveSection>
         <h2>External Resources</h2>
-        <SVReferenceList variant={variant} />
+        <SVReferenceList variant={variant} datasetId={datasetId} />
         <h2>Feedback</h2>
         {/* @ts-expect-error TS(2786) FIXME: 'ExternalLink' cannot be used as a JSX component. */}
         <ExternalLink href={variantFeedbackUrl(variant, datasetId)}>

--- a/browser/src/StructuralVariantPage/__snapshots__/SVReferenceList.spec.tsx.snap
+++ b/browser/src/StructuralVariantPage/__snapshots__/SVReferenceList.spec.tsx.snap
@@ -1,0 +1,5797 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SVReferenceList with dataset exac selected for SV of type CPX has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset exac selected for SV of type DEL has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset exac selected for SV of type DUP has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset exac selected for SV of type INS has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A0-5123"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset exac selected for SV of type INV has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset exac selected for SV of type MCNV has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset exac selected for SV of type OTH has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_cnv_r4 selected for SV of type CPX has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_cnv_r4 selected for SV of type DEL has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_cnv_r4 selected for SV of type DUP has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_cnv_r4 selected for SV of type INS has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A0-5123"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_cnv_r4 selected for SV of type INV has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_cnv_r4 selected for SV of type MCNV has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_cnv_r4 selected for SV of type OTH has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r2_1 selected for SV of type CPX has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r2_1 selected for SV of type DEL has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r2_1 selected for SV of type DUP has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r2_1 selected for SV of type INS has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A0-5123"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r2_1 selected for SV of type INV has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r2_1 selected for SV of type MCNV has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r2_1 selected for SV of type OTH has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r2_1_controls selected for SV of type CPX has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r2_1_controls selected for SV of type DEL has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r2_1_controls selected for SV of type DUP has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r2_1_controls selected for SV of type INS has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A0-5123"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r2_1_controls selected for SV of type INV has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r2_1_controls selected for SV of type MCNV has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r2_1_controls selected for SV of type OTH has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r2_1_non_cancer selected for SV of type CPX has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r2_1_non_cancer selected for SV of type DEL has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r2_1_non_cancer selected for SV of type DUP has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r2_1_non_cancer selected for SV of type INS has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A0-5123"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r2_1_non_cancer selected for SV of type INV has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r2_1_non_cancer selected for SV of type MCNV has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r2_1_non_cancer selected for SV of type OTH has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r2_1_non_neuro selected for SV of type CPX has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r2_1_non_neuro selected for SV of type DEL has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r2_1_non_neuro selected for SV of type DUP has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r2_1_non_neuro selected for SV of type INS has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A0-5123"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r2_1_non_neuro selected for SV of type INV has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r2_1_non_neuro selected for SV of type MCNV has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r2_1_non_neuro selected for SV of type OTH has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r2_1_non_topmed selected for SV of type CPX has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r2_1_non_topmed selected for SV of type DEL has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r2_1_non_topmed selected for SV of type DUP has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r2_1_non_topmed selected for SV of type INS has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A0-5123"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r2_1_non_topmed selected for SV of type INV has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r2_1_non_topmed selected for SV of type MCNV has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r2_1_non_topmed selected for SV of type OTH has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r3 selected for SV of type CPX has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r3 selected for SV of type DEL has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r3 selected for SV of type DUP has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r3 selected for SV of type INS has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A0-5123"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r3 selected for SV of type INV has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r3 selected for SV of type MCNV has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r3 selected for SV of type OTH has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r3_controls_and_biobanks selected for SV of type CPX has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r3_controls_and_biobanks selected for SV of type DEL has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r3_controls_and_biobanks selected for SV of type DUP has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r3_controls_and_biobanks selected for SV of type INS has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A0-5123"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r3_controls_and_biobanks selected for SV of type INV has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r3_controls_and_biobanks selected for SV of type MCNV has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r3_controls_and_biobanks selected for SV of type OTH has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r3_non_cancer selected for SV of type CPX has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r3_non_cancer selected for SV of type DEL has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r3_non_cancer selected for SV of type DUP has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r3_non_cancer selected for SV of type INS has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A0-5123"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r3_non_cancer selected for SV of type INV has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r3_non_cancer selected for SV of type MCNV has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r3_non_cancer selected for SV of type OTH has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r3_non_neuro selected for SV of type CPX has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r3_non_neuro selected for SV of type DEL has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r3_non_neuro selected for SV of type DUP has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r3_non_neuro selected for SV of type INS has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A0-5123"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r3_non_neuro selected for SV of type INV has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r3_non_neuro selected for SV of type MCNV has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r3_non_neuro selected for SV of type OTH has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r3_non_topmed selected for SV of type CPX has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r3_non_topmed selected for SV of type DEL has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r3_non_topmed selected for SV of type DUP has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r3_non_topmed selected for SV of type INS has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A0-5123"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r3_non_topmed selected for SV of type INV has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r3_non_topmed selected for SV of type MCNV has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r3_non_topmed selected for SV of type OTH has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r3_non_v2 selected for SV of type CPX has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r3_non_v2 selected for SV of type DEL has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r3_non_v2 selected for SV of type DUP has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r3_non_v2 selected for SV of type INS has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A0-5123"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r3_non_v2 selected for SV of type INV has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r3_non_v2 selected for SV of type MCNV has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r3_non_v2 selected for SV of type OTH has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r4 selected for SV of type CPX has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r4 selected for SV of type DEL has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r4 selected for SV of type DUP has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r4 selected for SV of type INS has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A0-5123"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r4 selected for SV of type INV has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r4 selected for SV of type MCNV has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_r4 selected for SV of type OTH has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_sv_r2_1 selected for SV of type CPX has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_sv_r2_1 selected for SV of type DEL has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_sv_r2_1 selected for SV of type DUP has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_sv_r2_1 selected for SV of type INS has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A0-5123"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_sv_r2_1 selected for SV of type INV has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_sv_r2_1 selected for SV of type MCNV has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_sv_r2_1 selected for SV of type OTH has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_sv_r2_1_controls selected for SV of type CPX has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_sv_r2_1_controls selected for SV of type DEL has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_sv_r2_1_controls selected for SV of type DUP has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_sv_r2_1_controls selected for SV of type INS has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A0-5123"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_sv_r2_1_controls selected for SV of type INV has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_sv_r2_1_controls selected for SV of type MCNV has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_sv_r2_1_controls selected for SV of type OTH has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_sv_r2_1_non_neuro selected for SV of type CPX has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_sv_r2_1_non_neuro selected for SV of type DEL has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_sv_r2_1_non_neuro selected for SV of type DUP has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_sv_r2_1_non_neuro selected for SV of type INS has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A0-5123"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_sv_r2_1_non_neuro selected for SV of type INV has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_sv_r2_1_non_neuro selected for SV of type MCNV has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_sv_r2_1_non_neuro selected for SV of type OTH has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_sv_r4 selected for SV of type CPX has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_sv_r4 selected for SV of type DEL has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_sv_r4 selected for SV of type DUP has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_sv_r4 selected for SV of type INS has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A0-5123"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_sv_r4 selected for SV of type INV has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_sv_r4 selected for SV of type MCNV has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SVReferenceList with dataset gnomad_sv_r4 selected for SV of type OTH has no unexpected changes 1`] = `
+.c2 {
+  color: #1173bb;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:visited,
+.c2:active {
+  color: #1173bb;
+}
+
+.c2:focus,
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  margin-bottom: 0.5em;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+  >
+    <a
+      className="c2"
+      href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21%3A123-456"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      UCSC
+    </a>
+  </li>
+</ul>
+`;


### PR DESCRIPTION
Currently, for the v4 SVs, the UCSC link redirects to the variant's coordinates in UCSC HG19 instead of HG38. This PR implements the inclusion of the two reference genome builds of v2 and v4 to correctly redirect the v4 SVs on the reference genome build of GRCh38 / HG38. 

Fixes #1277 