### PR TITLE
remove old certificate from ingress descriptor

### DIFF
--- a/deploy/manifests/ingress/gnomad.ingress.yaml
+++ b/deploy/manifests/ingress/gnomad.ingress.yaml
@@ -7,7 +7,6 @@ metadata:
   annotations:
     kubernetes.io/ingress.global-static-ip-name: gnomad-prod-global-ip
     networking.gke.io/managed-certificates: gnomad-prod-certificate
-    ingress.gcp.kubernetes.io/pre-shared-cert: gnomad-browser-cert # TODO: remove this after new cert is provisioned
     networking.gke.io/v1beta1.FrontendConfig: 'gnomad-frontend-config'
 spec:
   rules:


### PR DESCRIPTION
part of #1343 

Now that the new managedcertificate has been provisioned, we can remove the standalone one.