### PR TITLE
Update links to two recent papers

### DIFF
--- a/browser/src/PublicationsPage.tsx
+++ b/browser/src/PublicationsPage.tsx
@@ -39,13 +39,12 @@ export default () => (
             Tibbetts, K., gnomAD Project Consortium, O’Donnell-Luria, A., Solomonson, M., Seed, C.,
             Martin, A. R., Talkowski, M. E., Rehm, H. L., Daly, M. J., Tiao, G., Neale, B. M.†,
             MacArthur, D. G.† & Karczewski, K. J. A genome-wide mutational constraint map quantified
-            from variation in 76,156 human genomes. <em>bioRxiv</em> 2022.03.20.485034 (2022).{' '}
-            {/* @ts-expect-error */}
-            <ExternalLink href="https://doi.org/10.1101/2022.03.20.485034">
-              https://doi.org/10.1101/2022.03.20.485034
+            from variation in 76,156 human genomes. <em>Nature</em> (2023). {/* @ts-expect-error */}
+            <ExternalLink href="https://doi.org/10.1038/s41586-023-06045-0">
+              https://doi.org/10.1038/s41586-023-06045-0
             </ExternalLink>{' '}
             {/* @ts-expect-error */}
-            <ExternalLink href="https://www.biorxiv.org/highwire/citation/2787225/endnote-tagged">
+            <ExternalLink href="https://citation-needed.springer.com/v2/references/10.1038/s41586-023-06045-0?format=refman&flavour=citation">
               Download citation
             </ExternalLink>
           </Citation>
@@ -109,10 +108,10 @@ export default () => (
             Singer-Berk, M., Groopman, E., Darnowsky, P. W., Solomonson, M., Baxter, S., gnomAD
             Project Consortium, Tiao, G., Neale, B. M., Hirschhorn, J. N., Rehm, H., Daly, M. J.,
             O’Donnell-Luria, A., Karczewski, K., MacArthur, D. G., Samocha, K. E. Inferring compound
-            heterozygosity from large-scale exome sequencing data.{' '}
-            <em>Cold Spring Harbor Laboratory</em>. {/* @ts-expect-error */}
-            <ExternalLink href="https://doi.org/10.1101/2023.03.19.533370">
-              https://doi.org/10.1101/2023.03.19.533370
+            heterozygosity from large-scale exome sequencing data. <em>Nature Genetics</em> (2023).{' '}
+            {/* @ts-expect-error */}
+            <ExternalLink href="https://doi.org/10.1038/s41588-023-01608-3">
+              https://doi.org/10.1038/s41588-023-01608-3
             </ExternalLink>
           </Citation>
         </ListItem>

--- a/browser/src/__snapshots__/PublicationsPage.spec.tsx.snap
+++ b/browser/src/__snapshots__/PublicationsPage.spec.tsx.snap
@@ -140,22 +140,21 @@ exports[`Publications Page has no unexpected changes 1`] = `
         >
           Chen, S.*, Francioli, L. C.*, Goodrich, J. K., Collins, R. L., Wang, Q., Alföldi, J., Watts, N. A., Vittal, C., Gauthier, L. D., Poterba, T., Wilson, M. W., Tarasova, Y., Phu, W., Yohannes, M. T., Koenig, Z., Farjoun, Y., Banks, E., Donnelly, S., Gabriel, S., Gupta, N., Ferriera, S., Tolonen, C., Novod, S., Bergelson, L., Roazen, D., Ruano-Rubio, V., Covarrubias, M., Llanwarne, C., Petrillo, N., Wade, G., Jeandet, T., Munshi, R., Tibbetts, K., gnomAD Project Consortium, O’Donnell-Luria, A., Solomonson, M., Seed, C., Martin, A. R., Talkowski, M. E., Rehm, H. L., Daly, M. J., Tiao, G., Neale, B. M.†, MacArthur, D. G.† & Karczewski, K. J. A genome-wide mutational constraint map quantified from variation in 76,156 human genomes. 
           <em>
-            bioRxiv
+            Nature
           </em>
-           2022.03.20.485034 (2022).
-           
+           (2023). 
           <a
             className="c6"
-            href="https://doi.org/10.1101/2022.03.20.485034"
+            href="https://doi.org/10.1038/s41586-023-06045-0"
             rel="noopener noreferrer"
             target="_blank"
           >
-            https://doi.org/10.1101/2022.03.20.485034
+            https://doi.org/10.1038/s41586-023-06045-0
           </a>
            
           <a
             className="c6"
-            href="https://www.biorxiv.org/highwire/citation/2787225/endnote-tagged"
+            href="https://citation-needed.springer.com/v2/references/10.1038/s41586-023-06045-0?format=refman&flavour=citation"
             rel="noopener noreferrer"
             target="_blank"
           >
@@ -259,19 +258,19 @@ exports[`Publications Page has no unexpected changes 1`] = `
         <cite
           className="c5"
         >
-          Guo, M. H.†, Francioli, L. C.†, Stenton, S. L., Goodrich, J. K., Watts, N. A., Singer-Berk, M., Groopman, E., Darnowsky, P. W., Solomonson, M., Baxter, S., gnomAD Project Consortium, Tiao, G., Neale, B. M., Hirschhorn, J. N., Rehm, H., Daly, M. J., O’Donnell-Luria, A., Karczewski, K., MacArthur, D. G., Samocha, K. E. Inferring compound heterozygosity from large-scale exome sequencing data.
-           
+          Guo, M. H.†, Francioli, L. C.†, Stenton, S. L., Goodrich, J. K., Watts, N. A., Singer-Berk, M., Groopman, E., Darnowsky, P. W., Solomonson, M., Baxter, S., gnomAD Project Consortium, Tiao, G., Neale, B. M., Hirschhorn, J. N., Rehm, H., Daly, M. J., O’Donnell-Luria, A., Karczewski, K., MacArthur, D. G., Samocha, K. E. Inferring compound heterozygosity from large-scale exome sequencing data. 
           <em>
-            Cold Spring Harbor Laboratory
+            Nature Genetics
           </em>
-          . 
+           (2023).
+           
           <a
             className="c6"
-            href="https://doi.org/10.1101/2023.03.19.533370"
+            href="https://doi.org/10.1038/s41588-023-01608-3"
             rel="noopener noreferrer"
             target="_blank"
           >
-            https://doi.org/10.1101/2023.03.19.533370
+            https://doi.org/10.1038/s41588-023-01608-3
           </a>
         </cite>
       </li>


### PR DESCRIPTION
Updates the links on the publication page to two articles recently published in Nature and Nature Genetics
- https://www.nature.com/articles/s41586-023-06045-0
- https://www.nature.com/articles/s41588-023-01608-3