### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,7 @@ This should be enough to use the Docker Compose development environment. However
   ```
   pip install -r data-pipeline/requirements.txt
   pip install -r requirements-dev.txt
+  pip install -r deploy/deployctl/requirements.txt
   ```
 
 ## Browser


### PR DESCRIPTION
Adds another `pip install` line for deployctl dependencies. This is required to prevent deployctl from complaining about not having `Jinja2`.

Another tiny documentation PR :smile: 