### PR TITLE
Update mane select help text

### DIFF
--- a/browser/help/topics/mane-select-transcript.md
+++ b/browser/help/topics/mane-select-transcript.md
@@ -5,4 +5,4 @@ title: MANE Select transcript
 
 MANE stands for Matched Annotation from NCBI and EMBL-EBI and MANE Select identifies one high-quality representative transcript per protein-coding gene that is well-supported by experimental data and represents the biology of the gene. More background can be found on [the MANE project's website](https://www.ncbi.nlm.nih.gov/refseq/MANE/).
 
-Please note, the browser represents transcript versions from GENCODE v35, which may differ from more recent versions selected by the MANE Select project. Please check the version number here (drawn from the MANE Select FTP site) and the version on the transcript list down below in the browser to be aware of possible discrepancies.
+Please note, the browser represents transcript versions from GENCODE v39, which may differ from more recent versions selected by the MANE Select project. Please check the version number here (drawn from the MANE Select FTP site) and the version on the transcript list down below in the browser to be aware of possible discrepancies.


### PR DESCRIPTION
Updates the help text for Mane Select transcripts to reference Gencode v39 rather than v35.

Resolves: https://the-tgg.slack.com/archives/C03P7FA3W3T/p1701383142938469