### PR TITLE
Update Downloads page v4 checksums and sizes

### DIFF
--- a/browser/src/DownloadsPage/GnomadV4Downloads.tsx
+++ b/browser/src/DownloadsPage/GnomadV4Downloads.tsx
@@ -39,7 +39,7 @@ const exomeChromosomeVcfs = [
   { chrom: '21', size: '3.27 GiB', md5: '206afe8d9dbe544697e1b67eee6d2f7f' },
   { chrom: '22', size: '7.31 GiB', md5: '3084349c03194e8cf5063a1e46473248' },
   { chrom: 'X', size: '7.96 GiB', md5: '6d33a288735eda242c473905ccb6743b' },
-  { chrom: 'Y', size: '860.03 MiB', md5: '8c231b75745b6670555915847c9999e8' },
+  { chrom: 'Y', size: '163.66 MiB', md5: 'c8414744cf75fa498e2497a9391eb1ad' },
 ]
 
 const genomeChromosomeVcfs = [
@@ -66,7 +66,7 @@ const genomeChromosomeVcfs = [
   { chrom: '21', size: '11.47 GiB', md5: '4d2e808cbaafcd2ddc7692be0a45a924' },
   { chrom: '22', size: '12.77 GiB', md5: 'd6ba3b18b07423e3a1af56e8405a26c2' },
   { chrom: 'X', size: '37.05 GiB', md5: 'b77d8f0219fa9a033a6f747d5fef12d9' },
-  { chrom: 'Y', size: '890.03 MiB', md5: 'b39443d98eeb5f6735aa57e37d378edf' },
+  { chrom: 'Y', size: '890.03 MiB', md5: '8c231b75745b6670555915847c9999e8' },
 ]
 
 const svChromosomeVcfs = [

--- a/browser/src/DownloadsPage/__snapshots__/DownloadsPage.spec.tsx.snap
+++ b/browser/src/DownloadsPage/__snapshots__/DownloadsPage.spec.tsx.snap
@@ -2176,9 +2176,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                860.03 MiB
+                163.66 MiB
                 , MD5: 
-                8c231b75745b6670555915847c9999e8
+                c8414744cf75fa498e2497a9391eb1ad
               </span>
               <br />
               <span>
@@ -3680,7 +3680,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               <span>
                 890.03 MiB
                 , MD5: 
-                b39443d98eeb5f6735aa57e37d378edf
+                8c231b75745b6670555915847c9999e8
               </span>
               <br />
               <span>


### PR DESCRIPTION
This updates the MD5s for both exome and genome chrY VCFs. It looks like something happened during creation or transfer of the chrY exome VCF so that it was a duplicate of the genomes chrY VCF. The exome VCF was regenerated and is currently syncing to the same location in the public bucket. For this file, the size and MD5 are updated in this PR. 

```
gsutil hash -h gs://gnomad-public-requester-pays/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chrY.vcf.bgz

Hashes [hex] for release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chrY.vcf.bgz:
	Hash (md5):		c8414744cf75fa498e2497a9391eb1ad
	Hash (crc32c):		7eadc442
``` 

For the genome VCF, a user pointed out our downloads page MD5 did not match the public file's MD5. I confirmed they do not and have also updated that files MD5 in this PR. 

```
gsutil hash -h gs://gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chrY.vcf.bgz

Hashes [hex] for release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chrY.vcf.bgz:
	Hash (md5):		8c231b75745b6670555915847c9999e8
	Hash (crc32c):		4b5875ee
```

Note the exome VCF will likely sync sometime tonight so this probably shouldn't go in until tomorrow. Also sorry if this is not how I should update this, was just trying to save you a bit of time!