### PR TITLE
Update v4 mvp help text

### DIFF
--- a/browser/help/faq/general/what-features-are-not-yet-in-v4-and-where-can-i-find-them.md
+++ b/browser/help/faq/general/what-features-are-not-yet-in-v4-and-where-can-i-find-them.md
@@ -17,5 +17,3 @@ Below is a list of all features not included in the v4 MVP and where to find the
 | Manual LoF curation                             | v2 variant table and variant page                     |
 | Regional Missense Constraint                    | Now available on v2 gene page                         |
 | Linkage disequilibrium scores                   | [v2](/downloads/#v2-linkage-disequilibrium) downloads |
-| Short Tandem Repeats (STRs)                     | [v3](/short-tandem-repeats?dataset=gnomad_r3)         |
-| Mitochondrial Variants                          | v3                                                    |

--- a/browser/src/help/__snapshots__/HelpPage.spec.tsx.snap
+++ b/browser/src/help/__snapshots__/HelpPage.spec.tsx.snap
@@ -1170,8 +1170,6 @@ Below is a list of all features not included in the v4 MVP and where to find the
 | Manual LoF curation                             | v2 variant table and variant page                     |
 | Regional Missense Constraint                    | Now available on v2 gene page                         |
 | Linkage disequilibrium scores                   | [v2](/downloads/#v2-linkage-disequilibrium) downloads |
-| Short Tandem Repeats (STRs)                     | [v3](/short-tandem-repeats?dataset=gnomad_r3)         |
-| Mitochondrial Variants                          | v3                                                    |
 ",
                       }
                     }


### PR DESCRIPTION
Resolves https://atgu.slack.com/archives/CNNTF8Z46/p1699556110404269?thread_ts=1699454725.463319&cid=CNNTF8Z46

Updates v4 MVP help text to remove the row for mitochondrial variants from the 'coming soon' table, as they are now displayed in v4 per #1282 