### PR TITLE
For STR pages, show the read data section by default

### DIFF
--- a/browser/src/ShortTandemRepeatPage/ShortTandemRepeatPage.tsx
+++ b/browser/src/ShortTandemRepeatPage/ShortTandemRepeatPage.tsx
@@ -69,7 +69,7 @@ const ShortTandemRepeatPage = ({ datasetId, shortTandemRepeat }: ShortTandemRepe
   const [selectedRepeatUnit, setSelectedRepeatUnit] = useState(
     shortTandemRepeat.allele_size_distribution.repeat_units.length === 1
       ? shortTandemRepeat.allele_size_distribution.repeat_units[0].repeat_unit
-      : ''
+      : '',
   )
 
   const [selectedPopulationId, setSelectedPopulationId] = useState('')
@@ -79,15 +79,14 @@ const ShortTandemRepeatPage = ({ datasetId, shortTandemRepeat }: ShortTandemRepe
     useState(
       shortTandemRepeat.genotype_distribution.repeat_units.length === 1
         ? shortTandemRepeat.genotype_distribution.repeat_units[0].repeat_units.join(' / ')
-        : ''
+        : '',
     )
 
   const [selectedDisease, setSelectedDisease] = useState(
-    shortTandemRepeat.associated_diseases[0].name
+    shortTandemRepeat.associated_diseases[0].name,
   )
 
   const [showAdjacentRepeats, setShowAdjacentRepeats] = useState(false)
-  const [showReadData, setShowReadData] = useState(false)
 
   const populationIds = shortTandemRepeat.allele_size_distribution.populations.map((pop) => pop.id)
 
@@ -106,8 +105,8 @@ const ShortTandemRepeatPage = ({ datasetId, shortTandemRepeat }: ShortTandemRepe
   // shortTandemRepeat.repeat_units may include repeat units that do not appear in gnomAD.
   const repeatUnitsFoundInGnomad = new Set(
     shortTandemRepeat.allele_size_distribution.repeat_units.map(
-      (repeatUnit) => repeatUnit.repeat_unit
-    )
+      (repeatUnit) => repeatUnit.repeat_unit,
+    ),
   )
 
   const repeatUnitsFoundInGnomadByClassification = {}
@@ -119,13 +118,13 @@ const ShortTandemRepeatPage = ({ datasetId, shortTandemRepeat }: ShortTandemRepe
   })
 
   const allRepeatUnitsFoundInGnomadArePathogenic = Object.keys(
-    repeatUnitsFoundInGnomadByClassification
+    repeatUnitsFoundInGnomadByClassification,
   )
     .filter((classification) => classification !== 'pathogenic')
     .every(
       (classification) =>
         // @ts-expect-error TS(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-        (repeatUnitsFoundInGnomadByClassification[classification] || []).length === 0
+        (repeatUnitsFoundInGnomadByClassification[classification] || []).length === 0,
     )
 
   // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
@@ -206,7 +205,7 @@ const ShortTandemRepeatPage = ({ datasetId, shortTandemRepeat }: ShortTandemRepe
             (selectedRepeatUnit === '' && allRepeatUnitsFoundInGnomadArePathogenic) ||
             selectedRepeatUnit === 'classification/pathogenic' ||
             ((repeatUnitsFoundInGnomadByClassification as any).pathogenic || []).includes(
-              selectedRepeatUnit
+              selectedRepeatUnit,
             )
               ? plotRanges
               : []
@@ -268,13 +267,13 @@ const ShortTandemRepeatPage = ({ datasetId, shortTandemRepeat }: ShortTandemRepe
                     .filter(
                       (classification) =>
                         // @ts-expect-error TS(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-                        (allRepeatUnitsByClassification[classification] || []).length > 0
+                        (allRepeatUnitsByClassification[classification] || []).length > 0,
                     )
                     .map((classification) => (
                       <optgroup
                         key={classification}
                         label={`${classification.charAt(0).toUpperCase()}${classification.slice(
-                          1
+                          1,
                         )}`}
                       >
                         {/* @ts-expect-error TS(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message */}
@@ -366,10 +365,10 @@ const ShortTandemRepeatPage = ({ datasetId, shortTandemRepeat }: ShortTandemRepe
           })}
           maxRepeats={[
             max(shortTandemRepeat.genotype_distribution.distribution, (d: any) =>
-              max(d.slice(0, 2))
+              max(d.slice(0, 2)),
             ),
             max(shortTandemRepeat.genotype_distribution.distribution, (d: any) =>
-              min(d.slice(0, 2))
+              min(d.slice(0, 2)),
             ),
           ]}
           genotypeDistribution={getSelectedGenotypeDistribution(shortTandemRepeat, {
@@ -380,7 +379,7 @@ const ShortTandemRepeatPage = ({ datasetId, shortTandemRepeat }: ShortTandemRepe
             (selectedGenotypeDistributionRepeatUnits === '' &&
               allRepeatUnitsFoundInGnomadArePathogenic) ||
             ((allRepeatUnitsByClassification as any).pathogenic || []).includes(
-              selectedGenotypeDistributionRepeatUnits.split(' / ')[0]
+              selectedGenotypeDistributionRepeatUnits.split(' / ')[0],
             )
               ? plotRanges
               : []
@@ -389,7 +388,7 @@ const ShortTandemRepeatPage = ({ datasetId, shortTandemRepeat }: ShortTandemRepe
             (selectedGenotypeDistributionRepeatUnits === '' &&
               allRepeatUnitsFoundInGnomadArePathogenic) ||
             ((allRepeatUnitsByClassification as any).pathogenic || []).includes(
-              selectedGenotypeDistributionRepeatUnits.split(' / ')[1]
+              selectedGenotypeDistributionRepeatUnits.split(' / ')[1],
             )
               ? plotRanges
               : []
@@ -445,7 +444,7 @@ const ShortTandemRepeatPage = ({ datasetId, shortTandemRepeat }: ShortTandemRepe
           !selectedGenotypeDistributionRepeatUnits
             .split(' / ')
             .every((repeatUnit) =>
-              ((allRepeatUnitsByClassification as any).pathogenic || []).includes(repeatUnit)
+              ((allRepeatUnitsByClassification as any).pathogenic || []).includes(repeatUnit),
             )) && (
           <p style={{ marginBottom: 0 }}>
             <Badge level="info">Note</Badge> This plot includes non-pathogenic repeat units. Use the
@@ -537,33 +536,21 @@ const ShortTandemRepeatPage = ({ datasetId, shortTandemRepeat }: ShortTandemRepe
             }
           />
         </h2>
-        {showReadData ? (
-          <>
-            <ControlSection style={{ marginBottom: '1em' }}>
-              <ShortTandemRepeatPopulationOptions
-                id={`${shortTandemRepeat.id}-read-data`}
-                populationIds={populationIds}
-                selectedPopulationId={selectedPopulationId}
-                onSelectPopulationId={setSelectedPopulationId}
-              />
-            </ControlSection>
-            <ShortTandemRepeatReads
-              datasetId={datasetId}
-              shortTandemRepeat={shortTandemRepeat}
-              filter={{
-                ...parseCombinedPopulationId(selectedPopulationId),
-              }}
-            />
-          </>
-        ) : (
-          <Button
-            onClick={() => {
-              setShowReadData(true)
-            }}
-          >
-            Show read data
-          </Button>
-        )}
+        <ControlSection style={{ marginBottom: '1em' }}>
+          <ShortTandemRepeatPopulationOptions
+            id={`${shortTandemRepeat.id}-read-data`}
+            populationIds={populationIds}
+            selectedPopulationId={selectedPopulationId}
+            onSelectPopulationId={setSelectedPopulationId}
+          />
+        </ControlSection>
+        <ShortTandemRepeatReads
+          datasetId={datasetId}
+          shortTandemRepeat={shortTandemRepeat}
+          filter={{
+            ...parseCombinedPopulationId(selectedPopulationId),
+          }}
+        />
       </section>
     </>
   )


### PR DESCRIPTION
REViewer images are frequently used to assess genotype quality and interruptions in the most-expanded genotypes, and are arguably as important as the population frequency histograms