### PR TITLE
Support viewing mitochondrial variants when gnomad v4 is selected

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -61,6 +61,8 @@ module.exports = {
     'no-use-before-define': 'off',
     'react/destructuring-assignment': 'off',
     'prefer-destructuring': 'off',
+    "no-shadow": "off",
+    "@typescript-eslint/no-shadow": ["error"]
   },
   overrides: [
     {

--- a/browser/src/CoverageTrack.tsx
+++ b/browser/src/CoverageTrack.tsx
@@ -118,6 +118,8 @@ class CoverageTrack extends Component<CoverageTrackProps, CoverageTrackState> {
     maxCoverage: 100,
   }
 
+  plotElement: any
+
   constructor(props: CoverageTrackProps) {
     super(props)
     if (this.props.metric) {
@@ -128,8 +130,6 @@ class CoverageTrack extends Component<CoverageTrackProps, CoverageTrackState> {
       this.state = { selectedMetric: MetricOptions.mean }
     }
   }
-
-  plotElement: any
 
   plotRef = (el: any) => {
     this.plotElement = el

--- a/browser/src/CoverageTrack.tsx
+++ b/browser/src/CoverageTrack.tsx
@@ -74,6 +74,20 @@ const TitlePanel = styled.div`
   padding-right: 40px;
 `
 
+export enum MetricOptions {
+  mean = "mean",
+  median = "median",
+  over_1 = "over_1",
+  over_5 = "over_5",
+  over_10 = "over_10",
+  over_15 = "over_15",
+  over_20 = "over_20",
+  over_25 = "over_25",
+  over_30 = "over_30",
+  over_50 = "over_50",
+  over_100 = "over_100",
+}
+
 type OwnCoverageTrackProps = {
   datasets: {
     buckets: {
@@ -90,25 +104,32 @@ type OwnCoverageTrackProps = {
   height?: number
   maxCoverage?: number
   datasetId: DatasetId
+  metric?: MetricOptions
 }
 
-type CoverageTrackState = any
+type CoverageTrackState = { selectedMetric: MetricOptions }
 
 type CoverageTrackProps = OwnCoverageTrackProps & typeof CoverageTrack.defaultProps
 
 class CoverageTrack extends Component<CoverageTrackProps, CoverageTrackState> {
   static defaultProps = {
-    coverageOverThresholds: [],
     filenameForExport: () => 'coverage',
     height: 190,
     maxCoverage: 100,
   }
 
-  plotElement: any
-
-  state = {
-    selectedMetric: isV4(this.props.datasetId) ? 'over_20' : 'mean',
+  constructor(props: CoverageTrackProps) {
+    super(props)
+    if (this.props.metric) {
+      this.state = { selectedMetric: this.props.metric }
+    } else if (isV4(this.props.datasetId)) {
+      this.state = { selectedMetric: MetricOptions.over_20 }
+    } else {
+      this.state = { selectedMetric: MetricOptions.mean }
+    }
   }
+
+  plotElement: any
 
   plotRef = (el: any) => {
     this.plotElement = el
@@ -200,19 +221,19 @@ class CoverageTrack extends Component<CoverageTrackProps, CoverageTrackState> {
     )
     return totalBases < 100
       ? this.renderBars({
-          isPositionDefined,
-          scaleCoverageMetric,
-          scalePosition,
-          totalBases,
-          width,
-        })
+        isPositionDefined,
+        scaleCoverageMetric,
+        scalePosition,
+        totalBases,
+        width,
+      })
       : this.renderArea({
-          isPositionDefined,
-          scaleCoverageMetric,
-          scalePosition,
-          totalBases,
-          width,
-        })
+        isPositionDefined,
+        scaleCoverageMetric,
+        scalePosition,
+        totalBases,
+        width,
+      })
   }
 
   render() {
@@ -244,7 +265,7 @@ class CoverageTrack extends Component<CoverageTrackProps, CoverageTrackState> {
                   <option value="mean">Mean</option>
                   <option value="median">Median</option>
                 </optgroup>
-                {coverageOverThresholds.length > 0 && (
+                {coverageOverThresholds && (
                   <optgroup label="Fraction of individuals with coverage over X">
                     {coverageOverThresholds.map((threshold) => (
                       <option key={`${threshold}`} value={`over_${threshold}`}>

--- a/browser/src/GenePage/GeneCoverageTrack.tsx
+++ b/browser/src/GenePage/GeneCoverageTrack.tsx
@@ -91,7 +91,6 @@ const GeneCoverageTrack = ({
           : coverageConfigNew(exomeCoverage, genomeCoverage)
 
         return (
-          // @ts-expect-error TS(2769) FIXME: No overload matches this call.
           <CoverageTrack
             coverageOverThresholds={[1, 5, 10, 15, 20, 25, 30, 50, 100]}
             datasets={coverageConfig}

--- a/browser/src/GenePage/MitochondrialGeneCoverageTrack.tsx
+++ b/browser/src/GenePage/MitochondrialGeneCoverageTrack.tsx
@@ -7,7 +7,7 @@ import {
   hasMitochondrialGenomeCoverage,
 } from '@gnomad/dataset-metadata/metadata'
 
-import CoverageTrack from '../CoverageTrack'
+import CoverageTrack, { MetricOptions } from '../CoverageTrack'
 import Query from '../Query'
 import StatusMessage from '../StatusMessage'
 
@@ -61,7 +61,6 @@ const MitochondrialGeneCoverageTrack = ({ datasetId, geneId }: Props) => {
         ]
 
         return (
-          // @ts-expect-error TS(2769) FIXME: No overload matches this call.
           <CoverageTrack
             coverageOverThresholds={[100, 1000]}
             datasets={coverage}
@@ -69,6 +68,7 @@ const MitochondrialGeneCoverageTrack = ({ datasetId, geneId }: Props) => {
             height={190}
             maxCoverage={3000}
             datasetId={datasetId}
+            metric={MetricOptions.mean}
           />
         )
       }}

--- a/browser/src/HomePage.tsx
+++ b/browser/src/HomePage.tsx
@@ -148,7 +148,7 @@ export default () => (
           preserveSelectedDataset={false}
           to={{
             pathname: '/variant/M-8602-T-C',
-            search: queryString.stringify({ dataset: 'gnomad_r3' }),
+            search: queryString.stringify({ dataset: 'gnomad_r4' }),
           }}
         >
           M-8602-T-C

--- a/browser/src/RegionPage/CopyNumberVariantsRegionCoverageTrack.tsx
+++ b/browser/src/RegionPage/CopyNumberVariantsRegionCoverageTrack.tsx
@@ -61,7 +61,6 @@ const CopyNumberVariantsRegionCoverageTrack = ({ datasetId, chrom, start, stop }
         ]
 
         return (
-          // @ts-expect-error TS(2769) FIXME: No overload matches this call.
           <CoverageTrack
             coverageOverThresholds={[100, 1000]}
             datasets={coverage}

--- a/browser/src/RegionPage/MitochondrialRegionCoverageTrack.tsx
+++ b/browser/src/RegionPage/MitochondrialRegionCoverageTrack.tsx
@@ -6,7 +6,7 @@ import {
   referenceGenome,
   hasMitochondrialGenomeCoverage,
 } from '@gnomad/dataset-metadata/metadata'
-import CoverageTrack from '../CoverageTrack'
+import CoverageTrack, { MetricOptions } from '../CoverageTrack'
 import Query from '../Query'
 import StatusMessage from '../StatusMessage'
 
@@ -63,7 +63,6 @@ const MitochondrialRegionCoverageTrack = ({ datasetId, start, stop }: Props) => 
         ]
 
         return (
-          // @ts-expect-error TS(2769) FIXME: No overload matches this call.
           <CoverageTrack
             coverageOverThresholds={[100, 1000]}
             datasets={coverage}
@@ -71,6 +70,7 @@ const MitochondrialRegionCoverageTrack = ({ datasetId, start, stop }: Props) => 
             height={190}
             maxCoverage={3000}
             datasetId={datasetId}
+            metric={MetricOptions.mean}
           />
         )
       }}

--- a/browser/src/RegionPage/RegionCoverageTrack.tsx
+++ b/browser/src/RegionPage/RegionCoverageTrack.tsx
@@ -99,7 +99,6 @@ const RegionCoverageTrack = ({
             : coverageConfigNew(exomeCoverage, genomeCoverage)
 
         return (
-          // @ts-expect-error TS(2769) FIXME: No overload matches this call.
           <CoverageTrack
             coverageOverThresholds={[1, 5, 10, 15, 20, 25, 30, 50, 100]}
             filenameForExport={() => `${chrom}-${start}-${stop}_coverage`}

--- a/browser/src/TranscriptPage/MitochondrialTranscriptCoverageTrack.tsx
+++ b/browser/src/TranscriptPage/MitochondrialTranscriptCoverageTrack.tsx
@@ -6,7 +6,7 @@ import {
   referenceGenome,
   hasMitochondrialGenomeCoverage,
 } from '@gnomad/dataset-metadata/metadata'
-import CoverageTrack from '../CoverageTrack'
+import CoverageTrack, { MetricOptions } from '../CoverageTrack'
 import Query from '../Query'
 import StatusMessage from '../StatusMessage'
 
@@ -60,7 +60,6 @@ const MitochondrialTranscriptCoverageTrack = ({ datasetId, transcriptId }: Props
         ]
 
         return (
-          // @ts-expect-error TS(2769) FIXME: No overload matches this call.
           <CoverageTrack
             coverageOverThresholds={[100, 1000]}
             datasets={coverage}
@@ -68,6 +67,7 @@ const MitochondrialTranscriptCoverageTrack = ({ datasetId, transcriptId }: Props
             height={190}
             maxCoverage={3000}
             datasetId={datasetId}
+            metric={MetricOptions.mean}
           />
         )
       }}

--- a/browser/src/TranscriptPage/TranscriptCoverageTrack.tsx
+++ b/browser/src/TranscriptPage/TranscriptCoverageTrack.tsx
@@ -93,7 +93,6 @@ const TranscriptCoverageTrack = ({
             : coverageConfigNew(exomeCoverage, genomeCoverage)
 
         return (
-          // @ts-expect-error TS(2769) FIXME: No overload matches this call.
           <CoverageTrack
             coverageOverThresholds={[1, 5, 10, 15, 20, 25, 30, 50, 100]}
             datasets={coverageConfig}

--- a/browser/src/__snapshots__/HomePage.spec.tsx.snap
+++ b/browser/src/__snapshots__/HomePage.spec.tsx.snap
@@ -434,7 +434,7 @@ exports[`Home Page has no unexpected changes 1`] = `
        
       <a
         className="-Link c8"
-        href="/variant/M-8602-T-C?dataset=gnomad_r3"
+        href="/variant/M-8602-T-C?dataset=gnomad_r4"
         onClick={[Function]}
       >
         M-8602-T-C

--- a/graphql-api/src/queries/mitochondrial-coverage-queries.ts
+++ b/graphql-api/src/queries/mitochondrial-coverage-queries.ts
@@ -7,6 +7,7 @@ import { extendRegions, mergeOverlappingRegions, totalRegionSize } from './helpe
 import { assertDatasetAndReferenceGenomeMatch } from './helpers/validation-helpers'
 
 const COVERAGE_INDICES = {
+  gnomad_r4: 'gnomad_v3_mitochondrial_coverage',
   gnomad_r3: 'gnomad_v3_mitochondrial_coverage',
 }
 

--- a/graphql-api/src/queries/mitochondrial-variant-queries.ts
+++ b/graphql-api/src/queries/mitochondrial-variant-queries.ts
@@ -6,6 +6,14 @@ import { assertDatasetAndReferenceGenomeMatch } from './helpers/validation-helpe
 import gnomadV3MitochondrialVariantQueries from './mitochondrial-variant-datasets/gnomad-v3-mitochondrial-variant-queries'
 
 const datasetQueries = {
+  gnomad_r4: {
+    fetchMitochondrialVariantById:
+      gnomadV3MitochondrialVariantQueries.fetchMitochondrialVariantById,
+    _fetchMitochondrialVariantsByGene:
+      gnomadV3MitochondrialVariantQueries.fetchMitochondrialVariantsByGene,
+    fetchMitochondrialVariantsByRegion:
+      gnomadV3MitochondrialVariantQueries.fetchMitochondrialVariantsByRegion,
+  },
   gnomad_r3: {
     fetchMitochondrialVariantById:
       gnomadV3MitochondrialVariantQueries.fetchMitochondrialVariantById,


### PR DESCRIPTION
Currently if a users queries a variant, gene, or region in the mitochondrial dataset (which was originally part of v3 genomes), they get an error saying mito variants not available for v4. Since v3 is now part of v4, this should not happen and they should see mito variants on the v4 dataset.

Furthermore the coverage track component required modification b/c when v4 is the current dataset, the `over_20` metric is default, which mito coverage does not have. This PR adds a new prop so that the metric can specified as needed; doing this will override the metric determined by the `datasetId` and the default metric (`mean`).

Examples:

Variant: http://localhost:8008/variant/M-4491-G-A?dataset=gnomad_r4
Gene: http://localhost:8008/gene/ENSG00000198763?dataset=gnomad_r4
Region: http://localhost:8008/region/M-4470-5511?dataset=gnomad_r4


Fixes #1278 