### PR TITLE
Update download links to v4 PCA and constraint files

### DIFF
--- a/browser/src/DownloadsPage/GnomadV4Downloads.tsx
+++ b/browser/src/DownloadsPage/GnomadV4Downloads.tsx
@@ -215,7 +215,7 @@ const GnomadV4Downloads = () => {
           <ListItem>
             <GetUrlButtons
               label="Principal component analysis (PCA) variant loadings"
-              path="/release/4.0/gnomad.v4.0.pca_loadings.ht"
+              path="/release/4.0/pca/gnomad.v4.0.pca_loadings.ht"
             />
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
@@ -243,20 +243,20 @@ const GnomadV4Downloads = () => {
         <FileList>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
-            <GenericDownloadLinks label="README" path="/release/v4.0/constraint/README.txt" />
+            <GenericDownloadLinks label="README" path="/release/4.0/constraint/README.txt" />
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
             <GetUrlButtons
               label="Constraint metrics Hail Table"
-              path="/release/v4.0/constraint/gnomad.v4.0.constraint_metrics.ht"
+              path="/release/4.0/constraint/gnomad.v4.0.constraint_metrics.ht"
             />
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
             <GenericDownloadLinks
               label="Constraint metrics TSV"
-              path="/release/v4.0/constraint/gnomad.v4.0.constraint_metrics.tsv"
+              path="/release/4.0/constraint/gnomad.v4.0.constraint_metrics.tsv"
             />
           </ListItem>
         </FileList>

--- a/browser/src/DownloadsPage/__snapshots__/DownloadsPage.spec.tsx.snap
+++ b/browser/src/DownloadsPage/__snapshots__/DownloadsPage.spec.tsx.snap
@@ -5031,7 +5031,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             <a
               aria-label="Download README from Google"
               className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/v4.0/constraint/README.txt"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/constraint/README.txt"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -5041,7 +5041,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             <a
               aria-label="Download README from Amazon"
               className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/v4.0/constraint/README.txt"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/constraint/README.txt"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -5051,7 +5051,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             <a
               aria-label="Download README from Microsoft"
               className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/v4.0/constraint/README.txt"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/constraint/README.txt"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -5108,7 +5108,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             <a
               aria-label="Download Constraint metrics TSV from Google"
               className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/v4.0/constraint/gnomad.v4.0.constraint_metrics.tsv"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/constraint/gnomad.v4.0.constraint_metrics.tsv"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -5118,7 +5118,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             <a
               aria-label="Download Constraint metrics TSV from Amazon"
               className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/v4.0/constraint/gnomad.v4.0.constraint_metrics.tsv"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/constraint/gnomad.v4.0.constraint_metrics.tsv"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -5128,7 +5128,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             <a
               aria-label="Download Constraint metrics TSV from Microsoft"
               className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/v4.0/constraint/gnomad.v4.0.constraint_metrics.tsv"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/constraint/gnomad.v4.0.constraint_metrics.tsv"
               rel="noopener noreferrer"
               target="_blank"
             >


### PR DESCRIPTION
Resolves #1359

Updates links on the v4 Downloads page:
- PCA link to be the correct path
- Constraint links to use the typical `.../4.0/...` instead of the soon to be removed `.../v4.0/...` that was only used for constraint per this [Slack thread](https://the-tgg.slack.com/archives/C018PB68VU5/p1702654695406309)