### PR TITLE
Makes downloadsPageStyles more DRY

### DIFF
--- a/browser/src/DownloadsPage/ExacDownloads.tsx
+++ b/browser/src/DownloadsPage/ExacDownloads.tsx
@@ -5,9 +5,8 @@ import { ListItem } from '@gnomad/ui'
 import {
   DownloadsSection,
   FileList,
-  GenericDownloadLinks,
+  DownloadLinks,
   GetUrlButtons,
-  IndexedFileDownloadLinks,
   SectionTitle,
   StyledParagraph,
 } from './downloadsPageStyles'
@@ -62,11 +61,12 @@ const ExacDownloads = () => (
       <FileList>
         {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
         <ListItem>
-          <IndexedFileDownloadLinks
+          <DownloadLinks
             label="All chromosomes VCF"
             path="/legacy/exac_browser/ExAC.r1.sites.vep.vcf.gz"
             size="4.56 GiB"
             md5="f2b57a6f0660a00e7550f62da2654948"
+            includeTBI
           />
         </ListItem>
       </FileList>
@@ -78,7 +78,7 @@ const ExacDownloads = () => (
         {coverageFiles.map(({ chrom, md5, size }) => (
           // @ts-expect-error TS(2769) FIXME: No overload matches this call.
           <ListItem key={chrom}>
-            <GenericDownloadLinks
+            <DownloadLinks
               label={`chr${chrom} exome coverage summary TSV`}
               path={`/legacy/exac_browser/coverage/Panel.chr${chrom}.coverage.txt.gz`}
               size={size}
@@ -94,7 +94,7 @@ const ExacDownloads = () => (
       <FileList>
         {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
         <ListItem>
-          <GenericDownloadLinks
+          <DownloadLinks
             label="Gene constraint scores TSV"
             path="/legacy/exac_browser/forweb_cleaned_exac_r03_march16_z_data_pLI_CNV-final.txt.gz"
           />
@@ -109,7 +109,7 @@ const ExacDownloads = () => (
       <FileList>
         {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
         <ListItem>
-          <GenericDownloadLinks
+          <DownloadLinks
             label="Regional missense constraint TSV"
             path="/legacy/exac_browser/regional_missense_constraint.tsv"
           />
@@ -122,7 +122,7 @@ const ExacDownloads = () => (
       <FileList>
         {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
         <ListItem>
-          <GenericDownloadLinks
+          <DownloadLinks
             label="Exome calling regions"
             path="/intervals/exome_calling_regions.v1.interval_list"
           />

--- a/browser/src/DownloadsPage/GnomadV2Downloads.tsx
+++ b/browser/src/DownloadsPage/GnomadV2Downloads.tsx
@@ -7,11 +7,10 @@ import { GNOMAD_POPULATION_NAMES } from '@gnomad/dataset-metadata/gnomadPopulati
 import {
   Column,
   ColumnsWrapper,
+  DownloadLinks,
   DownloadsSection,
   FileList,
-  GenericDownloadLinks,
   GetUrlButtons,
-  IndexedFileDownloadLinks,
   SectionTitle,
   StyledParagraph,
 } from './downloadsPageStyles'
@@ -129,7 +128,7 @@ const LDFiles = () => {
         </ListItem>
         {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
         <ListItem>
-          <GenericDownloadLinks
+          <DownloadLinks
             // @ts-expect-error TS(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
             label={`LDSC .ldscore.bgz file for ${GNOMAD_POPULATION_NAMES[selectedPopulation]} population`}
             path={`/release/2.1.1/ld/scores/gnomad.genomes.r2.1.1.${urlPopId}.adj.ld_scores.ldscore.bgz`}
@@ -137,7 +136,7 @@ const LDFiles = () => {
         </ListItem>
         {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
         <ListItem>
-          <GenericDownloadLinks
+          <DownloadLinks
             // @ts-expect-error TS(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
             label={`LDSC .M file for ${GNOMAD_POPULATION_NAMES[selectedPopulation]} population`}
             path={`/release/2.1.1/ld/scores/gnomad.genomes.r2.1.1.${urlPopId}.adj.ld_scores.M`}
@@ -145,7 +144,7 @@ const LDFiles = () => {
         </ListItem>
         {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
         <ListItem>
-          <GenericDownloadLinks
+          <DownloadLinks
             // @ts-expect-error TS(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
             label={`LDSC .M_5_50 file for ${GNOMAD_POPULATION_NAMES[selectedPopulation]} population`}
             path={`/release/2.1.1/ld/scores/gnomad.genomes.r2.1.1.${urlPopId}.adj.ld_scores.M_5_50`}
@@ -202,21 +201,23 @@ const GnomadV2Downloads = () => {
 
               {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
               <ListItem>
-                <IndexedFileDownloadLinks
+                <DownloadLinks
                   label="All chromosomes sites VCF"
                   path="/release/2.1.1/vcf/exomes/gnomad.exomes.r2.1.1.sites.vcf.bgz"
                   size="58.81 GiB"
                   md5="f034173bf6e57fbb5e8ce680e95134f2"
+                  includeTBI
                 />
               </ListItem>
               {exomeChromosomeVcfs.map(({ chrom, size, md5 }) => (
                 // @ts-expect-error TS(2769) FIXME: No overload matches this call.
                 <ListItem key={chrom}>
-                  <IndexedFileDownloadLinks
+                  <DownloadLinks
                     label={`chr${chrom} sites VCF`}
                     path={`/release/2.1.1/vcf/exomes/gnomad.exomes.r2.1.1.sites.${chrom}.vcf.bgz`}
                     size={size}
                     md5={md5}
+                    includeTBI
                   />
                 </ListItem>
               ))}
@@ -235,30 +236,33 @@ const GnomadV2Downloads = () => {
               </ListItem>
               {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
               <ListItem>
-                <IndexedFileDownloadLinks
+                <DownloadLinks
                   label="All chromosomes sites VCF"
                   path="/release/2.1.1/vcf/genomes/gnomad.genomes.r2.1.1.sites.vcf.bgz"
                   size="460.93 GiB"
                   md5="e6eadf5ac7b2821b40f350da6e1279a2"
+                  includeTBI
                 />
               </ListItem>
               {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
               <ListItem>
-                <IndexedFileDownloadLinks
+                <DownloadLinks
                   label="Exome calling intervals VCF"
                   path="/release/2.1.1/vcf/genomes/gnomad.genomes.r2.1.1.exome_calling_intervals.sites.vcf.bgz"
                   size="9.7 GiB"
                   md5="e5bd69a0f89468149bc3afca78cd5acc"
+                  includeTBI
                 />
               </ListItem>
               {genomeChromosomeVcfs.map(({ chrom, size, md5 }) => (
                 // @ts-expect-error TS(2769) FIXME: No overload matches this call.
                 <ListItem key={chrom}>
-                  <IndexedFileDownloadLinks
+                  <DownloadLinks
                     label={`chr${chrom} sites VCF`}
                     path={`/release/2.1.1/vcf/genomes/gnomad.genomes.r2.1.1.sites.${chrom}.vcf.bgz`}
                     size={size}
                     md5={md5}
+                    includeTBI
                   />
                 </ListItem>
               ))}
@@ -279,7 +283,7 @@ const GnomadV2Downloads = () => {
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
-            <GenericDownloadLinks
+            <DownloadLinks
               label="Exome coverage summary TSV"
               path="/release/2.1/coverage/exomes/gnomad.exomes.coverage.summary.tsv.bgz"
               size="1.57 GiB"
@@ -295,7 +299,7 @@ const GnomadV2Downloads = () => {
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
-            <GenericDownloadLinks
+            <DownloadLinks
               label="Genome coverage summary TSV"
               path="/release/2.1/coverage/genomes/gnomad.genomes.coverage.summary.tsv.bgz"
               size="50.74 GiB"
@@ -318,44 +322,50 @@ const GnomadV2Downloads = () => {
         <FileList>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
-            <IndexedFileDownloadLinks
+            <DownloadLinks
               label="SV 2.1 sites VCF"
               path="/papers/2019-sv/gnomad_v2.1_sv.sites.vcf.gz"
+              includeTBI
             />
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
-            <IndexedFileDownloadLinks
+            <DownloadLinks
               label="SV 2.1 sites BED"
               path="/papers/2019-sv/gnomad_v2.1_sv.sites.bed.gz"
+              includeTBI
             />
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
-            <IndexedFileDownloadLinks
+            <DownloadLinks
               label="SV 2.1 (controls) sites VCF"
               path="/papers/2019-sv/gnomad_v2.1_sv.controls_only.sites.vcf.gz"
+              includeTBI
             />
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
-            <IndexedFileDownloadLinks
+            <DownloadLinks
               label="SV 2.1 (controls) sites BED"
               path="/papers/2019-sv/gnomad_v2.1_sv.controls_only.sites.bed.gz"
+              includeTBI
             />
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
-            <IndexedFileDownloadLinks
+            <DownloadLinks
               label="SV 2.1 (non-neuro) sites VCF"
               path="/papers/2019-sv/gnomad_v2.1_sv.nonneuro.sites.vcf.gz"
+              includeTBI
             />
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
-            <IndexedFileDownloadLinks
+            <DownloadLinks
               label="SV 2.1 (non-neuro) sites BED"
               path="/papers/2019-sv/gnomad_v2.1_sv.nonneuro.sites.bed.gz"
+              includeTBI
             />
           </ListItem>
         </FileList>
@@ -388,7 +398,7 @@ const GnomadV2Downloads = () => {
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
-            <GenericDownloadLinks
+            <DownloadLinks
               label="Random forest (RF) model"
               path="/release/2.1/pca/gnomad.r2.1.RF_fit.onnx"
             />
@@ -410,14 +420,14 @@ const GnomadV2Downloads = () => {
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
-            <GenericDownloadLinks
+            <DownloadLinks
               label="Regional missense constraint TSV (transcripts with RMC)"
               path="/release/2.1.1/regional_missense_constraint/gnomAD_v2.1.1_transcripts_with_rmc.tsv"
             />
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
-            <GenericDownloadLinks
+            <DownloadLinks
               label="Regional missense constraint TSV (transcripts without RMC)"
               path="/release/2.1.1/regional_missense_constraint/gnomAD_v2.1.1_transcripts_without_rmc.tsv"
             />
@@ -430,21 +440,21 @@ const GnomadV2Downloads = () => {
         <FileList>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
-            <GenericDownloadLinks
+            <DownloadLinks
               label="Exome calling regions"
               path="/intervals/exome_calling_regions.v1.interval_list"
             />
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
-            <GenericDownloadLinks
+            <DownloadLinks
               label="Genome calling regions"
               path="/intervals/hg19-v0-wgs_evaluation_regions.v1.interval_list"
             />
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
-            <GenericDownloadLinks
+            <DownloadLinks
               label="All pLoF variants"
               path="/papers/2019-flagship-lof/v1.0/gnomad.v2.1.1.all_lofs.txt.bgz"
             />
@@ -501,21 +511,21 @@ const GnomadV2Downloads = () => {
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
-            <GenericDownloadLinks
+            <DownloadLinks
               label="pLoF Metrics by Transcript TSV"
               path="/release/2.1.1/constraint/gnomad.v2.1.1.lof_metrics.by_transcript.txt.bgz"
             />
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
-            <GenericDownloadLinks
+            <DownloadLinks
               label="pLoF Metrics by Gene TSV"
               path="/release/2.1.1/constraint/gnomad.v2.1.1.lof_metrics.by_gene.txt.bgz"
             />
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
-            <GenericDownloadLinks
+            <DownloadLinks
               label="pLoF Metrics Downsamplings TSV"
               path="/release/2.1.1/constraint/gnomad.v2.1.1.lof_metrics.downsamplings.txt.bgz"
             />
@@ -540,18 +550,18 @@ const GnomadV2Downloads = () => {
         <FileList>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
-            <GenericDownloadLinks label="README" path="/release/2.1/mnv/readme.md" />
+            <DownloadLinks label="README" path="/release/2.1/mnv/readme.md" />
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
-            <GenericDownloadLinks
+            <DownloadLinks
               label="Coding MNVs TSV"
               path="/release/2.1/mnv/gnomad_mnv_coding.tsv"
             />
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
-            <GenericDownloadLinks
+            <DownloadLinks
               label="Coding MNVs consisting of 3 SNVs TSV"
               path="/release/2.1/mnv/gnomad_mnv_coding_3bp.tsv"
             />
@@ -570,7 +580,7 @@ const GnomadV2Downloads = () => {
               </ListItem>
               {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
               <ListItem>
-                <GenericDownloadLinks
+                <DownloadLinks
                   label={`Distance = ${n} TSV`}
                   path={`/release/2.1/mnv/genome/gnomad_mnv_genome_d${n}.tsv.bgz`}
                 />
@@ -600,7 +610,7 @@ const GnomadV2Downloads = () => {
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
-            <GenericDownloadLinks
+            <DownloadLinks
               label="Annotation-level pext for all possible SNVs TSV"
               path="/papers/2019-tx-annotation/pre_computed/all.possible.snvs.tx_annotated.GTEx.v7.021520.tsv.bgz"
             />
@@ -614,7 +624,7 @@ const GnomadV2Downloads = () => {
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
-            <GenericDownloadLinks
+            <DownloadLinks
               label="Base-level pext TSV"
               path="/papers/2019-tx-annotation/gnomad_browser/all.baselevel.021620.tsv.bgz"
             />
@@ -627,7 +637,7 @@ const GnomadV2Downloads = () => {
         <FileList>
           {/* @ts-expect-error */}
           <ListItem>
-            <GenericDownloadLinks
+            <DownloadLinks
               label="README"
               path="/release/2.1.1/secondary_analyses/variant_cooccurrence/readme_for_download_tables.txt"
             />
@@ -641,14 +651,14 @@ const GnomadV2Downloads = () => {
           </ListItem>
           {/* @ts-expect-error */}
           <ListItem>
-            <GenericDownloadLinks
+            <DownloadLinks
               label="Variant co-occurrence by gene (homozygous rare variants)"
               path="/release/2.1.1/secondary_analyses/variant_cooccurrence/gnomAD_v2_homozygous_rare_variants_table_for_download.tsv"
             />
           </ListItem>
           {/* @ts-expect-error */}
           <ListItem>
-            <GenericDownloadLinks
+            <DownloadLinks
               label="Variant co-occurrence by gene (two heterozygous rare variants)"
               path="/release/2.1.1/secondary_analyses/variant_cooccurrence/gnomAD_v2_two_heterozygous_rare_variants_table_for_download.tsv"
             />
@@ -677,63 +687,63 @@ const GnomadV2Downloads = () => {
         <FileList>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
-            <GenericDownloadLinks
+            <DownloadLinks
               label="All homozygous LoF curation results"
               path="/truth-sets/source/lof-curation/all_homozygous_curation_results.csv"
             />
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
-            <GenericDownloadLinks
+            <DownloadLinks
               label="Lysosomal storage disease genes LoF curation results"
               path="/truth-sets/source/lof-curation/lysosomal_storage_disease_genes_curation_results.csv"
             />
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
-            <GenericDownloadLinks
+            <DownloadLinks
               label="AP4 LoF curation results"
               path="/truth-sets/source/lof-curation/AP4_curation_results.csv"
             />
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
-            <GenericDownloadLinks
+            <DownloadLinks
               label="FIG4 LoF curation results"
               path="/truth-sets/source/lof-curation/FIG4_curation_results.csv"
             />
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
-            <GenericDownloadLinks
+            <DownloadLinks
               label="MCOLN1 LoF curation results"
               path="/truth-sets/source/lof-curation/MCOLN1_curation_results.csv"
             />
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
-            <GenericDownloadLinks
+            <DownloadLinks
               label="Haploinsufficient genes LoF curation results"
               path="/truth-sets/source/lof-curation/haploinsufficient_genes_curation_results.csv"
             />
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
-            <GenericDownloadLinks
+            <DownloadLinks
               label="Metabolic conditions genes LoF curation results"
               path="/truth-sets/source/lof-curation/metabolic_conditions_genes_curation_results.csv"
             />
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
-            <GenericDownloadLinks
+            <DownloadLinks
               label="gnomAD addendum LoF curation results"
               path="/truth-sets/source/lof-curation/gnomAD_addendum_curation_results.csv"
             />
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
-            <GenericDownloadLinks
+            <DownloadLinks
               label="NSD1 LoF curation results"
               path="/truth-sets/source/lof-curation/NSD1_curation_results.csv"
             />

--- a/browser/src/DownloadsPage/GnomadV2LiftoverDownloads.tsx
+++ b/browser/src/DownloadsPage/GnomadV2LiftoverDownloads.tsx
@@ -5,10 +5,10 @@ import { Badge, ExternalLink, ListItem } from '@gnomad/ui'
 import {
   Column,
   ColumnsWrapper,
+  DownloadLinks,
   DownloadsSection,
   FileList,
   GetUrlButtons,
-  IndexedFileDownloadLinks,
   SectionTitle,
   StyledParagraph,
 } from './downloadsPageStyles'
@@ -104,21 +104,23 @@ const Gnomadv2LiftoverDownloads = () => {
 
               {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
               <ListItem>
-                <IndexedFileDownloadLinks
+                <DownloadLinks
                   label="All chromosomes VCF"
                   path="/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.liftover_grch38.vcf.bgz"
                   size="85.31 GiB"
                   md5="cff8d0cfed50adc9211d1feaed2d4ca7"
+                  includeTBI
                 />
               </ListItem>
               {liftoverExomeChromosomeVcfs.map(({ chrom, size, md5 }) => (
                 // @ts-expect-error TS(2769) FIXME: No overload matches this call.
                 <ListItem key={chrom}>
-                  <IndexedFileDownloadLinks
+                  <DownloadLinks
                     label={`chr${chrom} sites VCF`}
                     path={`/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.${chrom}.liftover_grch38.vcf.bgz`}
                     size={size}
                     md5={md5}
+                    includeTBI
                   />
                 </ListItem>
               ))}
@@ -137,21 +139,23 @@ const Gnomadv2LiftoverDownloads = () => {
               </ListItem>
               {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
               <ListItem>
-                <IndexedFileDownloadLinks
+                <DownloadLinks
                   label="All chromosomes VCF"
                   path="/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.liftover_grch38.vcf.bgz"
                   size="743.06 GiB"
                   md5="83de3d5b52669f714e810d4fcf047c18"
+                  includeTBI
                 />
               </ListItem>
               {liftoverGenomeChromosomeVcfs.map(({ chrom, size, md5 }) => (
                 // @ts-expect-error TS(2769) FIXME: No overload matches this call.
                 <ListItem key={chrom}>
-                  <IndexedFileDownloadLinks
+                  <DownloadLinks
                     label={`chr${chrom} sites VCF`}
                     path={`/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.${chrom}.liftover_grch38.vcf.bgz`}
                     size={size}
                     md5={md5}
+                    includeTBI
                   />
                 </ListItem>
               ))}

--- a/browser/src/DownloadsPage/GnomadV3Downloads.tsx
+++ b/browser/src/DownloadsPage/GnomadV3Downloads.tsx
@@ -5,11 +5,10 @@ import { Badge, ExternalLink, Link as StyledLink, ListItem } from '@gnomad/ui'
 import Link from '../Link'
 
 import {
+  DownloadLinks,
   DownloadsSection,
   FileList,
-  GenericDownloadLinks,
   GetUrlButtons,
-  IndexedFileDownloadLinks,
   SectionTitle,
   StyledParagraph,
 } from './downloadsPageStyles'
@@ -112,11 +111,12 @@ const GnomadV3Downloads = () => (
         {genomeChromosomeVcfs.map(({ chrom, size, md5 }) => (
           // @ts-expect-error TS(2769) FIXME: No overload matches this call.
           <ListItem key={chrom}>
-            <IndexedFileDownloadLinks
+            <DownloadLinks
               label={`chr${chrom} sites VCF`}
               path={`/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr${chrom}.vcf.bgz`}
               size={size}
               md5={md5}
+              includeTBI
             />
           </ListItem>
         ))}
@@ -135,7 +135,7 @@ const GnomadV3Downloads = () => (
         </ListItem>
         {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
         <ListItem>
-          <GenericDownloadLinks
+          <DownloadLinks
             label="Genome coverage summary TSV"
             path="/release/3.0.1/coverage/genomes/gnomad.genomes.r3.0.1.coverage.summary.tsv.bgz"
             size="75.38 GiB"
@@ -193,7 +193,7 @@ const GnomadV3Downloads = () => (
         </ListItem>
         {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
         <ListItem>
-          <GenericDownloadLinks
+          <DownloadLinks
             label="Sample metadata TSV"
             path="/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_1kg_subset_sample_meta.tsv.bgz"
           />
@@ -201,11 +201,12 @@ const GnomadV3Downloads = () => (
         {hgdpAnd1kgChromosomeVcfs.map(({ chrom, size, md5 }) => (
           // @ts-expect-error TS(2769) FIXME: No overload matches this call.
           <ListItem key={chrom}>
-            <IndexedFileDownloadLinks
+            <DownloadLinks
               label={`chr${chrom} VCF`}
               path={`/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr${chrom}.vcf.bgz`}
               size={size}
               md5={md5}
+              includeTBI
             />
           </ListItem>
         ))}
@@ -232,11 +233,12 @@ const GnomadV3Downloads = () => (
         </ListItem>
         {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
         <ListItem>
-          <IndexedFileDownloadLinks
+          <DownloadLinks
             label="chrM sites VCF"
             path="/release/3.1/vcf/genomes/gnomad.genomes.v3.1.sites.chrM.vcf.bgz"
             size="4.77 MiB"
             md5="d0ef2bd882ae44236897d743cb5528cf"
+            includeTBI
           />
         </ListItem>
         {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
@@ -248,7 +250,7 @@ const GnomadV3Downloads = () => (
         </ListItem>
         {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
         <ListItem>
-          <GenericDownloadLinks
+          <DownloadLinks
             label="chrM sites TSV (reduced annotations)"
             path="/release/3.1/vcf/genomes/gnomad.genomes.v3.1.sites.chrM.reduced_annotations.tsv"
             size="1 MiB"
@@ -282,7 +284,7 @@ const GnomadV3Downloads = () => (
         </ListItem>
         {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
         <ListItem>
-          <GenericDownloadLinks
+          <DownloadLinks
             label="Random forest (RF) model"
             path="/release/3.1/pca/gnomad.v3.1.RF_fit.onnx"
           />
@@ -304,7 +306,7 @@ const GnomadV3Downloads = () => (
       <FileList>
         {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
         <ListItem>
-          <GenericDownloadLinks
+          <DownloadLinks
             label="Sites VCF"
             path="/release/3.1/local_ancestry/genomes/gnomad.genomes.v3.1.local_ancestry.amr.vcf.bgz"
           />
@@ -326,18 +328,18 @@ const GnomadV3Downloads = () => (
       <FileList>
         {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
         <ListItem>
-          <GenericDownloadLinks label="README" path="/release/3.1.3/tsv/README.txt" />
+          <DownloadLinks label="README" path="/release/3.1.3/tsv/README.txt" />
         </ListItem>
         {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
         <ListItem>
-          <GenericDownloadLinks
+          <DownloadLinks
             label="Genotypes (TSV)"
             path="/release/3.1.3/tsv/gnomAD_STR_genotypes__2022_01_20.tsv.gz"
           />
         </ListItem>
         {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
         <ListItem>
-          <GenericDownloadLinks
+          <DownloadLinks
             label="Distributions (JSON)"
             path="/release/3.1.3/json/gnomAD_STR_distributions__2022_01_20.json.gz"
           />
@@ -359,28 +361,28 @@ const GnomadV3Downloads = () => (
       <FileList>
         {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
         <ListItem>
-          <GenericDownloadLinks
+          <DownloadLinks
             label="README"
             path="/release/3.1/secondary_analyses/genomic_constraint/nc_constraint_gnomad_v31_README.docx"
           />
         </ListItem>
         {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
         <ListItem>
-          <GenericDownloadLinks
+          <DownloadLinks
             label="Raw genomic constraint by 1kb regions"
             path="/release/3.1/secondary_analyses/genomic_constraint/constraint_z_genome_1kb.raw.download.txt.gz"
           />
         </ListItem>
         {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
         <ListItem>
-          <GenericDownloadLinks
+          <DownloadLinks
             label="QCed genomic constraint by 1kb regions"
             path="/release/3.1/secondary_analyses/genomic_constraint/constraint_z_genome_1kb.qc.download.txt.gz"
           />
         </ListItem>
         {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
         <ListItem>
-          <GenericDownloadLinks
+          <DownloadLinks
             label="Non-coding constraint for gene tissue enhancers"
             path="/release/3.1/secondary_analyses/genomic_constraint/constraint_z_enh_gene_roadmaplinks.all.download.txt.gz"
           />
@@ -431,7 +433,7 @@ const GnomadV3Downloads = () => (
         </ListItem>
         {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
         <ListItem>
-          <GenericDownloadLinks
+          <DownloadLinks
             label="Sample metadata TSV"
             path="/release/3.1/secondary_analyses/hgdp_1kg/metadata_and_qc/gnomad_meta_v1.tsv"
           />
@@ -460,7 +462,7 @@ const GnomadV3Downloads = () => (
         </ListItem>
         {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
         <ListItem>
-          <GenericDownloadLinks
+          <DownloadLinks
             label="PCA outliers table"
             path="/release/3.1/secondary_analyses/hgdp_1kg/pca/pca_outliers.txt"
           />
@@ -489,14 +491,14 @@ const GnomadV3Downloads = () => (
         </ListItem>
         {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
         <ListItem>
-          <GenericDownloadLinks
+          <DownloadLinks
             label="Population-level statistical summary TSV"
             path="/release/3.1/secondary_analyses/hgdp_1kg/metadata_and_qc/post_qc_summary.tsv"
           />
         </ListItem>
         {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
         <ListItem>
-          <GenericDownloadLinks
+          <DownloadLinks
             label="Doubleton counts CSV"
             path="/release/3.1/secondary_analyses/hgdp_1kg/f2_fst/doubleton_count.csv"
           />
@@ -510,7 +512,7 @@ const GnomadV3Downloads = () => (
         </ListItem>
         {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
         <ListItem>
-          <GenericDownloadLinks
+          <DownloadLinks
             label="Population-level mean fixation index table"
             path="/release/3.1/secondary_analyses/hgdp_1kg/f2_fst/mean_fst.txt"
           />
@@ -531,7 +533,7 @@ const GnomadV3Downloads = () => (
         </ListItem>
         {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
         <ListItem>
-          <GenericDownloadLinks
+          <DownloadLinks
             label="Random forest (RF) model PKL"
             path="/release/3.1/pca/gnomad.v3.1.RF_fit.pkl"
           />
@@ -545,7 +547,7 @@ const GnomadV3Downloads = () => (
         </ListItem>
         {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
         <ListItem>
-          <GenericDownloadLinks
+          <DownloadLinks
             label="Super population labels TSV"
             path="/release/3.1/secondary_analyses/hgdp_1kg/data_intersection/hgdp_1kg_sample_info.unrelateds.pca_outliers_removed.with_project.tsv"
           />
@@ -605,7 +607,7 @@ const GnomadV3Downloads = () => (
         </ListItem>
         {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
         <ListItem>
-          <GenericDownloadLinks
+          <DownloadLinks
             label="Post-QC site frequency spectrum table"
             path="/release/3.1/secondary_analyses/hgdp_1kg/plot_datasets/sfs_post_qc.txt"
           />

--- a/browser/src/DownloadsPage/GnomadV4Downloads.tsx
+++ b/browser/src/DownloadsPage/GnomadV4Downloads.tsx
@@ -5,11 +5,10 @@ import { ExternalLink, ListItem } from '@gnomad/ui'
 import {
   Column,
   ColumnsWrapper,
+  DownloadLinks,
   DownloadsSection,
   FileList,
-  GenericDownloadLinks,
   GetUrlButtons,
-  IndexedFileDownloadLinks,
   SectionTitle,
   StyledParagraph,
 } from './downloadsPageStyles'
@@ -138,11 +137,12 @@ const GnomadV4Downloads = () => {
               {exomeChromosomeVcfs.map(({ chrom, size, md5 }) => (
                 // @ts-expect-error TS(2769) FIXME: No overload matches this call.
                 <ListItem key={chrom}>
-                  <IndexedFileDownloadLinks
+                  <DownloadLinks
                     label={`chr${chrom} sites VCF`}
                     path={`/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr${chrom}.vcf.bgz`}
                     size={size}
                     md5={md5}
+                    includeTBI
                   />
                 </ListItem>
               ))}
@@ -162,11 +162,12 @@ const GnomadV4Downloads = () => {
               {genomeChromosomeVcfs.map(({ chrom, size, md5 }) => (
                 // @ts-expect-error TS(2769) FIXME: No overload matches this call.
                 <ListItem key={chrom}>
-                  <IndexedFileDownloadLinks
+                  <DownloadLinks
                     label={`chr${chrom} sites VCF`}
                     path={`/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr${chrom}.vcf.bgz`}
                     size={size}
                     md5={md5}
+                    includeTBI
                   />
                 </ListItem>
               ))}
@@ -187,7 +188,7 @@ const GnomadV4Downloads = () => {
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
-            <GenericDownloadLinks
+            <DownloadLinks
               label="Exome coverage summary TSV"
               path="/release/4.0/coverage/exomes/gnomad.exomes.v4.0.coverage.summary.tsv.bgz"
               size="3.77 GiB"
@@ -220,14 +221,14 @@ const GnomadV4Downloads = () => {
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
-            <GenericDownloadLinks
+            <DownloadLinks
               label="Random forest (RF) .pkl model"
               path="/release/4.0/pca/gnomad.v4.0.RF_fit.pkl"
             />
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
-            <GenericDownloadLinks
+            <DownloadLinks
               label="Random forest (RF) .onnx model"
               path="/release/4.0/pca/gnomad.v4.0.RF_fit.onnx"
             />
@@ -243,7 +244,7 @@ const GnomadV4Downloads = () => {
         <FileList>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
-            <GenericDownloadLinks label="README" path="/release/4.0/constraint/README.txt" />
+            <DownloadLinks label="README" path="/release/4.0/constraint/README.txt" />
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
@@ -254,7 +255,7 @@ const GnomadV4Downloads = () => {
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
-            <GenericDownloadLinks
+            <DownloadLinks
               label="Constraint metrics TSV"
               path="/release/4.0/constraint/gnomad.v4.0.constraint_metrics.tsv"
             />
@@ -272,11 +273,12 @@ const GnomadV4Downloads = () => {
           {svChromosomeVcfs.map(({ chrom, size, crc32 }) => (
             // @ts-expect-error TS(2769) FIXME: No overload matches this call.
             <ListItem key={chrom}>
-              <IndexedFileDownloadLinks
+              <DownloadLinks
                 label={`chr${chrom} VCF`}
                 path={`/release/4.0/genome_sv/gnomad.v4.0.sv.chr${chrom}.vcf.gz`}
                 size={size}
                 crc32={crc32}
+                includeTBI
               />
             </ListItem>
           ))}
@@ -292,21 +294,21 @@ const GnomadV4Downloads = () => {
         <FileList>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
-            <GenericDownloadLinks
+            <DownloadLinks
               label="Exome CNV VCF"
               path="/release/4.0/exome_cnv/gnomad.v4.0.cnv.all.vcf.gz"
             />
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
-            <GenericDownloadLinks
+            <DownloadLinks
               label="Exome CNV non neuro VCF"
               path="/release/4.0/exome_cnv/gnomad.v4.0.cnv.non_neuro.vcf.gz"
             />
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
-            <GenericDownloadLinks
+            <DownloadLinks
               label="Exome CNV non-neuro controls VCF"
               path="/release/4.0/exome_cnv/gnomad.v4.0.cnv.non_neuro_controls.vcf.gz"
             />
@@ -319,7 +321,7 @@ const GnomadV4Downloads = () => {
         <FileList>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
-            <GenericDownloadLinks
+            <DownloadLinks
               label="Exome sex ploidy cutoffs TSV"
               path="/release/4.0/sex_inference/gnomad.exomes.v4.0.sample_qc.sex_inference.ploidy_cutoffs.tsv"
             />
@@ -333,7 +335,7 @@ const GnomadV4Downloads = () => {
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
-            <GenericDownloadLinks
+            <DownloadLinks
               label="Exome calling intervals flat file"
               path="/resources/grch38/intervals/ukb.pad50.broad.pad50.union.intervals"
             />

--- a/browser/src/DownloadsPage/downloadsPageStyles.tsx
+++ b/browser/src/DownloadsPage/downloadsPageStyles.tsx
@@ -237,93 +237,7 @@ GetUrlButtons.defaultProps = {
   includeAzure: true,
 }
 
-type OwnGenericDownloadLinksProps = {
-  gcsBucket?: string
-  label: string
-  path: string
-  size?: string
-  md5?: string
-  includeGCP?: boolean
-  includeAWS?: boolean
-  includeAzure?: boolean
-}
-
-// @ts-expect-error TS(2456) FIXME: Type alias 'GenericDownloadLinksProps' circularly ... Remove this comment to see the full error message
-type GenericDownloadLinksProps = OwnGenericDownloadLinksProps &
-  typeof GenericDownloadLinks.defaultProps
-
-// @ts-expect-error TS(7022) FIXME: 'GenericDownloadLinks' implicitly has type 'any' b... Remove this comment to see the full error message
-export const GenericDownloadLinks = ({
-  gcsBucket,
-  label,
-  path,
-  size,
-  md5,
-  includeGCP,
-  includeAWS,
-  includeAzure,
-}: GenericDownloadLinksProps) => {
-  return (
-    <>
-      <span>{label}</span>
-      <br />
-      {size && md5 && (
-        <>
-          <span>
-            {size}, MD5:&nbsp;{md5}
-          </span>
-          <br />
-        </>
-      )}
-      <span>
-        Download from{' '}
-        {renderDownloadOptions([
-          includeGCP && (
-            // @ts-expect-error TS(2786) FIXME: 'ExternalLink' cannot be used as a JSX component.
-            <ExternalLink
-              key="gcp"
-              aria-label={`Download ${label} from Google`}
-              href={`https://storage.googleapis.com/${gcsBucket}${path}`}
-            >
-              Google
-            </ExternalLink>
-          ),
-          includeAWS && (
-            // @ts-expect-error TS(2786) FIXME: 'ExternalLink' cannot be used as a JSX component.
-            <ExternalLink
-              key="aws"
-              aria-label={`Download ${label} from Amazon`}
-              href={`https://gnomad-public-us-east-1.s3.amazonaws.com${path}`}
-            >
-              Amazon
-            </ExternalLink>
-          ),
-          includeAzure && (
-            // @ts-expect-error TS(2786) FIXME: 'ExternalLink' cannot be used as a JSX component.
-            <ExternalLink
-              key="azure"
-              aria-label={`Download ${label} from Microsoft`}
-              href={`https://datasetgnomad.blob.core.windows.net/dataset${path}`}
-            >
-              Microsoft
-            </ExternalLink>
-          ),
-        ])}
-      </span>
-    </>
-  )
-}
-
-GenericDownloadLinks.defaultProps = {
-  gcsBucket: 'gcp-public-data--gnomad',
-  size: undefined,
-  md5: undefined,
-  includeGCP: true,
-  includeAWS: true,
-  includeAzure: true,
-}
-
-type OwnIndexedFileDownloadLinksProps = {
+type OwnDownloadLinksProps = {
   label: string
   path: string
   size?: string
@@ -333,14 +247,15 @@ type OwnIndexedFileDownloadLinksProps = {
   includeGCP?: boolean
   includeAWS?: boolean
   includeAzure?: boolean
+  includeTBI?: boolean
 }
 
-// @ts-expect-error TS(2456) FIXME: Type alias 'IndexedFileDownloadLinksProps' circula... Remove this comment to see the full error message
-type IndexedFileDownloadLinksProps = OwnIndexedFileDownloadLinksProps &
-  typeof IndexedFileDownloadLinks.defaultProps
+// @ts-expect-error TS(2456) FIXME: Type alias 'DownloadLinksProps' circula... Remove this comment to see the full error message
+type DownloadLinksProps = OwnDownloadLinksProps &
+  typeof DownloadLinks.defaultProps
 
-// @ts-expect-error TS(7022) FIXME: 'IndexedFileDownloadLinks' implicitly has type 'an... Remove this comment to see the full error message
-export const IndexedFileDownloadLinks = ({
+// @ts-expect-error TS(7022) FIXME: 'DownloadLinks' implicitly has type 'an... Remove this comment to see the full error message
+export const DownloadLinks = ({
   label,
   path,
   size,
@@ -350,7 +265,8 @@ export const IndexedFileDownloadLinks = ({
   includeGCP,
   includeAWS,
   includeAzure,
-}: IndexedFileDownloadLinksProps) => {
+  includeTBI,
+}: DownloadLinksProps) => {
   return (
     <>
       <span>{label}</span>
@@ -406,51 +322,56 @@ export const IndexedFileDownloadLinks = ({
           ),
         ])}
       </span>
-      <br />
-      <span>
-        Download TBI from{' '}
-        {renderDownloadOptions([
-          includeGCP && (
-            // @ts-expect-error TS(2786) FIXME: 'ExternalLink' cannot be used as a JSX component.
-            <ExternalLink
-              key="gcp"
-              aria-label={`Download TBI file for ${label} from Google`}
-              href={`https://storage.googleapis.com/${gcsBucket}${path}.tbi`}
-            >
-              Google
-            </ExternalLink>
-          ),
-          includeAWS && (
-            // @ts-expect-error TS(2786) FIXME: 'ExternalLink' cannot be used as a JSX component.
-            <ExternalLink
-              key="aws"
-              aria-label={`Download TBI file for ${label} from Amazon`}
-              href={`https://gnomad-public-us-east-1.s3.amazonaws.com${path}.tbi`}
-            >
-              Amazon
-            </ExternalLink>
-          ),
-          includeAzure && (
-            // @ts-expect-error TS(2786) FIXME: 'ExternalLink' cannot be used as a JSX component.
-            <ExternalLink
-              key="azure"
-              aria-label={`Download TBI file for ${label} from Microsoft`}
-              href={`https://datasetgnomad.blob.core.windows.net/dataset${path}.tbi`}
-            >
-              Microsoft
-            </ExternalLink>
-          ),
-        ])}
-      </span>
+      {includeTBI && (
+        <>
+        <br />
+        <span>
+          Download TBI from{' '}
+          {renderDownloadOptions([
+            includeGCP && (
+              // @ts-expect-error TS(2786) FIXME: 'ExternalLink' cannot be used as a JSX component.
+              <ExternalLink
+                key="gcp"
+                aria-label={`Download TBI file for ${label} from Google`}
+                href={`https://storage.googleapis.com/${gcsBucket}${path}.tbi`}
+              >
+                Google
+              </ExternalLink>
+            ),
+            includeAWS && (
+              // @ts-expect-error TS(2786) FIXME: 'ExternalLink' cannot be used as a JSX component.
+              <ExternalLink
+                key="aws"
+                aria-label={`Download TBI file for ${label} from Amazon`}
+                href={`https://gnomad-public-us-east-1.s3.amazonaws.com${path}.tbi`}
+              >
+                Amazon
+              </ExternalLink>
+            ),
+            includeAzure && (
+              // @ts-expect-error TS(2786) FIXME: 'ExternalLink' cannot be used as a JSX component.
+              <ExternalLink
+                key="azure"
+                aria-label={`Download TBI file for ${label} from Microsoft`}
+                href={`https://datasetgnomad.blob.core.windows.net/dataset${path}.tbi`}
+              >
+                Microsoft
+              </ExternalLink>
+            ),
+          ])}
+        </span>
+        </>
+      )}
     </>
   )
 }
 
-IndexedFileDownloadLinks.defaultProps = {
+DownloadLinks.defaultProps = {
   size: undefined,
   md5: undefined,
   gcsBucket: 'gcp-public-data--gnomad',
   includeGCP: true,
   includeAWS: true,
   includeAzure: true,
+  includeTBI: false,
 }


### PR DESCRIPTION
Addresses another of the items in the table of copy-pasted code in issue #1154 

Replaces `GenericDownloadLinks` and `IndexedFileDownloadLinks` with just plain old `DownloadLinks`.

I've done a visual check of an ad-hoc selection of links from each of the data releases (v2-v4, EXAC) to check things look good and work well. All tests from `.github/workflows/browser-ci.yaml` run locally and passing :)

FYI @rileyhgrant 