### PR TITLE
Take liftover into account when switching from v2 to v4 variants

### DIFF
--- a/browser/src/DatasetSelector.spec.tsx
+++ b/browser/src/DatasetSelector.spec.tsx
@@ -30,6 +30,7 @@ forAllDatasets('DataSelector with "%s" dataset selected', (datasetId) => {
             includeGnomad3: true,
             includeGnomad3Subsets: true,
             includeCopyNumberVariants: true,
+            includeGnomad4: true,
           }}
         />
       )

--- a/browser/src/DatasetSelector.tsx
+++ b/browser/src/DatasetSelector.tsx
@@ -433,9 +433,9 @@ class NavigationMenu extends Component<NavigationMenuProps, State> {
   }
 }
 
-type URLBuilder = (currentLocation: Location, targetDatasetId: DatasetId) => Location
+export type URLBuilder = (currentLocation: Location, targetDatasetId: DatasetId) => Location
 
-type DatasetOptions = {
+export type DatasetOptions = {
   includeShortVariants?: boolean
   includeStructuralVariants?: boolean
   includeExac?: boolean

--- a/browser/src/DatasetSelector.tsx
+++ b/browser/src/DatasetSelector.tsx
@@ -1,7 +1,6 @@
 // @ts-expect-error TS(2307) FIXME: Cannot find module '@fortawesome/fontawesome-free/... Remove this comment to see the full error message
 import CaretDown from '@fortawesome/fontawesome-free/svgs/solid/caret-down.svg'
 import { darken, transparentize } from 'polished'
-import PropTypes from 'prop-types'
 import queryString from 'query-string'
 import React, { Component } from 'react'
 import { Link, withRouter, RouteComponentProps } from 'react-router-dom'
@@ -434,6 +433,8 @@ class NavigationMenu extends Component<NavigationMenuProps, State> {
   }
 }
 
+type URLBuilder = (currentLocation: Location, targetDatasetId: DatasetId) => Location
+
 type DatasetOptions = {
   includeShortVariants?: boolean
   includeStructuralVariants?: boolean
@@ -444,22 +445,23 @@ type DatasetOptions = {
   includeGnomad3Subsets?: boolean
   includeGnomad4?: boolean
   includeCopyNumberVariants?: boolean
+  urlBuilder?: URLBuilder
 }
-
-type URLBuilder = (targetDatasetId: DatasetId) => Location
 
 type DatasetSelectorProps = {
   datasetOptions: DatasetOptions
   selectedDataset: DatasetId
   history: History
-  urlBuilder?: URLBuilder
 }
 
-const UnwrappedDatasetSelector = ({
-  datasetOptions,
-  history,
-  selectedDataset,
-}: DatasetSelectorProps) => {
+const datasetLink: URLBuilder = (currentLocation: Location, datasetId: DatasetId): Location => ({
+  ...currentLocation,
+  search: queryString.stringify({ dataset: datasetId }),
+})
+
+const UnwrappedDatasetSelector = (props: DatasetSelectorProps) => {
+  const { datasetOptions, history, selectedDataset } = props
+
   const {
     includeShortVariants = true,
     includeStructuralVariants = true,
@@ -470,12 +472,8 @@ const UnwrappedDatasetSelector = ({
     includeGnomad3Subsets = true,
     includeGnomad4 = true,
     includeCopyNumberVariants = true,
+    urlBuilder = datasetLink,
   } = datasetOptions
-
-  const datasetLink: URLBuilder = (datasetId: DatasetId): Location => ({
-    ...history.location,
-    search: queryString.stringify({ dataset: datasetId }),
-  })
 
   const topLevelShortVariantDataset = shortVariantDatasetId(selectedDataset)
 
@@ -487,7 +485,7 @@ const UnwrappedDatasetSelector = ({
         id: 'current_short_variant',
         isActive: hasShortVariants(selectedDataset),
         label: labelForDataset(topLevelShortVariantDataset),
-        url: datasetLink(topLevelShortVariantDataset),
+        url: urlBuilder(history.location, topLevelShortVariantDataset),
         childReferenceGenome: referenceGenome(topLevelShortVariantDataset),
       },
       {
@@ -504,7 +502,7 @@ const UnwrappedDatasetSelector = ({
       shortVariantDatasets[1].children.push({
         id: 'gnomad_r4',
         label: labelForDataset('gnomad_r4'),
-        url: datasetLink('gnomad_r4'),
+        url: urlBuilder(history.location, 'gnomad_r4'),
         description: `${sampleCounts.gnomad_r4.total.toLocaleString()} samples`,
         childReferenceGenome: referenceGenome('gnomad_r4'),
       })
@@ -514,7 +512,7 @@ const UnwrappedDatasetSelector = ({
       shortVariantDatasets[1].children.push({
         id: 'gnomad_r3',
         label: labelForDataset('gnomad_r3'),
-        url: datasetLink('gnomad_r3'),
+        url: urlBuilder(history.location, 'gnomad_r3'),
         description: `${sampleCounts.gnomad_r3.total.toLocaleString()} samples`,
         childReferenceGenome: referenceGenome('gnomad_r3'),
       })
@@ -525,35 +523,35 @@ const UnwrappedDatasetSelector = ({
         {
           id: 'gnomad_r3_non_cancer',
           label: labelForDataset('gnomad_r3_non_cancer'),
-          url: datasetLink('gnomad_r3_non_cancer'),
+          url: urlBuilder(history.location, 'gnomad_r3_non_cancer'),
           description: `${sampleCounts.gnomad_r3_non_cancer.total.toLocaleString()} samples`,
           childReferenceGenome: referenceGenome('gnomad_r3_non_cancer'),
         },
         {
           id: 'gnomad_r3_non_neuro',
           label: labelForDataset('gnomad_r3_non_neuro'),
-          url: datasetLink('gnomad_r3_non_neuro'),
+          url: urlBuilder(history.location, 'gnomad_r3_non_neuro'),
           description: `${sampleCounts.gnomad_r3_non_neuro.total.toLocaleString()} samples`,
           childReferenceGenome: referenceGenome('gnomad_r3_non_neuro'),
         },
         {
           id: 'gnomad_r3_non_v2',
           label: labelForDataset('gnomad_r3_non_v2'),
-          url: datasetLink('gnomad_r3_non_v2'),
+          url: urlBuilder(history.location, 'gnomad_r3_non_v2'),
           description: `${sampleCounts.gnomad_r3_non_v2.total.toLocaleString()} samples`,
           childReferenceGenome: referenceGenome('gnomad_r3_non_v2'),
         },
         {
           id: 'gnomad_r3_non_topmed',
           label: labelForDataset('gnomad_r3_non_topmed'),
-          url: datasetLink('gnomad_r3_non_topmed'),
+          url: urlBuilder(history.location, 'gnomad_r3_non_topmed'),
           description: `${sampleCounts.gnomad_r3_non_topmed.total.toLocaleString()} samples`,
           childReferenceGenome: referenceGenome('gnomad_r3_non_topmed'),
         },
         {
           id: 'gnomad_r3_controls_and_biobanks',
           label: labelForDataset('gnomad_r3_controls_and_biobanks'),
-          url: datasetLink('gnomad_r3_controls_and_biobanks'),
+          url: urlBuilder(history.location, 'gnomad_r3_controls_and_biobanks'),
           description: `${sampleCounts.gnomad_r3_controls_and_biobanks.total.toLocaleString()} samples`,
           childReferenceGenome: referenceGenome('gnomad_r3_controls_and_biobanks'),
         }
@@ -564,7 +562,7 @@ const UnwrappedDatasetSelector = ({
       shortVariantDatasets[1].children.push({
         id: 'gnomad_r2_1',
         label: labelForDataset('gnomad_r2_1'),
-        url: datasetLink('gnomad_r2_1'),
+        url: urlBuilder(history.location, 'gnomad_r2_1'),
         description: `${sampleCounts.gnomad_r2_1.total.toLocaleString()} samples`,
         childReferenceGenome: referenceGenome('gnomad_r2_1'),
       })
@@ -575,28 +573,28 @@ const UnwrappedDatasetSelector = ({
         {
           id: 'gnomad_r2_1_non_topmed',
           label: labelForDataset('gnomad_r2_1_non_topmed'),
-          url: datasetLink('gnomad_r2_1_non_topmed'),
+          url: urlBuilder(history.location, 'gnomad_r2_1_non_topmed'),
           description: `${sampleCounts.gnomad_r2_1_non_topmed.total.toLocaleString()} samples`,
           childReferenceGenome: referenceGenome('gnomad_r2_1_non_topmed'),
         },
         {
           id: 'gnomad_r2_1_non_cancer',
           label: labelForDataset('gnomad_r2_1_non_cancer'),
-          url: datasetLink('gnomad_r2_1_non_cancer'),
+          url: urlBuilder(history.location, 'gnomad_r2_1_non_cancer'),
           description: `${sampleCounts.gnomad_r2_1_non_cancer.total.toLocaleString()} samples`,
           childReferenceGenome: referenceGenome('gnomad_r2_1_non_cancer'),
         },
         {
           id: 'gnomad_r2_1_non_neuro',
           label: labelForDataset('gnomad_r2_1_non_neuro'),
-          url: datasetLink('gnomad_r2_1_non_neuro'),
+          url: urlBuilder(history.location, 'gnomad_r2_1_non_neuro'),
           description: `${sampleCounts.gnomad_r2_1_non_neuro.total.toLocaleString()} samples`,
           childReferenceGenome: referenceGenome('gnomad_r2_1_non_neuro'),
         },
         {
           id: 'gnomad_r2_1_controls',
           label: labelForDataset('gnomad_r2_1_controls'),
-          url: datasetLink('gnomad_r2_1_controls'),
+          url: urlBuilder(history.location, 'gnomad_r2_1_controls'),
           description: `${sampleCounts.gnomad_r2_1_controls.total.toLocaleString()} samples`,
           childReferenceGenome: referenceGenome('gnomad_r2_1_controls'),
         }
@@ -607,7 +605,7 @@ const UnwrappedDatasetSelector = ({
       shortVariantDatasets[1].children.push({
         id: 'exac',
         label: labelForDataset('exac'),
-        url: datasetLink('exac'),
+        url: urlBuilder(history.location, 'exac'),
         description: `${sampleCounts.exac.total.toLocaleString()} samples`,
         childReferenceGenome: referenceGenome('exac'),
       })
@@ -642,7 +640,7 @@ const UnwrappedDatasetSelector = ({
         id: 'current_sv_dataset',
         isActive: hasStructuralVariants(selectedDataset) || hasCopyNumberVariants(selectedDataset),
         label: labelForDataset(currentDataset),
-        url: datasetLink(currentDataset),
+        url: urlBuilder(history.location, currentDataset),
       },
       {
         id: 'other_structural_variant',
@@ -652,35 +650,35 @@ const UnwrappedDatasetSelector = ({
           {
             id: 'gnomad_sv_r4',
             label: labelForDataset('gnomad_sv_r4'),
-            url: datasetLink('gnomad_sv_r4'),
+            url: urlBuilder(history.location, 'gnomad_sv_r4'),
             description: `${sampleCounts.gnomad_sv_r4.total.toLocaleString()} samples, genome`,
             childReferenceGenome: referenceGenome('gnomad_sv_r4'),
           },
           {
             id: 'gnomad_sv_r2_1',
             label: labelForDataset('gnomad_sv_r2_1'),
-            url: datasetLink('gnomad_sv_r2_1'),
+            url: urlBuilder(history.location, 'gnomad_sv_r2_1'),
             description: `${sampleCounts.gnomad_sv_r2_1.total.toLocaleString()} samples, genome`,
             childReferenceGenome: referenceGenome('gnomad_sv_r2_1'),
           },
           {
             id: 'gnomad_sv_r2_1_non_neuro',
             label: labelForDataset('gnomad_sv_r2_1_non_neuro'),
-            url: datasetLink('gnomad_sv_r2_1_non_neuro'),
+            url: urlBuilder(history.location, 'gnomad_sv_r2_1_non_neuro'),
             description: `${sampleCounts.gnomad_sv_r2_1_non_neuro.total.toLocaleString()} samples, genome`,
             childReferenceGenome: referenceGenome('gnomad_sv_r2_1_non_neuro'),
           },
           {
             id: 'gnomad_sv_r2_1_controls',
             label: labelForDataset('gnomad_sv_r2_1_controls'),
-            url: datasetLink('gnomad_sv_r2_1_controls'),
+            url: urlBuilder(history.location, 'gnomad_sv_r2_1_controls'),
             description: `${sampleCounts.gnomad_sv_r2_1_controls.total.toLocaleString()} samples, genome`,
             childReferenceGenome: referenceGenome('gnomad_sv_r2_1_controls'),
           },
           {
             id: 'gnomad_cnv_r4',
             label: labelForDataset('gnomad_cnv_r4'),
-            url: datasetLink('gnomad_cnv_r4'),
+            url: urlBuilder(history.location, 'gnomad_cnv_r4'),
             description: `${sampleCounts.gnomad_cnv_r4.total.toLocaleString()} samples, exome, rare (<0.01)`,
             childReferenceGenome: referenceGenome('gnomad_cnv_r4'),
           },

--- a/browser/src/DatasetSelector.tsx
+++ b/browser/src/DatasetSelector.tsx
@@ -4,8 +4,10 @@ import { darken, transparentize } from 'polished'
 import PropTypes from 'prop-types'
 import queryString from 'query-string'
 import React, { Component } from 'react'
-import { Link, withRouter } from 'react-router-dom'
+import { Link, withRouter, RouteComponentProps } from 'react-router-dom'
 import styled from 'styled-components'
+import { History, Location } from 'history'
+
 import sampleCounts from '@gnomad/dataset-metadata/sampleCounts'
 
 import {
@@ -144,12 +146,12 @@ const GroupedNav = styled.div`
 type ChildDataset = {
   id: string
   label: string
-  url: string
+  url: Location
   description: string
   childReferenceGenome?: string
 }
 
-type Props = {
+type NavigationMenuProps = {
   items: {
     id: string
     isActive?: boolean
@@ -161,14 +163,14 @@ type Props = {
 
 type State = any
 
-class NavigationMenu extends Component<Props, State> {
+class NavigationMenu extends Component<NavigationMenuProps, State> {
   container: any
 
   state = {
     expandedItem: null,
   }
 
-  constructor(props: Props) {
+  constructor(props: NavigationMenuProps) {
     super(props)
 
     this.container = React.createRef()
@@ -432,7 +434,32 @@ class NavigationMenu extends Component<Props, State> {
   }
 }
 
-const DatasetSelector = withRouter(({ datasetOptions, history, selectedDataset }: any) => {
+type DatasetOptions = {
+  includeShortVariants?: boolean
+  includeStructuralVariants?: boolean
+  includeExac?: boolean
+  includeGnomad2?: boolean
+  includeGnomad2Subsets?: boolean
+  includeGnomad3?: boolean
+  includeGnomad3Subsets?: boolean
+  includeGnomad4?: boolean
+  includeCopyNumberVariants?: boolean
+}
+
+type URLBuilder = (targetDatasetId: DatasetId) => Location
+
+type DatasetSelectorProps = {
+  datasetOptions: DatasetOptions
+  selectedDataset: DatasetId
+  history: History
+  urlBuilder?: URLBuilder
+}
+
+const UnwrappedDatasetSelector = ({
+  datasetOptions,
+  history,
+  selectedDataset,
+}: DatasetSelectorProps) => {
   const {
     includeShortVariants = true,
     includeStructuralVariants = true,
@@ -445,7 +472,7 @@ const DatasetSelector = withRouter(({ datasetOptions, history, selectedDataset }
     includeCopyNumberVariants = true,
   } = datasetOptions
 
-  const datasetLink = (datasetId: DatasetId) => ({
+  const datasetLink: URLBuilder = (datasetId: DatasetId): Location => ({
     ...history.location,
     search: queryString.stringify({ dataset: datasetId }),
   })
@@ -663,32 +690,11 @@ const DatasetSelector = withRouter(({ datasetOptions, history, selectedDataset }
   }
 
   return <NavigationMenu items={datasets} />
-})
-
-DatasetSelector.propTypes = {
-  datasetOptions: PropTypes.shape({
-    includeShortVariants: PropTypes.bool,
-    includeStructuralVariants: PropTypes.bool,
-    includeCopyNumberVariants: PropTypes.bool,
-    includeExac: PropTypes.bool,
-    includeGnomad2Subsets: PropTypes.bool,
-    includeGnomad3: PropTypes.bool,
-    includeGnomad3Subsets: PropTypes.bool,
-  }),
-  selectedDataset: PropTypes.string.isRequired,
 }
 
-DatasetSelector.defaultProps = {
-  datasetOptions: {
-    includeShortVariants: true,
-    includeStructuralVariants: true,
-    includeCopyNumberVariants: true,
-    includeExac: true,
-    includeGnomad2: true,
-    includeGnomad2Subsets: true,
-    includeGnomad3: true,
-    includeGnomad3Subsets: true,
-  },
-}
+const DatasetSelector = withRouter<
+  RouteComponentProps & DatasetSelectorProps,
+  typeof UnwrappedDatasetSelector
+>(UnwrappedDatasetSelector)
 
 export default DatasetSelector

--- a/browser/src/DatasetSelector.tsx
+++ b/browser/src/DatasetSelector.tsx
@@ -9,6 +9,7 @@ import styled from 'styled-components'
 import sampleCounts from '@gnomad/dataset-metadata/sampleCounts'
 
 import {
+  DatasetId,
   labelForDataset,
   hasShortVariants,
   hasStructuralVariants,
@@ -444,7 +445,7 @@ const DatasetSelector = withRouter(({ datasetOptions, history, selectedDataset }
     includeCopyNumberVariants = true,
   } = datasetOptions
 
-  const datasetLink = (datasetId: any) => ({
+  const datasetLink = (datasetId: DatasetId) => ({
     ...history.location,
     search: queryString.stringify({ dataset: datasetId }),
   })

--- a/browser/src/GnomadPageHeading.tsx
+++ b/browser/src/GnomadPageHeading.tsx
@@ -1,8 +1,10 @@
 import React from 'react'
 import styled from 'styled-components'
 
-import DatasetSelector from './DatasetSelector'
+import DatasetSelector, { DatasetOptions } from './DatasetSelector'
 import InfoButton from './help/InfoButton'
+
+import { DatasetId } from '@gnomad/dataset-metadata/metadata'
 
 const PageHeadingWrapper = styled.div`
   display: flex;
@@ -78,19 +80,13 @@ const Label = styled.span`
   margin-right: 0.5em;
 `
 
-/*
-(ts-migrate) TODO: Migrate the remaining prop types
-...DatasetSelector.propTypes
-*/
-type OwnProps = {
+type Props = {
   children: React.ReactNode
   extra?: React.ReactNode
+  datasetOptions: DatasetOptions
+  selectedDataset: DatasetId
 }
 
-// @ts-expect-error TS(2456) FIXME: Type alias 'Props' circularly references itself.
-type Props = OwnProps & typeof GnomadPageHeading.defaultProps
-
-// @ts-expect-error TS(7022) FIXME: 'GnomadPageHeading' implicitly has type 'any' beca... Remove this comment to see the full error message
 const GnomadPageHeading = ({ children, extra, datasetOptions, selectedDataset }: Props) => (
   <PageHeadingWrapper>
     <PageHeadingInnerWrapper>

--- a/browser/src/Routes.tsx
+++ b/browser/src/Routes.tsx
@@ -6,6 +6,7 @@ import { isRegionId, normalizeRegionId } from '@gnomad/identifiers'
 import { Page, PageHeading } from '@gnomad/ui'
 
 import DocumentTitle from './DocumentTitle'
+import { DatasetId } from '@gnomad/dataset-metadata/metadata'
 
 // Content pages
 const AboutPage = lazy(() => import('./AboutPage'))
@@ -30,6 +31,7 @@ const ShortTandemRepeatsPage = lazy(() => import('./ShortTandemRepeatsPage/Short
 const VariantCooccurrencePage = lazy(
   () => import('./VariantCooccurrencePage/VariantCooccurrencePage')
 )
+const LiftoverDisambiguationPage = lazy(() => import('./VariantPage/LiftoverDisambiguationPage'))
 
 // Other pages
 const PageNotFoundPage = lazy(() => import('./PageNotFoundPage'))
@@ -106,6 +108,24 @@ const Routes = () => {
         }}
       />
 
+      <Route
+        exact
+        path="/variant/liftover/:fromVariantId/:fromDatasetId/:toDatasetId"
+        render={({ match }) => {
+          const { fromVariantId, fromDatasetId, toDatasetId } = match.params as {
+            fromVariantId: string
+            fromDatasetId: DatasetId
+            toDatasetId: DatasetId
+          }
+          return (
+            <LiftoverDisambiguationPage
+              fromVariantId={fromVariantId}
+              fromDatasetId={fromDatasetId}
+              toDatasetId={toDatasetId}
+            />
+          )
+        }}
+      />
       <Route
         exact
         path="/variant/:variantId"

--- a/browser/src/VariantCooccurrencePage/VariantCooccurrencePage.tsx
+++ b/browser/src/VariantCooccurrencePage/VariantCooccurrencePage.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components'
 import { Badge, ExternalLink, List, ListItem, Page } from '@gnomad/ui'
 
 import { GNOMAD_POPULATION_NAMES } from '@gnomad/dataset-metadata/gnomadPopulations'
+import { DatasetId } from '@gnomad/dataset-metadata/metadata'
 
 import DocumentTitle from '../DocumentTitle'
 import GnomadPageHeading from '../GnomadPageHeading'
@@ -430,7 +431,7 @@ const VariantCoocurrenceContainer = ({
 }
 
 type VariantCoocurrencePageProps = {
-  datasetId: string
+  datasetId: DatasetId
 }
 
 const VariantCoocurrencePage = ({ datasetId }: VariantCoocurrencePageProps) => {

--- a/browser/src/VariantPage/LiftoverDisambiguationPage.spec.tsx
+++ b/browser/src/VariantPage/LiftoverDisambiguationPage.spec.tsx
@@ -1,0 +1,242 @@
+import React from 'react'
+import { jest, describe, expect, test, beforeEach, afterEach } from '@jest/globals'
+import renderer from 'react-test-renderer'
+import { mockQueries } from '../../../tests/__helpers__/queries'
+import { withDummyRouter } from '../../../tests/__helpers__/router'
+import Query, { BaseQuery } from '../Query'
+import LiftoverDisambiguationPage from './LiftoverDisambiguationPage'
+import { createMemoryHistory } from 'history'
+
+import {
+  DatasetId,
+  allDatasetIds,
+  isLiftoverSource,
+  isLiftoverTarget,
+} from '@gnomad/dataset-metadata/metadata'
+
+jest.mock('../Query', () => {
+  const originalModule = jest.requireActual('../Query')
+
+  return {
+    __esModule: true,
+    ...(originalModule as object),
+    default: jest.fn(),
+    BaseQuery: jest.fn(),
+  }
+})
+
+const {
+  resetMockApiCalls,
+  resetMockApiResponses,
+  simulateApiResponse,
+  setMockApiResponses,
+  mockApiCalls,
+} = mockQueries()
+
+beforeEach(() => {
+  Query.mockImplementation(
+    jest.fn(({ query, children, operationName, variables }) =>
+      simulateApiResponse('Query', query, children, operationName, variables)
+    )
+  )
+  ;(BaseQuery as any).mockImplementation(
+    jest.fn(({ query, children, operationName, variables }) =>
+      simulateApiResponse('BaseQuery', query, children, operationName, variables)
+    )
+  )
+})
+
+afterEach(() => {
+  resetMockApiCalls()
+  resetMockApiResponses()
+})
+
+const liftoverSourceDatasets = allDatasetIds.filter(isLiftoverSource)
+const liftoverTargetDatasets = allDatasetIds.filter(isLiftoverTarget)
+
+describe('LiftoverDisambiguationPage', () => {
+  describe.each(liftoverSourceDatasets)(
+    'starting from liftover source dataset %s',
+    (fromDatasetId: DatasetId) => {
+      test('makes the correct query', () => {
+        setMockApiResponses({
+          LiftoverDisambiguation: () => ({}),
+        })
+
+        renderer.create(
+          withDummyRouter(
+            <LiftoverDisambiguationPage
+              fromVariantId="fakevariant"
+              fromDatasetId={fromDatasetId}
+              toDatasetId="gnomad_r4"
+            />
+          )
+        )
+
+        const queries = mockApiCalls()
+        expect(queries.length).toEqual(1)
+
+        const query = queries[0]
+        expect(query.operationName).toEqual('LiftoverDisambiguation')
+        expect(query.variables.source_variant_id).toEqual('fakevariant')
+        expect(query.variables.liftover_variant_id).toEqual(undefined)
+        expect(query.variables.reference_genome).toEqual('GRCh37')
+      })
+      test('has appropriate message if no corresponding variant found', () => {
+        setMockApiResponses({
+          LiftoverDisambiguation: () => ({ liftover: [] }),
+        })
+
+        const tree = renderer.create(
+          withDummyRouter(
+            <LiftoverDisambiguationPage
+              fromVariantId="fakevariant"
+              fromDatasetId={fromDatasetId}
+              toDatasetId="gnomad_r4"
+            />
+          )
+        )
+        expect(tree).toMatchSnapshot()
+      })
+
+      test('redirects if one corresponding variant found', () => {
+        setMockApiResponses({
+          LiftoverDisambiguation: () => ({
+            liftover: [{ liftover: { variant_id: 'source1' } }],
+          }),
+        })
+
+        const history = createMemoryHistory()
+
+        const router = withDummyRouter(
+          <LiftoverDisambiguationPage
+            fromVariantId="fakevariant"
+            fromDatasetId={fromDatasetId}
+            toDatasetId="gnomad_r4"
+          />,
+          history
+        )
+        renderer.create(router)
+        const { location } = history
+        expect(location.pathname).toEqual('/variant/source1')
+        expect(location.search).toEqual('?dataset=gnomad_r4')
+      })
+
+      test('renders links to each variant if multiple corresponding variants found', () => {
+        setMockApiResponses({
+          LiftoverDisambiguation: () => ({
+            liftover: [
+              { liftover: { variant_id: 'source1' } },
+              { liftover: { variant_id: 'source2' } },
+            ],
+          }),
+        })
+
+        const tree = renderer.create(
+          withDummyRouter(
+            <LiftoverDisambiguationPage
+              fromVariantId="fakevariant"
+              fromDatasetId={fromDatasetId}
+              toDatasetId="gnomad_r4"
+            />
+          )
+        )
+
+        expect(tree).toMatchSnapshot()
+      })
+    }
+  )
+
+  describe.each(liftoverTargetDatasets)(
+    'starting from liftover target dataset %s',
+    (fromDatasetId: DatasetId) => {
+      test('makes the correct query', () => {
+        setMockApiResponses({
+          LiftoverDisambiguation: () => ({}),
+        })
+
+        renderer.create(
+          withDummyRouter(
+            <LiftoverDisambiguationPage
+              fromVariantId="fakevariant"
+              fromDatasetId={fromDatasetId}
+              toDatasetId="gnomad_r2_1"
+            />
+          )
+        )
+
+        const queries = mockApiCalls()
+        expect(queries.length).toEqual(1)
+
+        const query = queries[0]
+        expect(query.operationName).toEqual('LiftoverDisambiguation')
+        expect(query.variables.source_variant_id).toEqual(undefined)
+        expect(query.variables.liftover_variant_id).toEqual('fakevariant')
+        expect(query.variables.reference_genome).toEqual('GRCh38')
+      })
+
+      test('has appropriate message if no corresponding variant found', () => {
+        setMockApiResponses({
+          LiftoverDisambiguation: () => ({ liftover: [] }),
+        })
+
+        const tree = renderer.create(
+          withDummyRouter(
+            <LiftoverDisambiguationPage
+              fromVariantId="fakevariant"
+              fromDatasetId={fromDatasetId}
+              toDatasetId="gnomad_r2_1"
+            />
+          )
+        )
+        expect(tree).toMatchSnapshot()
+      })
+
+      test('redirects if one corresponding variant found', () => {
+        setMockApiResponses({
+          LiftoverDisambiguation: () => ({
+            liftover: [{ source: { variant_id: 'source1' } }],
+          }),
+        })
+
+        const history = createMemoryHistory()
+
+        const router = withDummyRouter(
+          <LiftoverDisambiguationPage
+            fromVariantId="fakevariant"
+            fromDatasetId={fromDatasetId}
+            toDatasetId="gnomad_r2_1"
+          />,
+          history
+        )
+        renderer.create(router)
+        const { location } = history
+        expect(location.pathname).toEqual('/variant/source1')
+        expect(location.search).toEqual('?dataset=gnomad_r2_1')
+      })
+
+      test('renders links to each variant if multiple corresponding variants found', () => {
+        setMockApiResponses({
+          LiftoverDisambiguation: () => ({
+            liftover: [
+              { source: { variant_id: 'source1' } },
+              { source: { variant_id: 'source2' } },
+            ],
+          }),
+        })
+
+        const tree = renderer.create(
+          withDummyRouter(
+            <LiftoverDisambiguationPage
+              fromVariantId="fakevariant"
+              fromDatasetId={fromDatasetId}
+              toDatasetId="gnomad_r2_1"
+            />
+          )
+        )
+
+        expect(tree).toMatchSnapshot()
+      })
+    }
+  )
+})

--- a/browser/src/VariantPage/LiftoverDisambiguationPage.tsx
+++ b/browser/src/VariantPage/LiftoverDisambiguationPage.tsx
@@ -1,0 +1,140 @@
+import React from 'react'
+import {
+  DatasetId,
+  labelForDataset,
+  referenceGenome,
+  isLiftoverSource,
+  baseDatasetForReferenceGenome,
+} from '@gnomad/dataset-metadata/metadata'
+import { TrackPage, TrackPageSection } from '../TrackPage'
+import DocumentTitle from '../DocumentTitle'
+import { BaseQuery } from '../Query'
+import Delayed from '../Delayed'
+import StatusMessage from '../StatusMessage'
+import Link from '../Link'
+import { Redirect } from 'react-router-dom'
+
+type LiftoverDisambiguationPageProps = {
+  fromVariantId: string
+  fromDatasetId: DatasetId
+  toDatasetId: DatasetId
+}
+
+type CorrespondingVariantField = 'liftover' | 'source'
+
+const LiftoverDisambiguationPage = ({
+  fromVariantId,
+  fromDatasetId,
+  toDatasetId,
+}: LiftoverDisambiguationPageProps) => {
+  const fromLabel = labelForDataset(fromDatasetId)
+  const fromReferenceGenome = referenceGenome(fromDatasetId)
+  const toReferenceGenome = referenceGenome(toDatasetId)
+
+  const operationName = 'LiftoverDisambiguation'
+  const correspondingVariantField: CorrespondingVariantField = isLiftoverSource(fromDatasetId)
+    ? 'liftover'
+    : 'source'
+  const disambiguationQuery = `
+query ${operationName}($source_variant_id: String, $liftover_variant_id: String, $reference_genome: ReferenceGenomeId!) {
+  liftover(source_variant_id: $source_variant_id, liftover_variant_id: $liftover_variant_id, reference_genome: $reference_genome) {
+	${correspondingVariantField} {
+	  variant_id
+	}
+    }
+  }
+`
+
+  const baseQueryVariables = { reference_genome: referenceGenome(fromDatasetId) }
+  const queryVariables =
+    fromReferenceGenome === 'GRCh37'
+      ? { ...baseQueryVariables, source_variant_id: fromVariantId }
+      : { ...baseQueryVariables, liftover_variant_id: fromVariantId }
+
+  return (
+    <TrackPage>
+      <TrackPageSection>
+        <DocumentTitle
+          title={`${fromVariantId} liftover | ${fromReferenceGenome} to ${toReferenceGenome}`}
+        />
+        <>
+          Due to liftover, variant {fromVariantId} in dataset {fromLabel} may correspond to a
+          different variant or variants in {toReferenceGenome}.
+        </>
+        <BaseQuery
+          operationName="LiftoverDisambiguation"
+          query={disambiguationQuery}
+          variables={queryVariables}
+        >
+          {({ data, error, graphQLErrors, loading }: any) => {
+            let pageContent = null
+            if (loading) {
+              pageContent = (
+                <Delayed>
+                  <StatusMessage>Loading corresponding variants...</StatusMessage>
+                </Delayed>
+              )
+            } else if (error) {
+              pageContent = <StatusMessage>Unable to load corresponding variants</StatusMessage>
+            } else if (!(data || {}).liftover) {
+              pageContent = (
+                <StatusMessage>
+                  {graphQLErrors && graphQLErrors.length
+                    ? Array.from(
+                        new Set(
+                          graphQLErrors
+                            .filter((e: any) => !e.message.includes('ClinVar'))
+                            .map((e: any) => e.message)
+                        )
+                      ).join(', ')
+                    : 'Unable to load corresponding variants'}
+                </StatusMessage>
+              )
+            } else if (data.liftover.length === 0) {
+              pageContent = <StatusMessage>No corresponding variants found</StatusMessage>
+            } else if (data.liftover.length === 1) {
+              pageContent = (
+                <Redirect
+                  to={{
+                    pathname: `/variant/${data.liftover[0][correspondingVariantField].variant_id}`,
+                    search: `dataset=${baseDatasetForReferenceGenome(toReferenceGenome)}`,
+                  }}
+                />
+              )
+            } else {
+              pageContent = (
+                <>
+                  <ul>
+                    {data.liftover.map(
+                      (
+                        correspondingVariant: Record<
+                          CorrespondingVariantField,
+                          { variant_id: string } | undefined
+                        >
+                      ) => {
+                        const variantId =
+                          correspondingVariant[correspondingVariantField]!.variant_id
+                        const datasetToLink = baseDatasetForReferenceGenome(toReferenceGenome)
+                        return (
+                          <li key={variantId}>
+                            <Link to={`/variant/${variantId}?dataset=${datasetToLink}`}>
+                              {variantId}
+                            </Link>
+                          </li>
+                        )
+                      }
+                    )}
+                  </ul>
+                </>
+              )
+            }
+
+            return <>{pageContent}</>
+          }}
+        </BaseQuery>
+      </TrackPageSection>
+    </TrackPage>
+  )
+}
+
+export default LiftoverDisambiguationPage

--- a/browser/src/VariantPage/LiftoverDisambiguationPage.tsx
+++ b/browser/src/VariantPage/LiftoverDisambiguationPage.tsx
@@ -117,7 +117,10 @@ query ${operationName}($source_variant_id: String, $liftover_variant_id: String,
                         const datasetToLink = baseDatasetForReferenceGenome(toReferenceGenome)
                         return (
                           <li key={variantId}>
-                            <Link to={`/variant/${variantId}?dataset=${datasetToLink}`}>
+                            <Link
+                              to={`/variant/${variantId}?dataset=${datasetToLink}`}
+                              preserveSelectedDataset={false}
+                            >
                               {variantId}
                             </Link>
                           </li>

--- a/browser/src/VariantPage/VariantLiftover.tsx
+++ b/browser/src/VariantPage/VariantLiftover.tsx
@@ -6,32 +6,17 @@ import { parseVariantId } from '@gnomad/identifiers'
 import { labelForDataset } from '@gnomad/dataset-metadata/metadata'
 import Link from '../Link'
 
-type Props = {
-  variant: {
-    reference_genome: 'GRCh37' | 'GRCh38'
-    liftover?: {
-      liftover: {
-        variant_id: string
-      }
-      datasets: string[]
-    }[]
-    liftover_sources?: {
-      source: {
-        variant_id: string
-      }
-      datasets: string[]
-    }[]
-  }
-}
+import { Variant } from './VariantPage'
+
+type Props = { variant: Variant }
 
 const VariantLiftover = ({ variant }: Props) => {
-  if ((variant.liftover || []).length > 0) {
+  if (variant.liftover && variant.liftover.length > 0) {
     const liftoverTargetReferenceGenome =
       variant.reference_genome === 'GRCh37' ? 'GRCh38' : 'GRCh37'
     const liftoverTargetDataset =
       variant.reference_genome === 'GRCh37' ? 'gnomad_r4' : 'gnomad_r2_1'
 
-    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     const isPlural = variant.liftover.length > 1
     return (
       <>
@@ -41,7 +26,6 @@ const VariantLiftover = ({ variant }: Props) => {
         </p>
 
         <ul>
-          {/* @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'. */}
           {variant.liftover.map((l) => {
             const { chrom, pos } = parseVariantId(l.liftover.variant_id)
             return (
@@ -77,13 +61,12 @@ const VariantLiftover = ({ variant }: Props) => {
     )
   }
 
-  if ((variant.liftover_sources || []).length > 0) {
+  if (variant.liftover_sources && variant.liftover_sources.length > 0) {
     const liftoverSourceReferenceGenome =
       variant.reference_genome === 'GRCh37' ? 'GRCh38' : 'GRCh37'
     const liftoverSourceDataset =
       variant.reference_genome === 'GRCh37' ? 'gnomad_r4' : 'gnomad_r2_1'
 
-    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     const isPlural = variant.liftover_sources.length > 1
     return (
       <>
@@ -93,7 +76,6 @@ const VariantLiftover = ({ variant }: Props) => {
         </p>
 
         <ul>
-          {/* @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'. */}
           {variant.liftover_sources.map((l) => {
             const { chrom, pos } = parseVariantId(l.source.variant_id)
             return (

--- a/browser/src/VariantPage/VariantPage.tsx
+++ b/browser/src/VariantPage/VariantPage.tsx
@@ -257,6 +257,20 @@ export type Coverage = {
   over_100: number | null
 }
 
+type Liftover = {
+  liftover: {
+    variant_id: string
+  }
+  datasets: string[]
+}
+
+type LiftoverSource = {
+  source: {
+    variant_id: string
+  }
+  datasets: string[]
+}
+
 export type Variant = {
   variant_id: string
   reference_genome: ReferenceGenome
@@ -273,8 +287,8 @@ export type Variant = {
   lof_curations: LofCuration[] | null
   in_silico_predictors: InSilicoPredictor[] | null
   transcript_consequences: TranscriptConsequence[] | null
-  liftover: any[] | null
-  liftover_sources: any[] | null
+  liftover: Liftover[] | null
+  liftover_sources: LiftoverSource[] | null
   multi_nucleotide_variants?: any[]
   caid: string | null
   rsids: string[] | null

--- a/browser/src/VariantPage/VariantPage.tsx
+++ b/browser/src/VariantPage/VariantPage.tsx
@@ -44,6 +44,7 @@ import VariantPopulationFrequencies from './VariantPopulationFrequencies'
 import VariantRelatedVariants from './VariantRelatedVariants'
 import VariantSiteQualityMetrics from './VariantSiteQualityMetrics'
 import VariantTranscriptConsequences from './VariantTranscriptConsequences'
+import { URLBuilder } from '../DatasetSelector'
 
 const Section = styled.section`
   width: 100%;
@@ -842,6 +843,24 @@ const VariantPage = ({ datasetId, variantId }: VariantPageProps) => {
             pageContent = <VariantPageContent datasetId={datasetId} variant={variant} />
           }
 
+          const datasetLinkWithLiftover: URLBuilder = (currentLocation, toDatasetId) => {
+            const needsLiftoverDisambiguation =
+              (isLiftoverSource(datasetId) && isLiftoverTarget(toDatasetId)) ||
+              (isLiftoverSource(toDatasetId) && isLiftoverTarget(datasetId))
+
+            return needsLiftoverDisambiguation
+              ? {
+                  ...currentLocation,
+                  pathname: `/variant/liftover/${variantId}/${datasetId}/${toDatasetId}`,
+                  search: '',
+                }
+              : {
+                  ...currentLocation,
+                  pathname: `/variant/${variantId}`,
+                  search: `?dataset=${toDatasetId}`,
+                }
+          }
+
           return (
             <React.Fragment>
               <GnomadPageHeading
@@ -854,6 +873,7 @@ const VariantPage = ({ datasetId, variantId }: VariantPageProps) => {
                   // Variant ID not valid for SVs
                   includeStructuralVariants: false,
                   includeCopyNumberVariants: false,
+                  urlBuilder: datasetLinkWithLiftover,
                 }}
                 selectedDataset={datasetId}
                 extra={

--- a/browser/src/VariantPage/VariantPage.tsx
+++ b/browser/src/VariantPage/VariantPage.tsx
@@ -14,7 +14,6 @@ import {
   isLiftoverSource,
   isLiftoverTarget,
   usesGrch37,
-  usesGrch38,
   isV3,
   isV3Subset,
   isV4,
@@ -868,8 +867,8 @@ const VariantPage = ({ datasetId, variantId }: VariantPageProps) => {
                   // Include ExAC for GRCh37 datasets
                   includeExac: usesGrch37(datasetId),
                   // Include gnomAD versions based on the same reference genome as the current dataset
-                  includeGnomad2: usesGrch37(datasetId),
-                  includeGnomad3: usesGrch38(datasetId),
+                  includeGnomad2: true,
+                  includeGnomad3: true,
                   // Variant ID not valid for SVs
                   includeStructuralVariants: false,
                   includeCopyNumberVariants: false,

--- a/browser/src/VariantPage/VariantRelatedVariants.tsx
+++ b/browser/src/VariantPage/VariantRelatedVariants.tsx
@@ -105,7 +105,6 @@ const VariantRelatedVariants = ({ datasetId, variant }: VariantRelatedVariantsPr
       {(variant.liftover || variant.liftover_sources || []).length > 0 && (
         <Item>
           <h3>Liftover</h3>
-          {/* @ts-expect-error TS(2741) FIXME: Property 'reference_genome' is missing in type '{ ... Remove this comment to see the full error message */}
           <VariantLiftover variant={variant} />
         </Item>
       )}

--- a/browser/src/VariantPage/__snapshots__/LiftoverDisambiguationPage.spec.tsx.snap
+++ b/browser/src/VariantPage/__snapshots__/LiftoverDisambiguationPage.spec.tsx.snap
@@ -1,0 +1,367 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LiftoverDisambiguationPage starting from liftover source dataset gnomad_r2_1 has appropriate message if no corresponding variant found 1`] = `
+<div
+  className="Page-w7h773-0 TrackPage-sc-1xq3qi7-0 dWdnsu"
+>
+  <div
+    className="TrackPage__TrackPageSection-sc-1xq3qi7-1 fQVUsz"
+  >
+    Due to liftover, variant 
+    fakevariant
+     in dataset 
+    gnomAD v2.1.1
+     may correspond to a different variant or variants in 
+    GRCh38
+    .
+    <div
+      className="StatusMessage-sc-neg7mh-0 hJFlwG"
+    >
+      No corresponding variants found
+    </div>
+  </div>
+</div>
+`;
+
+exports[`LiftoverDisambiguationPage starting from liftover source dataset gnomad_r2_1 renders links to each variant if multiple corresponding variants found 1`] = `
+<div
+  className="Page-w7h773-0 TrackPage-sc-1xq3qi7-0 dWdnsu"
+>
+  <div
+    className="TrackPage__TrackPageSection-sc-1xq3qi7-1 fQVUsz"
+  >
+    Due to liftover, variant 
+    fakevariant
+     in dataset 
+    gnomAD v2.1.1
+     may correspond to a different variant or variants in 
+    GRCh38
+    .
+    <ul>
+      <li>
+        <a
+          className="Link-sc-14lgydv-0-Link jBvaYQ"
+          href="/variant/source1?dataset=gnomad_r4"
+          onClick={[Function]}
+        >
+          source1
+        </a>
+      </li>
+      <li>
+        <a
+          className="Link-sc-14lgydv-0-Link jBvaYQ"
+          href="/variant/source2?dataset=gnomad_r4"
+          onClick={[Function]}
+        >
+          source2
+        </a>
+      </li>
+    </ul>
+  </div>
+</div>
+`;
+
+exports[`LiftoverDisambiguationPage starting from liftover source dataset gnomad_r2_1_controls has appropriate message if no corresponding variant found 1`] = `
+<div
+  className="Page-w7h773-0 TrackPage-sc-1xq3qi7-0 dWdnsu"
+>
+  <div
+    className="TrackPage__TrackPageSection-sc-1xq3qi7-1 fQVUsz"
+  >
+    Due to liftover, variant 
+    fakevariant
+     in dataset 
+    gnomAD v2.1.1 (controls)
+     may correspond to a different variant or variants in 
+    GRCh38
+    .
+    <div
+      className="StatusMessage-sc-neg7mh-0 hJFlwG"
+    >
+      No corresponding variants found
+    </div>
+  </div>
+</div>
+`;
+
+exports[`LiftoverDisambiguationPage starting from liftover source dataset gnomad_r2_1_controls renders links to each variant if multiple corresponding variants found 1`] = `
+<div
+  className="Page-w7h773-0 TrackPage-sc-1xq3qi7-0 dWdnsu"
+>
+  <div
+    className="TrackPage__TrackPageSection-sc-1xq3qi7-1 fQVUsz"
+  >
+    Due to liftover, variant 
+    fakevariant
+     in dataset 
+    gnomAD v2.1.1 (controls)
+     may correspond to a different variant or variants in 
+    GRCh38
+    .
+    <ul>
+      <li>
+        <a
+          className="Link-sc-14lgydv-0-Link jBvaYQ"
+          href="/variant/source1?dataset=gnomad_r4"
+          onClick={[Function]}
+        >
+          source1
+        </a>
+      </li>
+      <li>
+        <a
+          className="Link-sc-14lgydv-0-Link jBvaYQ"
+          href="/variant/source2?dataset=gnomad_r4"
+          onClick={[Function]}
+        >
+          source2
+        </a>
+      </li>
+    </ul>
+  </div>
+</div>
+`;
+
+exports[`LiftoverDisambiguationPage starting from liftover source dataset gnomad_r2_1_non_cancer has appropriate message if no corresponding variant found 1`] = `
+<div
+  className="Page-w7h773-0 TrackPage-sc-1xq3qi7-0 dWdnsu"
+>
+  <div
+    className="TrackPage__TrackPageSection-sc-1xq3qi7-1 fQVUsz"
+  >
+    Due to liftover, variant 
+    fakevariant
+     in dataset 
+    gnomAD v2.1.1 (non-cancer)
+     may correspond to a different variant or variants in 
+    GRCh38
+    .
+    <div
+      className="StatusMessage-sc-neg7mh-0 hJFlwG"
+    >
+      No corresponding variants found
+    </div>
+  </div>
+</div>
+`;
+
+exports[`LiftoverDisambiguationPage starting from liftover source dataset gnomad_r2_1_non_cancer renders links to each variant if multiple corresponding variants found 1`] = `
+<div
+  className="Page-w7h773-0 TrackPage-sc-1xq3qi7-0 dWdnsu"
+>
+  <div
+    className="TrackPage__TrackPageSection-sc-1xq3qi7-1 fQVUsz"
+  >
+    Due to liftover, variant 
+    fakevariant
+     in dataset 
+    gnomAD v2.1.1 (non-cancer)
+     may correspond to a different variant or variants in 
+    GRCh38
+    .
+    <ul>
+      <li>
+        <a
+          className="Link-sc-14lgydv-0-Link jBvaYQ"
+          href="/variant/source1?dataset=gnomad_r4"
+          onClick={[Function]}
+        >
+          source1
+        </a>
+      </li>
+      <li>
+        <a
+          className="Link-sc-14lgydv-0-Link jBvaYQ"
+          href="/variant/source2?dataset=gnomad_r4"
+          onClick={[Function]}
+        >
+          source2
+        </a>
+      </li>
+    </ul>
+  </div>
+</div>
+`;
+
+exports[`LiftoverDisambiguationPage starting from liftover source dataset gnomad_r2_1_non_neuro has appropriate message if no corresponding variant found 1`] = `
+<div
+  className="Page-w7h773-0 TrackPage-sc-1xq3qi7-0 dWdnsu"
+>
+  <div
+    className="TrackPage__TrackPageSection-sc-1xq3qi7-1 fQVUsz"
+  >
+    Due to liftover, variant 
+    fakevariant
+     in dataset 
+    gnomAD v2.1.1 (non-neuro)
+     may correspond to a different variant or variants in 
+    GRCh38
+    .
+    <div
+      className="StatusMessage-sc-neg7mh-0 hJFlwG"
+    >
+      No corresponding variants found
+    </div>
+  </div>
+</div>
+`;
+
+exports[`LiftoverDisambiguationPage starting from liftover source dataset gnomad_r2_1_non_neuro renders links to each variant if multiple corresponding variants found 1`] = `
+<div
+  className="Page-w7h773-0 TrackPage-sc-1xq3qi7-0 dWdnsu"
+>
+  <div
+    className="TrackPage__TrackPageSection-sc-1xq3qi7-1 fQVUsz"
+  >
+    Due to liftover, variant 
+    fakevariant
+     in dataset 
+    gnomAD v2.1.1 (non-neuro)
+     may correspond to a different variant or variants in 
+    GRCh38
+    .
+    <ul>
+      <li>
+        <a
+          className="Link-sc-14lgydv-0-Link jBvaYQ"
+          href="/variant/source1?dataset=gnomad_r4"
+          onClick={[Function]}
+        >
+          source1
+        </a>
+      </li>
+      <li>
+        <a
+          className="Link-sc-14lgydv-0-Link jBvaYQ"
+          href="/variant/source2?dataset=gnomad_r4"
+          onClick={[Function]}
+        >
+          source2
+        </a>
+      </li>
+    </ul>
+  </div>
+</div>
+`;
+
+exports[`LiftoverDisambiguationPage starting from liftover source dataset gnomad_r2_1_non_topmed has appropriate message if no corresponding variant found 1`] = `
+<div
+  className="Page-w7h773-0 TrackPage-sc-1xq3qi7-0 dWdnsu"
+>
+  <div
+    className="TrackPage__TrackPageSection-sc-1xq3qi7-1 fQVUsz"
+  >
+    Due to liftover, variant 
+    fakevariant
+     in dataset 
+    gnomAD v2.1.1 (non-TOPMed)
+     may correspond to a different variant or variants in 
+    GRCh38
+    .
+    <div
+      className="StatusMessage-sc-neg7mh-0 hJFlwG"
+    >
+      No corresponding variants found
+    </div>
+  </div>
+</div>
+`;
+
+exports[`LiftoverDisambiguationPage starting from liftover source dataset gnomad_r2_1_non_topmed renders links to each variant if multiple corresponding variants found 1`] = `
+<div
+  className="Page-w7h773-0 TrackPage-sc-1xq3qi7-0 dWdnsu"
+>
+  <div
+    className="TrackPage__TrackPageSection-sc-1xq3qi7-1 fQVUsz"
+  >
+    Due to liftover, variant 
+    fakevariant
+     in dataset 
+    gnomAD v2.1.1 (non-TOPMed)
+     may correspond to a different variant or variants in 
+    GRCh38
+    .
+    <ul>
+      <li>
+        <a
+          className="Link-sc-14lgydv-0-Link jBvaYQ"
+          href="/variant/source1?dataset=gnomad_r4"
+          onClick={[Function]}
+        >
+          source1
+        </a>
+      </li>
+      <li>
+        <a
+          className="Link-sc-14lgydv-0-Link jBvaYQ"
+          href="/variant/source2?dataset=gnomad_r4"
+          onClick={[Function]}
+        >
+          source2
+        </a>
+      </li>
+    </ul>
+  </div>
+</div>
+`;
+
+exports[`LiftoverDisambiguationPage starting from liftover target dataset gnomad_r4 has appropriate message if no corresponding variant found 1`] = `
+<div
+  className="Page-w7h773-0 TrackPage-sc-1xq3qi7-0 dWdnsu"
+>
+  <div
+    className="TrackPage__TrackPageSection-sc-1xq3qi7-1 fQVUsz"
+  >
+    Due to liftover, variant 
+    fakevariant
+     in dataset 
+    gnomAD v4.0.0
+     may correspond to a different variant or variants in 
+    GRCh37
+    .
+    <div
+      className="StatusMessage-sc-neg7mh-0 hJFlwG"
+    >
+      No corresponding variants found
+    </div>
+  </div>
+</div>
+`;
+
+exports[`LiftoverDisambiguationPage starting from liftover target dataset gnomad_r4 renders links to each variant if multiple corresponding variants found 1`] = `
+<div
+  className="Page-w7h773-0 TrackPage-sc-1xq3qi7-0 dWdnsu"
+>
+  <div
+    className="TrackPage__TrackPageSection-sc-1xq3qi7-1 fQVUsz"
+  >
+    Due to liftover, variant 
+    fakevariant
+     in dataset 
+    gnomAD v4.0.0
+     may correspond to a different variant or variants in 
+    GRCh37
+    .
+    <ul>
+      <li>
+        <a
+          className="Link-sc-14lgydv-0-Link jBvaYQ"
+          href="/variant/source1?dataset=gnomad_r2_1"
+          onClick={[Function]}
+        >
+          source1
+        </a>
+      </li>
+      <li>
+        <a
+          className="Link-sc-14lgydv-0-Link jBvaYQ"
+          href="/variant/source2?dataset=gnomad_r2_1"
+          onClick={[Function]}
+        >
+          source2
+        </a>
+      </li>
+    </ul>
+  </div>
+</div>
+`;

--- a/browser/src/VariantPage/__snapshots__/VariantPage.spec.tsx.snap
+++ b/browser/src/VariantPage/__snapshots__/VariantPage.spec.tsx.snap
@@ -101,7 +101,7 @@ exports[`VariantPage with dataset "gnomad_r3" has no unexpected changes 1`] = `
           <a
             className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
             data-item="current_short_variant"
-            href="/?dataset=gnomad_r3"
+            href="/variant/13-123-A-C?dataset=gnomad_r3"
             onBlur={[Function]}
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -147,7 +147,7 @@ exports[`VariantPage with dataset "gnomad_r3" has no unexpected changes 1`] = `
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r4"
-                  href="/?dataset=gnomad_r4"
+                  href="/variant/13-123-A-C?dataset=gnomad_r4"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -164,7 +164,7 @@ exports[`VariantPage with dataset "gnomad_r3" has no unexpected changes 1`] = `
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r3"
-                  href="/?dataset=gnomad_r3"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -181,7 +181,7 @@ exports[`VariantPage with dataset "gnomad_r3" has no unexpected changes 1`] = `
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r3_non_cancer"
-                  href="/?dataset=gnomad_r3_non_cancer"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_non_cancer"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -198,7 +198,7 @@ exports[`VariantPage with dataset "gnomad_r3" has no unexpected changes 1`] = `
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r3_non_neuro"
-                  href="/?dataset=gnomad_r3_non_neuro"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_non_neuro"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -215,7 +215,7 @@ exports[`VariantPage with dataset "gnomad_r3" has no unexpected changes 1`] = `
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r3_non_v2"
-                  href="/?dataset=gnomad_r3_non_v2"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_non_v2"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -232,7 +232,7 @@ exports[`VariantPage with dataset "gnomad_r3" has no unexpected changes 1`] = `
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r3_non_topmed"
-                  href="/?dataset=gnomad_r3_non_topmed"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_non_topmed"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -249,7 +249,7 @@ exports[`VariantPage with dataset "gnomad_r3" has no unexpected changes 1`] = `
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r3_controls_and_biobanks"
-                  href="/?dataset=gnomad_r3_controls_and_biobanks"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_controls_and_biobanks"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -8930,7 +8930,7 @@ exports[`VariantPage with dataset "gnomad_r3_controls_and_biobanks" has no unexp
           <a
             className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
             data-item="current_short_variant"
-            href="/?dataset=gnomad_r3_controls_and_biobanks"
+            href="/variant/13-123-A-C?dataset=gnomad_r3_controls_and_biobanks"
             onBlur={[Function]}
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -8976,7 +8976,7 @@ exports[`VariantPage with dataset "gnomad_r3_controls_and_biobanks" has no unexp
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r4"
-                  href="/?dataset=gnomad_r4"
+                  href="/variant/13-123-A-C?dataset=gnomad_r4"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -8993,7 +8993,7 @@ exports[`VariantPage with dataset "gnomad_r3_controls_and_biobanks" has no unexp
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r3"
-                  href="/?dataset=gnomad_r3"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -9010,7 +9010,7 @@ exports[`VariantPage with dataset "gnomad_r3_controls_and_biobanks" has no unexp
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r3_non_cancer"
-                  href="/?dataset=gnomad_r3_non_cancer"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_non_cancer"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -9027,7 +9027,7 @@ exports[`VariantPage with dataset "gnomad_r3_controls_and_biobanks" has no unexp
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r3_non_neuro"
-                  href="/?dataset=gnomad_r3_non_neuro"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_non_neuro"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -9044,7 +9044,7 @@ exports[`VariantPage with dataset "gnomad_r3_controls_and_biobanks" has no unexp
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r3_non_v2"
-                  href="/?dataset=gnomad_r3_non_v2"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_non_v2"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -9061,7 +9061,7 @@ exports[`VariantPage with dataset "gnomad_r3_controls_and_biobanks" has no unexp
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r3_non_topmed"
-                  href="/?dataset=gnomad_r3_non_topmed"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_non_topmed"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -9078,7 +9078,7 @@ exports[`VariantPage with dataset "gnomad_r3_controls_and_biobanks" has no unexp
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r3_controls_and_biobanks"
-                  href="/?dataset=gnomad_r3_controls_and_biobanks"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_controls_and_biobanks"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -17762,7 +17762,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_cancer" has no unexpected chang
           <a
             className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
             data-item="current_short_variant"
-            href="/?dataset=gnomad_r3_non_cancer"
+            href="/variant/13-123-A-C?dataset=gnomad_r3_non_cancer"
             onBlur={[Function]}
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -17808,7 +17808,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_cancer" has no unexpected chang
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r4"
-                  href="/?dataset=gnomad_r4"
+                  href="/variant/13-123-A-C?dataset=gnomad_r4"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -17825,7 +17825,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_cancer" has no unexpected chang
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r3"
-                  href="/?dataset=gnomad_r3"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -17842,7 +17842,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_cancer" has no unexpected chang
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r3_non_cancer"
-                  href="/?dataset=gnomad_r3_non_cancer"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_non_cancer"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -17859,7 +17859,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_cancer" has no unexpected chang
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r3_non_neuro"
-                  href="/?dataset=gnomad_r3_non_neuro"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_non_neuro"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -17876,7 +17876,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_cancer" has no unexpected chang
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r3_non_v2"
-                  href="/?dataset=gnomad_r3_non_v2"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_non_v2"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -17893,7 +17893,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_cancer" has no unexpected chang
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r3_non_topmed"
-                  href="/?dataset=gnomad_r3_non_topmed"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_non_topmed"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -17910,7 +17910,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_cancer" has no unexpected chang
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r3_controls_and_biobanks"
-                  href="/?dataset=gnomad_r3_controls_and_biobanks"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_controls_and_biobanks"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -26594,7 +26594,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_neuro" has no unexpected change
           <a
             className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
             data-item="current_short_variant"
-            href="/?dataset=gnomad_r3_non_neuro"
+            href="/variant/13-123-A-C?dataset=gnomad_r3_non_neuro"
             onBlur={[Function]}
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -26640,7 +26640,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_neuro" has no unexpected change
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r4"
-                  href="/?dataset=gnomad_r4"
+                  href="/variant/13-123-A-C?dataset=gnomad_r4"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -26657,7 +26657,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_neuro" has no unexpected change
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r3"
-                  href="/?dataset=gnomad_r3"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -26674,7 +26674,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_neuro" has no unexpected change
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r3_non_cancer"
-                  href="/?dataset=gnomad_r3_non_cancer"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_non_cancer"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -26691,7 +26691,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_neuro" has no unexpected change
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r3_non_neuro"
-                  href="/?dataset=gnomad_r3_non_neuro"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_non_neuro"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -26708,7 +26708,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_neuro" has no unexpected change
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r3_non_v2"
-                  href="/?dataset=gnomad_r3_non_v2"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_non_v2"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -26725,7 +26725,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_neuro" has no unexpected change
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r3_non_topmed"
-                  href="/?dataset=gnomad_r3_non_topmed"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_non_topmed"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -26742,7 +26742,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_neuro" has no unexpected change
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r3_controls_and_biobanks"
-                  href="/?dataset=gnomad_r3_controls_and_biobanks"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_controls_and_biobanks"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -35426,7 +35426,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_topmed" has no unexpected chang
           <a
             className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
             data-item="current_short_variant"
-            href="/?dataset=gnomad_r3_non_topmed"
+            href="/variant/13-123-A-C?dataset=gnomad_r3_non_topmed"
             onBlur={[Function]}
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -35472,7 +35472,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_topmed" has no unexpected chang
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r4"
-                  href="/?dataset=gnomad_r4"
+                  href="/variant/13-123-A-C?dataset=gnomad_r4"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -35489,7 +35489,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_topmed" has no unexpected chang
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r3"
-                  href="/?dataset=gnomad_r3"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -35506,7 +35506,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_topmed" has no unexpected chang
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r3_non_cancer"
-                  href="/?dataset=gnomad_r3_non_cancer"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_non_cancer"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -35523,7 +35523,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_topmed" has no unexpected chang
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r3_non_neuro"
-                  href="/?dataset=gnomad_r3_non_neuro"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_non_neuro"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -35540,7 +35540,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_topmed" has no unexpected chang
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r3_non_v2"
-                  href="/?dataset=gnomad_r3_non_v2"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_non_v2"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -35557,7 +35557,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_topmed" has no unexpected chang
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r3_non_topmed"
-                  href="/?dataset=gnomad_r3_non_topmed"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_non_topmed"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -35574,7 +35574,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_topmed" has no unexpected chang
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r3_controls_and_biobanks"
-                  href="/?dataset=gnomad_r3_controls_and_biobanks"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_controls_and_biobanks"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -44258,7 +44258,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_v2" has no unexpected changes 1
           <a
             className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
             data-item="current_short_variant"
-            href="/?dataset=gnomad_r3_non_v2"
+            href="/variant/13-123-A-C?dataset=gnomad_r3_non_v2"
             onBlur={[Function]}
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -44304,7 +44304,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_v2" has no unexpected changes 1
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r4"
-                  href="/?dataset=gnomad_r4"
+                  href="/variant/13-123-A-C?dataset=gnomad_r4"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -44321,7 +44321,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_v2" has no unexpected changes 1
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r3"
-                  href="/?dataset=gnomad_r3"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -44338,7 +44338,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_v2" has no unexpected changes 1
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r3_non_cancer"
-                  href="/?dataset=gnomad_r3_non_cancer"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_non_cancer"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -44355,7 +44355,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_v2" has no unexpected changes 1
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r3_non_neuro"
-                  href="/?dataset=gnomad_r3_non_neuro"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_non_neuro"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -44372,7 +44372,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_v2" has no unexpected changes 1
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r3_non_v2"
-                  href="/?dataset=gnomad_r3_non_v2"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_non_v2"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -44389,7 +44389,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_v2" has no unexpected changes 1
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r3_non_topmed"
-                  href="/?dataset=gnomad_r3_non_topmed"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_non_topmed"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -44406,7 +44406,7 @@ exports[`VariantPage with dataset "gnomad_r3_non_v2" has no unexpected changes 1
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r3_controls_and_biobanks"
-                  href="/?dataset=gnomad_r3_controls_and_biobanks"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_controls_and_biobanks"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -53090,7 +53090,7 @@ exports[`VariantPage with dataset exac has no unexpected changes 1`] = `
           <a
             className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
             data-item="current_short_variant"
-            href="/?dataset=exac"
+            href="/variant/13-123-A-C?dataset=exac"
             onBlur={[Function]}
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -53136,7 +53136,7 @@ exports[`VariantPage with dataset exac has no unexpected changes 1`] = `
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r4"
-                  href="/?dataset=gnomad_r4"
+                  href="/variant/13-123-A-C?dataset=gnomad_r4"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -53160,7 +53160,7 @@ exports[`VariantPage with dataset exac has no unexpected changes 1`] = `
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r2_1"
-                  href="/?dataset=gnomad_r2_1"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -53177,7 +53177,7 @@ exports[`VariantPage with dataset exac has no unexpected changes 1`] = `
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r2_1_non_topmed"
-                  href="/?dataset=gnomad_r2_1_non_topmed"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1_non_topmed"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -53194,7 +53194,7 @@ exports[`VariantPage with dataset exac has no unexpected changes 1`] = `
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r2_1_non_cancer"
-                  href="/?dataset=gnomad_r2_1_non_cancer"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1_non_cancer"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -53211,7 +53211,7 @@ exports[`VariantPage with dataset exac has no unexpected changes 1`] = `
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r2_1_non_neuro"
-                  href="/?dataset=gnomad_r2_1_non_neuro"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1_non_neuro"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -53228,7 +53228,7 @@ exports[`VariantPage with dataset exac has no unexpected changes 1`] = `
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r2_1_controls"
-                  href="/?dataset=gnomad_r2_1_controls"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1_controls"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -53245,7 +53245,7 @@ exports[`VariantPage with dataset exac has no unexpected changes 1`] = `
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="exac"
-                  href="/?dataset=exac"
+                  href="/variant/13-123-A-C?dataset=exac"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -60228,7 +60228,7 @@ exports[`VariantPage with dataset gnomad_r2_1 has no unexpected changes 1`] = `
           <a
             className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
             data-item="current_short_variant"
-            href="/?dataset=gnomad_r2_1"
+            href="/variant/13-123-A-C?dataset=gnomad_r2_1"
             onBlur={[Function]}
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -60274,7 +60274,7 @@ exports[`VariantPage with dataset gnomad_r2_1 has no unexpected changes 1`] = `
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r4"
-                  href="/?dataset=gnomad_r4"
+                  href="/variant/liftover/13-123-A-C/gnomad_r2_1/gnomad_r4"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -60298,7 +60298,7 @@ exports[`VariantPage with dataset gnomad_r2_1 has no unexpected changes 1`] = `
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r2_1"
-                  href="/?dataset=gnomad_r2_1"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -60315,7 +60315,7 @@ exports[`VariantPage with dataset gnomad_r2_1 has no unexpected changes 1`] = `
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r2_1_non_topmed"
-                  href="/?dataset=gnomad_r2_1_non_topmed"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1_non_topmed"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -60332,7 +60332,7 @@ exports[`VariantPage with dataset gnomad_r2_1 has no unexpected changes 1`] = `
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r2_1_non_cancer"
-                  href="/?dataset=gnomad_r2_1_non_cancer"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1_non_cancer"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -60349,7 +60349,7 @@ exports[`VariantPage with dataset gnomad_r2_1 has no unexpected changes 1`] = `
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r2_1_non_neuro"
-                  href="/?dataset=gnomad_r2_1_non_neuro"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1_non_neuro"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -60366,7 +60366,7 @@ exports[`VariantPage with dataset gnomad_r2_1 has no unexpected changes 1`] = `
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r2_1_controls"
-                  href="/?dataset=gnomad_r2_1_controls"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1_controls"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -60383,7 +60383,7 @@ exports[`VariantPage with dataset gnomad_r2_1 has no unexpected changes 1`] = `
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="exac"
-                  href="/?dataset=exac"
+                  href="/variant/13-123-A-C?dataset=exac"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -69252,7 +69252,7 @@ exports[`VariantPage with dataset gnomad_r2_1_controls has no unexpected changes
           <a
             className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
             data-item="current_short_variant"
-            href="/?dataset=gnomad_r2_1_controls"
+            href="/variant/13-123-A-C?dataset=gnomad_r2_1_controls"
             onBlur={[Function]}
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -69298,7 +69298,7 @@ exports[`VariantPage with dataset gnomad_r2_1_controls has no unexpected changes
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r4"
-                  href="/?dataset=gnomad_r4"
+                  href="/variant/liftover/13-123-A-C/gnomad_r2_1_controls/gnomad_r4"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -69322,7 +69322,7 @@ exports[`VariantPage with dataset gnomad_r2_1_controls has no unexpected changes
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r2_1"
-                  href="/?dataset=gnomad_r2_1"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -69339,7 +69339,7 @@ exports[`VariantPage with dataset gnomad_r2_1_controls has no unexpected changes
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r2_1_non_topmed"
-                  href="/?dataset=gnomad_r2_1_non_topmed"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1_non_topmed"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -69356,7 +69356,7 @@ exports[`VariantPage with dataset gnomad_r2_1_controls has no unexpected changes
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r2_1_non_cancer"
-                  href="/?dataset=gnomad_r2_1_non_cancer"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1_non_cancer"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -69373,7 +69373,7 @@ exports[`VariantPage with dataset gnomad_r2_1_controls has no unexpected changes
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r2_1_non_neuro"
-                  href="/?dataset=gnomad_r2_1_non_neuro"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1_non_neuro"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -69390,7 +69390,7 @@ exports[`VariantPage with dataset gnomad_r2_1_controls has no unexpected changes
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r2_1_controls"
-                  href="/?dataset=gnomad_r2_1_controls"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1_controls"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -69407,7 +69407,7 @@ exports[`VariantPage with dataset gnomad_r2_1_controls has no unexpected changes
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="exac"
-                  href="/?dataset=exac"
+                  href="/variant/13-123-A-C?dataset=exac"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -78276,7 +78276,7 @@ exports[`VariantPage with dataset gnomad_r2_1_non_cancer has no unexpected chang
           <a
             className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
             data-item="current_short_variant"
-            href="/?dataset=gnomad_r2_1_non_cancer"
+            href="/variant/13-123-A-C?dataset=gnomad_r2_1_non_cancer"
             onBlur={[Function]}
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -78322,7 +78322,7 @@ exports[`VariantPage with dataset gnomad_r2_1_non_cancer has no unexpected chang
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r4"
-                  href="/?dataset=gnomad_r4"
+                  href="/variant/liftover/13-123-A-C/gnomad_r2_1_non_cancer/gnomad_r4"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -78346,7 +78346,7 @@ exports[`VariantPage with dataset gnomad_r2_1_non_cancer has no unexpected chang
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r2_1"
-                  href="/?dataset=gnomad_r2_1"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -78363,7 +78363,7 @@ exports[`VariantPage with dataset gnomad_r2_1_non_cancer has no unexpected chang
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r2_1_non_topmed"
-                  href="/?dataset=gnomad_r2_1_non_topmed"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1_non_topmed"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -78380,7 +78380,7 @@ exports[`VariantPage with dataset gnomad_r2_1_non_cancer has no unexpected chang
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r2_1_non_cancer"
-                  href="/?dataset=gnomad_r2_1_non_cancer"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1_non_cancer"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -78397,7 +78397,7 @@ exports[`VariantPage with dataset gnomad_r2_1_non_cancer has no unexpected chang
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r2_1_non_neuro"
-                  href="/?dataset=gnomad_r2_1_non_neuro"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1_non_neuro"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -78414,7 +78414,7 @@ exports[`VariantPage with dataset gnomad_r2_1_non_cancer has no unexpected chang
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r2_1_controls"
-                  href="/?dataset=gnomad_r2_1_controls"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1_controls"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -78431,7 +78431,7 @@ exports[`VariantPage with dataset gnomad_r2_1_non_cancer has no unexpected chang
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="exac"
-                  href="/?dataset=exac"
+                  href="/variant/13-123-A-C?dataset=exac"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -87300,7 +87300,7 @@ exports[`VariantPage with dataset gnomad_r2_1_non_neuro has no unexpected change
           <a
             className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
             data-item="current_short_variant"
-            href="/?dataset=gnomad_r2_1_non_neuro"
+            href="/variant/13-123-A-C?dataset=gnomad_r2_1_non_neuro"
             onBlur={[Function]}
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -87346,7 +87346,7 @@ exports[`VariantPage with dataset gnomad_r2_1_non_neuro has no unexpected change
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r4"
-                  href="/?dataset=gnomad_r4"
+                  href="/variant/liftover/13-123-A-C/gnomad_r2_1_non_neuro/gnomad_r4"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -87370,7 +87370,7 @@ exports[`VariantPage with dataset gnomad_r2_1_non_neuro has no unexpected change
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r2_1"
-                  href="/?dataset=gnomad_r2_1"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -87387,7 +87387,7 @@ exports[`VariantPage with dataset gnomad_r2_1_non_neuro has no unexpected change
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r2_1_non_topmed"
-                  href="/?dataset=gnomad_r2_1_non_topmed"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1_non_topmed"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -87404,7 +87404,7 @@ exports[`VariantPage with dataset gnomad_r2_1_non_neuro has no unexpected change
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r2_1_non_cancer"
-                  href="/?dataset=gnomad_r2_1_non_cancer"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1_non_cancer"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -87421,7 +87421,7 @@ exports[`VariantPage with dataset gnomad_r2_1_non_neuro has no unexpected change
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r2_1_non_neuro"
-                  href="/?dataset=gnomad_r2_1_non_neuro"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1_non_neuro"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -87438,7 +87438,7 @@ exports[`VariantPage with dataset gnomad_r2_1_non_neuro has no unexpected change
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r2_1_controls"
-                  href="/?dataset=gnomad_r2_1_controls"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1_controls"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -87455,7 +87455,7 @@ exports[`VariantPage with dataset gnomad_r2_1_non_neuro has no unexpected change
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="exac"
-                  href="/?dataset=exac"
+                  href="/variant/13-123-A-C?dataset=exac"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -96324,7 +96324,7 @@ exports[`VariantPage with dataset gnomad_r2_1_non_topmed has no unexpected chang
           <a
             className="DatasetSelector__TopLevelNavigationLink-sc-1p2fxbn-1-Link eggTrD"
             data-item="current_short_variant"
-            href="/?dataset=gnomad_r2_1_non_topmed"
+            href="/variant/13-123-A-C?dataset=gnomad_r2_1_non_topmed"
             onBlur={[Function]}
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -96370,7 +96370,7 @@ exports[`VariantPage with dataset gnomad_r2_1_non_topmed has no unexpected chang
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r4"
-                  href="/?dataset=gnomad_r4"
+                  href="/variant/liftover/13-123-A-C/gnomad_r2_1_non_topmed/gnomad_r4"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -96394,7 +96394,7 @@ exports[`VariantPage with dataset gnomad_r2_1_non_topmed has no unexpected chang
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r2_1"
-                  href="/?dataset=gnomad_r2_1"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -96411,7 +96411,7 @@ exports[`VariantPage with dataset gnomad_r2_1_non_topmed has no unexpected chang
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r2_1_non_topmed"
-                  href="/?dataset=gnomad_r2_1_non_topmed"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1_non_topmed"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -96428,7 +96428,7 @@ exports[`VariantPage with dataset gnomad_r2_1_non_topmed has no unexpected chang
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r2_1_non_cancer"
-                  href="/?dataset=gnomad_r2_1_non_cancer"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1_non_cancer"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -96445,7 +96445,7 @@ exports[`VariantPage with dataset gnomad_r2_1_non_topmed has no unexpected chang
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r2_1_non_neuro"
-                  href="/?dataset=gnomad_r2_1_non_neuro"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1_non_neuro"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -96462,7 +96462,7 @@ exports[`VariantPage with dataset gnomad_r2_1_non_topmed has no unexpected chang
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="gnomad_r2_1_controls"
-                  href="/?dataset=gnomad_r2_1_controls"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1_controls"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -96479,7 +96479,7 @@ exports[`VariantPage with dataset gnomad_r2_1_non_topmed has no unexpected chang
                 <a
                   className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
                   data-item="exac"
-                  href="/?dataset=exac"
+                  href="/variant/13-123-A-C?dataset=exac"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}

--- a/browser/src/VariantPage/__snapshots__/VariantPage.spec.tsx.snap
+++ b/browser/src/VariantPage/__snapshots__/VariantPage.spec.tsx.snap
@@ -263,6 +263,98 @@ exports[`VariantPage with dataset "gnomad_r3" has no unexpected changes 1`] = `
                 </a>
               </li>
             </li>
+            <li>
+              <div
+                className="DatasetSelector__GroupedNav-sc-1p2fxbn-7 cJJZPz"
+              >
+                GRCh37
+              </div>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r2_1"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v2.1.1
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    141,456 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r2_1_non_topmed"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1_non_topmed"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v2.1.1 (non-TOPMed)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    135,743 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r2_1_non_cancer"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1_non_cancer"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v2.1.1 (non-cancer)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    134,187 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r2_1_non_neuro"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1_non_neuro"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v2.1.1 (non-neuro)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    114,704 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r2_1_controls"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1_controls"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v2.1.1 (controls)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    60,146 samples
+                  </div>
+                </a>
+              </li>
+            </li>
           </ul>
         </li>
       </ul>
@@ -9088,6 +9180,98 @@ exports[`VariantPage with dataset "gnomad_r3_controls_and_biobanks" has no unexp
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >
                     16,465 samples
+                  </div>
+                </a>
+              </li>
+            </li>
+            <li>
+              <div
+                className="DatasetSelector__GroupedNav-sc-1p2fxbn-7 cJJZPz"
+              >
+                GRCh37
+              </div>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r2_1"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v2.1.1
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    141,456 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r2_1_non_topmed"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1_non_topmed"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v2.1.1 (non-TOPMed)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    135,743 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r2_1_non_cancer"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1_non_cancer"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v2.1.1 (non-cancer)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    134,187 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r2_1_non_neuro"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1_non_neuro"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v2.1.1 (non-neuro)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    114,704 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r2_1_controls"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1_controls"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v2.1.1 (controls)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    60,146 samples
                   </div>
                 </a>
               </li>
@@ -17924,6 +18108,98 @@ exports[`VariantPage with dataset "gnomad_r3_non_cancer" has no unexpected chang
                 </a>
               </li>
             </li>
+            <li>
+              <div
+                className="DatasetSelector__GroupedNav-sc-1p2fxbn-7 cJJZPz"
+              >
+                GRCh37
+              </div>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r2_1"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v2.1.1
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    141,456 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r2_1_non_topmed"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1_non_topmed"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v2.1.1 (non-TOPMed)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    135,743 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r2_1_non_cancer"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1_non_cancer"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v2.1.1 (non-cancer)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    134,187 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r2_1_non_neuro"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1_non_neuro"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v2.1.1 (non-neuro)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    114,704 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r2_1_controls"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1_controls"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v2.1.1 (controls)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    60,146 samples
+                  </div>
+                </a>
+              </li>
+            </li>
           </ul>
         </li>
       </ul>
@@ -26752,6 +27028,98 @@ exports[`VariantPage with dataset "gnomad_r3_non_neuro" has no unexpected change
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >
                     16,465 samples
+                  </div>
+                </a>
+              </li>
+            </li>
+            <li>
+              <div
+                className="DatasetSelector__GroupedNav-sc-1p2fxbn-7 cJJZPz"
+              >
+                GRCh37
+              </div>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r2_1"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v2.1.1
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    141,456 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r2_1_non_topmed"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1_non_topmed"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v2.1.1 (non-TOPMed)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    135,743 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r2_1_non_cancer"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1_non_cancer"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v2.1.1 (non-cancer)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    134,187 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r2_1_non_neuro"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1_non_neuro"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v2.1.1 (non-neuro)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    114,704 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r2_1_controls"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1_controls"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v2.1.1 (controls)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    60,146 samples
                   </div>
                 </a>
               </li>
@@ -35588,6 +35956,98 @@ exports[`VariantPage with dataset "gnomad_r3_non_topmed" has no unexpected chang
                 </a>
               </li>
             </li>
+            <li>
+              <div
+                className="DatasetSelector__GroupedNav-sc-1p2fxbn-7 cJJZPz"
+              >
+                GRCh37
+              </div>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r2_1"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v2.1.1
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    141,456 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r2_1_non_topmed"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1_non_topmed"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v2.1.1 (non-TOPMed)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    135,743 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r2_1_non_cancer"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1_non_cancer"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v2.1.1 (non-cancer)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    134,187 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r2_1_non_neuro"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1_non_neuro"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v2.1.1 (non-neuro)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    114,704 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r2_1_controls"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1_controls"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v2.1.1 (controls)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    60,146 samples
+                  </div>
+                </a>
+              </li>
+            </li>
           </ul>
         </li>
       </ul>
@@ -44420,6 +44880,98 @@ exports[`VariantPage with dataset "gnomad_r3_non_v2" has no unexpected changes 1
                 </a>
               </li>
             </li>
+            <li>
+              <div
+                className="DatasetSelector__GroupedNav-sc-1p2fxbn-7 cJJZPz"
+              >
+                GRCh37
+              </div>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r2_1"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v2.1.1
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    141,456 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r2_1_non_topmed"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1_non_topmed"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v2.1.1 (non-TOPMed)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    135,743 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r2_1_non_cancer"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1_non_cancer"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v2.1.1 (non-cancer)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    134,187 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r2_1_non_neuro"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1_non_neuro"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v2.1.1 (non-neuro)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    114,704 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r2_1_controls"
+                  href="/variant/13-123-A-C?dataset=gnomad_r2_1_controls"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v2.1.1 (controls)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    60,146 samples
+                  </div>
+                </a>
+              </li>
+            </li>
           </ul>
         </li>
       </ul>
@@ -53149,6 +53701,108 @@ exports[`VariantPage with dataset exac has no unexpected changes 1`] = `
                   </div>
                 </a>
               </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r3"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v3.1.2
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    76,156 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r3_non_cancer"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_non_cancer"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v3.1.2 (non-cancer)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    74,023 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r3_non_neuro"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_non_neuro"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v3.1.2 (non-neuro)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    67,442 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r3_non_v2"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_non_v2"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v3.1.2 (non-v2)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    57,344 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r3_non_topmed"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_non_topmed"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v3.1.2 (non-TOPMed)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    40,433 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r3_controls_and_biobanks"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_controls_and_biobanks"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v3.1.2 (controls/biobanks)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    16,465 samples
+                  </div>
+                </a>
+              </li>
             </li>
             <li>
               <div
@@ -60284,6 +60938,108 @@ exports[`VariantPage with dataset gnomad_r2_1 has no unexpected changes 1`] = `
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >
                     807,162 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r3"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v3.1.2
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    76,156 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r3_non_cancer"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_non_cancer"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v3.1.2 (non-cancer)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    74,023 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r3_non_neuro"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_non_neuro"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v3.1.2 (non-neuro)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    67,442 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r3_non_v2"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_non_v2"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v3.1.2 (non-v2)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    57,344 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r3_non_topmed"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_non_topmed"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v3.1.2 (non-TOPMed)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    40,433 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r3_controls_and_biobanks"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_controls_and_biobanks"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v3.1.2 (controls/biobanks)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    16,465 samples
                   </div>
                 </a>
               </li>
@@ -69311,6 +70067,108 @@ exports[`VariantPage with dataset gnomad_r2_1_controls has no unexpected changes
                   </div>
                 </a>
               </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r3"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v3.1.2
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    76,156 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r3_non_cancer"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_non_cancer"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v3.1.2 (non-cancer)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    74,023 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r3_non_neuro"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_non_neuro"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v3.1.2 (non-neuro)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    67,442 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r3_non_v2"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_non_v2"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v3.1.2 (non-v2)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    57,344 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r3_non_topmed"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_non_topmed"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v3.1.2 (non-TOPMed)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    40,433 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r3_controls_and_biobanks"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_controls_and_biobanks"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v3.1.2 (controls/biobanks)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    16,465 samples
+                  </div>
+                </a>
+              </li>
             </li>
             <li>
               <div
@@ -78332,6 +79190,108 @@ exports[`VariantPage with dataset gnomad_r2_1_non_cancer has no unexpected chang
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >
                     807,162 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r3"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v3.1.2
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    76,156 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r3_non_cancer"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_non_cancer"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v3.1.2 (non-cancer)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    74,023 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r3_non_neuro"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_non_neuro"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v3.1.2 (non-neuro)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    67,442 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r3_non_v2"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_non_v2"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v3.1.2 (non-v2)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    57,344 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r3_non_topmed"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_non_topmed"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v3.1.2 (non-TOPMed)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    40,433 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r3_controls_and_biobanks"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_controls_and_biobanks"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v3.1.2 (controls/biobanks)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    16,465 samples
                   </div>
                 </a>
               </li>
@@ -87359,6 +88319,108 @@ exports[`VariantPage with dataset gnomad_r2_1_non_neuro has no unexpected change
                   </div>
                 </a>
               </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r3"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v3.1.2
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    76,156 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r3_non_cancer"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_non_cancer"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v3.1.2 (non-cancer)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    74,023 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r3_non_neuro"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_non_neuro"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v3.1.2 (non-neuro)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    67,442 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r3_non_v2"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_non_v2"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v3.1.2 (non-v2)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    57,344 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r3_non_topmed"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_non_topmed"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v3.1.2 (non-TOPMed)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    40,433 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r3_controls_and_biobanks"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_controls_and_biobanks"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v3.1.2 (controls/biobanks)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    16,465 samples
+                  </div>
+                </a>
+              </li>
             </li>
             <li>
               <div
@@ -96380,6 +97442,108 @@ exports[`VariantPage with dataset gnomad_r2_1_non_topmed has no unexpected chang
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >
                     807,162 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r3"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v3.1.2
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    76,156 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r3_non_cancer"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_non_cancer"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v3.1.2 (non-cancer)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    74,023 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r3_non_neuro"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_non_neuro"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v3.1.2 (non-neuro)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    67,442 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r3_non_v2"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_non_v2"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v3.1.2 (non-v2)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    57,344 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r3_non_topmed"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_non_topmed"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v3.1.2 (non-TOPMed)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    40,433 samples
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="DatasetSelector__SubNavigationLink-sc-1p2fxbn-5-Link gbnrKe"
+                  data-item="gnomad_r3_controls_and_biobanks"
+                  href="/variant/13-123-A-C?dataset=gnomad_r3_controls_and_biobanks"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  gnomAD v3.1.2 (controls/biobanks)
+                  <div
+                    className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
+                  >
+                    16,465 samples
                   </div>
                 </a>
               </li>

--- a/dataset-metadata/metadata.ts
+++ b/dataset-metadata/metadata.ts
@@ -388,3 +388,6 @@ export const copyNumberVariantDatasetId = (datasetId: DatasetId) =>
 
 export const hasCopyNumberVariantCoverage = (datasetId: DatasetId) =>
   getMetadata(datasetId, 'hasCopyNumberVariantCoverage')
+
+export const baseDatasetForReferenceGenome = (genome: ReferenceGenome): DatasetId =>
+  genome === 'GRCh37' ? 'gnomad_r2_1' : 'gnomad_r4'

--- a/deploy/dockerfiles/browser/browser.nginx.conf
+++ b/deploy/dockerfiles/browser/browser.nginx.conf
@@ -74,6 +74,7 @@ server {
     rewrite ^/gene/[^/]+/transcript/[^/]+/?$ /index.html last;
     rewrite ^/transcript/[^/]+/?$ /index.html last;
     rewrite ^/region/[^/]+/?$ /index.html last;
+    rewrite ^/variant/liftover/[^/]/[^/]/[^/]+/?$ /index.html last;
     rewrite ^/variant/[^/]+/?$ /index.html last;
     rewrite ^/variant-cooccurrence/?$ /index.html last;
     rewrite ^/short-tandem-repeat/[^/]+/?$ /index.html last;

--- a/tests/__helpers__/router.tsx
+++ b/tests/__helpers__/router.tsx
@@ -2,6 +2,6 @@ import React, { ReactNode } from 'react'
 import { Router } from 'react-router'
 import { createBrowserHistory } from 'history'
 
-export const withDummyRouter = (children: ReactNode): JSX.Element => (
-  <Router history={createBrowserHistory()}>{children}</Router>
+export const withDummyRouter = (children: ReactNode, history: any = null): JSX.Element => (
+  <Router history={history || createBrowserHistory()}>{children}</Router>
 )


### PR DESCRIPTION
This adds a disambiguation page for liftover, similar to the existing one for RSIDs, since as with RSIDs, a v2 variant may lift over to multiple v4 variants, and vice versa. Switching to v4 via the dataset selector on the variants page will link to this new disambiguation page.