### PR TITLE
Correct default coverage metric for v4 CNV and SV pages

### DIFF
--- a/browser/src/GenePage/__snapshots__/GenePage.spec.tsx.snap
+++ b/browser/src/GenePage/__snapshots__/GenePage.spec.tsx.snap
@@ -758,7 +758,7 @@ exports[`GenePage with CNV dataset "gnomad_cnv_r4" has no unexpected changes 1`]
                 className="Select-sc-1lkyg9e-0 ivadCR"
                 id="coverage-metric"
                 onChange={[Function]}
-                value="mean"
+                value="over_20"
               >
                 <optgroup
                   label="Per-base depth of coverage"
@@ -862,7 +862,7 @@ exports[`GenePage with CNV dataset "gnomad_cnv_r4" has no unexpected changes 1`]
             <div
               className="CoverageTrack__TitlePanel-sc-1kumbsx-4 bwGOoh"
             >
-              Per-base mean depth of coverage
+              Fraction of individuals with coverage over 20
             </div>
           </div>
           <div
@@ -923,7 +923,7 @@ exports[`GenePage with CNV dataset "gnomad_cnv_r4" has no unexpected changes 1`]
                           dy="0em"
                           x={-8}
                         >
-                          10
+                          0.1
                         </tspan>
                       </text>
                     </svg>
@@ -963,7 +963,7 @@ exports[`GenePage with CNV dataset "gnomad_cnv_r4" has no unexpected changes 1`]
                           dy="0em"
                           x={-8}
                         >
-                          20
+                          0.2
                         </tspan>
                       </text>
                     </svg>
@@ -1003,7 +1003,7 @@ exports[`GenePage with CNV dataset "gnomad_cnv_r4" has no unexpected changes 1`]
                           dy="0em"
                           x={-8}
                         >
-                          30
+                          0.3
                         </tspan>
                       </text>
                     </svg>
@@ -1043,7 +1043,7 @@ exports[`GenePage with CNV dataset "gnomad_cnv_r4" has no unexpected changes 1`]
                           dy="0em"
                           x={-8}
                         >
-                          40
+                          0.4
                         </tspan>
                       </text>
                     </svg>
@@ -1083,7 +1083,7 @@ exports[`GenePage with CNV dataset "gnomad_cnv_r4" has no unexpected changes 1`]
                           dy="0em"
                           x={-8}
                         >
-                          50
+                          0.5
                         </tspan>
                       </text>
                     </svg>
@@ -1123,7 +1123,7 @@ exports[`GenePage with CNV dataset "gnomad_cnv_r4" has no unexpected changes 1`]
                           dy="0em"
                           x={-8}
                         >
-                          60
+                          0.6
                         </tspan>
                       </text>
                     </svg>
@@ -1163,7 +1163,7 @@ exports[`GenePage with CNV dataset "gnomad_cnv_r4" has no unexpected changes 1`]
                           dy="0em"
                           x={-8}
                         >
-                          70
+                          0.7
                         </tspan>
                       </text>
                     </svg>
@@ -1203,7 +1203,7 @@ exports[`GenePage with CNV dataset "gnomad_cnv_r4" has no unexpected changes 1`]
                           dy="0em"
                           x={-8}
                         >
-                          80
+                          0.8
                         </tspan>
                       </text>
                     </svg>
@@ -1243,7 +1243,7 @@ exports[`GenePage with CNV dataset "gnomad_cnv_r4" has no unexpected changes 1`]
                           dy="0em"
                           x={-8}
                         >
-                          90
+                          0.9
                         </tspan>
                       </text>
                     </svg>
@@ -1283,7 +1283,7 @@ exports[`GenePage with CNV dataset "gnomad_cnv_r4" has no unexpected changes 1`]
                           dy="0em"
                           x={-8}
                         >
-                          100
+                          1.0
                         </tspan>
                       </text>
                     </svg>
@@ -6594,7 +6594,7 @@ exports[`GenePage with SV dataset "gnomad_sv_r4" has no unexpected changes 1`] =
                 className="Select-sc-1lkyg9e-0 ivadCR"
                 id="coverage-metric"
                 onChange={[Function]}
-                value="mean"
+                value="over_20"
               >
                 <optgroup
                   label="Per-base depth of coverage"
@@ -6698,7 +6698,7 @@ exports[`GenePage with SV dataset "gnomad_sv_r4" has no unexpected changes 1`] =
             <div
               className="CoverageTrack__TitlePanel-sc-1kumbsx-4 bwGOoh"
             >
-              Per-base mean depth of coverage
+              Fraction of individuals with coverage over 20
             </div>
           </div>
           <div
@@ -6759,7 +6759,7 @@ exports[`GenePage with SV dataset "gnomad_sv_r4" has no unexpected changes 1`] =
                           dy="0em"
                           x={-8}
                         >
-                          10
+                          0.1
                         </tspan>
                       </text>
                     </svg>
@@ -6799,7 +6799,7 @@ exports[`GenePage with SV dataset "gnomad_sv_r4" has no unexpected changes 1`] =
                           dy="0em"
                           x={-8}
                         >
-                          20
+                          0.2
                         </tspan>
                       </text>
                     </svg>
@@ -6839,7 +6839,7 @@ exports[`GenePage with SV dataset "gnomad_sv_r4" has no unexpected changes 1`] =
                           dy="0em"
                           x={-8}
                         >
-                          30
+                          0.3
                         </tspan>
                       </text>
                     </svg>
@@ -6879,7 +6879,7 @@ exports[`GenePage with SV dataset "gnomad_sv_r4" has no unexpected changes 1`] =
                           dy="0em"
                           x={-8}
                         >
-                          40
+                          0.4
                         </tspan>
                       </text>
                     </svg>
@@ -6919,7 +6919,7 @@ exports[`GenePage with SV dataset "gnomad_sv_r4" has no unexpected changes 1`] =
                           dy="0em"
                           x={-8}
                         >
-                          50
+                          0.5
                         </tspan>
                       </text>
                     </svg>
@@ -6959,7 +6959,7 @@ exports[`GenePage with SV dataset "gnomad_sv_r4" has no unexpected changes 1`] =
                           dy="0em"
                           x={-8}
                         >
-                          60
+                          0.6
                         </tspan>
                       </text>
                     </svg>
@@ -6999,7 +6999,7 @@ exports[`GenePage with SV dataset "gnomad_sv_r4" has no unexpected changes 1`] =
                           dy="0em"
                           x={-8}
                         >
-                          70
+                          0.7
                         </tspan>
                       </text>
                     </svg>
@@ -7039,7 +7039,7 @@ exports[`GenePage with SV dataset "gnomad_sv_r4" has no unexpected changes 1`] =
                           dy="0em"
                           x={-8}
                         >
-                          80
+                          0.8
                         </tspan>
                       </text>
                     </svg>
@@ -7079,7 +7079,7 @@ exports[`GenePage with SV dataset "gnomad_sv_r4" has no unexpected changes 1`] =
                           dy="0em"
                           x={-8}
                         >
-                          90
+                          0.9
                         </tspan>
                       </text>
                     </svg>
@@ -7119,7 +7119,7 @@ exports[`GenePage with SV dataset "gnomad_sv_r4" has no unexpected changes 1`] =
                           dy="0em"
                           x={-8}
                         >
-                          100
+                          1.0
                         </tspan>
                       </text>
                     </svg>
@@ -9557,7 +9557,7 @@ exports[`GenePage with non-SV dataset "gnomad_cnv_r4" has no unexpected changes 
                 className="Select-sc-1lkyg9e-0 ivadCR"
                 id="coverage-metric"
                 onChange={[Function]}
-                value="mean"
+                value="over_20"
               >
                 <optgroup
                   label="Per-base depth of coverage"
@@ -9661,7 +9661,7 @@ exports[`GenePage with non-SV dataset "gnomad_cnv_r4" has no unexpected changes 
             <div
               className="CoverageTrack__TitlePanel-sc-1kumbsx-4 bwGOoh"
             >
-              Per-base mean depth of coverage
+              Fraction of individuals with coverage over 20
             </div>
           </div>
           <div
@@ -9722,7 +9722,7 @@ exports[`GenePage with non-SV dataset "gnomad_cnv_r4" has no unexpected changes 
                           dy="0em"
                           x={-8}
                         >
-                          10
+                          0.1
                         </tspan>
                       </text>
                     </svg>
@@ -9762,7 +9762,7 @@ exports[`GenePage with non-SV dataset "gnomad_cnv_r4" has no unexpected changes 
                           dy="0em"
                           x={-8}
                         >
-                          20
+                          0.2
                         </tspan>
                       </text>
                     </svg>
@@ -9802,7 +9802,7 @@ exports[`GenePage with non-SV dataset "gnomad_cnv_r4" has no unexpected changes 
                           dy="0em"
                           x={-8}
                         >
-                          30
+                          0.3
                         </tspan>
                       </text>
                     </svg>
@@ -9842,7 +9842,7 @@ exports[`GenePage with non-SV dataset "gnomad_cnv_r4" has no unexpected changes 
                           dy="0em"
                           x={-8}
                         >
-                          40
+                          0.4
                         </tspan>
                       </text>
                     </svg>
@@ -9882,7 +9882,7 @@ exports[`GenePage with non-SV dataset "gnomad_cnv_r4" has no unexpected changes 
                           dy="0em"
                           x={-8}
                         >
-                          50
+                          0.5
                         </tspan>
                       </text>
                     </svg>
@@ -9922,7 +9922,7 @@ exports[`GenePage with non-SV dataset "gnomad_cnv_r4" has no unexpected changes 
                           dy="0em"
                           x={-8}
                         >
-                          60
+                          0.6
                         </tspan>
                       </text>
                     </svg>
@@ -9962,7 +9962,7 @@ exports[`GenePage with non-SV dataset "gnomad_cnv_r4" has no unexpected changes 
                           dy="0em"
                           x={-8}
                         >
-                          70
+                          0.7
                         </tspan>
                       </text>
                     </svg>
@@ -10002,7 +10002,7 @@ exports[`GenePage with non-SV dataset "gnomad_cnv_r4" has no unexpected changes 
                           dy="0em"
                           x={-8}
                         >
-                          80
+                          0.8
                         </tspan>
                       </text>
                     </svg>
@@ -10042,7 +10042,7 @@ exports[`GenePage with non-SV dataset "gnomad_cnv_r4" has no unexpected changes 
                           dy="0em"
                           x={-8}
                         >
-                          90
+                          0.9
                         </tspan>
                       </text>
                     </svg>
@@ -10082,7 +10082,7 @@ exports[`GenePage with non-SV dataset "gnomad_cnv_r4" has no unexpected changes 
                           dy="0em"
                           x={-8}
                         >
-                          100
+                          1.0
                         </tspan>
                       </text>
                     </svg>

--- a/browser/src/TranscriptPage/__snapshots__/TranscriptPageContainer.spec.tsx.snap
+++ b/browser/src/TranscriptPage/__snapshots__/TranscriptPageContainer.spec.tsx.snap
@@ -2085,7 +2085,7 @@ exports[`TranscriptPageContainer with dataset gnomad_cnv_r4 has no unexpected ch
                 className="Select-sc-1lkyg9e-0 ivadCR"
                 id="coverage-metric"
                 onChange={[Function]}
-                value="mean"
+                value="over_20"
               >
                 <optgroup
                   label="Per-base depth of coverage"
@@ -2189,7 +2189,7 @@ exports[`TranscriptPageContainer with dataset gnomad_cnv_r4 has no unexpected ch
             <div
               className="CoverageTrack__TitlePanel-sc-1kumbsx-4 bwGOoh"
             >
-              Per-base mean depth of coverage
+              Fraction of individuals with coverage over 20
             </div>
           </div>
           <div
@@ -2250,7 +2250,7 @@ exports[`TranscriptPageContainer with dataset gnomad_cnv_r4 has no unexpected ch
                           dy="0em"
                           x={-8}
                         >
-                          10
+                          0.1
                         </tspan>
                       </text>
                     </svg>
@@ -2290,7 +2290,7 @@ exports[`TranscriptPageContainer with dataset gnomad_cnv_r4 has no unexpected ch
                           dy="0em"
                           x={-8}
                         >
-                          20
+                          0.2
                         </tspan>
                       </text>
                     </svg>
@@ -2330,7 +2330,7 @@ exports[`TranscriptPageContainer with dataset gnomad_cnv_r4 has no unexpected ch
                           dy="0em"
                           x={-8}
                         >
-                          30
+                          0.3
                         </tspan>
                       </text>
                     </svg>
@@ -2370,7 +2370,7 @@ exports[`TranscriptPageContainer with dataset gnomad_cnv_r4 has no unexpected ch
                           dy="0em"
                           x={-8}
                         >
-                          40
+                          0.4
                         </tspan>
                       </text>
                     </svg>
@@ -2410,7 +2410,7 @@ exports[`TranscriptPageContainer with dataset gnomad_cnv_r4 has no unexpected ch
                           dy="0em"
                           x={-8}
                         >
-                          50
+                          0.5
                         </tspan>
                       </text>
                     </svg>
@@ -2450,7 +2450,7 @@ exports[`TranscriptPageContainer with dataset gnomad_cnv_r4 has no unexpected ch
                           dy="0em"
                           x={-8}
                         >
-                          60
+                          0.6
                         </tspan>
                       </text>
                     </svg>
@@ -2490,7 +2490,7 @@ exports[`TranscriptPageContainer with dataset gnomad_cnv_r4 has no unexpected ch
                           dy="0em"
                           x={-8}
                         >
-                          70
+                          0.7
                         </tspan>
                       </text>
                     </svg>
@@ -2530,7 +2530,7 @@ exports[`TranscriptPageContainer with dataset gnomad_cnv_r4 has no unexpected ch
                           dy="0em"
                           x={-8}
                         >
-                          80
+                          0.8
                         </tspan>
                       </text>
                     </svg>
@@ -2570,7 +2570,7 @@ exports[`TranscriptPageContainer with dataset gnomad_cnv_r4 has no unexpected ch
                           dy="0em"
                           x={-8}
                         >
-                          90
+                          0.9
                         </tspan>
                       </text>
                     </svg>
@@ -2610,7 +2610,7 @@ exports[`TranscriptPageContainer with dataset gnomad_cnv_r4 has no unexpected ch
                           dy="0em"
                           x={-8}
                         >
-                          100
+                          1.0
                         </tspan>
                       </text>
                     </svg>

--- a/dataset-metadata/metadata.ts
+++ b/dataset-metadata/metadata.ts
@@ -232,7 +232,7 @@ const metadataForDataset = (datasetId: DatasetId): DatasetMetadata => ({
     datasetId === 'gnomad_sv_r4',
   isV2: datasetId.startsWith('gnomad_r2'),
   isV3: datasetId.startsWith('gnomad_r3'),
-  isV4: datasetId.startsWith('gnomad_r4'),
+  isV4: datasetId.startsWith('gnomad_r4') || datasetId.includes('r4'),
   isSVs: datasetId.startsWith('gnomad_sv'),
   isCNVs: datasetId.startsWith('gnomad_cnv'),
   isV4CNVs: datasetId === 'gnomad_cnv_r4',

--- a/dataset-metadata/metadata.ts
+++ b/dataset-metadata/metadata.ts
@@ -232,7 +232,7 @@ const metadataForDataset = (datasetId: DatasetId): DatasetMetadata => ({
     datasetId === 'gnomad_sv_r4',
   isV2: datasetId.startsWith('gnomad_r2'),
   isV3: datasetId.startsWith('gnomad_r3'),
-  isV4: datasetId.startsWith('gnomad_r4') || datasetId.includes('r4'),
+  isV4: datasetId.includes('r4'),
   isSVs: datasetId.startsWith('gnomad_sv'),
   isCNVs: datasetId.startsWith('gnomad_cnv'),
   isV4CNVs: datasetId === 'gnomad_cnv_r4',


### PR DESCRIPTION
This PR corrects the default metric issue with the coverage tracks on CNV and SV pages, changing it from `mean` to `Over 20`. The correction involves incorporating the CNV and SV v4 datasetId in the `isV4` logic.

Fixes #1280 