### PR TITLE
fixup: need to escape braces in our custom template

### DIFF
--- a/deploy/deployctl/subcommands/ingress_production.py
+++ b/deploy/deployctl/subcommands/ingress_production.py
@@ -15,7 +15,7 @@ metadata:
   labels:
     tier: production
   annotations:
-    cloud.google.com/backend-config: '{"ports": {"80":"gnomad-backend-config"}}'
+    cloud.google.com/backend-config: '{{"ports": {{"80":"gnomad-backend-config"}}}}'
 spec:
   type: NodePort
   selector:
@@ -96,6 +96,7 @@ def apply_ingress(browser_deployment: str = None, reads_deployment: str = None, 
     apply_services(browser_deployment, reads_deployment)
 
     if quiet or input("Apply changes to production ingress (y/n) ").lower() == "y":
+        kubectl(["apply", "-f", os.path.join(manifests_directory(), "gnomad.backendconfig.yaml")])
         kubectl(["apply", "-f", os.path.join(manifests_directory(), "gnomad.frontendconfig.yaml")])
         kubectl(["apply", "-f", os.path.join(manifests_directory(), "gnomad.ingress.yaml")])
 


### PR DESCRIPTION
Didn't catch that our string template for ingress services was a python format-string, and thus needs curly braces escaped.