### PR TITLE
update genes pipeline - garch38 extract transcript genes_path

### DIFF
--- a/data-pipeline/src/data_pipeline/pipelines/genes.py
+++ b/data-pipeline/src/data_pipeline/pipelines/genes.py
@@ -377,7 +377,7 @@ pipeline.add_task(
     "extract_grch38_transcripts",
     extract_transcripts,
     f"/{genes_subdir}/transcripts_grch38_base.ht",
-    {"genes_path": pipeline.get_task("annotate_grch38_genes_step_6")},
+    {"genes_path": pipeline.get_task("annotate_grch38_genes_step_4")},
 )
 
 ###############################################


### PR DESCRIPTION
It is really cool to see all the GnomAD v4 development! There was a commit last week that removed a stage from the grch38 part of the `genes` pipeline. I think there was a remnant of the old numbering scheme left in the code (it was looking for `step_6` when it had been removed). This prevents the pipeline from running.

I have changed the `genes_path` to point to `annotate_grch38_genes_step_4` (pattern matching from the grch37 approach) however this may be incorrect. You may be wanting to extract transcripts from the outputs of a different step (e.g. after reject_par_y_genes / step_5)! Please review this as I have very little understanding of the pipeline steps at the moment!