### PR TITLE
Update v4 downloads to remove fake README link

### DIFF
--- a/browser/src/DownloadsPage/GnomadV4Downloads.tsx
+++ b/browser/src/DownloadsPage/GnomadV4Downloads.tsx
@@ -120,12 +120,7 @@ const GnomadV4Downloads = () => {
           For more information, read the{' '}
           {/* @ts-expect-error TS(2786) FIXME: 'ExternalLink' cannot be used as a JSX component. */}
           <ExternalLink href="https://gnomad.broadinstitute.org/news/2023-11-gnomad-v4-0">
-            v4 blog post
-          </ExternalLink>
-          , and the{' '}
-          {/* @ts-expect-error TS(2786) FIXME: 'ExternalLink' cannot be used as a JSX component. */}
-          <ExternalLink href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/README.txt">
-            gnomAD v4.0.0 README
+            gnomAD v4.0.0 blog post
           </ExternalLink>
           .
         </p>

--- a/browser/src/DownloadsPage/__snapshots__/DownloadsPage.spec.tsx.snap
+++ b/browser/src/DownloadsPage/__snapshots__/DownloadsPage.spec.tsx.snap
@@ -712,17 +712,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           rel="noopener noreferrer"
           target="_blank"
         >
-          v4 blog post
-        </a>
-        , and the
-         
-        <a
-          className="c10"
-          href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/README.txt"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          gnomAD v4.0.0 README
+          gnomAD v4.0.0 blog post
         </a>
         .
       </p>


### PR DESCRIPTION
Resolves #1299 

Very smol PR.

I had incorrectly added a link to a v4 README at the top of the v4 downloads section, falsely assuming this was something that had been done in the past.

There is no such README, and in the past, data releases have direct users to the blog post. This PR removes the link to the non-existent README, and leaves the link to the blog post.