### PR TITLE
switch to a GKE initiated managedcertificate

### DIFF
--- a/deploy/deployctl/subcommands/ingress_production.py
+++ b/deploy/deployctl/subcommands/ingress_production.py
@@ -99,6 +99,7 @@ def apply_ingress(browser_deployment: str = None, reads_deployment: str = None, 
         kubectl(["apply", "-f", os.path.join(manifests_directory(), "gnomad.backendconfig.yaml")])
         kubectl(["apply", "-f", os.path.join(manifests_directory(), "gnomad.frontendconfig.yaml")])
         kubectl(["apply", "-f", os.path.join(manifests_directory(), "gnomad.ingress.yaml")])
+        kubectl(["apply", "-f", os.path.join(manifests_directory(), "gnomad.managedcertificate.yaml")])
 
 
 def main(argv: typing.List[str]) -> None:

--- a/deploy/manifests/ingress/gnomad.ingress.yaml
+++ b/deploy/manifests/ingress/gnomad.ingress.yaml
@@ -6,7 +6,7 @@ metadata:
     tier: production
   annotations:
     kubernetes.io/ingress.global-static-ip-name: gnomad-prod-global-ip
-    ingress.gcp.kubernetes.io/pre-shared-cert: gnomad-browser-cert
+    networking.gke.io/managed-certificates: gnomad-prod-certificate
     networking.gke.io/v1beta1.FrontendConfig: 'gnomad-frontend-config'
 spec:
   rules:

--- a/deploy/manifests/ingress/gnomad.ingress.yaml
+++ b/deploy/manifests/ingress/gnomad.ingress.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.global-static-ip-name: gnomad-prod-global-ip
     networking.gke.io/managed-certificates: gnomad-prod-certificate
+    ingress.gcp.kubernetes.io/pre-shared-cert: gnomad-browser-cert # TODO: remove this after new cert is provisioned
     networking.gke.io/v1beta1.FrontendConfig: 'gnomad-frontend-config'
 spec:
   rules:

--- a/deploy/manifests/ingress/gnomad.managedcertificate.yaml
+++ b/deploy/manifests/ingress/gnomad.managedcertificate.yaml
@@ -1,0 +1,9 @@
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: gnomad-prod-certificate
+  labels:
+    tier: production
+spec:
+  domains:
+    - gnomad.broadinstitute.org

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,9 @@
 [tool.black]
 line-length = 120
 
+[tool.ruff]
+line-length = 120
+
 [tool.pylint.basic]
 # ds: frequently used name for a variable containing a Hail table
 good-names = [


### PR DESCRIPTION
We previously created a managedcertificate out of band, in setup.py. This switches to the GKE built-in managedcertificate object. This removes a chicken and egg scenario where we couldn't deploy the app until a cert was present, and couldn't issue the cert until there was an app present.