### PR TITLE
Update terminology on v4 mvp help text

### DIFF
--- a/browser/help/faq/general/what-features-are-not-yet-in-v4-and-where-can-i-find-them.md
+++ b/browser/help/faq/general/what-features-are-not-yet-in-v4-and-where-can-i-find-them.md
@@ -8,12 +8,12 @@ Below is a list of all features not included in the v4 MVP and where to find the
 
 <br />
 
-| Non MVP feature                                 | Past versions with this data                          |
-| ----------------------------------------------- | ----------------------------------------------------- |
-| Pext score                                      | v2 gene page                                          |
-| Sub-genetic ancestry groups (prevously subpops) | v2 variant page                                       |
-| Multi Nucleotide (MNV) calls                    | v2 variant table and variant page                     |
-| Variant co-occurrence                           | v2 gene page                                          |
-| Manual LoF curation                             | v2 variant table and variant page                     |
-| Regional Missense Constraint                    | Now available on v2 gene page                         |
-| Linkage disequilibrium scores                   | [v2](/downloads/#v2-linkage-disequilibrium) downloads |
+| Non MVP feature                                | Past versions with this data                          |
+| ---------------------------------------------- | ----------------------------------------------------- |
+| Pext score                                     | v2 gene page                                          |
+| Genetic ancestry subgroups (prevously subpops) | v2 variant page                                       |
+| Multi Nucleotide (MNV) calls                   | v2 variant table and variant page                     |
+| Variant co-occurrence                          | v2 gene page                                          |
+| Manual LoF curation                            | v2 variant table and variant page                     |
+| Regional Missense Constraint                   | Now available on v2 gene page                         |
+| Linkage disequilibrium scores                  | [v2](/downloads/#v2-linkage-disequilibrium) downloads |

--- a/browser/src/help/__snapshots__/HelpPage.spec.tsx.snap
+++ b/browser/src/help/__snapshots__/HelpPage.spec.tsx.snap
@@ -1161,15 +1161,15 @@ Below is a list of all features not included in the v4 MVP and where to find the
 
 <br />
 
-| Non MVP feature                                 | Past versions with this data                          |
-| ----------------------------------------------- | ----------------------------------------------------- |
-| Pext score                                      | v2 gene page                                          |
-| Sub-genetic ancestry groups (prevously subpops) | v2 variant page                                       |
-| Multi Nucleotide (MNV) calls                    | v2 variant table and variant page                     |
-| Variant co-occurrence                           | v2 gene page                                          |
-| Manual LoF curation                             | v2 variant table and variant page                     |
-| Regional Missense Constraint                    | Now available on v2 gene page                         |
-| Linkage disequilibrium scores                   | [v2](/downloads/#v2-linkage-disequilibrium) downloads |
+| Non MVP feature                                | Past versions with this data                          |
+| ---------------------------------------------- | ----------------------------------------------------- |
+| Pext score                                     | v2 gene page                                          |
+| Genetic ancestry subgroups (prevously subpops) | v2 variant page                                       |
+| Multi Nucleotide (MNV) calls                   | v2 variant table and variant page                     |
+| Variant co-occurrence                          | v2 gene page                                          |
+| Manual LoF curation                            | v2 variant table and variant page                     |
+| Regional Missense Constraint                   | Now available on v2 gene page                         |
+| Linkage disequilibrium scores                  | [v2](/downloads/#v2-linkage-disequilibrium) downloads |
 ",
                       }
                     }


### PR DESCRIPTION
Resolves #1337 

Updates terminology in the v4 mvp help text from "sub-genetic ancestry group" to "genetic ancestry subgroup".