### PR TITLE
Update paths to variant cooccurrence tsv files

### DIFF
--- a/browser/src/DownloadsPage/GnomadV2Downloads.tsx
+++ b/browser/src/DownloadsPage/GnomadV2Downloads.tsx
@@ -641,14 +641,14 @@ const GnomadV2Downloads = () => {
           </ListItem>
           {/* @ts-expect-error */}
           <ListItem>
-            <GetUrlButtons
+            <GenericDownloadLinks
               label="Variant co-occurrence by gene (homozygous rare variants)"
               path="/release/2.1.1/secondary_analyses/variant_cooccurrence/gnomAD_v2_homozygous_rare_variants_table_for_download.tsv"
             />
           </ListItem>
           {/* @ts-expect-error */}
           <ListItem>
-            <GetUrlButtons
+            <GenericDownloadLinks
               label="Variant co-occurrence by gene (two heterozygous rare variants)"
               path="/release/2.1.1/secondary_analyses/variant_cooccurrence/gnomAD_v2_two_heterozygous_rare_variants_table_for_download.tsv"
             />

--- a/browser/src/DownloadsPage/__snapshots__/DownloadsPage.spec.tsx.snap
+++ b/browser/src/DownloadsPage/__snapshots__/DownloadsPage.spec.tsx.snap
@@ -25220,34 +25220,39 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             Variant co-occurrence by gene (homozygous rare variants)
           </span>
           <br />
-          Show URL for
-           
-          <button
-            aria-label="Show Google URL for Variant co-occurrence by gene (homozygous rare variants)"
-            className="c21"
-            onClick={[Function]}
-            type="button"
-          >
-            Google
-          </button>
-           / 
-          <button
-            aria-label="Show Amazon URL for Variant co-occurrence by gene (homozygous rare variants)"
-            className="c21"
-            onClick={[Function]}
-            type="button"
-          >
-            Amazon
-          </button>
-           / 
-          <button
-            aria-label="Show Microsoft URL for Variant co-occurrence by gene (homozygous rare variants)"
-            className="c21"
-            onClick={[Function]}
-            type="button"
-          >
-            Microsoft
-          </button>
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download Variant co-occurrence by gene (homozygous rare variants) from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/secondary_analyses/variant_cooccurrence/gnomAD_v2_homozygous_rare_variants_table_for_download.tsv"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download Variant co-occurrence by gene (homozygous rare variants) from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/secondary_analyses/variant_cooccurrence/gnomAD_v2_homozygous_rare_variants_table_for_download.tsv"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download Variant co-occurrence by gene (homozygous rare variants) from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/secondary_analyses/variant_cooccurrence/gnomAD_v2_homozygous_rare_variants_table_for_download.tsv"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
         </li>
         <li
           className="c20"
@@ -25256,34 +25261,39 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             Variant co-occurrence by gene (two heterozygous rare variants)
           </span>
           <br />
-          Show URL for
-           
-          <button
-            aria-label="Show Google URL for Variant co-occurrence by gene (two heterozygous rare variants)"
-            className="c21"
-            onClick={[Function]}
-            type="button"
-          >
-            Google
-          </button>
-           / 
-          <button
-            aria-label="Show Amazon URL for Variant co-occurrence by gene (two heterozygous rare variants)"
-            className="c21"
-            onClick={[Function]}
-            type="button"
-          >
-            Amazon
-          </button>
-           / 
-          <button
-            aria-label="Show Microsoft URL for Variant co-occurrence by gene (two heterozygous rare variants)"
-            className="c21"
-            onClick={[Function]}
-            type="button"
-          >
-            Microsoft
-          </button>
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download Variant co-occurrence by gene (two heterozygous rare variants) from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/secondary_analyses/variant_cooccurrence/gnomAD_v2_two_heterozygous_rare_variants_table_for_download.tsv"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download Variant co-occurrence by gene (two heterozygous rare variants) from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/2.1.1/secondary_analyses/variant_cooccurrence/gnomAD_v2_two_heterozygous_rare_variants_table_for_download.tsv"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download Variant co-occurrence by gene (two heterozygous rare variants) from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/2.1.1/secondary_analyses/variant_cooccurrence/gnomAD_v2_two_heterozygous_rare_variants_table_for_download.tsv"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
         </li>
       </ul>
     </section>

--- a/data-pipeline/src/data_pipeline/pipelines/variant_cooccurrence_counts.py
+++ b/data-pipeline/src/data_pipeline/pipelines/variant_cooccurrence_counts.py
@@ -1,9 +1,7 @@
 import hail as hl
 
-TWO_HET_DATA_PATH = "gs://gnomad-browser-data-pipeline/inputs/secondary-analyses/variant-cooccurrence/2023-11-29/chet_unphased_same_hap_per_gene.tsv"
-HOMOZYGOUS_DATA_PATH = (
-    "gs://gnomad-browser-data-pipeline/inputs/secondary-analyses/variant-cooccurrence/2023-02-24/het_hom_per_gene.tsv"
-)
+TWO_HET_DATA_PATH = "gs://gcp-public-data--gnomad/release/2.1.1/secondary_analyses/variant_cooccurrence/gnomAD_v2_two_heterozygous_rare_variants_table_for_download.tsv"
+HOMOZYGOUS_DATA_PATH = "gs://gcp-public-data--gnomad/release/2.1.1/secondary_analyses/variant_cooccurrence/gnomAD_v2_homozygous_rare_variants_table_for_download.tsv"
 
 AF_CUTOFF_MAPPING = hl.literal(
     {
@@ -27,7 +25,7 @@ HOMOZYGOUS_AF_CUTOFFS_TO_EXPORT = hl.literal(["af_cutoff_0_05", "af_cutoff_0_01"
 
 
 def prepare_variant_cooccurrence_counts(tsv_path, field_name_map):
-    key_field_types = {"gene_id": hl.tstr, "csq": hl.tstr, "af_cutoff": hl.tstr}
+    key_field_types = {"gene_id": hl.tstr, "csq": hl.tstr, "af_threshold": hl.tstr}
     input_field_types = dict(map(lambda field_name: (field_name, hl.tint), field_name_map.values()))
 
     result = hl.import_table(
@@ -36,7 +34,7 @@ def prepare_variant_cooccurrence_counts(tsv_path, field_name_map):
         key=["gene_id"],
         min_partitions=100,
     )
-    result = result.transmute(af_cutoff=AF_CUTOFF_MAPPING[result.af_cutoff])
+    result = result.transmute(af_cutoff=AF_CUTOFF_MAPPING[result.af_threshold])
     result = result.key_by("gene_id", "csq", "af_cutoff")
     struct_schema = {
         processed_field_name: result[result.gene_id, result.csq, result.af_cutoff][raw_field_name]


### PR DESCRIPTION
Resolves #1328 

- Minorly updates v2 downloads to use the correct download links
- Updates the variant coocurrence pipeline task to refer to the publicly released `.tsv` files
  - Changes the name of a field in the pipeline task to accomodate the field name change in the public file

I tested running the task locally and it succeeds using the public data. I did not run it in the context of the whole pipeline, fwiw, but the return schema from the tasks are unchanged.