### PR TITLE
Update v4 Downloads page with Azure links

### DIFF
--- a/browser/src/DownloadsPage/GnomadV4Downloads.tsx
+++ b/browser/src/DownloadsPage/GnomadV4Downloads.tsx
@@ -138,7 +138,6 @@ const GnomadV4Downloads = () => {
                 <GetUrlButtons
                   label="Sites Hail Table"
                   path="/release/4.0/ht/exomes/gnomad.exomes.v4.0.sites.ht"
-                  includeAzure={false}
                 />
               </ListItem>
               {exomeChromosomeVcfs.map(({ chrom, size, md5 }) => (
@@ -149,7 +148,6 @@ const GnomadV4Downloads = () => {
                     path={`/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr${chrom}.vcf.bgz`}
                     size={size}
                     md5={md5}
-                    includeAzure={false}
                   />
                 </ListItem>
               ))}
@@ -164,7 +162,6 @@ const GnomadV4Downloads = () => {
                 <GetUrlButtons
                   label="Sites Hail Table"
                   path="/release/4.0/ht/genomes/gnomad.genomes.v4.0.sites.ht/"
-                  includeAzure={false}
                 />
               </ListItem>
               {genomeChromosomeVcfs.map(({ chrom, size, md5 }) => (
@@ -175,7 +172,6 @@ const GnomadV4Downloads = () => {
                     path={`/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr${chrom}.vcf.bgz`}
                     size={size}
                     md5={md5}
-                    includeAzure={false}
                   />
                 </ListItem>
               ))}
@@ -192,7 +188,6 @@ const GnomadV4Downloads = () => {
             <GetUrlButtons
               label="Exome coverage Hail Table"
               path="/release/4.0/coverage/exomes/gnomad.exomes.v4.0.coverage.ht"
-              includeAzure={false}
             />
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
@@ -202,7 +197,6 @@ const GnomadV4Downloads = () => {
               path="/release/4.0/coverage/exomes/gnomad.exomes.v4.0.coverage.summary.tsv.bgz"
               size="3.77 GiB"
               md5="a6955332c9cccae7efb9c95581282a73"
-              includeAzure={false}
             />
           </ListItem>
         </FileList>
@@ -223,8 +217,6 @@ const GnomadV4Downloads = () => {
             <GetUrlButtons
               label="Constraint metrics Hail Table"
               path="/release/v4.0/constraint/gnomad.v4.0.constraint_metrics.ht"
-              includeAWS={false}
-              includeAzure={false}
             />
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
@@ -232,8 +224,6 @@ const GnomadV4Downloads = () => {
             <GenericDownloadLinks
               label="Constraint metrics TSV"
               path="/release/v4.0/constraint/gnomad.v4.0.constraint_metrics.tsv"
-              includeAWS={false}
-              includeAzure={false}
             />
           </ListItem>
         </FileList>
@@ -254,7 +244,6 @@ const GnomadV4Downloads = () => {
                 path={`/release/4.0/genome_sv/gnomad.v4.0.sv.chr${chrom}.vcf.gz`}
                 size={size}
                 crc32={crc32}
-                includeAzure={false}
               />
             </ListItem>
           ))}
@@ -273,7 +262,6 @@ const GnomadV4Downloads = () => {
             <GenericDownloadLinks
               label="Exome CNV VCF"
               path="/release/4.0/exome_cnv/gnomad.v4.0.cnv.all.vcf.gz"
-              includeAzure={false}
             />
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
@@ -281,7 +269,6 @@ const GnomadV4Downloads = () => {
             <GenericDownloadLinks
               label="Exome CNV non neuro VCF"
               path="/release/4.0/exome_cnv/gnomad.v4.0.cnv.non_neuro.vcf.gz"
-              includeAzure={false}
             />
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
@@ -289,7 +276,6 @@ const GnomadV4Downloads = () => {
             <GenericDownloadLinks
               label="Exome CNV non-neuro controls VCF"
               path="/release/4.0/exome_cnv/gnomad.v4.0.cnv.non_neuro_controls.vcf.gz"
-              includeAzure={false}
             />
           </ListItem>
         </FileList>
@@ -303,7 +289,6 @@ const GnomadV4Downloads = () => {
             <GenericDownloadLinks
               label="Exome sex ploidy cutoffs TSV"
               path="/release/4.0/sex_inference/gnomad.exomes.v4.0.sample_qc.sex_inference.ploidy_cutoffs.tsv"
-              includeAzure={false}
             />
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
@@ -311,7 +296,6 @@ const GnomadV4Downloads = () => {
             <GetUrlButtons
               label="Exome calling intervals Hail Table"
               path="/resources/grch38/intervals/ukb.pad50.broad.pad50.union.interval_list.ht"
-              includeAzure={false}
             />
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
@@ -319,7 +303,6 @@ const GnomadV4Downloads = () => {
             <GenericDownloadLinks
               label="Exome calling intervals flat file"
               path="/resources/grch38/intervals/ukb.pad50.broad.pad50.union.intervals"
-              includeAzure={false}
             />
           </ListItem>
         </FileList>

--- a/browser/src/DownloadsPage/__snapshots__/DownloadsPage.spec.tsx.snap
+++ b/browser/src/DownloadsPage/__snapshots__/DownloadsPage.spec.tsx.snap
@@ -764,6 +764,15 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               >
                 Amazon
               </button>
+               / 
+              <button
+                aria-label="Show Microsoft URL for Sites Hail Table"
+                className="c21"
+                onClick={[Function]}
+                type="button"
+              >
+                Microsoft
+              </button>
             </li>
             <li
               className="c20"
@@ -800,6 +809,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 >
                   Amazon
                 </a>
+                 / 
+                <a
+                  aria-label="Download chr1 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr1.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
               </span>
               <br />
               <span>
@@ -823,6 +842,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                   target="_blank"
                 >
                   Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr1 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr1.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
                 </a>
               </span>
             </li>
@@ -861,6 +890,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 >
                   Amazon
                 </a>
+                 / 
+                <a
+                  aria-label="Download chr2 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr2.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
               </span>
               <br />
               <span>
@@ -884,6 +923,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                   target="_blank"
                 >
                   Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr2 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr2.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
                 </a>
               </span>
             </li>
@@ -922,6 +971,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 >
                   Amazon
                 </a>
+                 / 
+                <a
+                  aria-label="Download chr3 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr3.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
               </span>
               <br />
               <span>
@@ -945,6 +1004,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                   target="_blank"
                 >
                   Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr3 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr3.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
                 </a>
               </span>
             </li>
@@ -983,6 +1052,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 >
                   Amazon
                 </a>
+                 / 
+                <a
+                  aria-label="Download chr4 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr4.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
               </span>
               <br />
               <span>
@@ -1006,6 +1085,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                   target="_blank"
                 >
                   Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr4 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr4.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
                 </a>
               </span>
             </li>
@@ -1044,6 +1133,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 >
                   Amazon
                 </a>
+                 / 
+                <a
+                  aria-label="Download chr5 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr5.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
               </span>
               <br />
               <span>
@@ -1067,6 +1166,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                   target="_blank"
                 >
                   Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr5 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr5.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
                 </a>
               </span>
             </li>
@@ -1105,6 +1214,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 >
                   Amazon
                 </a>
+                 / 
+                <a
+                  aria-label="Download chr6 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr6.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
               </span>
               <br />
               <span>
@@ -1128,6 +1247,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                   target="_blank"
                 >
                   Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr6 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr6.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
                 </a>
               </span>
             </li>
@@ -1166,6 +1295,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 >
                   Amazon
                 </a>
+                 / 
+                <a
+                  aria-label="Download chr7 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr7.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
               </span>
               <br />
               <span>
@@ -1189,6 +1328,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                   target="_blank"
                 >
                   Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr7 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr7.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
                 </a>
               </span>
             </li>
@@ -1227,6 +1376,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 >
                   Amazon
                 </a>
+                 / 
+                <a
+                  aria-label="Download chr8 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr8.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
               </span>
               <br />
               <span>
@@ -1250,6 +1409,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                   target="_blank"
                 >
                   Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr8 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr8.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
                 </a>
               </span>
             </li>
@@ -1288,6 +1457,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 >
                   Amazon
                 </a>
+                 / 
+                <a
+                  aria-label="Download chr9 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr9.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
               </span>
               <br />
               <span>
@@ -1311,6 +1490,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                   target="_blank"
                 >
                   Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr9 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr9.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
                 </a>
               </span>
             </li>
@@ -1349,6 +1538,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 >
                   Amazon
                 </a>
+                 / 
+                <a
+                  aria-label="Download chr10 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr10.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
               </span>
               <br />
               <span>
@@ -1372,6 +1571,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                   target="_blank"
                 >
                   Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr10 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr10.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
                 </a>
               </span>
             </li>
@@ -1410,6 +1619,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 >
                   Amazon
                 </a>
+                 / 
+                <a
+                  aria-label="Download chr11 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr11.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
               </span>
               <br />
               <span>
@@ -1433,6 +1652,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                   target="_blank"
                 >
                   Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr11 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr11.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
                 </a>
               </span>
             </li>
@@ -1471,6 +1700,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 >
                   Amazon
                 </a>
+                 / 
+                <a
+                  aria-label="Download chr12 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr12.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
               </span>
               <br />
               <span>
@@ -1494,6 +1733,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                   target="_blank"
                 >
                   Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr12 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr12.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
                 </a>
               </span>
             </li>
@@ -1532,6 +1781,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 >
                   Amazon
                 </a>
+                 / 
+                <a
+                  aria-label="Download chr13 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr13.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
               </span>
               <br />
               <span>
@@ -1555,6 +1814,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                   target="_blank"
                 >
                   Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr13 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr13.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
                 </a>
               </span>
             </li>
@@ -1593,6 +1862,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 >
                   Amazon
                 </a>
+                 / 
+                <a
+                  aria-label="Download chr14 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr14.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
               </span>
               <br />
               <span>
@@ -1616,6 +1895,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                   target="_blank"
                 >
                   Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr14 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr14.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
                 </a>
               </span>
             </li>
@@ -1654,6 +1943,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 >
                   Amazon
                 </a>
+                 / 
+                <a
+                  aria-label="Download chr15 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr15.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
               </span>
               <br />
               <span>
@@ -1677,6 +1976,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                   target="_blank"
                 >
                   Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr15 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr15.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
                 </a>
               </span>
             </li>
@@ -1715,6 +2024,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 >
                   Amazon
                 </a>
+                 / 
+                <a
+                  aria-label="Download chr16 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr16.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
               </span>
               <br />
               <span>
@@ -1738,6 +2057,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                   target="_blank"
                 >
                   Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr16 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr16.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
                 </a>
               </span>
             </li>
@@ -1776,6 +2105,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 >
                   Amazon
                 </a>
+                 / 
+                <a
+                  aria-label="Download chr17 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr17.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
               </span>
               <br />
               <span>
@@ -1799,6 +2138,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                   target="_blank"
                 >
                   Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr17 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr17.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
                 </a>
               </span>
             </li>
@@ -1837,6 +2186,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 >
                   Amazon
                 </a>
+                 / 
+                <a
+                  aria-label="Download chr18 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr18.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
               </span>
               <br />
               <span>
@@ -1860,6 +2219,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                   target="_blank"
                 >
                   Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr18 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr18.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
                 </a>
               </span>
             </li>
@@ -1898,6 +2267,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 >
                   Amazon
                 </a>
+                 / 
+                <a
+                  aria-label="Download chr19 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr19.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
               </span>
               <br />
               <span>
@@ -1921,6 +2300,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                   target="_blank"
                 >
                   Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr19 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr19.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
                 </a>
               </span>
             </li>
@@ -1959,6 +2348,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 >
                   Amazon
                 </a>
+                 / 
+                <a
+                  aria-label="Download chr20 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr20.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
               </span>
               <br />
               <span>
@@ -1982,6 +2381,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                   target="_blank"
                 >
                   Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr20 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr20.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
                 </a>
               </span>
             </li>
@@ -2020,6 +2429,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 >
                   Amazon
                 </a>
+                 / 
+                <a
+                  aria-label="Download chr21 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr21.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
               </span>
               <br />
               <span>
@@ -2043,6 +2462,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                   target="_blank"
                 >
                   Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr21 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr21.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
                 </a>
               </span>
             </li>
@@ -2081,6 +2510,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 >
                   Amazon
                 </a>
+                 / 
+                <a
+                  aria-label="Download chr22 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr22.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
               </span>
               <br />
               <span>
@@ -2104,6 +2543,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                   target="_blank"
                 >
                   Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr22 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr22.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
                 </a>
               </span>
             </li>
@@ -2142,6 +2591,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 >
                   Amazon
                 </a>
+                 / 
+                <a
+                  aria-label="Download chrX sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chrX.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
               </span>
               <br />
               <span>
@@ -2165,6 +2624,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                   target="_blank"
                 >
                   Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chrX sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chrX.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
                 </a>
               </span>
             </li>
@@ -2203,6 +2672,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 >
                   Amazon
                 </a>
+                 / 
+                <a
+                  aria-label="Download chrY sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chrY.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
               </span>
               <br />
               <span>
@@ -2226,6 +2705,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                   target="_blank"
                 >
                   Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chrY sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chrY.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
                 </a>
               </span>
             </li>
@@ -2266,6 +2755,15 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               >
                 Amazon
               </button>
+               / 
+              <button
+                aria-label="Show Microsoft URL for Sites Hail Table"
+                className="c21"
+                onClick={[Function]}
+                type="button"
+              >
+                Microsoft
+              </button>
             </li>
             <li
               className="c20"
@@ -2302,6 +2800,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 >
                   Amazon
                 </a>
+                 / 
+                <a
+                  aria-label="Download chr1 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr1.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
               </span>
               <br />
               <span>
@@ -2325,6 +2833,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                   target="_blank"
                 >
                   Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr1 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr1.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
                 </a>
               </span>
             </li>
@@ -2363,6 +2881,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 >
                   Amazon
                 </a>
+                 / 
+                <a
+                  aria-label="Download chr2 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr2.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
               </span>
               <br />
               <span>
@@ -2386,6 +2914,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                   target="_blank"
                 >
                   Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr2 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr2.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
                 </a>
               </span>
             </li>
@@ -2424,6 +2962,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 >
                   Amazon
                 </a>
+                 / 
+                <a
+                  aria-label="Download chr3 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr3.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
               </span>
               <br />
               <span>
@@ -2447,6 +2995,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                   target="_blank"
                 >
                   Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr3 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr3.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
                 </a>
               </span>
             </li>
@@ -2485,6 +3043,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 >
                   Amazon
                 </a>
+                 / 
+                <a
+                  aria-label="Download chr4 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr4.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
               </span>
               <br />
               <span>
@@ -2508,6 +3076,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                   target="_blank"
                 >
                   Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr4 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr4.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
                 </a>
               </span>
             </li>
@@ -2546,6 +3124,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 >
                   Amazon
                 </a>
+                 / 
+                <a
+                  aria-label="Download chr5 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr5.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
               </span>
               <br />
               <span>
@@ -2569,6 +3157,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                   target="_blank"
                 >
                   Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr5 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr5.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
                 </a>
               </span>
             </li>
@@ -2607,6 +3205,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 >
                   Amazon
                 </a>
+                 / 
+                <a
+                  aria-label="Download chr6 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr6.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
               </span>
               <br />
               <span>
@@ -2630,6 +3238,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                   target="_blank"
                 >
                   Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr6 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr6.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
                 </a>
               </span>
             </li>
@@ -2668,6 +3286,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 >
                   Amazon
                 </a>
+                 / 
+                <a
+                  aria-label="Download chr7 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr7.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
               </span>
               <br />
               <span>
@@ -2691,6 +3319,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                   target="_blank"
                 >
                   Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr7 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr7.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
                 </a>
               </span>
             </li>
@@ -2729,6 +3367,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 >
                   Amazon
                 </a>
+                 / 
+                <a
+                  aria-label="Download chr8 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr8.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
               </span>
               <br />
               <span>
@@ -2752,6 +3400,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                   target="_blank"
                 >
                   Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr8 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr8.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
                 </a>
               </span>
             </li>
@@ -2790,6 +3448,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 >
                   Amazon
                 </a>
+                 / 
+                <a
+                  aria-label="Download chr9 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr9.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
               </span>
               <br />
               <span>
@@ -2813,6 +3481,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                   target="_blank"
                 >
                   Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr9 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr9.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
                 </a>
               </span>
             </li>
@@ -2851,6 +3529,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 >
                   Amazon
                 </a>
+                 / 
+                <a
+                  aria-label="Download chr10 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr10.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
               </span>
               <br />
               <span>
@@ -2874,6 +3562,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                   target="_blank"
                 >
                   Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr10 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr10.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
                 </a>
               </span>
             </li>
@@ -2912,6 +3610,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 >
                   Amazon
                 </a>
+                 / 
+                <a
+                  aria-label="Download chr11 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr11.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
               </span>
               <br />
               <span>
@@ -2935,6 +3643,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                   target="_blank"
                 >
                   Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr11 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr11.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
                 </a>
               </span>
             </li>
@@ -2973,6 +3691,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 >
                   Amazon
                 </a>
+                 / 
+                <a
+                  aria-label="Download chr12 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr12.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
               </span>
               <br />
               <span>
@@ -2996,6 +3724,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                   target="_blank"
                 >
                   Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr12 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr12.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
                 </a>
               </span>
             </li>
@@ -3034,6 +3772,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 >
                   Amazon
                 </a>
+                 / 
+                <a
+                  aria-label="Download chr13 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr13.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
               </span>
               <br />
               <span>
@@ -3057,6 +3805,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                   target="_blank"
                 >
                   Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr13 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr13.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
                 </a>
               </span>
             </li>
@@ -3095,6 +3853,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 >
                   Amazon
                 </a>
+                 / 
+                <a
+                  aria-label="Download chr14 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr14.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
               </span>
               <br />
               <span>
@@ -3118,6 +3886,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                   target="_blank"
                 >
                   Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr14 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr14.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
                 </a>
               </span>
             </li>
@@ -3156,6 +3934,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 >
                   Amazon
                 </a>
+                 / 
+                <a
+                  aria-label="Download chr15 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr15.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
               </span>
               <br />
               <span>
@@ -3179,6 +3967,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                   target="_blank"
                 >
                   Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr15 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr15.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
                 </a>
               </span>
             </li>
@@ -3217,6 +4015,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 >
                   Amazon
                 </a>
+                 / 
+                <a
+                  aria-label="Download chr16 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr16.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
               </span>
               <br />
               <span>
@@ -3240,6 +4048,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                   target="_blank"
                 >
                   Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr16 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr16.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
                 </a>
               </span>
             </li>
@@ -3278,6 +4096,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 >
                   Amazon
                 </a>
+                 / 
+                <a
+                  aria-label="Download chr17 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr17.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
               </span>
               <br />
               <span>
@@ -3301,6 +4129,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                   target="_blank"
                 >
                   Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr17 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr17.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
                 </a>
               </span>
             </li>
@@ -3339,6 +4177,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 >
                   Amazon
                 </a>
+                 / 
+                <a
+                  aria-label="Download chr18 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr18.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
               </span>
               <br />
               <span>
@@ -3362,6 +4210,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                   target="_blank"
                 >
                   Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr18 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr18.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
                 </a>
               </span>
             </li>
@@ -3400,6 +4258,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 >
                   Amazon
                 </a>
+                 / 
+                <a
+                  aria-label="Download chr19 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr19.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
               </span>
               <br />
               <span>
@@ -3423,6 +4291,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                   target="_blank"
                 >
                   Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr19 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr19.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
                 </a>
               </span>
             </li>
@@ -3461,6 +4339,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 >
                   Amazon
                 </a>
+                 / 
+                <a
+                  aria-label="Download chr20 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr20.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
               </span>
               <br />
               <span>
@@ -3484,6 +4372,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                   target="_blank"
                 >
                   Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr20 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr20.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
                 </a>
               </span>
             </li>
@@ -3522,6 +4420,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 >
                   Amazon
                 </a>
+                 / 
+                <a
+                  aria-label="Download chr21 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr21.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
               </span>
               <br />
               <span>
@@ -3545,6 +4453,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                   target="_blank"
                 >
                   Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr21 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr21.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
                 </a>
               </span>
             </li>
@@ -3583,6 +4501,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 >
                   Amazon
                 </a>
+                 / 
+                <a
+                  aria-label="Download chr22 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr22.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
               </span>
               <br />
               <span>
@@ -3606,6 +4534,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                   target="_blank"
                 >
                   Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chr22 sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr22.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
                 </a>
               </span>
             </li>
@@ -3644,6 +4582,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 >
                   Amazon
                 </a>
+                 / 
+                <a
+                  aria-label="Download chrX sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chrX.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
               </span>
               <br />
               <span>
@@ -3667,6 +4615,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                   target="_blank"
                 >
                   Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chrX sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chrX.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
                 </a>
               </span>
             </li>
@@ -3705,6 +4663,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 >
                   Amazon
                 </a>
+                 / 
+                <a
+                  aria-label="Download chrY sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chrY.vcf.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
               </span>
               <br />
               <span>
@@ -3728,6 +4696,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                   target="_blank"
                 >
                   Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download TBI file for chrY sites VCF from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chrY.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
                 </a>
               </span>
             </li>
@@ -3790,6 +4768,15 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           >
             Amazon
           </button>
+           / 
+          <button
+            aria-label="Show Microsoft URL for Exome coverage Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Microsoft
+          </button>
         </li>
         <li
           className="c20"
@@ -3825,6 +4812,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               target="_blank"
             >
               Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download Exome coverage summary TSV from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/coverage/exomes/gnomad.exomes.v4.0.coverage.summary.tsv.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
             </a>
           </span>
         </li>
@@ -3927,6 +4924,24 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           >
             Google
           </button>
+           / 
+          <button
+            aria-label="Show Amazon URL for Constraint metrics Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Amazon
+          </button>
+           / 
+          <button
+            aria-label="Show Microsoft URL for Constraint metrics Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Microsoft
+          </button>
         </li>
         <li
           className="c20"
@@ -3946,6 +4961,26 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               target="_blank"
             >
               Google
+            </a>
+             / 
+            <a
+              aria-label="Download Constraint metrics TSV from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/v4.0/constraint/gnomad.v4.0.constraint_metrics.tsv"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download Constraint metrics TSV from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/v4.0/constraint/gnomad.v4.0.constraint_metrics.tsv"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
             </a>
           </span>
         </li>
@@ -4026,6 +5061,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             >
               Amazon
             </a>
+             / 
+            <a
+              aria-label="Download chr1 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr1.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
           </span>
           <br />
           <span>
@@ -4049,6 +5094,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               target="_blank"
             >
               Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr1 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr1.vcf.gz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
             </a>
           </span>
         </li>
@@ -4087,6 +5142,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             >
               Amazon
             </a>
+             / 
+            <a
+              aria-label="Download chr2 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr2.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
           </span>
           <br />
           <span>
@@ -4110,6 +5175,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               target="_blank"
             >
               Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr2 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr2.vcf.gz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
             </a>
           </span>
         </li>
@@ -4148,6 +5223,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             >
               Amazon
             </a>
+             / 
+            <a
+              aria-label="Download chr3 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr3.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
           </span>
           <br />
           <span>
@@ -4171,6 +5256,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               target="_blank"
             >
               Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr3 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr3.vcf.gz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
             </a>
           </span>
         </li>
@@ -4209,6 +5304,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             >
               Amazon
             </a>
+             / 
+            <a
+              aria-label="Download chr4 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr4.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
           </span>
           <br />
           <span>
@@ -4232,6 +5337,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               target="_blank"
             >
               Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr4 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr4.vcf.gz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
             </a>
           </span>
         </li>
@@ -4270,6 +5385,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             >
               Amazon
             </a>
+             / 
+            <a
+              aria-label="Download chr5 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr5.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
           </span>
           <br />
           <span>
@@ -4293,6 +5418,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               target="_blank"
             >
               Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr5 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr5.vcf.gz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
             </a>
           </span>
         </li>
@@ -4331,6 +5466,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             >
               Amazon
             </a>
+             / 
+            <a
+              aria-label="Download chr6 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr6.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
           </span>
           <br />
           <span>
@@ -4354,6 +5499,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               target="_blank"
             >
               Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr6 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr6.vcf.gz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
             </a>
           </span>
         </li>
@@ -4392,6 +5547,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             >
               Amazon
             </a>
+             / 
+            <a
+              aria-label="Download chr7 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr7.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
           </span>
           <br />
           <span>
@@ -4415,6 +5580,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               target="_blank"
             >
               Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr7 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr7.vcf.gz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
             </a>
           </span>
         </li>
@@ -4453,6 +5628,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             >
               Amazon
             </a>
+             / 
+            <a
+              aria-label="Download chr8 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr8.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
           </span>
           <br />
           <span>
@@ -4476,6 +5661,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               target="_blank"
             >
               Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr8 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr8.vcf.gz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
             </a>
           </span>
         </li>
@@ -4514,6 +5709,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             >
               Amazon
             </a>
+             / 
+            <a
+              aria-label="Download chr9 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr9.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
           </span>
           <br />
           <span>
@@ -4537,6 +5742,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               target="_blank"
             >
               Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr9 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr9.vcf.gz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
             </a>
           </span>
         </li>
@@ -4575,6 +5790,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             >
               Amazon
             </a>
+             / 
+            <a
+              aria-label="Download chr10 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr10.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
           </span>
           <br />
           <span>
@@ -4598,6 +5823,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               target="_blank"
             >
               Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr10 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr10.vcf.gz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
             </a>
           </span>
         </li>
@@ -4636,6 +5871,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             >
               Amazon
             </a>
+             / 
+            <a
+              aria-label="Download chr11 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr11.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
           </span>
           <br />
           <span>
@@ -4659,6 +5904,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               target="_blank"
             >
               Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr11 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr11.vcf.gz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
             </a>
           </span>
         </li>
@@ -4697,6 +5952,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             >
               Amazon
             </a>
+             / 
+            <a
+              aria-label="Download chr12 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr12.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
           </span>
           <br />
           <span>
@@ -4720,6 +5985,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               target="_blank"
             >
               Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr12 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr12.vcf.gz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
             </a>
           </span>
         </li>
@@ -4758,6 +6033,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             >
               Amazon
             </a>
+             / 
+            <a
+              aria-label="Download chr13 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr13.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
           </span>
           <br />
           <span>
@@ -4781,6 +6066,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               target="_blank"
             >
               Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr13 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr13.vcf.gz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
             </a>
           </span>
         </li>
@@ -4819,6 +6114,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             >
               Amazon
             </a>
+             / 
+            <a
+              aria-label="Download chr14 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr14.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
           </span>
           <br />
           <span>
@@ -4842,6 +6147,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               target="_blank"
             >
               Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr14 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr14.vcf.gz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
             </a>
           </span>
         </li>
@@ -4880,6 +6195,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             >
               Amazon
             </a>
+             / 
+            <a
+              aria-label="Download chr15 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr15.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
           </span>
           <br />
           <span>
@@ -4903,6 +6228,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               target="_blank"
             >
               Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr15 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr15.vcf.gz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
             </a>
           </span>
         </li>
@@ -4941,6 +6276,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             >
               Amazon
             </a>
+             / 
+            <a
+              aria-label="Download chr16 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr16.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
           </span>
           <br />
           <span>
@@ -4964,6 +6309,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               target="_blank"
             >
               Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr16 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr16.vcf.gz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
             </a>
           </span>
         </li>
@@ -5002,6 +6357,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             >
               Amazon
             </a>
+             / 
+            <a
+              aria-label="Download chr17 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr17.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
           </span>
           <br />
           <span>
@@ -5025,6 +6390,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               target="_blank"
             >
               Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr17 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr17.vcf.gz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
             </a>
           </span>
         </li>
@@ -5063,6 +6438,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             >
               Amazon
             </a>
+             / 
+            <a
+              aria-label="Download chr18 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr18.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
           </span>
           <br />
           <span>
@@ -5086,6 +6471,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               target="_blank"
             >
               Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr18 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr18.vcf.gz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
             </a>
           </span>
         </li>
@@ -5124,6 +6519,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             >
               Amazon
             </a>
+             / 
+            <a
+              aria-label="Download chr19 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr19.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
           </span>
           <br />
           <span>
@@ -5147,6 +6552,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               target="_blank"
             >
               Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr19 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr19.vcf.gz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
             </a>
           </span>
         </li>
@@ -5185,6 +6600,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             >
               Amazon
             </a>
+             / 
+            <a
+              aria-label="Download chr20 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr20.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
           </span>
           <br />
           <span>
@@ -5208,6 +6633,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               target="_blank"
             >
               Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr20 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr20.vcf.gz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
             </a>
           </span>
         </li>
@@ -5246,6 +6681,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             >
               Amazon
             </a>
+             / 
+            <a
+              aria-label="Download chr21 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr21.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
           </span>
           <br />
           <span>
@@ -5269,6 +6714,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               target="_blank"
             >
               Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr21 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr21.vcf.gz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
             </a>
           </span>
         </li>
@@ -5307,6 +6762,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             >
               Amazon
             </a>
+             / 
+            <a
+              aria-label="Download chr22 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr22.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
           </span>
           <br />
           <span>
@@ -5330,6 +6795,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               target="_blank"
             >
               Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chr22 VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr22.vcf.gz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
             </a>
           </span>
         </li>
@@ -5368,6 +6843,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             >
               Amazon
             </a>
+             / 
+            <a
+              aria-label="Download chrX VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chrX.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
           </span>
           <br />
           <span>
@@ -5391,6 +6876,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               target="_blank"
             >
               Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chrX VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chrX.vcf.gz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
             </a>
           </span>
         </li>
@@ -5429,6 +6924,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             >
               Amazon
             </a>
+             / 
+            <a
+              aria-label="Download chrY VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chrY.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
           </span>
           <br />
           <span>
@@ -5452,6 +6957,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               target="_blank"
             >
               Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download TBI file for chrY VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chrY.vcf.gz.tbi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
             </a>
           </span>
         </li>
@@ -5526,6 +7041,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             >
               Amazon
             </a>
+             / 
+            <a
+              aria-label="Download Exome CNV VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/exome_cnv/gnomad.v4.0.cnv.all.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
           </span>
         </li>
         <li
@@ -5557,6 +7082,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             >
               Amazon
             </a>
+             / 
+            <a
+              aria-label="Download Exome CNV non neuro VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/exome_cnv/gnomad.v4.0.cnv.non_neuro.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
           </span>
         </li>
         <li
@@ -5587,6 +7122,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               target="_blank"
             >
               Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download Exome CNV non-neuro controls VCF from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/exome_cnv/gnomad.v4.0.cnv.non_neuro_controls.vcf.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
             </a>
           </span>
         </li>
@@ -5650,6 +7195,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             >
               Amazon
             </a>
+             / 
+            <a
+              aria-label="Download Exome sex ploidy cutoffs TSV from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/sex_inference/gnomad.exomes.v4.0.sample_qc.sex_inference.ploidy_cutoffs.tsv"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
           </span>
         </li>
         <li
@@ -5677,6 +7232,15 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             type="button"
           >
             Amazon
+          </button>
+           / 
+          <button
+            aria-label="Show Microsoft URL for Exome calling intervals Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Microsoft
           </button>
         </li>
         <li
@@ -5707,6 +7271,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               target="_blank"
             >
               Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download Exome calling intervals flat file from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/resources/grch38/intervals/ukb.pad50.broad.pad50.union.intervals"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
             </a>
           </span>
         </li>


### PR DESCRIPTION
Resolves #1286 

Updates the v4 downloads to have Azure links now that the files have synced.