### PR TITLE
bug: actually use the provided redis port in single host configs

### DIFF
--- a/graphql-api/src/cache.ts
+++ b/graphql-api/src/cache.ts
@@ -7,6 +7,12 @@ import logger from './logger'
 import { JsonCache } from './queries/helpers/json-cache'
 import largeGenes from './queries/helpers/large-genes'
 
+type WithCacheOptions = {
+  expiration?: number
+  jsonCacheEnableAll?: boolean
+  jsonCacheLargeGenes?: boolean
+}
+
 let fetchCacheValue = () => Promise.resolve(null)
 let setCacheValue = () => Promise.resolve()
 let setCacheExpiration = () => Promise.resolve()
@@ -69,9 +75,7 @@ if (config.REDIS_HOST) {
   logger.warn('No cache configured')
 }
 
-export const withCache = (fn: any, keyFn: any, options = {}) => {
-  // @ts-expect-error TS(2339) FIXME: Property 'expiration' does not exist on type '{}'.
-  //
+export const withCache = (fn: any, keyFn: any, options: WithCacheOptions = {}) => {
   const {
     expiration = 3600,
     jsonCacheEnableAll = config.JSON_CACHE_ENABLE_ALL,

--- a/graphql-api/src/cache.ts
+++ b/graphql-api/src/cache.ts
@@ -30,11 +30,13 @@ if (config.REDIS_HOST) {
   } else {
     readCacheDb = new Redis({
       host: config.REDIS_HOST,
+      port: config.REDIS_PORT,
       db: 1,
     })
 
     writeCacheDb = new Redis({
       host: config.REDIS_HOST,
+      port: config.REDIS_PORT,
       db: 1,
     })
   }
@@ -70,7 +72,11 @@ if (config.REDIS_HOST) {
 export const withCache = (fn: any, keyFn: any, options = {}) => {
   // @ts-expect-error TS(2339) FIXME: Property 'expiration' does not exist on type '{}'.
   //
-  const { expiration = 3600, jsonCacheEnableAll = config.JSON_CACHE_ENABLE_ALL, jsonCacheLargeGenes = config.JSON_CACHE_LARGE_GENES } = options
+  const {
+    expiration = 3600,
+    jsonCacheEnableAll = config.JSON_CACHE_ENABLE_ALL,
+    jsonCacheLargeGenes = config.JSON_CACHE_LARGE_GENES,
+  } = options
 
   return async (...args: any[]) => {
     const cacheKey = keyFn(...args)
@@ -88,9 +94,8 @@ export const withCache = (fn: any, keyFn: any, options = {}) => {
       return result
     }
 
-
     if (jsonCacheLargeGenes) {
-      const isLargeGene = largeGenes.some(g => cacheKey.includes(g))
+      const isLargeGene = largeGenes.some((g) => cacheKey.includes(g))
 
       if (isLargeGene) {
         const json_cache = new JsonCache(config.JSON_CACHE_PATH, config.JSON_CACHE_COMPRESSION)
@@ -115,7 +120,7 @@ export const withCache = (fn: any, keyFn: any, options = {}) => {
     }
     if (cachedResult) {
       // @ts-expect-error TS(2554) FIXME: Expected 0 arguments, but got 1.
-      setCacheExpiration([cacheKey, expiration]).catch(() => { })
+      setCacheExpiration([cacheKey, expiration]).catch(() => {})
       return JSON.parse(cachedResult)
     }
 

--- a/graphql-api/src/cache.ts
+++ b/graphql-api/src/cache.ts
@@ -7,6 +7,10 @@ import logger from './logger'
 import { JsonCache } from './queries/helpers/json-cache'
 import largeGenes from './queries/helpers/large-genes'
 
+type AsyncCacheFunction = (...args: any[]) => Promise<any>
+
+type keyFunction = (...args: any[]) => string
+
 type WithCacheOptions = {
   expiration?: number
   jsonCacheEnableAll?: boolean
@@ -75,7 +79,11 @@ if (config.REDIS_HOST) {
   logger.warn('No cache configured')
 }
 
-export const withCache = (fn: any, keyFn: any, options: WithCacheOptions = {}) => {
+export const withCache = (
+  fn: AsyncCacheFunction,
+  keyFn: keyFunction,
+  options: WithCacheOptions = {}
+) => {
   const {
     expiration = 3600,
     jsonCacheEnableAll = config.JSON_CACHE_ENABLE_ALL,


### PR DESCRIPTION
realized when looking at something else that the single-host branch of the redis config logic wasn't passing the REDIS_PORT environment variable through and using it.