### PR TITLE
Update variant page in silico predictor display

### DIFF
--- a/browser/src/VariantPage/VariantInSilicoPredictors.tsx
+++ b/browser/src/VariantPage/VariantInSilicoPredictors.tsx
@@ -20,13 +20,43 @@ const FLAG_DESCRIPTIONS = {
 }
 
 const PREDICTORS_V4 = {
-  revel_max: { label: 'REVEL', warningThreshold: 0.644, dangerThreshold: 0.773 },
-  spliceai_ds_max: { label: 'SpliceAI', warningThreshold: 0.2, dangerThreshold: 0.5 },
-  pangolin_largest_ds: { label: 'Pangolin', warningThreshold: 0.2, dangerThreshold: 0.5 },
-  phylop: { label: 'phyloP', warningThreshold: 7.367, dangerThreshold: 9.741 },
-  sift_max: { label: 'SIFT (max)', warningThreshold: 0.001, dangerThreshold: 0 },
-  polyphen_max: { label: 'PolyPhen (max)', warningThreshold: 0.978, dangerThreshold: 0.999 },
-  cadd: { label: 'CADD', warningThreshold: 25.3, dangerThreshold: 28.1 },
+  revel_max: {
+    label: 'REVEL',
+    warningThreshold: 0.644,
+    dangerThreshold: 0.773,
+    absoluteValue: false,
+  },
+  spliceai_ds_max: {
+    label: 'SpliceAI',
+    warningThreshold: 0.2,
+    dangerThreshold: 0.5,
+    absoluteValue: false,
+  },
+  pangolin_largest_ds: {
+    label: 'Pangolin',
+    warningThreshold: 0.2,
+    dangerThreshold: 0.5,
+    absoluteValue: true,
+  },
+  phylop: {
+    label: 'phyloP',
+    warningThreshold: 7.367,
+    dangerThreshold: 9.741,
+    absoluteValue: false,
+  },
+  sift_max: {
+    label: 'SIFT (max)',
+    warningThreshold: 0.001,
+    dangerThreshold: 0,
+    absoluteValue: false,
+  },
+  polyphen_max: {
+    label: 'PolyPhen (max)',
+    warningThreshold: 0.978,
+    dangerThreshold: 0.999,
+    absoluteValue: false,
+  },
+  cadd: { label: 'CADD', warningThreshold: 25.3, dangerThreshold: 28.1, absoluteValue: false },
 }
 
 const EXCLUDED_v4_PREDICTORS = ['sift_max']
@@ -88,7 +118,9 @@ const VariantInSilicoPredictors = ({ variant, datasetId }: Props) => {
               const predictor = predictors[id]
 
               let color = null
-              const parsedValue = parseFloat(value)
+              const parsedValue = predictor.absoluteValue
+                ? Math.abs(parseFloat(value))
+                : parseFloat(value)
               if (!Number.isNaN(parsedValue)) {
                 if (!predictor.dangerThreshold || !predictor.warningThreshold) {
                   color = 'grey'

--- a/browser/src/VariantPage/VariantInSilicoPredictors.tsx
+++ b/browser/src/VariantPage/VariantInSilicoPredictors.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 
 import { Badge, List, ListItem } from '@gnomad/ui'
 import { DatasetId, isV4 } from '@gnomad/dataset-metadata/metadata'
+import { Variant } from './VariantPage'
 
 const PREDICTORS = {
   cadd: { label: 'CADD', warningThreshold: 10, dangerThreshold: 20 },
@@ -56,13 +57,7 @@ const Marker = styled.span`
 `
 
 type Props = {
-  variant: {
-    in_silico_predictors: {
-      id: string
-      value: string
-      flags: string[]
-    }[]
-  }
+  variant: Variant
   datasetId: DatasetId
 }
 

--- a/browser/src/VariantPage/VariantInSilicoPredictors.tsx
+++ b/browser/src/VariantPage/VariantInSilicoPredictors.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
 
-import { Badge, List, ListItem } from '@gnomad/ui'
+import { Badge, ExternalLink, List, ListItem } from '@gnomad/ui'
 import { DatasetId, isV4 } from '@gnomad/dataset-metadata/metadata'
 import { Variant } from './VariantPage'
 
@@ -140,6 +140,17 @@ const VariantInSilicoPredictors = ({ variant, datasetId }: Props) => {
               )
             })}
       </List>
+      {isV4(datasetId) && (
+        <>
+          <Badge level="info">Note</Badge> For more detailed and up to date SpliceAI and Pangolin
+          predictions, please visit our {/* @ts-expect-error */}
+          <ExternalLink
+            href={`https://spliceailookup.broadinstitute.org/#variant=chr${variant.variant_id}&hg=38&distance=500&mask=0&ra=0}`}
+          >
+            SpliceAI Lookup browser
+          </ExternalLink>
+        </>
+      )}
     </div>
   )
 }

--- a/browser/src/VariantPage/VariantPage.tsx
+++ b/browser/src/VariantPage/VariantPage.tsx
@@ -397,7 +397,6 @@ export const VariantPageContent = ({ datasetId, variant }: VariantPageContentPro
         {variant.in_silico_predictors && variant.in_silico_predictors.length && (
           <ResponsiveSection>
             <h2>In Silico Predictors</h2>
-            {/* @ts-expect-error TS(2322) FIXME: Type '{ variant_id: string; chrom: string; flags: ... Remove this comment to see the full error message */}
             <VariantInSilicoPredictors variant={variant} datasetId={datasetId} />
           </ResponsiveSection>
         )}


### PR DESCRIPTION
Resolves #1345

- Re-adds a note referring users to SpliceAI Lookup that was mistakenly dropped after being included in mockups
- Updates Pangolin scores warning and danger thresholds to be based off of the absolute value of the score so negative (splice loss) predictions get correctly colored

Example localhost link to variant [http://localhost:8008/variant/7-66991136-C-T?dataset=gnomad_r4](http://localhost:8008/variant/7-66991136-C-T?dataset=gnomad_r4)

<img src="https://github.com/broadinstitute/gnomad-browser/assets/59549713/eb9f4366-3989-4037-8fd7-19c90f958c0f" width="500" />

