### PR TITLE
Fix Gene page "export to CSV" genetic ancestry group data mismatch

### DIFF
--- a/browser/src/VariantList/ExportVariantsButton.spec.tsx
+++ b/browser/src/VariantList/ExportVariantsButton.spec.tsx
@@ -1,0 +1,67 @@
+import { test, expect } from '@jest/globals'
+
+import { forAllDatasets } from '../../../tests/__helpers__/datasets'
+import { createPopulationColumns } from './ExportVariantsButton'
+import {
+  GNOMAD_POPULATION_NAMES,
+  PopulationId,
+  populationsInDataset,
+} from '@gnomad/dataset-metadata/gnomadPopulations'
+import { DatasetId, isV4, isV3, isV2, isExac } from '@gnomad/dataset-metadata/metadata'
+
+const getAllPopulationColumns = (columns: { label: string }[]) => {
+  let populationColumns: string[] = []
+  columns.forEach((column) => {
+    populationColumns = populationColumns.concat(column.label)
+  })
+  return populationColumns
+}
+
+const getDatasetPopulations = (datasetId: DatasetId) => {
+  /* eslint-disable no-nested-ternary */
+  const topLevelDataset = isV4(datasetId)
+    ? 'v4'
+    : isV3(datasetId)
+    ? 'v3'
+    : isV2(datasetId)
+    ? 'v2'
+    : isExac(datasetId)
+    ? 'ExAC'
+    : 'default'
+  /* eslint-enable no-nested-ternary */
+
+  const datasetPopulations: PopulationId[] = populationsInDataset[topLevelDataset]
+
+  return datasetPopulations
+}
+
+const createExpectedPopulationColumns = (populations: PopulationId[]) => {
+  const columnCategories: string[] = [
+    'Allele Count',
+    'Allele Number',
+    'Homozygote Count',
+    'Hemizygote Count',
+  ]
+
+  let populationColumns: string[] = []
+  populations.forEach((population) => {
+    columnCategories.forEach((category) => {
+      populationColumns = populationColumns.concat(
+        `${category} ${GNOMAD_POPULATION_NAMES[population]}`
+      )
+    })
+  })
+
+  return populationColumns
+}
+
+forAllDatasets('DatasetSelector with "%s" selected', (datasetId) => {
+  test('returns the expected genetic ancestry group columns', () => {
+    const expectedPopulations = getDatasetPopulations(datasetId)
+    const result = createPopulationColumns(datasetId)
+
+    expect(getAllPopulationColumns(result)).toStrictEqual(
+      createExpectedPopulationColumns(expectedPopulations)
+    )
+  })
+})

--- a/browser/src/VariantList/mergeExomeAndGenomeData.spec.ts
+++ b/browser/src/VariantList/mergeExomeAndGenomeData.spec.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from '@jest/globals'
+
+import { populationFactory, variantFactory } from '../__factories__/Variant'
+import { Population } from '../VariantPage/VariantPage'
+
+import { mergeExomeAndGenomePopulationData } from './mergeExomeAndGenomeData'
+import { PopulationId } from '@gnomad/dataset-metadata/gnomadPopulations'
+
+type AncestryGroupShorthand = {
+  id: PopulationId
+  value: number
+}
+
+const createAncestryGroupObjects = (shorthands: AncestryGroupShorthand[]) => {
+  const geneticAncestryGroupObjects: Population[] = shorthands.map((shorthand) => {
+    return populationFactory.build({
+      id: shorthand.id,
+      ac: shorthand.value,
+      an: shorthand.value * 10,
+      ac_hemi: shorthand.value + 1,
+      ac_hom: shorthand.value + 2,
+    })
+  })
+
+  return geneticAncestryGroupObjects
+}
+
+describe('mergeExomeAndGenomePopulationData', () => {
+  it('returns expected values when exomes and genomes have the same populations', () => {
+    const geneticAncestryGroupObjects = createAncestryGroupObjects([
+      { id: 'afr', value: 1 },
+      { id: 'remaining', value: 2 },
+      { id: 'eur', value: 4 },
+    ])
+
+    const testVariant = variantFactory.build({
+      variant_id: 'test_variant',
+      exome: { populations: geneticAncestryGroupObjects },
+      genome: { populations: geneticAncestryGroupObjects },
+    })
+
+    const result = mergeExomeAndGenomePopulationData(testVariant.exome!, testVariant.genome!)
+
+    const expected = [
+      { ac: 2, ac_hemi: 4, ac_hom: 6, an: 20, id: 'afr' },
+      { ac: 4, ac_hemi: 6, ac_hom: 8, an: 40, id: 'remaining' },
+      { ac: 8, ac_hemi: 10, ac_hom: 12, an: 80, id: 'eur' },
+    ]
+
+    expect(result).toStrictEqual(expected)
+  })
+
+  it('returns expected values when exomes have less populations than genomes', () => {
+    const exomeGeneticAncestryGroupObjects = createAncestryGroupObjects([
+      { id: 'afr', value: 1 },
+      { id: 'remaining', value: 2 },
+      { id: 'eur', value: 4 },
+    ])
+
+    const genomeGeneticAncestryGroupObjects = createAncestryGroupObjects([
+      { id: 'afr', value: 8 },
+      { id: 'remaining', value: 16 },
+      { id: 'eur', value: 32 },
+      { id: 'mid', value: 64 },
+    ])
+
+    const testVariant = variantFactory.build({
+      variant_id: 'test_variant',
+      exome: { populations: exomeGeneticAncestryGroupObjects },
+      genome: { populations: genomeGeneticAncestryGroupObjects },
+    })
+
+    const result = mergeExomeAndGenomePopulationData(testVariant.exome!, testVariant.genome!)
+
+    const expected = [
+      { ac: 9, ac_hemi: 11, ac_hom: 13, an: 90, id: 'afr' },
+      { ac: 18, ac_hemi: 20, ac_hom: 22, an: 180, id: 'remaining' },
+      { ac: 36, ac_hemi: 38, ac_hom: 40, an: 360, id: 'eur' },
+      { ac: 64, ac_hemi: 65, ac_hom: 66, an: 640, id: 'mid' },
+    ]
+
+    expect(result).toStrictEqual(expected)
+  })
+
+  it('returns expected values exomes have more populations than genomes', () => {
+    const exomeGeneticAncestryGroupObjects = createAncestryGroupObjects([
+      { id: 'afr', value: 1 },
+      { id: 'remaining', value: 2 },
+      { id: 'eur', value: 4 },
+      { id: 'mid', value: 8 },
+    ])
+
+    const genomeGeneticAncestryGroupObjects = createAncestryGroupObjects([
+      { id: 'afr', value: 16 },
+      { id: 'remaining', value: 32 },
+      { id: 'eur', value: 64 },
+    ])
+
+    const testVariant = variantFactory.build({
+      variant_id: 'test_variant',
+      exome: { populations: exomeGeneticAncestryGroupObjects },
+      genome: { populations: genomeGeneticAncestryGroupObjects },
+    })
+
+    const result = mergeExomeAndGenomePopulationData(testVariant.exome!, testVariant.genome!)
+
+    const expected = [
+      { ac: 17, ac_hemi: 19, ac_hom: 21, an: 170, id: 'afr' },
+      { ac: 34, ac_hemi: 36, ac_hom: 38, an: 340, id: 'remaining' },
+      { ac: 68, ac_hemi: 70, ac_hom: 72, an: 680, id: 'eur' },
+      { ac: 8, ac_hemi: 9, ac_hom: 10, an: 80, id: 'mid' },
+    ]
+
+    expect(result).toStrictEqual(expected)
+  })
+
+  it('returns expected values when exome and genome populations are in a different order', () => {
+    const exomeGeneticAncestryGroupObjects = createAncestryGroupObjects([
+      { id: 'eur', value: 1 },
+      { id: 'afr', value: 2 },
+      { id: 'remaining', value: 4 },
+    ])
+
+    const genomeGeneticAncestryGroupObjects = createAncestryGroupObjects([
+      { id: 'afr', value: 8 },
+      { id: 'remaining', value: 16 },
+      { id: 'eur', value: 32 },
+    ])
+
+    const testVariant = variantFactory.build({
+      variant_id: 'test_variant',
+      exome: { populations: exomeGeneticAncestryGroupObjects },
+      genome: { populations: genomeGeneticAncestryGroupObjects },
+    })
+
+    const result = mergeExomeAndGenomePopulationData(testVariant.exome!, testVariant.genome!)
+
+    const expected = [
+      { ac: 33, ac_hemi: 35, ac_hom: 37, an: 330, id: 'eur' },
+      { ac: 10, ac_hemi: 12, ac_hom: 14, an: 100, id: 'afr' },
+      { ac: 20, ac_hemi: 22, ac_hom: 24, an: 200, id: 'remaining' },
+    ]
+
+    expect(result).toStrictEqual(expected)
+  })
+})

--- a/browser/src/VariantPage/VariantPage.tsx
+++ b/browser/src/VariantPage/VariantPage.tsx
@@ -147,8 +147,6 @@ export type Population = {
   an: number
   ac_hemi: number | null
   ac_hom: number
-  homozygote_count: number
-  hemizygote_count: number | null
 }
 
 export type LocalAncestryPopulation = {

--- a/browser/src/VariantPage/VariantPage.tsx
+++ b/browser/src/VariantPage/VariantPage.tsx
@@ -44,6 +44,7 @@ import VariantRelatedVariants from './VariantRelatedVariants'
 import VariantSiteQualityMetrics from './VariantSiteQualityMetrics'
 import VariantTranscriptConsequences from './VariantTranscriptConsequences'
 import { URLBuilder } from '../DatasetSelector'
+import { PopulationId } from '@gnomad/dataset-metadata/gnomadPopulations'
 
 const Section = styled.section`
   width: 100%;
@@ -141,7 +142,7 @@ export type Histogram = {
 }
 
 export type Population = {
-  id: string
+  id: PopulationId
   ac: number
   an: number
   ac_hemi: number | null

--- a/browser/src/__factories__/Variant.ts
+++ b/browser/src/__factories__/Variant.ts
@@ -1,9 +1,11 @@
 import { Factory } from 'fishery'
+import { VariantTableVariant } from '../VariantList/ExportVariantsButton'
 import {
   Variant,
   SequencingType,
   TranscriptConsequence,
   Histogram,
+  Population,
 } from '../VariantPage/VariantPage'
 
 export const defaultHistogram: Histogram = {
@@ -66,7 +68,7 @@ const transcriptConsequenceFactory = Factory.define<TranscriptConsequence>(({ pa
   }
 })
 
-const variantFactory = Factory.define<Variant>(({ params, associations }) => {
+export const variantFactory = Factory.define<Variant>(({ params, associations }) => {
   const {
     reference_genome = 'GRCh37',
     variant_id = '13-123-A-C',
@@ -120,6 +122,77 @@ const variantFactory = Factory.define<Variant>(({ params, associations }) => {
     liftover_sources,
   }
 })
+
+export const populationFactory = Factory.define<Population>(({ params }) => {
+  const {
+    id = 'afr',
+    ac = 1,
+    an = 1,
+    ac_hemi = 1,
+    ac_hom = 1,
+    homozygote_count = 1,
+    hemizygote_count = 1,
+  } = params
+
+  return {
+    id,
+    ac,
+    an,
+    ac_hemi,
+    ac_hom,
+    homozygote_count,
+    hemizygote_count,
+  }
+})
+
+export const variantTableVariantFactory = Factory.define<VariantTableVariant>(
+  ({ params, associations }) => {
+    const {
+      ac = 1,
+      ac_hemi = 1,
+      ac_hom = 1,
+      an = 1,
+      af = 1,
+      consequence = 'synonymous',
+      flags = [],
+      hgvs = 'string',
+      hgvsc = 'string',
+      hgvsp = 'string',
+      populations = [],
+      pos = 1,
+      rsids = [],
+      variant_id = '',
+    } = params
+
+    const {
+      exome = {
+        filters: [],
+      },
+      genome = {
+        filters: [],
+      },
+    } = associations
+
+    return {
+      ac,
+      ac_hemi,
+      ac_hom,
+      an,
+      af,
+      consequence,
+      flags,
+      hgvs,
+      hgvsc,
+      hgvsp,
+      populations,
+      pos,
+      rsids,
+      variant_id,
+      exome,
+      genome,
+    }
+  }
+)
 
 export const sequencingFactory = Factory.define<SequencingType>(({ params, associations }) => {
   const {

--- a/browser/src/__factories__/Variant.ts
+++ b/browser/src/__factories__/Variant.ts
@@ -124,15 +124,7 @@ export const variantFactory = Factory.define<Variant>(({ params, associations })
 })
 
 export const populationFactory = Factory.define<Population>(({ params }) => {
-  const {
-    id = 'afr',
-    ac = 1,
-    an = 1,
-    ac_hemi = 1,
-    ac_hom = 1,
-    homozygote_count = 1,
-    hemizygote_count = 1,
-  } = params
+  const { id = 'afr', ac = 1, an = 1, ac_hemi = 1, ac_hom = 1 } = params
 
   return {
     id,
@@ -140,8 +132,6 @@ export const populationFactory = Factory.define<Population>(({ params }) => {
     an,
     ac_hemi,
     ac_hom,
-    homozygote_count,
-    hemizygote_count,
   }
 })
 

--- a/dataset-metadata/gnomadPopulations.ts
+++ b/dataset-metadata/gnomadPopulations.ts
@@ -32,3 +32,52 @@ export type PopulationId = keyof typeof GNOMAD_POPULATION_NAMES
 
 export const populationName = (populationId: string) =>
   textOrMissingTextWarning('genetic ancestry group name', GNOMAD_POPULATION_NAMES, populationId)
+
+const ExACPopulations: PopulationId[] = ['sas', 'afr', 'amr', 'eas', 'fin', 'nfe', 'remaining']
+const v2Populations: PopulationId[] = ['afr', 'nfe', 'afr', 'asj', 'eas', 'fin', 'sas', 'remaining']
+const v3Populations: PopulationId[] = [
+  'nfe',
+  'amr',
+  'eur',
+  'ami',
+  'eas',
+  'mid',
+  'afr',
+  'sas',
+  'asj',
+  'remaining',
+]
+const v4Populations: PopulationId[] = [
+  'afr',
+  'amr',
+  'asj',
+  'eas',
+  'fin',
+  'mid',
+  'nfe',
+  'ami', // v4 does not directly include amish, but v3 does and v4 genomes are from v3
+  'sas',
+  'remaining',
+]
+const allPopulations: PopulationId[] = [
+  'afr',
+  'ami',
+  'amr',
+  'asj',
+  'eas',
+  'mid',
+  'eur',
+  'nfe',
+  'fin',
+  'oth',
+  'sas',
+  'remaining',
+]
+
+export const populationsInDataset = {
+  ExAC: ExACPopulations,
+  v2: v2Populations,
+  v3: v3Populations,
+  v4: v4Populations,
+  default: allPopulations,
+}


### PR DESCRIPTION
Resolves #1307 

On the gene page there is a button that allows users to export the variant list to a `.csv`. As of v4, the variants in the list can have a differing set of genetic ancestry groups (e.g. some variants may have `AC`, `AN`, etc, for `mid` while others may not, this is because of v4 using v3 for its genomes, and its own values for its genomes).

The gene page combines the genome and exome level data variants in an early processing step, presumably for ease of exporting. It accomplishes this by accessing values based on their position in a list. Now that the exomes and genomes populations can differ in size and order, this export produces a list with incorrect values for v4 variants that occur in both exomes and genomes (e.g. taking `[4]` from genomes is Amish, but `[4]` in exomes is Middle Eastern).

This PR changes the logic to make it more general to fix this bug.

- Removes the assumption that the 0th element of the array's genetic ancestry groups are representative of every element in the array (which is a faulty assumption for v4 variants that are in both exomes and genomes)
- Combines genetic ancestry group values using the `id` field, rather than combining based purely on index

It also adds tests to confirm this behavior.