### PR TITLE
feat(Clinvar Submissions): more dry

### DIFF
--- a/browser/src/ClinvarVariantsTrack/ClinvarVariantDetails.tsx
+++ b/browser/src/ClinvarVariantsTrack/ClinvarVariantDetails.tsx
@@ -1,70 +1,13 @@
 import React from 'react'
 
-import { ExternalLink, List, ListItem } from '@gnomad/ui'
+import { ExternalLink } from '@gnomad/ui'
 
 import AttributeList from '../AttributeList'
+import SubmissionsList from '../SubmissionsList'
 import Link from '../Link'
 import Query from '../Query'
 
 import formatClinvarDate from './formatClinvarDate'
-
-type SubmissionsListProps = {
-  submissions: {
-    clinical_significance?: string
-    conditions?: {
-      medgen_id?: string
-      name: string
-    }[]
-    last_evaluated?: string
-    review_status: string
-    submitter_name: string
-  }[]
-}
-
-const SubmissionsList = ({ submissions }: SubmissionsListProps) => (
-  // @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message
-  <List>
-    {submissions.map((submission) => (
-      // @ts-expect-error TS(2769) FIXME: No overload matches this call.
-      <ListItem key={`${submission.submitter_name}-${submission.last_evaluated}`}>
-        <AttributeList>
-          {/* @ts-expect-error TS(2604) FIXME: JSX element type 'AttributeList.Item' does not hav... Remove this comment to see the full error message */}
-          <AttributeList.Item label="Submitter">{submission.submitter_name}</AttributeList.Item>
-          {/* @ts-expect-error TS(2604) FIXME: JSX element type 'AttributeList.Item' does not hav... Remove this comment to see the full error message */}
-          <AttributeList.Item label="Conditions">
-            {/* @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'. */}
-            {submission.conditions
-              .map((condition) =>
-                condition.medgen_id ? (
-                  // @ts-expect-error TS(2786) FIXME: 'ExternalLink' cannot be used as a JSX component.
-                  <ExternalLink
-                    key={condition.medgen_id}
-                    href={`https://www.ncbi.nlm.nih.gov/medgen/${condition.medgen_id}/`}
-                  >
-                    {condition.name}
-                  </ExternalLink>
-                ) : (
-                  <span>{condition.name}</span>
-                )
-              )
-              // @ts-expect-error TS(2769) FIXME: No overload matches this call.
-              .reduce((acc, el, i) => (i === 0 ? [...acc, el] : [...acc, ', ', el]), [])}
-          </AttributeList.Item>
-          {/* @ts-expect-error TS(2604) FIXME: JSX element type 'AttributeList.Item' does not hav... Remove this comment to see the full error message */}
-          <AttributeList.Item label="Clinical significance">
-            {submission.clinical_significance || '–'}
-          </AttributeList.Item>
-          {/* @ts-expect-error TS(2604) FIXME: JSX element type 'AttributeList.Item' does not hav... Remove this comment to see the full error message */}
-          <AttributeList.Item label="Review status">{submission.review_status}</AttributeList.Item>
-          {/* @ts-expect-error TS(2604) FIXME: JSX element type 'AttributeList.Item' does not hav... Remove this comment to see the full error message */}
-          <AttributeList.Item label="Last evaluated">
-            {submission.last_evaluated ? formatClinvarDate(submission.last_evaluated) : '–'}
-          </AttributeList.Item>
-        </AttributeList>
-      </ListItem>
-    ))}
-  </List>
-)
 
 type ClinvarVariantDetailsGnomadDataProps = {
   clinvarVariant: {

--- a/browser/src/SubmissionsList.tsx
+++ b/browser/src/SubmissionsList.tsx
@@ -1,0 +1,66 @@
+import React from 'react'
+
+import { ExternalLink, List, ListItem } from '@gnomad/ui'
+
+import AttributeList from './AttributeList'
+import formatClinvarDate from './ClinvarVariantsTrack/formatClinvarDate'
+
+type SubmissionsListProps = {
+  submissions: {
+    clinical_significance?: string
+    conditions?: {
+      medgen_id?: string
+      name: string
+    }[]
+    last_evaluated?: string
+    review_status: string
+    submitter_name: string
+  }[]
+}
+
+const SubmissionsList = ({ submissions }: SubmissionsListProps) => (
+  // @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message
+  <List>
+    {submissions.map((submission) => (
+      // @ts-expect-error TS(2769) FIXME: No overload matches this call.
+      <ListItem key={`${submission.submitter_name}-${submission.last_evaluated}`}>
+        <AttributeList>
+          {/* @ts-expect-error TS(2604) FIXME: JSX element type 'AttributeList.Item' does not hav... Remove this comment to see the full error message */}
+          <AttributeList.Item label="Submitter">{submission.submitter_name}</AttributeList.Item>
+          {/* @ts-expect-error TS(2604) FIXME: JSX element type 'AttributeList.Item' does not hav... Remove this comment to see the full error message */}
+          <AttributeList.Item label="Conditions">
+            {/* @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'. */}
+            {submission.conditions
+              .map((condition) =>
+                condition.medgen_id ? (
+                  // @ts-expect-error TS(2786) FIXME: 'ExternalLink' cannot be used as a JSX component.
+                  <ExternalLink
+                    key={condition.medgen_id}
+                    href={`https://www.ncbi.nlm.nih.gov/medgen/${condition.medgen_id}/`}
+                  >
+                    {condition.name}
+                  </ExternalLink>
+                ) : (
+                  <span>{condition.name}</span>
+                )
+              )
+              // @ts-expect-error TS(2769) FIXME: No overload matches this call.
+              .reduce((acc, el, i) => (i === 0 ? [...acc, el] : [...acc, ', ', el]), [])}
+          </AttributeList.Item>
+          {/* @ts-expect-error TS(2604) FIXME: JSX element type 'AttributeList.Item' does not hav... Remove this comment to see the full error message */}
+          <AttributeList.Item label="Clinical significance">
+            {submission.clinical_significance || '–'}
+          </AttributeList.Item>
+          {/* @ts-expect-error TS(2604) FIXME: JSX element type 'AttributeList.Item' does not hav... Remove this comment to see the full error message */}
+          <AttributeList.Item label="Review status">{submission.review_status}</AttributeList.Item>
+          {/* @ts-expect-error TS(2604) FIXME: JSX element type 'AttributeList.Item' does not hav... Remove this comment to see the full error message */}
+          <AttributeList.Item label="Last evaluated">
+            {submission.last_evaluated ? formatClinvarDate(submission.last_evaluated) : '–'}
+          </AttributeList.Item>
+        </AttributeList>
+      </ListItem>
+    ))}
+  </List>
+)
+
+export default SubmissionsList

--- a/browser/src/VariantPage/VariantClinvarInfo.tsx
+++ b/browser/src/VariantPage/VariantClinvarInfo.tsx
@@ -1,68 +1,11 @@
 import React, { useState } from 'react'
 
-import { ExternalLink, List, ListItem, Modal, TextButton } from '@gnomad/ui'
+import { ExternalLink, Modal, TextButton } from '@gnomad/ui'
 
 import AttributeList from '../AttributeList'
+import SubmissionsList from '../SubmissionsList'
 import formatClinvarDate from '../ClinvarVariantsTrack/formatClinvarDate'
 import { ClinvarVariant } from './VariantPage'
-
-type SubmissionsListProps = {
-  submissions: {
-    clinical_significance?: string
-    conditions?: {
-      medgen_id?: string
-      name: string
-    }[]
-    last_evaluated?: string
-    review_status: string
-    submitter_name: string
-  }[]
-}
-
-const SubmissionsList = ({ submissions }: SubmissionsListProps) => (
-  // @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message
-  <List>
-    {submissions.map((submission) => (
-      // @ts-expect-error TS(2769) FIXME: No overload matches this call.
-      <ListItem key={`${submission.submitter_name}-${submission.last_evaluated}`}>
-        <AttributeList>
-          {/* @ts-expect-error TS(2604) FIXME: JSX element type 'AttributeList.Item' does not hav... Remove this comment to see the full error message */}
-          <AttributeList.Item label="Submitter">{submission.submitter_name}</AttributeList.Item>
-          {/* @ts-expect-error TS(2604) FIXME: JSX element type 'AttributeList.Item' does not hav... Remove this comment to see the full error message */}
-          <AttributeList.Item label="Conditions">
-            {/* @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'. */}
-            {submission.conditions
-              .map((condition) =>
-                condition.medgen_id ? (
-                  // @ts-expect-error TS(2786) FIXME: 'ExternalLink' cannot be used as a JSX component.
-                  <ExternalLink
-                    key={condition.medgen_id}
-                    href={`https://www.ncbi.nlm.nih.gov/medgen/${condition.medgen_id}/`}
-                  >
-                    {condition.name}
-                  </ExternalLink>
-                ) : (
-                  <span>{condition.name}</span>
-                )
-              )
-              // @ts-expect-error TS(2769) FIXME: No overload matches this call.
-              .reduce((acc, el, i) => (i === 0 ? [...acc, el] : [...acc, ', ', el]), [])}
-          </AttributeList.Item>
-          {/* @ts-expect-error TS(2604) FIXME: JSX element type 'AttributeList.Item' does not hav... Remove this comment to see the full error message */}
-          <AttributeList.Item label="Clinical significance">
-            {submission.clinical_significance || '–'}
-          </AttributeList.Item>
-          {/* @ts-expect-error TS(2604) FIXME: JSX element type 'AttributeList.Item' does not hav... Remove this comment to see the full error message */}
-          <AttributeList.Item label="Review status">{submission.review_status}</AttributeList.Item>
-          {/* @ts-expect-error TS(2604) FIXME: JSX element type 'AttributeList.Item' does not hav... Remove this comment to see the full error message */}
-          <AttributeList.Item label="Last evaluated">
-            {submission.last_evaluated ? formatClinvarDate(submission.last_evaluated) : '–'}
-          </AttributeList.Item>
-        </AttributeList>
-      </ListItem>
-    ))}
-  </List>
-)
 
 type VariantClinvarInfoProps = {
   clinvar: ClinvarVariant


### PR DESCRIPTION
A tiny PR in the series addressing copy-paste code in #1154 . This PR separates out a SubmissionsList component to make Variant Clinvar details and Gene Clinvar variants details modals more dry.

Ran tests locally and did eye ball check. Tests all green. No snapshots require updating :)

FYI @rileyhgrant 