### PR TITLE
adds a service account and deployctl bits for annotating it

### DIFF
--- a/deploy/deployctl/subcommands/browser_deployments.py
+++ b/deploy/deployctl/subcommands/browser_deployments.py
@@ -25,6 +25,14 @@ images:
   - name: gnomad-browser
     newName: {browser_image_repository}
     newTag: '{browser_tag}'
+patches:
+  - patch: |-
+      - op: add
+        path: /metadata/annotations/iam.gke.io~1gcp-service-account
+        value: '{service_account}@{project}.iam.gserviceaccount.com'
+    target:
+      kind: ServiceAccount
+      labelSelector: "component=gnomad-api"
 """
 
 
@@ -89,6 +97,8 @@ def create_deployment(name: str, browser_tag: str = None, api_tag: str = None) -
             browser_tag=browser_tag,
             api_image_repository=config.api_image_repository,
             api_tag=api_tag,
+            project=config.project,
+            service_account=f"{config.gke_cluster_name}-api",
         )
 
         kustomization_file.write(kustomization)

--- a/deploy/manifests/browser/base/add-suffix.yaml
+++ b/deploy/manifests/browser/base/add-suffix.yaml
@@ -1,0 +1,10 @@
+# We need to keep the names of ServiceAccounts stable for Workload Identity
+# This list tells kustomize to only apply dynamic suffixes to resources
+# that can have dynamic names, such as Deployments and Services
+nameSuffix:
+  - path: metadata/name
+    apiVersion: v1
+    kind: Deployment
+  - path: metadata/name
+    apiVersion: v1
+    kind: Service

--- a/deploy/manifests/browser/base/api.deployment.yaml
+++ b/deploy/manifests/browser/base/api.deployment.yaml
@@ -10,12 +10,12 @@ spec:
   selector:
     matchLabels:
       name: gnomad-api
-  serviceAccountName: gnomad-api
   template:
     metadata:
       labels:
         name: gnomad-api
     spec:
+      serviceAccountName: gnomad-api
       containers:
         - name: app
           image: gnomad-api

--- a/deploy/manifests/browser/base/api.deployment.yaml
+++ b/deploy/manifests/browser/base/api.deployment.yaml
@@ -10,6 +10,7 @@ spec:
   selector:
     matchLabels:
       name: gnomad-api
+  serviceAccountName: gnomad-api
   template:
     metadata:
       labels:

--- a/deploy/manifests/browser/base/api.serviceaccount.yaml
+++ b/deploy/manifests/browser/base/api.serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gnomad-api
+  labels:
+    component: gnomad-api

--- a/deploy/manifests/browser/base/kustomization.yaml
+++ b/deploy/manifests/browser/base/kustomization.yaml
@@ -3,7 +3,10 @@ kind: Kustomization
 resources:
   - ./api.deployment.yaml
   - ./api.service.yaml
+  - ./api.serviceaccount.yaml
   - ./browser.deployment.yaml
+configurations:
+  - ./add-suffix.yaml
 vars:
   - name: API_SERVICE
     objref:


### PR DESCRIPTION
Bits for managing a gnomad-api kubernetes service account and annotating it with the (expected) name of a GCP service account that is managed via terraform.

I had to exclude the k8s ServiceAccount object from being suffixed per deployment with kustomize, because GKE workload identity can only bind to an exact serviceaccount within a namespace. e.g. I can only bind to "namespace/service-acct-name", and not to "namespace/service-account-name-*". Which means it cannot handle the case where we have service accounts with a deployment suffix like "service-account-name-blue" or "service-account-name-green"

The result is that all deployments need to share the same service account, which i think is a reasonable workaround in this case.

The alternative is that we can create the kubernetes service account in terraform (like we do with the elasticsearch snapshots account), but I'm worried that creating an implicit dependency between a service account in terraform and the app deployment is going to create too many problems in our more dynamic browser deployments...