### PR TITLE
feat(styles): make more dry

### DIFF
--- a/browser/src/ChartStyles.ts
+++ b/browser/src/ChartStyles.ts
@@ -1,0 +1,56 @@
+import styled from 'styled-components'
+
+export const ControlPanel = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  align-items: center;
+  width: ${(props: any) => props.width}px;
+  margin-left: ${(props: any) => props.marginLeft}px;
+
+  @media (max-width: 600px) {
+    flex-direction: column;
+    align-items: flex-start;
+    margin-left: 0;
+  }
+`
+
+export const Legend = styled.ul`
+  display: flex;
+  flex-direction: row;
+  padding: 0;
+  margin: 0.5em 0;
+  list-style-type: none;
+`
+
+export const LegendItemWrapper = styled.li`
+  display: flex;
+  align-items: stretch;
+  margin-left: 1em;
+`
+
+export const Label = styled.label`
+  user-select: none;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+`
+
+export const CheckboxInput = styled.input.attrs({ type: 'checkbox' })`
+  margin-right: 0.5em;
+`
+
+export const LegendSwatch = styled.span`
+  display: flex;
+  align-items: center;
+  width: 16px;
+  margin-left: 0.5em;
+
+  &::before {
+    content: '';
+    display: inline-block;
+    width: 16px;
+    height: ${(props: any) => props.height}px;
+    background: ${(props: any) => props.color};
+  }
+`

--- a/browser/src/GenePage/GenePage.tsx
+++ b/browser/src/GenePage/GenePage.tsx
@@ -62,6 +62,8 @@ import {
   CopyNumberVariant,
 } from '../VariantPage/VariantPage'
 import CopyNumberVariantsInGene from './CopyNumberVariantsInGene'
+import { ControlPanel, Legend, LegendItemWrapper, Label, CheckboxInput, LegendSwatch } from '../ChartStyles'
+
 
 export type Strand = '+' | '-'
 
@@ -165,61 +167,6 @@ const ConstraintOrCooccurrenceColumn = styled.div`
 
   @media (max-width: 1200px) {
     width: 100%;
-  }
-`
-
-const ControlPanel = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: flex-end;
-  align-items: center;
-  width: ${(props: any) => props.width}px;
-  margin-left: ${(props: any) => props.marginLeft}px;
-
-  @media (max-width: 600px) {
-    flex-direction: column;
-    align-items: flex-start;
-    margin-left: 0;
-  }
-`
-
-const Legend = styled.ul`
-  display: flex;
-  flex-direction: row;
-  padding: 0;
-  margin: 0.5em 0;
-  list-style-type: none;
-`
-
-const LegendItemWrapper = styled.li`
-  display: flex;
-  align-items: stretch;
-  margin-left: 1em;
-`
-
-const Label = styled.label`
-  user-select: none;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-`
-
-const CheckboxInput = styled.input.attrs({ type: 'checkbox' })`
-  margin-right: 0.5em;
-`
-
-const LegendSwatch = styled.span`
-  display: flex;
-  align-items: center;
-  width: 16px;
-  margin-left: 0.5em;
-
-  &::before {
-    content: '';
-    display: inline-block;
-    width: 16px;
-    height: ${(props: any) => props.height}px;
-    background: ${(props: any) => props.color};
   }
 `
 

--- a/browser/src/GenePage/__snapshots__/GenePage.spec.tsx.snap
+++ b/browser/src/GenePage/__snapshots__/GenePage.spec.tsx.snap
@@ -631,7 +631,7 @@ exports[`GenePage with CNV dataset "gnomad_cnv_r4" has no unexpected changes 1`]
         className="GenePage__ConstraintOrCooccurrenceColumn-sc-rcxzgc-3 sHWJd"
       >
         <div
-          className="GenePage__TableSelectorWrapper-sc-rcxzgc-10 eFuLrR"
+          className="GenePage__TableSelectorWrapper-sc-rcxzgc-4 kTbSHB"
         >
           <div
             className="sc-bdVaJa dDlceV"
@@ -1317,23 +1317,23 @@ exports[`GenePage with CNV dataset "gnomad_cnv_r4" has no unexpected changes 1`]
         </div>
       </div>
       <div
-        className="GenePage__ControlPanel-sc-rcxzgc-4 hMLYBm"
+        className="ChartStyles__ControlPanel-sc-atxio9-0 iLJjwA"
         width={814}
       >
         Include:
         <ul
-          className="GenePage__Legend-sc-rcxzgc-5 jsPFfF"
+          className="ChartStyles__Legend-sc-atxio9-1 mfEDY"
         >
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-cds-regions"
             >
               <input
                 checked={false}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-cds-regions"
                 onChange={[Function]}
@@ -1341,22 +1341,22 @@ exports[`GenePage with CNV dataset "gnomad_cnv_r4" has no unexpected changes 1`]
               />
               Coding regions (CDS)
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 kVyAuC"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 dWcYqk"
                 color="#424242"
                 height={10}
               />
             </label>
           </li>
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-utr-regions"
             >
               <input
                 checked={false}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-utr-regions"
                 onChange={[Function]}
@@ -1364,22 +1364,22 @@ exports[`GenePage with CNV dataset "gnomad_cnv_r4" has no unexpected changes 1`]
               />
               Untranslated regions (UTRs)
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 gUeepi"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 lhFEQi"
                 color="#424242"
                 height={4}
               />
             </label>
           </li>
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-nc-transcripts"
             >
               <input
                 checked={true}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-nc-transcripts"
                 onChange={[Function]}
@@ -1387,7 +1387,7 @@ exports[`GenePage with CNV dataset "gnomad_cnv_r4" has no unexpected changes 1`]
               />
               Non-coding transcripts
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 kDzbaQ"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 fDzopB"
                 color="#bdbdbd"
                 height={4}
               />
@@ -1396,7 +1396,7 @@ exports[`GenePage with CNV dataset "gnomad_cnv_r4" has no unexpected changes 1`]
         </ul>
       </div>
       <div
-        className="GenePage__TrackWrapper-sc-rcxzgc-11 bOhTDW"
+        className="GenePage__TrackWrapper-sc-rcxzgc-5 bTCTZj"
       >
         <div
           className="Track__OuterWrapper-sc-1sdyh2h-0 bBMGlf"
@@ -1413,7 +1413,7 @@ exports[`GenePage with CNV dataset "gnomad_cnv_r4" has no unexpected changes 1`]
               }
             >
               <div
-                className="GenePage__ToggleTranscriptsPanel-sc-rcxzgc-12 gOGyWK"
+                className="GenePage__ToggleTranscriptsPanel-sc-rcxzgc-6 bLfCYD"
               >
                 <button
                   className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
@@ -1440,7 +1440,7 @@ exports[`GenePage with CNV dataset "gnomad_cnv_r4" has no unexpected changes 1`]
               }
             >
               <div
-                className="GenePage__CompositeTranscriptPlotWrapper-sc-rcxzgc-13 fAeljc"
+                className="GenePage__CompositeTranscriptPlotWrapper-sc-rcxzgc-7 hiaYli"
               >
                 <svg
                   height={20}
@@ -2101,7 +2101,7 @@ exports[`GenePage with SV dataset "gnomad_sv_r2_1" has no unexpected changes 1`]
         className="GenePage__ConstraintOrCooccurrenceColumn-sc-rcxzgc-3 sHWJd"
       >
         <div
-          className="GenePage__TableSelectorWrapper-sc-rcxzgc-10 eFuLrR"
+          className="GenePage__TableSelectorWrapper-sc-rcxzgc-4 kTbSHB"
         >
           <div
             className="sc-bdVaJa dDlceV"
@@ -2776,23 +2776,23 @@ exports[`GenePage with SV dataset "gnomad_sv_r2_1" has no unexpected changes 1`]
         </div>
       </div>
       <div
-        className="GenePage__ControlPanel-sc-rcxzgc-4 hMLYBm"
+        className="ChartStyles__ControlPanel-sc-atxio9-0 iLJjwA"
         width={814}
       >
         Include:
         <ul
-          className="GenePage__Legend-sc-rcxzgc-5 jsPFfF"
+          className="ChartStyles__Legend-sc-atxio9-1 mfEDY"
         >
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-cds-regions"
             >
               <input
                 checked={false}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-cds-regions"
                 onChange={[Function]}
@@ -2800,22 +2800,22 @@ exports[`GenePage with SV dataset "gnomad_sv_r2_1" has no unexpected changes 1`]
               />
               Coding regions (CDS)
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 kVyAuC"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 dWcYqk"
                 color="#424242"
                 height={10}
               />
             </label>
           </li>
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-utr-regions"
             >
               <input
                 checked={false}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-utr-regions"
                 onChange={[Function]}
@@ -2823,22 +2823,22 @@ exports[`GenePage with SV dataset "gnomad_sv_r2_1" has no unexpected changes 1`]
               />
               Untranslated regions (UTRs)
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 gUeepi"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 lhFEQi"
                 color="#424242"
                 height={4}
               />
             </label>
           </li>
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-nc-transcripts"
             >
               <input
                 checked={true}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-nc-transcripts"
                 onChange={[Function]}
@@ -2846,7 +2846,7 @@ exports[`GenePage with SV dataset "gnomad_sv_r2_1" has no unexpected changes 1`]
               />
               Non-coding transcripts
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 kDzbaQ"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 fDzopB"
                 color="#bdbdbd"
                 height={4}
               />
@@ -2855,7 +2855,7 @@ exports[`GenePage with SV dataset "gnomad_sv_r2_1" has no unexpected changes 1`]
         </ul>
       </div>
       <div
-        className="GenePage__TrackWrapper-sc-rcxzgc-11 bOhTDW"
+        className="GenePage__TrackWrapper-sc-rcxzgc-5 bTCTZj"
       >
         <div
           className="Track__OuterWrapper-sc-1sdyh2h-0 bBMGlf"
@@ -2872,7 +2872,7 @@ exports[`GenePage with SV dataset "gnomad_sv_r2_1" has no unexpected changes 1`]
               }
             >
               <div
-                className="GenePage__ToggleTranscriptsPanel-sc-rcxzgc-12 gOGyWK"
+                className="GenePage__ToggleTranscriptsPanel-sc-rcxzgc-6 bLfCYD"
               >
                 <button
                   className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
@@ -2899,7 +2899,7 @@ exports[`GenePage with SV dataset "gnomad_sv_r2_1" has no unexpected changes 1`]
               }
             >
               <div
-                className="GenePage__CompositeTranscriptPlotWrapper-sc-rcxzgc-13 fAeljc"
+                className="GenePage__CompositeTranscriptPlotWrapper-sc-rcxzgc-7 hiaYli"
               >
                 <svg
                   height={20}
@@ -3560,7 +3560,7 @@ exports[`GenePage with SV dataset "gnomad_sv_r2_1_controls" has no unexpected ch
         className="GenePage__ConstraintOrCooccurrenceColumn-sc-rcxzgc-3 sHWJd"
       >
         <div
-          className="GenePage__TableSelectorWrapper-sc-rcxzgc-10 eFuLrR"
+          className="GenePage__TableSelectorWrapper-sc-rcxzgc-4 kTbSHB"
         >
           <div
             className="sc-bdVaJa dDlceV"
@@ -4235,23 +4235,23 @@ exports[`GenePage with SV dataset "gnomad_sv_r2_1_controls" has no unexpected ch
         </div>
       </div>
       <div
-        className="GenePage__ControlPanel-sc-rcxzgc-4 hMLYBm"
+        className="ChartStyles__ControlPanel-sc-atxio9-0 iLJjwA"
         width={814}
       >
         Include:
         <ul
-          className="GenePage__Legend-sc-rcxzgc-5 jsPFfF"
+          className="ChartStyles__Legend-sc-atxio9-1 mfEDY"
         >
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-cds-regions"
             >
               <input
                 checked={false}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-cds-regions"
                 onChange={[Function]}
@@ -4259,22 +4259,22 @@ exports[`GenePage with SV dataset "gnomad_sv_r2_1_controls" has no unexpected ch
               />
               Coding regions (CDS)
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 kVyAuC"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 dWcYqk"
                 color="#424242"
                 height={10}
               />
             </label>
           </li>
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-utr-regions"
             >
               <input
                 checked={false}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-utr-regions"
                 onChange={[Function]}
@@ -4282,22 +4282,22 @@ exports[`GenePage with SV dataset "gnomad_sv_r2_1_controls" has no unexpected ch
               />
               Untranslated regions (UTRs)
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 gUeepi"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 lhFEQi"
                 color="#424242"
                 height={4}
               />
             </label>
           </li>
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-nc-transcripts"
             >
               <input
                 checked={true}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-nc-transcripts"
                 onChange={[Function]}
@@ -4305,7 +4305,7 @@ exports[`GenePage with SV dataset "gnomad_sv_r2_1_controls" has no unexpected ch
               />
               Non-coding transcripts
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 kDzbaQ"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 fDzopB"
                 color="#bdbdbd"
                 height={4}
               />
@@ -4314,7 +4314,7 @@ exports[`GenePage with SV dataset "gnomad_sv_r2_1_controls" has no unexpected ch
         </ul>
       </div>
       <div
-        className="GenePage__TrackWrapper-sc-rcxzgc-11 bOhTDW"
+        className="GenePage__TrackWrapper-sc-rcxzgc-5 bTCTZj"
       >
         <div
           className="Track__OuterWrapper-sc-1sdyh2h-0 bBMGlf"
@@ -4331,7 +4331,7 @@ exports[`GenePage with SV dataset "gnomad_sv_r2_1_controls" has no unexpected ch
               }
             >
               <div
-                className="GenePage__ToggleTranscriptsPanel-sc-rcxzgc-12 gOGyWK"
+                className="GenePage__ToggleTranscriptsPanel-sc-rcxzgc-6 bLfCYD"
               >
                 <button
                   className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
@@ -4358,7 +4358,7 @@ exports[`GenePage with SV dataset "gnomad_sv_r2_1_controls" has no unexpected ch
               }
             >
               <div
-                className="GenePage__CompositeTranscriptPlotWrapper-sc-rcxzgc-13 fAeljc"
+                className="GenePage__CompositeTranscriptPlotWrapper-sc-rcxzgc-7 hiaYli"
               >
                 <svg
                   height={20}
@@ -5019,7 +5019,7 @@ exports[`GenePage with SV dataset "gnomad_sv_r2_1_non_neuro" has no unexpected c
         className="GenePage__ConstraintOrCooccurrenceColumn-sc-rcxzgc-3 sHWJd"
       >
         <div
-          className="GenePage__TableSelectorWrapper-sc-rcxzgc-10 eFuLrR"
+          className="GenePage__TableSelectorWrapper-sc-rcxzgc-4 kTbSHB"
         >
           <div
             className="sc-bdVaJa dDlceV"
@@ -5694,23 +5694,23 @@ exports[`GenePage with SV dataset "gnomad_sv_r2_1_non_neuro" has no unexpected c
         </div>
       </div>
       <div
-        className="GenePage__ControlPanel-sc-rcxzgc-4 hMLYBm"
+        className="ChartStyles__ControlPanel-sc-atxio9-0 iLJjwA"
         width={814}
       >
         Include:
         <ul
-          className="GenePage__Legend-sc-rcxzgc-5 jsPFfF"
+          className="ChartStyles__Legend-sc-atxio9-1 mfEDY"
         >
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-cds-regions"
             >
               <input
                 checked={false}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-cds-regions"
                 onChange={[Function]}
@@ -5718,22 +5718,22 @@ exports[`GenePage with SV dataset "gnomad_sv_r2_1_non_neuro" has no unexpected c
               />
               Coding regions (CDS)
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 kVyAuC"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 dWcYqk"
                 color="#424242"
                 height={10}
               />
             </label>
           </li>
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-utr-regions"
             >
               <input
                 checked={false}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-utr-regions"
                 onChange={[Function]}
@@ -5741,22 +5741,22 @@ exports[`GenePage with SV dataset "gnomad_sv_r2_1_non_neuro" has no unexpected c
               />
               Untranslated regions (UTRs)
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 gUeepi"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 lhFEQi"
                 color="#424242"
                 height={4}
               />
             </label>
           </li>
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-nc-transcripts"
             >
               <input
                 checked={true}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-nc-transcripts"
                 onChange={[Function]}
@@ -5764,7 +5764,7 @@ exports[`GenePage with SV dataset "gnomad_sv_r2_1_non_neuro" has no unexpected c
               />
               Non-coding transcripts
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 kDzbaQ"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 fDzopB"
                 color="#bdbdbd"
                 height={4}
               />
@@ -5773,7 +5773,7 @@ exports[`GenePage with SV dataset "gnomad_sv_r2_1_non_neuro" has no unexpected c
         </ul>
       </div>
       <div
-        className="GenePage__TrackWrapper-sc-rcxzgc-11 bOhTDW"
+        className="GenePage__TrackWrapper-sc-rcxzgc-5 bTCTZj"
       >
         <div
           className="Track__OuterWrapper-sc-1sdyh2h-0 bBMGlf"
@@ -5790,7 +5790,7 @@ exports[`GenePage with SV dataset "gnomad_sv_r2_1_non_neuro" has no unexpected c
               }
             >
               <div
-                className="GenePage__ToggleTranscriptsPanel-sc-rcxzgc-12 gOGyWK"
+                className="GenePage__ToggleTranscriptsPanel-sc-rcxzgc-6 bLfCYD"
               >
                 <button
                   className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
@@ -5817,7 +5817,7 @@ exports[`GenePage with SV dataset "gnomad_sv_r2_1_non_neuro" has no unexpected c
               }
             >
               <div
-                className="GenePage__CompositeTranscriptPlotWrapper-sc-rcxzgc-13 fAeljc"
+                className="GenePage__CompositeTranscriptPlotWrapper-sc-rcxzgc-7 hiaYli"
               >
                 <svg
                   height={20}
@@ -6478,7 +6478,7 @@ exports[`GenePage with SV dataset "gnomad_sv_r4" has no unexpected changes 1`] =
         className="GenePage__ConstraintOrCooccurrenceColumn-sc-rcxzgc-3 sHWJd"
       >
         <div
-          className="GenePage__TableSelectorWrapper-sc-rcxzgc-10 eFuLrR"
+          className="GenePage__TableSelectorWrapper-sc-rcxzgc-4 kTbSHB"
         >
           <div
             className="sc-bdVaJa dDlceV"
@@ -7153,23 +7153,23 @@ exports[`GenePage with SV dataset "gnomad_sv_r4" has no unexpected changes 1`] =
         </div>
       </div>
       <div
-        className="GenePage__ControlPanel-sc-rcxzgc-4 hMLYBm"
+        className="ChartStyles__ControlPanel-sc-atxio9-0 iLJjwA"
         width={814}
       >
         Include:
         <ul
-          className="GenePage__Legend-sc-rcxzgc-5 jsPFfF"
+          className="ChartStyles__Legend-sc-atxio9-1 mfEDY"
         >
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-cds-regions"
             >
               <input
                 checked={false}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-cds-regions"
                 onChange={[Function]}
@@ -7177,22 +7177,22 @@ exports[`GenePage with SV dataset "gnomad_sv_r4" has no unexpected changes 1`] =
               />
               Coding regions (CDS)
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 kVyAuC"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 dWcYqk"
                 color="#424242"
                 height={10}
               />
             </label>
           </li>
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-utr-regions"
             >
               <input
                 checked={false}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-utr-regions"
                 onChange={[Function]}
@@ -7200,22 +7200,22 @@ exports[`GenePage with SV dataset "gnomad_sv_r4" has no unexpected changes 1`] =
               />
               Untranslated regions (UTRs)
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 gUeepi"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 lhFEQi"
                 color="#424242"
                 height={4}
               />
             </label>
           </li>
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-nc-transcripts"
             >
               <input
                 checked={true}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-nc-transcripts"
                 onChange={[Function]}
@@ -7223,7 +7223,7 @@ exports[`GenePage with SV dataset "gnomad_sv_r4" has no unexpected changes 1`] =
               />
               Non-coding transcripts
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 kDzbaQ"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 fDzopB"
                 color="#bdbdbd"
                 height={4}
               />
@@ -7232,7 +7232,7 @@ exports[`GenePage with SV dataset "gnomad_sv_r4" has no unexpected changes 1`] =
         </ul>
       </div>
       <div
-        className="GenePage__TrackWrapper-sc-rcxzgc-11 bOhTDW"
+        className="GenePage__TrackWrapper-sc-rcxzgc-5 bTCTZj"
       >
         <div
           className="Track__OuterWrapper-sc-1sdyh2h-0 bBMGlf"
@@ -7249,7 +7249,7 @@ exports[`GenePage with SV dataset "gnomad_sv_r4" has no unexpected changes 1`] =
               }
             >
               <div
-                className="GenePage__ToggleTranscriptsPanel-sc-rcxzgc-12 gOGyWK"
+                className="GenePage__ToggleTranscriptsPanel-sc-rcxzgc-6 bLfCYD"
               >
                 <button
                   className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
@@ -7276,7 +7276,7 @@ exports[`GenePage with SV dataset "gnomad_sv_r4" has no unexpected changes 1`] =
               }
             >
               <div
-                className="GenePage__CompositeTranscriptPlotWrapper-sc-rcxzgc-13 fAeljc"
+                className="GenePage__CompositeTranscriptPlotWrapper-sc-rcxzgc-7 hiaYli"
               >
                 <svg
                   height={20}
@@ -7937,7 +7937,7 @@ exports[`GenePage with non-SV dataset "exac" has no unexpected changes 1`] = `
         className="GenePage__ConstraintOrCooccurrenceColumn-sc-rcxzgc-3 sHWJd"
       >
         <div
-          className="GenePage__TableSelectorWrapper-sc-rcxzgc-10 eFuLrR"
+          className="GenePage__TableSelectorWrapper-sc-rcxzgc-4 kTbSHB"
         >
           <div
             className="sc-bdVaJa dDlceV"
@@ -8623,23 +8623,23 @@ exports[`GenePage with non-SV dataset "exac" has no unexpected changes 1`] = `
         </div>
       </div>
       <div
-        className="GenePage__ControlPanel-sc-rcxzgc-4 hMLYBm"
+        className="ChartStyles__ControlPanel-sc-atxio9-0 iLJjwA"
         width={814}
       >
         Include:
         <ul
-          className="GenePage__Legend-sc-rcxzgc-5 jsPFfF"
+          className="ChartStyles__Legend-sc-atxio9-1 mfEDY"
         >
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-cds-regions"
             >
               <input
                 checked={false}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-cds-regions"
                 onChange={[Function]}
@@ -8647,22 +8647,22 @@ exports[`GenePage with non-SV dataset "exac" has no unexpected changes 1`] = `
               />
               Coding regions (CDS)
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 kVyAuC"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 dWcYqk"
                 color="#424242"
                 height={10}
               />
             </label>
           </li>
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-utr-regions"
             >
               <input
                 checked={false}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-utr-regions"
                 onChange={[Function]}
@@ -8670,22 +8670,22 @@ exports[`GenePage with non-SV dataset "exac" has no unexpected changes 1`] = `
               />
               Untranslated regions (UTRs)
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 gUeepi"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 lhFEQi"
                 color="#424242"
                 height={4}
               />
             </label>
           </li>
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-nc-transcripts"
             >
               <input
                 checked={true}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-nc-transcripts"
                 onChange={[Function]}
@@ -8693,7 +8693,7 @@ exports[`GenePage with non-SV dataset "exac" has no unexpected changes 1`] = `
               />
               Non-coding transcripts
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 kDzbaQ"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 fDzopB"
                 color="#bdbdbd"
                 height={4}
               />
@@ -8702,7 +8702,7 @@ exports[`GenePage with non-SV dataset "exac" has no unexpected changes 1`] = `
         </ul>
       </div>
       <div
-        className="GenePage__TrackWrapper-sc-rcxzgc-11 bOhTDW"
+        className="GenePage__TrackWrapper-sc-rcxzgc-5 bTCTZj"
       >
         <div
           className="Track__OuterWrapper-sc-1sdyh2h-0 bBMGlf"
@@ -8719,7 +8719,7 @@ exports[`GenePage with non-SV dataset "exac" has no unexpected changes 1`] = `
               }
             >
               <div
-                className="GenePage__ToggleTranscriptsPanel-sc-rcxzgc-12 gOGyWK"
+                className="GenePage__ToggleTranscriptsPanel-sc-rcxzgc-6 bLfCYD"
               >
                 <button
                   className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
@@ -8746,7 +8746,7 @@ exports[`GenePage with non-SV dataset "exac" has no unexpected changes 1`] = `
               }
             >
               <div
-                className="GenePage__CompositeTranscriptPlotWrapper-sc-rcxzgc-13 fAeljc"
+                className="GenePage__CompositeTranscriptPlotWrapper-sc-rcxzgc-7 hiaYli"
               >
                 <svg
                   height={20}
@@ -9430,7 +9430,7 @@ exports[`GenePage with non-SV dataset "gnomad_cnv_r4" has no unexpected changes 
         className="GenePage__ConstraintOrCooccurrenceColumn-sc-rcxzgc-3 sHWJd"
       >
         <div
-          className="GenePage__TableSelectorWrapper-sc-rcxzgc-10 eFuLrR"
+          className="GenePage__TableSelectorWrapper-sc-rcxzgc-4 kTbSHB"
         >
           <div
             className="sc-bdVaJa dDlceV"
@@ -10116,23 +10116,23 @@ exports[`GenePage with non-SV dataset "gnomad_cnv_r4" has no unexpected changes 
         </div>
       </div>
       <div
-        className="GenePage__ControlPanel-sc-rcxzgc-4 hMLYBm"
+        className="ChartStyles__ControlPanel-sc-atxio9-0 iLJjwA"
         width={814}
       >
         Include:
         <ul
-          className="GenePage__Legend-sc-rcxzgc-5 jsPFfF"
+          className="ChartStyles__Legend-sc-atxio9-1 mfEDY"
         >
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-cds-regions"
             >
               <input
                 checked={false}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-cds-regions"
                 onChange={[Function]}
@@ -10140,22 +10140,22 @@ exports[`GenePage with non-SV dataset "gnomad_cnv_r4" has no unexpected changes 
               />
               Coding regions (CDS)
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 kVyAuC"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 dWcYqk"
                 color="#424242"
                 height={10}
               />
             </label>
           </li>
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-utr-regions"
             >
               <input
                 checked={false}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-utr-regions"
                 onChange={[Function]}
@@ -10163,22 +10163,22 @@ exports[`GenePage with non-SV dataset "gnomad_cnv_r4" has no unexpected changes 
               />
               Untranslated regions (UTRs)
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 gUeepi"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 lhFEQi"
                 color="#424242"
                 height={4}
               />
             </label>
           </li>
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-nc-transcripts"
             >
               <input
                 checked={true}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-nc-transcripts"
                 onChange={[Function]}
@@ -10186,7 +10186,7 @@ exports[`GenePage with non-SV dataset "gnomad_cnv_r4" has no unexpected changes 
               />
               Non-coding transcripts
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 kDzbaQ"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 fDzopB"
                 color="#bdbdbd"
                 height={4}
               />
@@ -10195,7 +10195,7 @@ exports[`GenePage with non-SV dataset "gnomad_cnv_r4" has no unexpected changes 
         </ul>
       </div>
       <div
-        className="GenePage__TrackWrapper-sc-rcxzgc-11 bOhTDW"
+        className="GenePage__TrackWrapper-sc-rcxzgc-5 bTCTZj"
       >
         <div
           className="Track__OuterWrapper-sc-1sdyh2h-0 bBMGlf"
@@ -10212,7 +10212,7 @@ exports[`GenePage with non-SV dataset "gnomad_cnv_r4" has no unexpected changes 
               }
             >
               <div
-                className="GenePage__ToggleTranscriptsPanel-sc-rcxzgc-12 gOGyWK"
+                className="GenePage__ToggleTranscriptsPanel-sc-rcxzgc-6 bLfCYD"
               >
                 <button
                   className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
@@ -10239,7 +10239,7 @@ exports[`GenePage with non-SV dataset "gnomad_cnv_r4" has no unexpected changes 
               }
             >
               <div
-                className="GenePage__CompositeTranscriptPlotWrapper-sc-rcxzgc-13 fAeljc"
+                className="GenePage__CompositeTranscriptPlotWrapper-sc-rcxzgc-7 hiaYli"
               >
                 <svg
                   height={20}
@@ -10900,7 +10900,7 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1" has no unexpected changes 1`
         className="GenePage__ConstraintOrCooccurrenceColumn-sc-rcxzgc-3 sHWJd"
       >
         <div
-          className="GenePage__TableSelectorWrapper-sc-rcxzgc-10 eFuLrR"
+          className="GenePage__TableSelectorWrapper-sc-rcxzgc-4 kTbSHB"
         >
           <div
             className="sc-bdVaJa dDlceV"
@@ -11586,23 +11586,23 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1" has no unexpected changes 1`
         </div>
       </div>
       <div
-        className="GenePage__ControlPanel-sc-rcxzgc-4 hMLYBm"
+        className="ChartStyles__ControlPanel-sc-atxio9-0 iLJjwA"
         width={814}
       >
         Include:
         <ul
-          className="GenePage__Legend-sc-rcxzgc-5 jsPFfF"
+          className="ChartStyles__Legend-sc-atxio9-1 mfEDY"
         >
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-cds-regions"
             >
               <input
                 checked={false}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-cds-regions"
                 onChange={[Function]}
@@ -11610,22 +11610,22 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1" has no unexpected changes 1`
               />
               Coding regions (CDS)
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 kVyAuC"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 dWcYqk"
                 color="#424242"
                 height={10}
               />
             </label>
           </li>
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-utr-regions"
             >
               <input
                 checked={false}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-utr-regions"
                 onChange={[Function]}
@@ -11633,22 +11633,22 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1" has no unexpected changes 1`
               />
               Untranslated regions (UTRs)
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 gUeepi"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 lhFEQi"
                 color="#424242"
                 height={4}
               />
             </label>
           </li>
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-nc-transcripts"
             >
               <input
                 checked={true}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-nc-transcripts"
                 onChange={[Function]}
@@ -11656,7 +11656,7 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1" has no unexpected changes 1`
               />
               Non-coding transcripts
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 kDzbaQ"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 fDzopB"
                 color="#bdbdbd"
                 height={4}
               />
@@ -11665,7 +11665,7 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1" has no unexpected changes 1`
         </ul>
       </div>
       <div
-        className="GenePage__TrackWrapper-sc-rcxzgc-11 bOhTDW"
+        className="GenePage__TrackWrapper-sc-rcxzgc-5 bTCTZj"
       >
         <div
           className="Track__OuterWrapper-sc-1sdyh2h-0 bBMGlf"
@@ -11682,7 +11682,7 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1" has no unexpected changes 1`
               }
             >
               <div
-                className="GenePage__ToggleTranscriptsPanel-sc-rcxzgc-12 gOGyWK"
+                className="GenePage__ToggleTranscriptsPanel-sc-rcxzgc-6 bLfCYD"
               >
                 <button
                   className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
@@ -11709,7 +11709,7 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1" has no unexpected changes 1`
               }
             >
               <div
-                className="GenePage__CompositeTranscriptPlotWrapper-sc-rcxzgc-13 fAeljc"
+                className="GenePage__CompositeTranscriptPlotWrapper-sc-rcxzgc-7 hiaYli"
               >
                 <svg
                   height={20}
@@ -12488,7 +12488,7 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_controls" has no unexpected c
         className="GenePage__ConstraintOrCooccurrenceColumn-sc-rcxzgc-3 sHWJd"
       >
         <div
-          className="GenePage__TableSelectorWrapper-sc-rcxzgc-10 eFuLrR"
+          className="GenePage__TableSelectorWrapper-sc-rcxzgc-4 kTbSHB"
         >
           <div
             className="sc-bdVaJa dDlceV"
@@ -13174,23 +13174,23 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_controls" has no unexpected c
         </div>
       </div>
       <div
-        className="GenePage__ControlPanel-sc-rcxzgc-4 hMLYBm"
+        className="ChartStyles__ControlPanel-sc-atxio9-0 iLJjwA"
         width={814}
       >
         Include:
         <ul
-          className="GenePage__Legend-sc-rcxzgc-5 jsPFfF"
+          className="ChartStyles__Legend-sc-atxio9-1 mfEDY"
         >
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-cds-regions"
             >
               <input
                 checked={false}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-cds-regions"
                 onChange={[Function]}
@@ -13198,22 +13198,22 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_controls" has no unexpected c
               />
               Coding regions (CDS)
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 kVyAuC"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 dWcYqk"
                 color="#424242"
                 height={10}
               />
             </label>
           </li>
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-utr-regions"
             >
               <input
                 checked={false}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-utr-regions"
                 onChange={[Function]}
@@ -13221,22 +13221,22 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_controls" has no unexpected c
               />
               Untranslated regions (UTRs)
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 gUeepi"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 lhFEQi"
                 color="#424242"
                 height={4}
               />
             </label>
           </li>
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-nc-transcripts"
             >
               <input
                 checked={true}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-nc-transcripts"
                 onChange={[Function]}
@@ -13244,7 +13244,7 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_controls" has no unexpected c
               />
               Non-coding transcripts
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 kDzbaQ"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 fDzopB"
                 color="#bdbdbd"
                 height={4}
               />
@@ -13253,7 +13253,7 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_controls" has no unexpected c
         </ul>
       </div>
       <div
-        className="GenePage__TrackWrapper-sc-rcxzgc-11 bOhTDW"
+        className="GenePage__TrackWrapper-sc-rcxzgc-5 bTCTZj"
       >
         <div
           className="Track__OuterWrapper-sc-1sdyh2h-0 bBMGlf"
@@ -13270,7 +13270,7 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_controls" has no unexpected c
               }
             >
               <div
-                className="GenePage__ToggleTranscriptsPanel-sc-rcxzgc-12 gOGyWK"
+                className="GenePage__ToggleTranscriptsPanel-sc-rcxzgc-6 bLfCYD"
               >
                 <button
                   className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
@@ -13297,7 +13297,7 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_controls" has no unexpected c
               }
             >
               <div
-                className="GenePage__CompositeTranscriptPlotWrapper-sc-rcxzgc-13 fAeljc"
+                className="GenePage__CompositeTranscriptPlotWrapper-sc-rcxzgc-7 hiaYli"
               >
                 <svg
                   height={20}
@@ -14076,7 +14076,7 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_non_cancer" has no unexpected
         className="GenePage__ConstraintOrCooccurrenceColumn-sc-rcxzgc-3 sHWJd"
       >
         <div
-          className="GenePage__TableSelectorWrapper-sc-rcxzgc-10 eFuLrR"
+          className="GenePage__TableSelectorWrapper-sc-rcxzgc-4 kTbSHB"
         >
           <div
             className="sc-bdVaJa dDlceV"
@@ -14762,23 +14762,23 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_non_cancer" has no unexpected
         </div>
       </div>
       <div
-        className="GenePage__ControlPanel-sc-rcxzgc-4 hMLYBm"
+        className="ChartStyles__ControlPanel-sc-atxio9-0 iLJjwA"
         width={814}
       >
         Include:
         <ul
-          className="GenePage__Legend-sc-rcxzgc-5 jsPFfF"
+          className="ChartStyles__Legend-sc-atxio9-1 mfEDY"
         >
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-cds-regions"
             >
               <input
                 checked={false}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-cds-regions"
                 onChange={[Function]}
@@ -14786,22 +14786,22 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_non_cancer" has no unexpected
               />
               Coding regions (CDS)
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 kVyAuC"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 dWcYqk"
                 color="#424242"
                 height={10}
               />
             </label>
           </li>
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-utr-regions"
             >
               <input
                 checked={false}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-utr-regions"
                 onChange={[Function]}
@@ -14809,22 +14809,22 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_non_cancer" has no unexpected
               />
               Untranslated regions (UTRs)
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 gUeepi"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 lhFEQi"
                 color="#424242"
                 height={4}
               />
             </label>
           </li>
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-nc-transcripts"
             >
               <input
                 checked={true}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-nc-transcripts"
                 onChange={[Function]}
@@ -14832,7 +14832,7 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_non_cancer" has no unexpected
               />
               Non-coding transcripts
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 kDzbaQ"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 fDzopB"
                 color="#bdbdbd"
                 height={4}
               />
@@ -14841,7 +14841,7 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_non_cancer" has no unexpected
         </ul>
       </div>
       <div
-        className="GenePage__TrackWrapper-sc-rcxzgc-11 bOhTDW"
+        className="GenePage__TrackWrapper-sc-rcxzgc-5 bTCTZj"
       >
         <div
           className="Track__OuterWrapper-sc-1sdyh2h-0 bBMGlf"
@@ -14858,7 +14858,7 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_non_cancer" has no unexpected
               }
             >
               <div
-                className="GenePage__ToggleTranscriptsPanel-sc-rcxzgc-12 gOGyWK"
+                className="GenePage__ToggleTranscriptsPanel-sc-rcxzgc-6 bLfCYD"
               >
                 <button
                   className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
@@ -14885,7 +14885,7 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_non_cancer" has no unexpected
               }
             >
               <div
-                className="GenePage__CompositeTranscriptPlotWrapper-sc-rcxzgc-13 fAeljc"
+                className="GenePage__CompositeTranscriptPlotWrapper-sc-rcxzgc-7 hiaYli"
               >
                 <svg
                   height={20}
@@ -15664,7 +15664,7 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_non_neuro" has no unexpected 
         className="GenePage__ConstraintOrCooccurrenceColumn-sc-rcxzgc-3 sHWJd"
       >
         <div
-          className="GenePage__TableSelectorWrapper-sc-rcxzgc-10 eFuLrR"
+          className="GenePage__TableSelectorWrapper-sc-rcxzgc-4 kTbSHB"
         >
           <div
             className="sc-bdVaJa dDlceV"
@@ -16350,23 +16350,23 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_non_neuro" has no unexpected 
         </div>
       </div>
       <div
-        className="GenePage__ControlPanel-sc-rcxzgc-4 hMLYBm"
+        className="ChartStyles__ControlPanel-sc-atxio9-0 iLJjwA"
         width={814}
       >
         Include:
         <ul
-          className="GenePage__Legend-sc-rcxzgc-5 jsPFfF"
+          className="ChartStyles__Legend-sc-atxio9-1 mfEDY"
         >
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-cds-regions"
             >
               <input
                 checked={false}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-cds-regions"
                 onChange={[Function]}
@@ -16374,22 +16374,22 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_non_neuro" has no unexpected 
               />
               Coding regions (CDS)
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 kVyAuC"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 dWcYqk"
                 color="#424242"
                 height={10}
               />
             </label>
           </li>
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-utr-regions"
             >
               <input
                 checked={false}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-utr-regions"
                 onChange={[Function]}
@@ -16397,22 +16397,22 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_non_neuro" has no unexpected 
               />
               Untranslated regions (UTRs)
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 gUeepi"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 lhFEQi"
                 color="#424242"
                 height={4}
               />
             </label>
           </li>
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-nc-transcripts"
             >
               <input
                 checked={true}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-nc-transcripts"
                 onChange={[Function]}
@@ -16420,7 +16420,7 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_non_neuro" has no unexpected 
               />
               Non-coding transcripts
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 kDzbaQ"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 fDzopB"
                 color="#bdbdbd"
                 height={4}
               />
@@ -16429,7 +16429,7 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_non_neuro" has no unexpected 
         </ul>
       </div>
       <div
-        className="GenePage__TrackWrapper-sc-rcxzgc-11 bOhTDW"
+        className="GenePage__TrackWrapper-sc-rcxzgc-5 bTCTZj"
       >
         <div
           className="Track__OuterWrapper-sc-1sdyh2h-0 bBMGlf"
@@ -16446,7 +16446,7 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_non_neuro" has no unexpected 
               }
             >
               <div
-                className="GenePage__ToggleTranscriptsPanel-sc-rcxzgc-12 gOGyWK"
+                className="GenePage__ToggleTranscriptsPanel-sc-rcxzgc-6 bLfCYD"
               >
                 <button
                   className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
@@ -16473,7 +16473,7 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_non_neuro" has no unexpected 
               }
             >
               <div
-                className="GenePage__CompositeTranscriptPlotWrapper-sc-rcxzgc-13 fAeljc"
+                className="GenePage__CompositeTranscriptPlotWrapper-sc-rcxzgc-7 hiaYli"
               >
                 <svg
                   height={20}
@@ -17252,7 +17252,7 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_non_topmed" has no unexpected
         className="GenePage__ConstraintOrCooccurrenceColumn-sc-rcxzgc-3 sHWJd"
       >
         <div
-          className="GenePage__TableSelectorWrapper-sc-rcxzgc-10 eFuLrR"
+          className="GenePage__TableSelectorWrapper-sc-rcxzgc-4 kTbSHB"
         >
           <div
             className="sc-bdVaJa dDlceV"
@@ -17938,23 +17938,23 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_non_topmed" has no unexpected
         </div>
       </div>
       <div
-        className="GenePage__ControlPanel-sc-rcxzgc-4 hMLYBm"
+        className="ChartStyles__ControlPanel-sc-atxio9-0 iLJjwA"
         width={814}
       >
         Include:
         <ul
-          className="GenePage__Legend-sc-rcxzgc-5 jsPFfF"
+          className="ChartStyles__Legend-sc-atxio9-1 mfEDY"
         >
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-cds-regions"
             >
               <input
                 checked={false}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-cds-regions"
                 onChange={[Function]}
@@ -17962,22 +17962,22 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_non_topmed" has no unexpected
               />
               Coding regions (CDS)
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 kVyAuC"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 dWcYqk"
                 color="#424242"
                 height={10}
               />
             </label>
           </li>
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-utr-regions"
             >
               <input
                 checked={false}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-utr-regions"
                 onChange={[Function]}
@@ -17985,22 +17985,22 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_non_topmed" has no unexpected
               />
               Untranslated regions (UTRs)
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 gUeepi"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 lhFEQi"
                 color="#424242"
                 height={4}
               />
             </label>
           </li>
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-nc-transcripts"
             >
               <input
                 checked={true}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-nc-transcripts"
                 onChange={[Function]}
@@ -18008,7 +18008,7 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_non_topmed" has no unexpected
               />
               Non-coding transcripts
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 kDzbaQ"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 fDzopB"
                 color="#bdbdbd"
                 height={4}
               />
@@ -18017,7 +18017,7 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_non_topmed" has no unexpected
         </ul>
       </div>
       <div
-        className="GenePage__TrackWrapper-sc-rcxzgc-11 bOhTDW"
+        className="GenePage__TrackWrapper-sc-rcxzgc-5 bTCTZj"
       >
         <div
           className="Track__OuterWrapper-sc-1sdyh2h-0 bBMGlf"
@@ -18034,7 +18034,7 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_non_topmed" has no unexpected
               }
             >
               <div
-                className="GenePage__ToggleTranscriptsPanel-sc-rcxzgc-12 gOGyWK"
+                className="GenePage__ToggleTranscriptsPanel-sc-rcxzgc-6 bLfCYD"
               >
                 <button
                   className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
@@ -18061,7 +18061,7 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_non_topmed" has no unexpected
               }
             >
               <div
-                className="GenePage__CompositeTranscriptPlotWrapper-sc-rcxzgc-13 fAeljc"
+                className="GenePage__CompositeTranscriptPlotWrapper-sc-rcxzgc-7 hiaYli"
               >
                 <svg
                   height={20}
@@ -18840,7 +18840,7 @@ exports[`GenePage with non-SV dataset "gnomad_r3" has no unexpected changes 1`] 
         className="GenePage__ConstraintOrCooccurrenceColumn-sc-rcxzgc-3 sHWJd"
       >
         <div
-          className="GenePage__TableSelectorWrapper-sc-rcxzgc-10 eFuLrR"
+          className="GenePage__TableSelectorWrapper-sc-rcxzgc-4 kTbSHB"
         >
           <div
             className="sc-bdVaJa dDlceV"
@@ -19527,23 +19527,23 @@ exports[`GenePage with non-SV dataset "gnomad_r3" has no unexpected changes 1`] 
         </div>
       </div>
       <div
-        className="GenePage__ControlPanel-sc-rcxzgc-4 hMLYBm"
+        className="ChartStyles__ControlPanel-sc-atxio9-0 iLJjwA"
         width={814}
       >
         Include:
         <ul
-          className="GenePage__Legend-sc-rcxzgc-5 jsPFfF"
+          className="ChartStyles__Legend-sc-atxio9-1 mfEDY"
         >
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-cds-regions"
             >
               <input
                 checked={false}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-cds-regions"
                 onChange={[Function]}
@@ -19551,22 +19551,22 @@ exports[`GenePage with non-SV dataset "gnomad_r3" has no unexpected changes 1`] 
               />
               Coding regions (CDS)
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 kVyAuC"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 dWcYqk"
                 color="#424242"
                 height={10}
               />
             </label>
           </li>
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-utr-regions"
             >
               <input
                 checked={false}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-utr-regions"
                 onChange={[Function]}
@@ -19574,22 +19574,22 @@ exports[`GenePage with non-SV dataset "gnomad_r3" has no unexpected changes 1`] 
               />
               Untranslated regions (UTRs)
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 gUeepi"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 lhFEQi"
                 color="#424242"
                 height={4}
               />
             </label>
           </li>
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-nc-transcripts"
             >
               <input
                 checked={true}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-nc-transcripts"
                 onChange={[Function]}
@@ -19597,7 +19597,7 @@ exports[`GenePage with non-SV dataset "gnomad_r3" has no unexpected changes 1`] 
               />
               Non-coding transcripts
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 kDzbaQ"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 fDzopB"
                 color="#bdbdbd"
                 height={4}
               />
@@ -19606,7 +19606,7 @@ exports[`GenePage with non-SV dataset "gnomad_r3" has no unexpected changes 1`] 
         </ul>
       </div>
       <div
-        className="GenePage__TrackWrapper-sc-rcxzgc-11 bOhTDW"
+        className="GenePage__TrackWrapper-sc-rcxzgc-5 bTCTZj"
       >
         <div
           className="Track__OuterWrapper-sc-1sdyh2h-0 bBMGlf"
@@ -19623,7 +19623,7 @@ exports[`GenePage with non-SV dataset "gnomad_r3" has no unexpected changes 1`] 
               }
             >
               <div
-                className="GenePage__ToggleTranscriptsPanel-sc-rcxzgc-12 gOGyWK"
+                className="GenePage__ToggleTranscriptsPanel-sc-rcxzgc-6 bLfCYD"
               >
                 <button
                   className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
@@ -19650,7 +19650,7 @@ exports[`GenePage with non-SV dataset "gnomad_r3" has no unexpected changes 1`] 
               }
             >
               <div
-                className="GenePage__CompositeTranscriptPlotWrapper-sc-rcxzgc-13 fAeljc"
+                className="GenePage__CompositeTranscriptPlotWrapper-sc-rcxzgc-7 hiaYli"
               >
                 <svg
                   height={20}
@@ -20334,7 +20334,7 @@ exports[`GenePage with non-SV dataset "gnomad_r3_controls_and_biobanks" has no u
         className="GenePage__ConstraintOrCooccurrenceColumn-sc-rcxzgc-3 sHWJd"
       >
         <div
-          className="GenePage__TableSelectorWrapper-sc-rcxzgc-10 eFuLrR"
+          className="GenePage__TableSelectorWrapper-sc-rcxzgc-4 kTbSHB"
         >
           <div
             className="sc-bdVaJa dDlceV"
@@ -21021,23 +21021,23 @@ exports[`GenePage with non-SV dataset "gnomad_r3_controls_and_biobanks" has no u
         </div>
       </div>
       <div
-        className="GenePage__ControlPanel-sc-rcxzgc-4 hMLYBm"
+        className="ChartStyles__ControlPanel-sc-atxio9-0 iLJjwA"
         width={814}
       >
         Include:
         <ul
-          className="GenePage__Legend-sc-rcxzgc-5 jsPFfF"
+          className="ChartStyles__Legend-sc-atxio9-1 mfEDY"
         >
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-cds-regions"
             >
               <input
                 checked={false}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-cds-regions"
                 onChange={[Function]}
@@ -21045,22 +21045,22 @@ exports[`GenePage with non-SV dataset "gnomad_r3_controls_and_biobanks" has no u
               />
               Coding regions (CDS)
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 kVyAuC"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 dWcYqk"
                 color="#424242"
                 height={10}
               />
             </label>
           </li>
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-utr-regions"
             >
               <input
                 checked={false}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-utr-regions"
                 onChange={[Function]}
@@ -21068,22 +21068,22 @@ exports[`GenePage with non-SV dataset "gnomad_r3_controls_and_biobanks" has no u
               />
               Untranslated regions (UTRs)
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 gUeepi"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 lhFEQi"
                 color="#424242"
                 height={4}
               />
             </label>
           </li>
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-nc-transcripts"
             >
               <input
                 checked={true}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-nc-transcripts"
                 onChange={[Function]}
@@ -21091,7 +21091,7 @@ exports[`GenePage with non-SV dataset "gnomad_r3_controls_and_biobanks" has no u
               />
               Non-coding transcripts
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 kDzbaQ"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 fDzopB"
                 color="#bdbdbd"
                 height={4}
               />
@@ -21100,7 +21100,7 @@ exports[`GenePage with non-SV dataset "gnomad_r3_controls_and_biobanks" has no u
         </ul>
       </div>
       <div
-        className="GenePage__TrackWrapper-sc-rcxzgc-11 bOhTDW"
+        className="GenePage__TrackWrapper-sc-rcxzgc-5 bTCTZj"
       >
         <div
           className="Track__OuterWrapper-sc-1sdyh2h-0 bBMGlf"
@@ -21117,7 +21117,7 @@ exports[`GenePage with non-SV dataset "gnomad_r3_controls_and_biobanks" has no u
               }
             >
               <div
-                className="GenePage__ToggleTranscriptsPanel-sc-rcxzgc-12 gOGyWK"
+                className="GenePage__ToggleTranscriptsPanel-sc-rcxzgc-6 bLfCYD"
               >
                 <button
                   className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
@@ -21144,7 +21144,7 @@ exports[`GenePage with non-SV dataset "gnomad_r3_controls_and_biobanks" has no u
               }
             >
               <div
-                className="GenePage__CompositeTranscriptPlotWrapper-sc-rcxzgc-13 fAeljc"
+                className="GenePage__CompositeTranscriptPlotWrapper-sc-rcxzgc-7 hiaYli"
               >
                 <svg
                   height={20}
@@ -21828,7 +21828,7 @@ exports[`GenePage with non-SV dataset "gnomad_r3_non_cancer" has no unexpected c
         className="GenePage__ConstraintOrCooccurrenceColumn-sc-rcxzgc-3 sHWJd"
       >
         <div
-          className="GenePage__TableSelectorWrapper-sc-rcxzgc-10 eFuLrR"
+          className="GenePage__TableSelectorWrapper-sc-rcxzgc-4 kTbSHB"
         >
           <div
             className="sc-bdVaJa dDlceV"
@@ -22515,23 +22515,23 @@ exports[`GenePage with non-SV dataset "gnomad_r3_non_cancer" has no unexpected c
         </div>
       </div>
       <div
-        className="GenePage__ControlPanel-sc-rcxzgc-4 hMLYBm"
+        className="ChartStyles__ControlPanel-sc-atxio9-0 iLJjwA"
         width={814}
       >
         Include:
         <ul
-          className="GenePage__Legend-sc-rcxzgc-5 jsPFfF"
+          className="ChartStyles__Legend-sc-atxio9-1 mfEDY"
         >
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-cds-regions"
             >
               <input
                 checked={false}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-cds-regions"
                 onChange={[Function]}
@@ -22539,22 +22539,22 @@ exports[`GenePage with non-SV dataset "gnomad_r3_non_cancer" has no unexpected c
               />
               Coding regions (CDS)
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 kVyAuC"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 dWcYqk"
                 color="#424242"
                 height={10}
               />
             </label>
           </li>
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-utr-regions"
             >
               <input
                 checked={false}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-utr-regions"
                 onChange={[Function]}
@@ -22562,22 +22562,22 @@ exports[`GenePage with non-SV dataset "gnomad_r3_non_cancer" has no unexpected c
               />
               Untranslated regions (UTRs)
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 gUeepi"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 lhFEQi"
                 color="#424242"
                 height={4}
               />
             </label>
           </li>
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-nc-transcripts"
             >
               <input
                 checked={true}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-nc-transcripts"
                 onChange={[Function]}
@@ -22585,7 +22585,7 @@ exports[`GenePage with non-SV dataset "gnomad_r3_non_cancer" has no unexpected c
               />
               Non-coding transcripts
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 kDzbaQ"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 fDzopB"
                 color="#bdbdbd"
                 height={4}
               />
@@ -22594,7 +22594,7 @@ exports[`GenePage with non-SV dataset "gnomad_r3_non_cancer" has no unexpected c
         </ul>
       </div>
       <div
-        className="GenePage__TrackWrapper-sc-rcxzgc-11 bOhTDW"
+        className="GenePage__TrackWrapper-sc-rcxzgc-5 bTCTZj"
       >
         <div
           className="Track__OuterWrapper-sc-1sdyh2h-0 bBMGlf"
@@ -22611,7 +22611,7 @@ exports[`GenePage with non-SV dataset "gnomad_r3_non_cancer" has no unexpected c
               }
             >
               <div
-                className="GenePage__ToggleTranscriptsPanel-sc-rcxzgc-12 gOGyWK"
+                className="GenePage__ToggleTranscriptsPanel-sc-rcxzgc-6 bLfCYD"
               >
                 <button
                   className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
@@ -22638,7 +22638,7 @@ exports[`GenePage with non-SV dataset "gnomad_r3_non_cancer" has no unexpected c
               }
             >
               <div
-                className="GenePage__CompositeTranscriptPlotWrapper-sc-rcxzgc-13 fAeljc"
+                className="GenePage__CompositeTranscriptPlotWrapper-sc-rcxzgc-7 hiaYli"
               >
                 <svg
                   height={20}
@@ -23322,7 +23322,7 @@ exports[`GenePage with non-SV dataset "gnomad_r3_non_neuro" has no unexpected ch
         className="GenePage__ConstraintOrCooccurrenceColumn-sc-rcxzgc-3 sHWJd"
       >
         <div
-          className="GenePage__TableSelectorWrapper-sc-rcxzgc-10 eFuLrR"
+          className="GenePage__TableSelectorWrapper-sc-rcxzgc-4 kTbSHB"
         >
           <div
             className="sc-bdVaJa dDlceV"
@@ -24009,23 +24009,23 @@ exports[`GenePage with non-SV dataset "gnomad_r3_non_neuro" has no unexpected ch
         </div>
       </div>
       <div
-        className="GenePage__ControlPanel-sc-rcxzgc-4 hMLYBm"
+        className="ChartStyles__ControlPanel-sc-atxio9-0 iLJjwA"
         width={814}
       >
         Include:
         <ul
-          className="GenePage__Legend-sc-rcxzgc-5 jsPFfF"
+          className="ChartStyles__Legend-sc-atxio9-1 mfEDY"
         >
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-cds-regions"
             >
               <input
                 checked={false}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-cds-regions"
                 onChange={[Function]}
@@ -24033,22 +24033,22 @@ exports[`GenePage with non-SV dataset "gnomad_r3_non_neuro" has no unexpected ch
               />
               Coding regions (CDS)
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 kVyAuC"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 dWcYqk"
                 color="#424242"
                 height={10}
               />
             </label>
           </li>
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-utr-regions"
             >
               <input
                 checked={false}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-utr-regions"
                 onChange={[Function]}
@@ -24056,22 +24056,22 @@ exports[`GenePage with non-SV dataset "gnomad_r3_non_neuro" has no unexpected ch
               />
               Untranslated regions (UTRs)
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 gUeepi"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 lhFEQi"
                 color="#424242"
                 height={4}
               />
             </label>
           </li>
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-nc-transcripts"
             >
               <input
                 checked={true}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-nc-transcripts"
                 onChange={[Function]}
@@ -24079,7 +24079,7 @@ exports[`GenePage with non-SV dataset "gnomad_r3_non_neuro" has no unexpected ch
               />
               Non-coding transcripts
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 kDzbaQ"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 fDzopB"
                 color="#bdbdbd"
                 height={4}
               />
@@ -24088,7 +24088,7 @@ exports[`GenePage with non-SV dataset "gnomad_r3_non_neuro" has no unexpected ch
         </ul>
       </div>
       <div
-        className="GenePage__TrackWrapper-sc-rcxzgc-11 bOhTDW"
+        className="GenePage__TrackWrapper-sc-rcxzgc-5 bTCTZj"
       >
         <div
           className="Track__OuterWrapper-sc-1sdyh2h-0 bBMGlf"
@@ -24105,7 +24105,7 @@ exports[`GenePage with non-SV dataset "gnomad_r3_non_neuro" has no unexpected ch
               }
             >
               <div
-                className="GenePage__ToggleTranscriptsPanel-sc-rcxzgc-12 gOGyWK"
+                className="GenePage__ToggleTranscriptsPanel-sc-rcxzgc-6 bLfCYD"
               >
                 <button
                   className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
@@ -24132,7 +24132,7 @@ exports[`GenePage with non-SV dataset "gnomad_r3_non_neuro" has no unexpected ch
               }
             >
               <div
-                className="GenePage__CompositeTranscriptPlotWrapper-sc-rcxzgc-13 fAeljc"
+                className="GenePage__CompositeTranscriptPlotWrapper-sc-rcxzgc-7 hiaYli"
               >
                 <svg
                   height={20}
@@ -24816,7 +24816,7 @@ exports[`GenePage with non-SV dataset "gnomad_r3_non_topmed" has no unexpected c
         className="GenePage__ConstraintOrCooccurrenceColumn-sc-rcxzgc-3 sHWJd"
       >
         <div
-          className="GenePage__TableSelectorWrapper-sc-rcxzgc-10 eFuLrR"
+          className="GenePage__TableSelectorWrapper-sc-rcxzgc-4 kTbSHB"
         >
           <div
             className="sc-bdVaJa dDlceV"
@@ -25503,23 +25503,23 @@ exports[`GenePage with non-SV dataset "gnomad_r3_non_topmed" has no unexpected c
         </div>
       </div>
       <div
-        className="GenePage__ControlPanel-sc-rcxzgc-4 hMLYBm"
+        className="ChartStyles__ControlPanel-sc-atxio9-0 iLJjwA"
         width={814}
       >
         Include:
         <ul
-          className="GenePage__Legend-sc-rcxzgc-5 jsPFfF"
+          className="ChartStyles__Legend-sc-atxio9-1 mfEDY"
         >
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-cds-regions"
             >
               <input
                 checked={false}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-cds-regions"
                 onChange={[Function]}
@@ -25527,22 +25527,22 @@ exports[`GenePage with non-SV dataset "gnomad_r3_non_topmed" has no unexpected c
               />
               Coding regions (CDS)
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 kVyAuC"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 dWcYqk"
                 color="#424242"
                 height={10}
               />
             </label>
           </li>
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-utr-regions"
             >
               <input
                 checked={false}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-utr-regions"
                 onChange={[Function]}
@@ -25550,22 +25550,22 @@ exports[`GenePage with non-SV dataset "gnomad_r3_non_topmed" has no unexpected c
               />
               Untranslated regions (UTRs)
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 gUeepi"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 lhFEQi"
                 color="#424242"
                 height={4}
               />
             </label>
           </li>
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-nc-transcripts"
             >
               <input
                 checked={true}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-nc-transcripts"
                 onChange={[Function]}
@@ -25573,7 +25573,7 @@ exports[`GenePage with non-SV dataset "gnomad_r3_non_topmed" has no unexpected c
               />
               Non-coding transcripts
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 kDzbaQ"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 fDzopB"
                 color="#bdbdbd"
                 height={4}
               />
@@ -25582,7 +25582,7 @@ exports[`GenePage with non-SV dataset "gnomad_r3_non_topmed" has no unexpected c
         </ul>
       </div>
       <div
-        className="GenePage__TrackWrapper-sc-rcxzgc-11 bOhTDW"
+        className="GenePage__TrackWrapper-sc-rcxzgc-5 bTCTZj"
       >
         <div
           className="Track__OuterWrapper-sc-1sdyh2h-0 bBMGlf"
@@ -25599,7 +25599,7 @@ exports[`GenePage with non-SV dataset "gnomad_r3_non_topmed" has no unexpected c
               }
             >
               <div
-                className="GenePage__ToggleTranscriptsPanel-sc-rcxzgc-12 gOGyWK"
+                className="GenePage__ToggleTranscriptsPanel-sc-rcxzgc-6 bLfCYD"
               >
                 <button
                   className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
@@ -25626,7 +25626,7 @@ exports[`GenePage with non-SV dataset "gnomad_r3_non_topmed" has no unexpected c
               }
             >
               <div
-                className="GenePage__CompositeTranscriptPlotWrapper-sc-rcxzgc-13 fAeljc"
+                className="GenePage__CompositeTranscriptPlotWrapper-sc-rcxzgc-7 hiaYli"
               >
                 <svg
                   height={20}
@@ -26310,7 +26310,7 @@ exports[`GenePage with non-SV dataset "gnomad_r3_non_v2" has no unexpected chang
         className="GenePage__ConstraintOrCooccurrenceColumn-sc-rcxzgc-3 sHWJd"
       >
         <div
-          className="GenePage__TableSelectorWrapper-sc-rcxzgc-10 eFuLrR"
+          className="GenePage__TableSelectorWrapper-sc-rcxzgc-4 kTbSHB"
         >
           <div
             className="sc-bdVaJa dDlceV"
@@ -26997,23 +26997,23 @@ exports[`GenePage with non-SV dataset "gnomad_r3_non_v2" has no unexpected chang
         </div>
       </div>
       <div
-        className="GenePage__ControlPanel-sc-rcxzgc-4 hMLYBm"
+        className="ChartStyles__ControlPanel-sc-atxio9-0 iLJjwA"
         width={814}
       >
         Include:
         <ul
-          className="GenePage__Legend-sc-rcxzgc-5 jsPFfF"
+          className="ChartStyles__Legend-sc-atxio9-1 mfEDY"
         >
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-cds-regions"
             >
               <input
                 checked={false}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-cds-regions"
                 onChange={[Function]}
@@ -27021,22 +27021,22 @@ exports[`GenePage with non-SV dataset "gnomad_r3_non_v2" has no unexpected chang
               />
               Coding regions (CDS)
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 kVyAuC"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 dWcYqk"
                 color="#424242"
                 height={10}
               />
             </label>
           </li>
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-utr-regions"
             >
               <input
                 checked={false}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-utr-regions"
                 onChange={[Function]}
@@ -27044,22 +27044,22 @@ exports[`GenePage with non-SV dataset "gnomad_r3_non_v2" has no unexpected chang
               />
               Untranslated regions (UTRs)
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 gUeepi"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 lhFEQi"
                 color="#424242"
                 height={4}
               />
             </label>
           </li>
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-nc-transcripts"
             >
               <input
                 checked={true}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-nc-transcripts"
                 onChange={[Function]}
@@ -27067,7 +27067,7 @@ exports[`GenePage with non-SV dataset "gnomad_r3_non_v2" has no unexpected chang
               />
               Non-coding transcripts
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 kDzbaQ"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 fDzopB"
                 color="#bdbdbd"
                 height={4}
               />
@@ -27076,7 +27076,7 @@ exports[`GenePage with non-SV dataset "gnomad_r3_non_v2" has no unexpected chang
         </ul>
       </div>
       <div
-        className="GenePage__TrackWrapper-sc-rcxzgc-11 bOhTDW"
+        className="GenePage__TrackWrapper-sc-rcxzgc-5 bTCTZj"
       >
         <div
           className="Track__OuterWrapper-sc-1sdyh2h-0 bBMGlf"
@@ -27093,7 +27093,7 @@ exports[`GenePage with non-SV dataset "gnomad_r3_non_v2" has no unexpected chang
               }
             >
               <div
-                className="GenePage__ToggleTranscriptsPanel-sc-rcxzgc-12 gOGyWK"
+                className="GenePage__ToggleTranscriptsPanel-sc-rcxzgc-6 bLfCYD"
               >
                 <button
                   className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
@@ -27120,7 +27120,7 @@ exports[`GenePage with non-SV dataset "gnomad_r3_non_v2" has no unexpected chang
               }
             >
               <div
-                className="GenePage__CompositeTranscriptPlotWrapper-sc-rcxzgc-13 fAeljc"
+                className="GenePage__CompositeTranscriptPlotWrapper-sc-rcxzgc-7 hiaYli"
               >
                 <svg
                   height={20}
@@ -27804,7 +27804,7 @@ exports[`GenePage with non-SV dataset "gnomad_r4" has no unexpected changes 1`] 
         className="GenePage__ConstraintOrCooccurrenceColumn-sc-rcxzgc-3 sHWJd"
       >
         <div
-          className="GenePage__TableSelectorWrapper-sc-rcxzgc-10 eFuLrR"
+          className="GenePage__TableSelectorWrapper-sc-rcxzgc-4 kTbSHB"
         >
           <div
             className="sc-bdVaJa dDlceV"
@@ -28490,23 +28490,23 @@ exports[`GenePage with non-SV dataset "gnomad_r4" has no unexpected changes 1`] 
         </div>
       </div>
       <div
-        className="GenePage__ControlPanel-sc-rcxzgc-4 hMLYBm"
+        className="ChartStyles__ControlPanel-sc-atxio9-0 iLJjwA"
         width={814}
       >
         Include:
         <ul
-          className="GenePage__Legend-sc-rcxzgc-5 jsPFfF"
+          className="ChartStyles__Legend-sc-atxio9-1 mfEDY"
         >
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-cds-regions"
             >
               <input
                 checked={false}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-cds-regions"
                 onChange={[Function]}
@@ -28514,22 +28514,22 @@ exports[`GenePage with non-SV dataset "gnomad_r4" has no unexpected changes 1`] 
               />
               Coding regions (CDS)
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 kVyAuC"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 dWcYqk"
                 color="#424242"
                 height={10}
               />
             </label>
           </li>
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-utr-regions"
             >
               <input
                 checked={false}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-utr-regions"
                 onChange={[Function]}
@@ -28537,22 +28537,22 @@ exports[`GenePage with non-SV dataset "gnomad_r4" has no unexpected changes 1`] 
               />
               Untranslated regions (UTRs)
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 gUeepi"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 lhFEQi"
                 color="#424242"
                 height={4}
               />
             </label>
           </li>
           <li
-            className="GenePage__LegendItemWrapper-sc-rcxzgc-6 bjByza"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="GenePage__Label-sc-rcxzgc-7 kDKwQo"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-nc-transcripts"
             >
               <input
                 checked={true}
-                className="GenePage__CheckboxInput-sc-rcxzgc-8 eimxFO"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-nc-transcripts"
                 onChange={[Function]}
@@ -28560,7 +28560,7 @@ exports[`GenePage with non-SV dataset "gnomad_r4" has no unexpected changes 1`] 
               />
               Non-coding transcripts
               <span
-                className="GenePage__LegendSwatch-sc-rcxzgc-9 kDzbaQ"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 fDzopB"
                 color="#bdbdbd"
                 height={4}
               />
@@ -28569,7 +28569,7 @@ exports[`GenePage with non-SV dataset "gnomad_r4" has no unexpected changes 1`] 
         </ul>
       </div>
       <div
-        className="GenePage__TrackWrapper-sc-rcxzgc-11 bOhTDW"
+        className="GenePage__TrackWrapper-sc-rcxzgc-5 bTCTZj"
       >
         <div
           className="Track__OuterWrapper-sc-1sdyh2h-0 bBMGlf"
@@ -28586,7 +28586,7 @@ exports[`GenePage with non-SV dataset "gnomad_r4" has no unexpected changes 1`] 
               }
             >
               <div
-                className="GenePage__ToggleTranscriptsPanel-sc-rcxzgc-12 gOGyWK"
+                className="GenePage__ToggleTranscriptsPanel-sc-rcxzgc-6 bLfCYD"
               >
                 <button
                   className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
@@ -28613,7 +28613,7 @@ exports[`GenePage with non-SV dataset "gnomad_r4" has no unexpected changes 1`] 
               }
             >
               <div
-                className="GenePage__CompositeTranscriptPlotWrapper-sc-rcxzgc-13 fAeljc"
+                className="GenePage__CompositeTranscriptPlotWrapper-sc-rcxzgc-7 hiaYli"
               >
                 <svg
                   height={20}

--- a/browser/src/TranscriptPage/TranscriptPage.tsx
+++ b/browser/src/TranscriptPage/TranscriptPage.tsx
@@ -32,6 +32,7 @@ import { ExacConstraint } from '../ConstraintTable/ExacConstraintTable'
 import { GtexTissueExpression } from '../GenePage/TranscriptsTissueExpression'
 import { Variant, ClinvarVariant } from '../VariantPage/VariantPage'
 import { MitochondrialVariant } from '../MitochondrialVariantPage/MitochondrialVariantPage'
+import { ControlPanel, Legend, LegendItemWrapper, Label, CheckboxInput, LegendSwatch } from '../ChartStyles'
 
 export type Exon = {
   feature_type: string
@@ -71,61 +72,6 @@ const TranscriptInfoColumnWrapper = styled.div`
   /* Matches responsive styles in AttributeList */
   @media (max-width: 600px) {
     align-items: stretch;
-  }
-`
-
-const ControlPanel = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: flex-end;
-  align-items: center;
-  width: ${(props: any) => props.width}px;
-  margin-left: ${(props: any) => props.marginLeft}px;
-
-  @media (max-width: 600px) {
-    flex-direction: column;
-    align-items: flex-start;
-    margin-left: 0;
-  }
-`
-
-const Legend = styled.ul`
-  display: flex;
-  flex-direction: row;
-  padding: 0;
-  margin: 0.5em 0;
-  list-style-type: none;
-`
-
-const LegendItemWrapper = styled.li`
-  display: flex;
-  align-items: stretch;
-  margin-left: 1em;
-`
-
-const Label = styled.label`
-  user-select: none;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-`
-
-const CheckboxInput = styled.input.attrs({ type: 'checkbox' })`
-  margin-right: 0.5em;
-`
-
-const LegendSwatch = styled.span`
-  display: flex;
-  align-items: center;
-  width: 16px;
-  margin-left: 0.5em;
-
-  &::before {
-    content: '';
-    display: inline-block;
-    width: 16px;
-    height: ${(props: any) => props.height}px;
-    background: ${(props: any) => props.color};
   }
 `
 

--- a/browser/src/TranscriptPage/__snapshots__/TranscriptPage.spec.tsx.snap
+++ b/browser/src/TranscriptPage/__snapshots__/TranscriptPage.spec.tsx.snap
@@ -659,23 +659,23 @@ exports[`TranscriptPage with dataset "exac" has no unexpected changes 1`] = `
         }
       />
       <div
-        className="TranscriptPage__ControlPanel-sc-1i4bfgh-1 litgDe"
+        className="ChartStyles__ControlPanel-sc-atxio9-0 iLJjwA"
         width={814}
       >
         Include:
         <ul
-          className="TranscriptPage__Legend-sc-1i4bfgh-2 cTBIfH"
+          className="ChartStyles__Legend-sc-atxio9-1 mfEDY"
         >
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-cds-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-cds-regions"
                 onChange={[Function]}
@@ -683,22 +683,22 @@ exports[`TranscriptPage with dataset "exac" has no unexpected changes 1`] = `
               />
               Coding regions (CDS)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 hPtBuL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 dWcYqk"
                 color="#424242"
                 height={10}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-utr-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-utr-regions"
                 onChange={[Function]}
@@ -706,22 +706,22 @@ exports[`TranscriptPage with dataset "exac" has no unexpected changes 1`] = `
               />
               Untranslated regions (UTRs)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 cEzNst"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 lhFEQi"
                 color="#424242"
                 height={4}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-nc-regions"
             >
               <input
                 checked={true}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-nc-regions"
                 onChange={[Function]}
@@ -729,7 +729,7 @@ exports[`TranscriptPage with dataset "exac" has no unexpected changes 1`] = `
               />
               Non-coding regions
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 dqkCL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 fDzopB"
                 color="#bdbdbd"
                 height={4}
               />
@@ -1467,23 +1467,23 @@ exports[`TranscriptPage with dataset "gnomad_cnv_r4" has no unexpected changes 1
         }
       />
       <div
-        className="TranscriptPage__ControlPanel-sc-1i4bfgh-1 litgDe"
+        className="ChartStyles__ControlPanel-sc-atxio9-0 iLJjwA"
         width={814}
       >
         Include:
         <ul
-          className="TranscriptPage__Legend-sc-1i4bfgh-2 cTBIfH"
+          className="ChartStyles__Legend-sc-atxio9-1 mfEDY"
         >
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-cds-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-cds-regions"
                 onChange={[Function]}
@@ -1491,22 +1491,22 @@ exports[`TranscriptPage with dataset "gnomad_cnv_r4" has no unexpected changes 1
               />
               Coding regions (CDS)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 hPtBuL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 dWcYqk"
                 color="#424242"
                 height={10}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-utr-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-utr-regions"
                 onChange={[Function]}
@@ -1514,22 +1514,22 @@ exports[`TranscriptPage with dataset "gnomad_cnv_r4" has no unexpected changes 1
               />
               Untranslated regions (UTRs)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 cEzNst"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 lhFEQi"
                 color="#424242"
                 height={4}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-nc-regions"
             >
               <input
                 checked={true}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-nc-regions"
                 onChange={[Function]}
@@ -1537,7 +1537,7 @@ exports[`TranscriptPage with dataset "gnomad_cnv_r4" has no unexpected changes 1
               />
               Non-coding regions
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 dqkCL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 fDzopB"
                 color="#bdbdbd"
                 height={4}
               />
@@ -2275,23 +2275,23 @@ exports[`TranscriptPage with dataset "gnomad_r2_1" has no unexpected changes 1`]
         }
       />
       <div
-        className="TranscriptPage__ControlPanel-sc-1i4bfgh-1 litgDe"
+        className="ChartStyles__ControlPanel-sc-atxio9-0 iLJjwA"
         width={814}
       >
         Include:
         <ul
-          className="TranscriptPage__Legend-sc-1i4bfgh-2 cTBIfH"
+          className="ChartStyles__Legend-sc-atxio9-1 mfEDY"
         >
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-cds-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-cds-regions"
                 onChange={[Function]}
@@ -2299,22 +2299,22 @@ exports[`TranscriptPage with dataset "gnomad_r2_1" has no unexpected changes 1`]
               />
               Coding regions (CDS)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 hPtBuL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 dWcYqk"
                 color="#424242"
                 height={10}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-utr-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-utr-regions"
                 onChange={[Function]}
@@ -2322,22 +2322,22 @@ exports[`TranscriptPage with dataset "gnomad_r2_1" has no unexpected changes 1`]
               />
               Untranslated regions (UTRs)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 cEzNst"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 lhFEQi"
                 color="#424242"
                 height={4}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-nc-regions"
             >
               <input
                 checked={true}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-nc-regions"
                 onChange={[Function]}
@@ -2345,7 +2345,7 @@ exports[`TranscriptPage with dataset "gnomad_r2_1" has no unexpected changes 1`]
               />
               Non-coding regions
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 dqkCL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 fDzopB"
                 color="#bdbdbd"
                 height={4}
               />
@@ -3083,23 +3083,23 @@ exports[`TranscriptPage with dataset "gnomad_r2_1_controls" has no unexpected ch
         }
       />
       <div
-        className="TranscriptPage__ControlPanel-sc-1i4bfgh-1 litgDe"
+        className="ChartStyles__ControlPanel-sc-atxio9-0 iLJjwA"
         width={814}
       >
         Include:
         <ul
-          className="TranscriptPage__Legend-sc-1i4bfgh-2 cTBIfH"
+          className="ChartStyles__Legend-sc-atxio9-1 mfEDY"
         >
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-cds-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-cds-regions"
                 onChange={[Function]}
@@ -3107,22 +3107,22 @@ exports[`TranscriptPage with dataset "gnomad_r2_1_controls" has no unexpected ch
               />
               Coding regions (CDS)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 hPtBuL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 dWcYqk"
                 color="#424242"
                 height={10}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-utr-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-utr-regions"
                 onChange={[Function]}
@@ -3130,22 +3130,22 @@ exports[`TranscriptPage with dataset "gnomad_r2_1_controls" has no unexpected ch
               />
               Untranslated regions (UTRs)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 cEzNst"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 lhFEQi"
                 color="#424242"
                 height={4}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-nc-regions"
             >
               <input
                 checked={true}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-nc-regions"
                 onChange={[Function]}
@@ -3153,7 +3153,7 @@ exports[`TranscriptPage with dataset "gnomad_r2_1_controls" has no unexpected ch
               />
               Non-coding regions
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 dqkCL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 fDzopB"
                 color="#bdbdbd"
                 height={4}
               />
@@ -3891,23 +3891,23 @@ exports[`TranscriptPage with dataset "gnomad_r2_1_non_cancer" has no unexpected 
         }
       />
       <div
-        className="TranscriptPage__ControlPanel-sc-1i4bfgh-1 litgDe"
+        className="ChartStyles__ControlPanel-sc-atxio9-0 iLJjwA"
         width={814}
       >
         Include:
         <ul
-          className="TranscriptPage__Legend-sc-1i4bfgh-2 cTBIfH"
+          className="ChartStyles__Legend-sc-atxio9-1 mfEDY"
         >
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-cds-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-cds-regions"
                 onChange={[Function]}
@@ -3915,22 +3915,22 @@ exports[`TranscriptPage with dataset "gnomad_r2_1_non_cancer" has no unexpected 
               />
               Coding regions (CDS)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 hPtBuL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 dWcYqk"
                 color="#424242"
                 height={10}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-utr-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-utr-regions"
                 onChange={[Function]}
@@ -3938,22 +3938,22 @@ exports[`TranscriptPage with dataset "gnomad_r2_1_non_cancer" has no unexpected 
               />
               Untranslated regions (UTRs)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 cEzNst"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 lhFEQi"
                 color="#424242"
                 height={4}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-nc-regions"
             >
               <input
                 checked={true}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-nc-regions"
                 onChange={[Function]}
@@ -3961,7 +3961,7 @@ exports[`TranscriptPage with dataset "gnomad_r2_1_non_cancer" has no unexpected 
               />
               Non-coding regions
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 dqkCL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 fDzopB"
                 color="#bdbdbd"
                 height={4}
               />
@@ -4699,23 +4699,23 @@ exports[`TranscriptPage with dataset "gnomad_r2_1_non_neuro" has no unexpected c
         }
       />
       <div
-        className="TranscriptPage__ControlPanel-sc-1i4bfgh-1 litgDe"
+        className="ChartStyles__ControlPanel-sc-atxio9-0 iLJjwA"
         width={814}
       >
         Include:
         <ul
-          className="TranscriptPage__Legend-sc-1i4bfgh-2 cTBIfH"
+          className="ChartStyles__Legend-sc-atxio9-1 mfEDY"
         >
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-cds-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-cds-regions"
                 onChange={[Function]}
@@ -4723,22 +4723,22 @@ exports[`TranscriptPage with dataset "gnomad_r2_1_non_neuro" has no unexpected c
               />
               Coding regions (CDS)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 hPtBuL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 dWcYqk"
                 color="#424242"
                 height={10}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-utr-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-utr-regions"
                 onChange={[Function]}
@@ -4746,22 +4746,22 @@ exports[`TranscriptPage with dataset "gnomad_r2_1_non_neuro" has no unexpected c
               />
               Untranslated regions (UTRs)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 cEzNst"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 lhFEQi"
                 color="#424242"
                 height={4}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-nc-regions"
             >
               <input
                 checked={true}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-nc-regions"
                 onChange={[Function]}
@@ -4769,7 +4769,7 @@ exports[`TranscriptPage with dataset "gnomad_r2_1_non_neuro" has no unexpected c
               />
               Non-coding regions
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 dqkCL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 fDzopB"
                 color="#bdbdbd"
                 height={4}
               />
@@ -5507,23 +5507,23 @@ exports[`TranscriptPage with dataset "gnomad_r2_1_non_topmed" has no unexpected 
         }
       />
       <div
-        className="TranscriptPage__ControlPanel-sc-1i4bfgh-1 litgDe"
+        className="ChartStyles__ControlPanel-sc-atxio9-0 iLJjwA"
         width={814}
       >
         Include:
         <ul
-          className="TranscriptPage__Legend-sc-1i4bfgh-2 cTBIfH"
+          className="ChartStyles__Legend-sc-atxio9-1 mfEDY"
         >
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-cds-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-cds-regions"
                 onChange={[Function]}
@@ -5531,22 +5531,22 @@ exports[`TranscriptPage with dataset "gnomad_r2_1_non_topmed" has no unexpected 
               />
               Coding regions (CDS)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 hPtBuL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 dWcYqk"
                 color="#424242"
                 height={10}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-utr-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-utr-regions"
                 onChange={[Function]}
@@ -5554,22 +5554,22 @@ exports[`TranscriptPage with dataset "gnomad_r2_1_non_topmed" has no unexpected 
               />
               Untranslated regions (UTRs)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 cEzNst"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 lhFEQi"
                 color="#424242"
                 height={4}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-nc-regions"
             >
               <input
                 checked={true}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-nc-regions"
                 onChange={[Function]}
@@ -5577,7 +5577,7 @@ exports[`TranscriptPage with dataset "gnomad_r2_1_non_topmed" has no unexpected 
               />
               Non-coding regions
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 dqkCL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 fDzopB"
                 color="#bdbdbd"
                 height={4}
               />
@@ -6316,23 +6316,23 @@ exports[`TranscriptPage with dataset "gnomad_r3" has no unexpected changes 1`] =
         }
       />
       <div
-        className="TranscriptPage__ControlPanel-sc-1i4bfgh-1 litgDe"
+        className="ChartStyles__ControlPanel-sc-atxio9-0 iLJjwA"
         width={814}
       >
         Include:
         <ul
-          className="TranscriptPage__Legend-sc-1i4bfgh-2 cTBIfH"
+          className="ChartStyles__Legend-sc-atxio9-1 mfEDY"
         >
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-cds-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-cds-regions"
                 onChange={[Function]}
@@ -6340,22 +6340,22 @@ exports[`TranscriptPage with dataset "gnomad_r3" has no unexpected changes 1`] =
               />
               Coding regions (CDS)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 hPtBuL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 dWcYqk"
                 color="#424242"
                 height={10}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-utr-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-utr-regions"
                 onChange={[Function]}
@@ -6363,22 +6363,22 @@ exports[`TranscriptPage with dataset "gnomad_r3" has no unexpected changes 1`] =
               />
               Untranslated regions (UTRs)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 cEzNst"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 lhFEQi"
                 color="#424242"
                 height={4}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-nc-regions"
             >
               <input
                 checked={true}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-nc-regions"
                 onChange={[Function]}
@@ -6386,7 +6386,7 @@ exports[`TranscriptPage with dataset "gnomad_r3" has no unexpected changes 1`] =
               />
               Non-coding regions
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 dqkCL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 fDzopB"
                 color="#bdbdbd"
                 height={4}
               />
@@ -7125,23 +7125,23 @@ exports[`TranscriptPage with dataset "gnomad_r3_controls_and_biobanks" has no un
         }
       />
       <div
-        className="TranscriptPage__ControlPanel-sc-1i4bfgh-1 litgDe"
+        className="ChartStyles__ControlPanel-sc-atxio9-0 iLJjwA"
         width={814}
       >
         Include:
         <ul
-          className="TranscriptPage__Legend-sc-1i4bfgh-2 cTBIfH"
+          className="ChartStyles__Legend-sc-atxio9-1 mfEDY"
         >
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-cds-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-cds-regions"
                 onChange={[Function]}
@@ -7149,22 +7149,22 @@ exports[`TranscriptPage with dataset "gnomad_r3_controls_and_biobanks" has no un
               />
               Coding regions (CDS)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 hPtBuL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 dWcYqk"
                 color="#424242"
                 height={10}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-utr-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-utr-regions"
                 onChange={[Function]}
@@ -7172,22 +7172,22 @@ exports[`TranscriptPage with dataset "gnomad_r3_controls_and_biobanks" has no un
               />
               Untranslated regions (UTRs)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 cEzNst"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 lhFEQi"
                 color="#424242"
                 height={4}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-nc-regions"
             >
               <input
                 checked={true}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-nc-regions"
                 onChange={[Function]}
@@ -7195,7 +7195,7 @@ exports[`TranscriptPage with dataset "gnomad_r3_controls_and_biobanks" has no un
               />
               Non-coding regions
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 dqkCL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 fDzopB"
                 color="#bdbdbd"
                 height={4}
               />
@@ -7934,23 +7934,23 @@ exports[`TranscriptPage with dataset "gnomad_r3_non_cancer" has no unexpected ch
         }
       />
       <div
-        className="TranscriptPage__ControlPanel-sc-1i4bfgh-1 litgDe"
+        className="ChartStyles__ControlPanel-sc-atxio9-0 iLJjwA"
         width={814}
       >
         Include:
         <ul
-          className="TranscriptPage__Legend-sc-1i4bfgh-2 cTBIfH"
+          className="ChartStyles__Legend-sc-atxio9-1 mfEDY"
         >
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-cds-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-cds-regions"
                 onChange={[Function]}
@@ -7958,22 +7958,22 @@ exports[`TranscriptPage with dataset "gnomad_r3_non_cancer" has no unexpected ch
               />
               Coding regions (CDS)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 hPtBuL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 dWcYqk"
                 color="#424242"
                 height={10}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-utr-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-utr-regions"
                 onChange={[Function]}
@@ -7981,22 +7981,22 @@ exports[`TranscriptPage with dataset "gnomad_r3_non_cancer" has no unexpected ch
               />
               Untranslated regions (UTRs)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 cEzNst"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 lhFEQi"
                 color="#424242"
                 height={4}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-nc-regions"
             >
               <input
                 checked={true}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-nc-regions"
                 onChange={[Function]}
@@ -8004,7 +8004,7 @@ exports[`TranscriptPage with dataset "gnomad_r3_non_cancer" has no unexpected ch
               />
               Non-coding regions
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 dqkCL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 fDzopB"
                 color="#bdbdbd"
                 height={4}
               />
@@ -8743,23 +8743,23 @@ exports[`TranscriptPage with dataset "gnomad_r3_non_neuro" has no unexpected cha
         }
       />
       <div
-        className="TranscriptPage__ControlPanel-sc-1i4bfgh-1 litgDe"
+        className="ChartStyles__ControlPanel-sc-atxio9-0 iLJjwA"
         width={814}
       >
         Include:
         <ul
-          className="TranscriptPage__Legend-sc-1i4bfgh-2 cTBIfH"
+          className="ChartStyles__Legend-sc-atxio9-1 mfEDY"
         >
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-cds-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-cds-regions"
                 onChange={[Function]}
@@ -8767,22 +8767,22 @@ exports[`TranscriptPage with dataset "gnomad_r3_non_neuro" has no unexpected cha
               />
               Coding regions (CDS)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 hPtBuL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 dWcYqk"
                 color="#424242"
                 height={10}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-utr-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-utr-regions"
                 onChange={[Function]}
@@ -8790,22 +8790,22 @@ exports[`TranscriptPage with dataset "gnomad_r3_non_neuro" has no unexpected cha
               />
               Untranslated regions (UTRs)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 cEzNst"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 lhFEQi"
                 color="#424242"
                 height={4}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-nc-regions"
             >
               <input
                 checked={true}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-nc-regions"
                 onChange={[Function]}
@@ -8813,7 +8813,7 @@ exports[`TranscriptPage with dataset "gnomad_r3_non_neuro" has no unexpected cha
               />
               Non-coding regions
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 dqkCL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 fDzopB"
                 color="#bdbdbd"
                 height={4}
               />
@@ -9552,23 +9552,23 @@ exports[`TranscriptPage with dataset "gnomad_r3_non_topmed" has no unexpected ch
         }
       />
       <div
-        className="TranscriptPage__ControlPanel-sc-1i4bfgh-1 litgDe"
+        className="ChartStyles__ControlPanel-sc-atxio9-0 iLJjwA"
         width={814}
       >
         Include:
         <ul
-          className="TranscriptPage__Legend-sc-1i4bfgh-2 cTBIfH"
+          className="ChartStyles__Legend-sc-atxio9-1 mfEDY"
         >
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-cds-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-cds-regions"
                 onChange={[Function]}
@@ -9576,22 +9576,22 @@ exports[`TranscriptPage with dataset "gnomad_r3_non_topmed" has no unexpected ch
               />
               Coding regions (CDS)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 hPtBuL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 dWcYqk"
                 color="#424242"
                 height={10}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-utr-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-utr-regions"
                 onChange={[Function]}
@@ -9599,22 +9599,22 @@ exports[`TranscriptPage with dataset "gnomad_r3_non_topmed" has no unexpected ch
               />
               Untranslated regions (UTRs)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 cEzNst"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 lhFEQi"
                 color="#424242"
                 height={4}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-nc-regions"
             >
               <input
                 checked={true}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-nc-regions"
                 onChange={[Function]}
@@ -9622,7 +9622,7 @@ exports[`TranscriptPage with dataset "gnomad_r3_non_topmed" has no unexpected ch
               />
               Non-coding regions
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 dqkCL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 fDzopB"
                 color="#bdbdbd"
                 height={4}
               />
@@ -10361,23 +10361,23 @@ exports[`TranscriptPage with dataset "gnomad_r3_non_v2" has no unexpected change
         }
       />
       <div
-        className="TranscriptPage__ControlPanel-sc-1i4bfgh-1 litgDe"
+        className="ChartStyles__ControlPanel-sc-atxio9-0 iLJjwA"
         width={814}
       >
         Include:
         <ul
-          className="TranscriptPage__Legend-sc-1i4bfgh-2 cTBIfH"
+          className="ChartStyles__Legend-sc-atxio9-1 mfEDY"
         >
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-cds-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-cds-regions"
                 onChange={[Function]}
@@ -10385,22 +10385,22 @@ exports[`TranscriptPage with dataset "gnomad_r3_non_v2" has no unexpected change
               />
               Coding regions (CDS)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 hPtBuL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 dWcYqk"
                 color="#424242"
                 height={10}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-utr-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-utr-regions"
                 onChange={[Function]}
@@ -10408,22 +10408,22 @@ exports[`TranscriptPage with dataset "gnomad_r3_non_v2" has no unexpected change
               />
               Untranslated regions (UTRs)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 cEzNst"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 lhFEQi"
                 color="#424242"
                 height={4}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-nc-regions"
             >
               <input
                 checked={true}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-nc-regions"
                 onChange={[Function]}
@@ -10431,7 +10431,7 @@ exports[`TranscriptPage with dataset "gnomad_r3_non_v2" has no unexpected change
               />
               Non-coding regions
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 dqkCL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 fDzopB"
                 color="#bdbdbd"
                 height={4}
               />
@@ -11169,23 +11169,23 @@ exports[`TranscriptPage with dataset "gnomad_r4" has no unexpected changes 1`] =
         }
       />
       <div
-        className="TranscriptPage__ControlPanel-sc-1i4bfgh-1 litgDe"
+        className="ChartStyles__ControlPanel-sc-atxio9-0 iLJjwA"
         width={814}
       >
         Include:
         <ul
-          className="TranscriptPage__Legend-sc-1i4bfgh-2 cTBIfH"
+          className="ChartStyles__Legend-sc-atxio9-1 mfEDY"
         >
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-cds-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-cds-regions"
                 onChange={[Function]}
@@ -11193,22 +11193,22 @@ exports[`TranscriptPage with dataset "gnomad_r4" has no unexpected changes 1`] =
               />
               Coding regions (CDS)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 hPtBuL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 dWcYqk"
                 color="#424242"
                 height={10}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-utr-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-utr-regions"
                 onChange={[Function]}
@@ -11216,22 +11216,22 @@ exports[`TranscriptPage with dataset "gnomad_r4" has no unexpected changes 1`] =
               />
               Untranslated regions (UTRs)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 cEzNst"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 lhFEQi"
                 color="#424242"
                 height={4}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-nc-regions"
             >
               <input
                 checked={true}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-nc-regions"
                 onChange={[Function]}
@@ -11239,7 +11239,7 @@ exports[`TranscriptPage with dataset "gnomad_r4" has no unexpected changes 1`] =
               />
               Non-coding regions
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 dqkCL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 fDzopB"
                 color="#bdbdbd"
                 height={4}
               />
@@ -11977,23 +11977,23 @@ exports[`TranscriptPage with dataset "gnomad_sv_r2_1" has no unexpected changes 
         }
       />
       <div
-        className="TranscriptPage__ControlPanel-sc-1i4bfgh-1 litgDe"
+        className="ChartStyles__ControlPanel-sc-atxio9-0 iLJjwA"
         width={814}
       >
         Include:
         <ul
-          className="TranscriptPage__Legend-sc-1i4bfgh-2 cTBIfH"
+          className="ChartStyles__Legend-sc-atxio9-1 mfEDY"
         >
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-cds-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-cds-regions"
                 onChange={[Function]}
@@ -12001,22 +12001,22 @@ exports[`TranscriptPage with dataset "gnomad_sv_r2_1" has no unexpected changes 
               />
               Coding regions (CDS)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 hPtBuL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 dWcYqk"
                 color="#424242"
                 height={10}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-utr-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-utr-regions"
                 onChange={[Function]}
@@ -12024,22 +12024,22 @@ exports[`TranscriptPage with dataset "gnomad_sv_r2_1" has no unexpected changes 
               />
               Untranslated regions (UTRs)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 cEzNst"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 lhFEQi"
                 color="#424242"
                 height={4}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-nc-regions"
             >
               <input
                 checked={true}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-nc-regions"
                 onChange={[Function]}
@@ -12047,7 +12047,7 @@ exports[`TranscriptPage with dataset "gnomad_sv_r2_1" has no unexpected changes 
               />
               Non-coding regions
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 dqkCL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 fDzopB"
                 color="#bdbdbd"
                 height={4}
               />
@@ -12785,23 +12785,23 @@ exports[`TranscriptPage with dataset "gnomad_sv_r2_1_controls" has no unexpected
         }
       />
       <div
-        className="TranscriptPage__ControlPanel-sc-1i4bfgh-1 litgDe"
+        className="ChartStyles__ControlPanel-sc-atxio9-0 iLJjwA"
         width={814}
       >
         Include:
         <ul
-          className="TranscriptPage__Legend-sc-1i4bfgh-2 cTBIfH"
+          className="ChartStyles__Legend-sc-atxio9-1 mfEDY"
         >
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-cds-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-cds-regions"
                 onChange={[Function]}
@@ -12809,22 +12809,22 @@ exports[`TranscriptPage with dataset "gnomad_sv_r2_1_controls" has no unexpected
               />
               Coding regions (CDS)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 hPtBuL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 dWcYqk"
                 color="#424242"
                 height={10}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-utr-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-utr-regions"
                 onChange={[Function]}
@@ -12832,22 +12832,22 @@ exports[`TranscriptPage with dataset "gnomad_sv_r2_1_controls" has no unexpected
               />
               Untranslated regions (UTRs)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 cEzNst"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 lhFEQi"
                 color="#424242"
                 height={4}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-nc-regions"
             >
               <input
                 checked={true}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-nc-regions"
                 onChange={[Function]}
@@ -12855,7 +12855,7 @@ exports[`TranscriptPage with dataset "gnomad_sv_r2_1_controls" has no unexpected
               />
               Non-coding regions
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 dqkCL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 fDzopB"
                 color="#bdbdbd"
                 height={4}
               />
@@ -13593,23 +13593,23 @@ exports[`TranscriptPage with dataset "gnomad_sv_r2_1_non_neuro" has no unexpecte
         }
       />
       <div
-        className="TranscriptPage__ControlPanel-sc-1i4bfgh-1 litgDe"
+        className="ChartStyles__ControlPanel-sc-atxio9-0 iLJjwA"
         width={814}
       >
         Include:
         <ul
-          className="TranscriptPage__Legend-sc-1i4bfgh-2 cTBIfH"
+          className="ChartStyles__Legend-sc-atxio9-1 mfEDY"
         >
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-cds-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-cds-regions"
                 onChange={[Function]}
@@ -13617,22 +13617,22 @@ exports[`TranscriptPage with dataset "gnomad_sv_r2_1_non_neuro" has no unexpecte
               />
               Coding regions (CDS)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 hPtBuL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 dWcYqk"
                 color="#424242"
                 height={10}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-utr-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-utr-regions"
                 onChange={[Function]}
@@ -13640,22 +13640,22 @@ exports[`TranscriptPage with dataset "gnomad_sv_r2_1_non_neuro" has no unexpecte
               />
               Untranslated regions (UTRs)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 cEzNst"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 lhFEQi"
                 color="#424242"
                 height={4}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-nc-regions"
             >
               <input
                 checked={true}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-nc-regions"
                 onChange={[Function]}
@@ -13663,7 +13663,7 @@ exports[`TranscriptPage with dataset "gnomad_sv_r2_1_non_neuro" has no unexpecte
               />
               Non-coding regions
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 dqkCL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 fDzopB"
                 color="#bdbdbd"
                 height={4}
               />
@@ -14401,23 +14401,23 @@ exports[`TranscriptPage with dataset "gnomad_sv_r4" has no unexpected changes 1`
         }
       />
       <div
-        className="TranscriptPage__ControlPanel-sc-1i4bfgh-1 litgDe"
+        className="ChartStyles__ControlPanel-sc-atxio9-0 iLJjwA"
         width={814}
       >
         Include:
         <ul
-          className="TranscriptPage__Legend-sc-1i4bfgh-2 cTBIfH"
+          className="ChartStyles__Legend-sc-atxio9-1 mfEDY"
         >
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-cds-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-cds-regions"
                 onChange={[Function]}
@@ -14425,22 +14425,22 @@ exports[`TranscriptPage with dataset "gnomad_sv_r4" has no unexpected changes 1`
               />
               Coding regions (CDS)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 hPtBuL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 dWcYqk"
                 color="#424242"
                 height={10}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-utr-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-utr-regions"
                 onChange={[Function]}
@@ -14448,22 +14448,22 @@ exports[`TranscriptPage with dataset "gnomad_sv_r4" has no unexpected changes 1`
               />
               Untranslated regions (UTRs)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 cEzNst"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 lhFEQi"
                 color="#424242"
                 height={4}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-nc-regions"
             >
               <input
                 checked={true}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-nc-regions"
                 onChange={[Function]}
@@ -14471,7 +14471,7 @@ exports[`TranscriptPage with dataset "gnomad_sv_r4" has no unexpected changes 1`
               />
               Non-coding regions
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 dqkCL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 fDzopB"
                 color="#bdbdbd"
                 height={4}
               />

--- a/browser/src/TranscriptPage/__snapshots__/TranscriptPageContainer.spec.tsx.snap
+++ b/browser/src/TranscriptPage/__snapshots__/TranscriptPageContainer.spec.tsx.snap
@@ -1237,23 +1237,23 @@ exports[`TranscriptPageContainer with dataset exac has no unexpected changes 1`]
         </div>
       </div>
       <div
-        className="TranscriptPage__ControlPanel-sc-1i4bfgh-1 litgDe"
+        className="ChartStyles__ControlPanel-sc-atxio9-0 iLJjwA"
         width={814}
       >
         Include:
         <ul
-          className="TranscriptPage__Legend-sc-1i4bfgh-2 cTBIfH"
+          className="ChartStyles__Legend-sc-atxio9-1 mfEDY"
         >
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-cds-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-cds-regions"
                 onChange={[Function]}
@@ -1261,22 +1261,22 @@ exports[`TranscriptPageContainer with dataset exac has no unexpected changes 1`]
               />
               Coding regions (CDS)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 hPtBuL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 dWcYqk"
                 color="#424242"
                 height={10}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-utr-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-utr-regions"
                 onChange={[Function]}
@@ -1284,22 +1284,22 @@ exports[`TranscriptPageContainer with dataset exac has no unexpected changes 1`]
               />
               Untranslated regions (UTRs)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 cEzNst"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 lhFEQi"
                 color="#424242"
                 height={4}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-nc-regions"
             >
               <input
                 checked={true}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-nc-regions"
                 onChange={[Function]}
@@ -1307,7 +1307,7 @@ exports[`TranscriptPageContainer with dataset exac has no unexpected changes 1`]
               />
               Non-coding regions
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 dqkCL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 fDzopB"
                 color="#bdbdbd"
                 height={4}
               />
@@ -2644,23 +2644,23 @@ exports[`TranscriptPageContainer with dataset gnomad_cnv_r4 has no unexpected ch
         </div>
       </div>
       <div
-        className="TranscriptPage__ControlPanel-sc-1i4bfgh-1 litgDe"
+        className="ChartStyles__ControlPanel-sc-atxio9-0 iLJjwA"
         width={814}
       >
         Include:
         <ul
-          className="TranscriptPage__Legend-sc-1i4bfgh-2 cTBIfH"
+          className="ChartStyles__Legend-sc-atxio9-1 mfEDY"
         >
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-cds-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-cds-regions"
                 onChange={[Function]}
@@ -2668,22 +2668,22 @@ exports[`TranscriptPageContainer with dataset gnomad_cnv_r4 has no unexpected ch
               />
               Coding regions (CDS)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 hPtBuL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 dWcYqk"
                 color="#424242"
                 height={10}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-utr-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-utr-regions"
                 onChange={[Function]}
@@ -2691,22 +2691,22 @@ exports[`TranscriptPageContainer with dataset gnomad_cnv_r4 has no unexpected ch
               />
               Untranslated regions (UTRs)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 cEzNst"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 lhFEQi"
                 color="#424242"
                 height={4}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-nc-regions"
             >
               <input
                 checked={true}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-nc-regions"
                 onChange={[Function]}
@@ -2714,7 +2714,7 @@ exports[`TranscriptPageContainer with dataset gnomad_cnv_r4 has no unexpected ch
               />
               Non-coding regions
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 dqkCL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 fDzopB"
                 color="#bdbdbd"
                 height={4}
               />
@@ -4051,23 +4051,23 @@ exports[`TranscriptPageContainer with dataset gnomad_r2_1 has no unexpected chan
         </div>
       </div>
       <div
-        className="TranscriptPage__ControlPanel-sc-1i4bfgh-1 litgDe"
+        className="ChartStyles__ControlPanel-sc-atxio9-0 iLJjwA"
         width={814}
       >
         Include:
         <ul
-          className="TranscriptPage__Legend-sc-1i4bfgh-2 cTBIfH"
+          className="ChartStyles__Legend-sc-atxio9-1 mfEDY"
         >
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-cds-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-cds-regions"
                 onChange={[Function]}
@@ -4075,22 +4075,22 @@ exports[`TranscriptPageContainer with dataset gnomad_r2_1 has no unexpected chan
               />
               Coding regions (CDS)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 hPtBuL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 dWcYqk"
                 color="#424242"
                 height={10}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-utr-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-utr-regions"
                 onChange={[Function]}
@@ -4098,22 +4098,22 @@ exports[`TranscriptPageContainer with dataset gnomad_r2_1 has no unexpected chan
               />
               Untranslated regions (UTRs)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 cEzNst"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 lhFEQi"
                 color="#424242"
                 height={4}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-nc-regions"
             >
               <input
                 checked={true}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-nc-regions"
                 onChange={[Function]}
@@ -4121,7 +4121,7 @@ exports[`TranscriptPageContainer with dataset gnomad_r2_1 has no unexpected chan
               />
               Non-coding regions
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 dqkCL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 fDzopB"
                 color="#bdbdbd"
                 height={4}
               />
@@ -5458,23 +5458,23 @@ exports[`TranscriptPageContainer with dataset gnomad_r2_1_controls has no unexpe
         </div>
       </div>
       <div
-        className="TranscriptPage__ControlPanel-sc-1i4bfgh-1 litgDe"
+        className="ChartStyles__ControlPanel-sc-atxio9-0 iLJjwA"
         width={814}
       >
         Include:
         <ul
-          className="TranscriptPage__Legend-sc-1i4bfgh-2 cTBIfH"
+          className="ChartStyles__Legend-sc-atxio9-1 mfEDY"
         >
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-cds-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-cds-regions"
                 onChange={[Function]}
@@ -5482,22 +5482,22 @@ exports[`TranscriptPageContainer with dataset gnomad_r2_1_controls has no unexpe
               />
               Coding regions (CDS)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 hPtBuL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 dWcYqk"
                 color="#424242"
                 height={10}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-utr-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-utr-regions"
                 onChange={[Function]}
@@ -5505,22 +5505,22 @@ exports[`TranscriptPageContainer with dataset gnomad_r2_1_controls has no unexpe
               />
               Untranslated regions (UTRs)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 cEzNst"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 lhFEQi"
                 color="#424242"
                 height={4}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-nc-regions"
             >
               <input
                 checked={true}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-nc-regions"
                 onChange={[Function]}
@@ -5528,7 +5528,7 @@ exports[`TranscriptPageContainer with dataset gnomad_r2_1_controls has no unexpe
               />
               Non-coding regions
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 dqkCL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 fDzopB"
                 color="#bdbdbd"
                 height={4}
               />
@@ -6865,23 +6865,23 @@ exports[`TranscriptPageContainer with dataset gnomad_r2_1_non_cancer has no unex
         </div>
       </div>
       <div
-        className="TranscriptPage__ControlPanel-sc-1i4bfgh-1 litgDe"
+        className="ChartStyles__ControlPanel-sc-atxio9-0 iLJjwA"
         width={814}
       >
         Include:
         <ul
-          className="TranscriptPage__Legend-sc-1i4bfgh-2 cTBIfH"
+          className="ChartStyles__Legend-sc-atxio9-1 mfEDY"
         >
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-cds-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-cds-regions"
                 onChange={[Function]}
@@ -6889,22 +6889,22 @@ exports[`TranscriptPageContainer with dataset gnomad_r2_1_non_cancer has no unex
               />
               Coding regions (CDS)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 hPtBuL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 dWcYqk"
                 color="#424242"
                 height={10}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-utr-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-utr-regions"
                 onChange={[Function]}
@@ -6912,22 +6912,22 @@ exports[`TranscriptPageContainer with dataset gnomad_r2_1_non_cancer has no unex
               />
               Untranslated regions (UTRs)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 cEzNst"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 lhFEQi"
                 color="#424242"
                 height={4}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-nc-regions"
             >
               <input
                 checked={true}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-nc-regions"
                 onChange={[Function]}
@@ -6935,7 +6935,7 @@ exports[`TranscriptPageContainer with dataset gnomad_r2_1_non_cancer has no unex
               />
               Non-coding regions
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 dqkCL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 fDzopB"
                 color="#bdbdbd"
                 height={4}
               />
@@ -8272,23 +8272,23 @@ exports[`TranscriptPageContainer with dataset gnomad_r2_1_non_neuro has no unexp
         </div>
       </div>
       <div
-        className="TranscriptPage__ControlPanel-sc-1i4bfgh-1 litgDe"
+        className="ChartStyles__ControlPanel-sc-atxio9-0 iLJjwA"
         width={814}
       >
         Include:
         <ul
-          className="TranscriptPage__Legend-sc-1i4bfgh-2 cTBIfH"
+          className="ChartStyles__Legend-sc-atxio9-1 mfEDY"
         >
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-cds-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-cds-regions"
                 onChange={[Function]}
@@ -8296,22 +8296,22 @@ exports[`TranscriptPageContainer with dataset gnomad_r2_1_non_neuro has no unexp
               />
               Coding regions (CDS)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 hPtBuL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 dWcYqk"
                 color="#424242"
                 height={10}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-utr-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-utr-regions"
                 onChange={[Function]}
@@ -8319,22 +8319,22 @@ exports[`TranscriptPageContainer with dataset gnomad_r2_1_non_neuro has no unexp
               />
               Untranslated regions (UTRs)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 cEzNst"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 lhFEQi"
                 color="#424242"
                 height={4}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-nc-regions"
             >
               <input
                 checked={true}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-nc-regions"
                 onChange={[Function]}
@@ -8342,7 +8342,7 @@ exports[`TranscriptPageContainer with dataset gnomad_r2_1_non_neuro has no unexp
               />
               Non-coding regions
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 dqkCL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 fDzopB"
                 color="#bdbdbd"
                 height={4}
               />
@@ -9679,23 +9679,23 @@ exports[`TranscriptPageContainer with dataset gnomad_r2_1_non_topmed has no unex
         </div>
       </div>
       <div
-        className="TranscriptPage__ControlPanel-sc-1i4bfgh-1 litgDe"
+        className="ChartStyles__ControlPanel-sc-atxio9-0 iLJjwA"
         width={814}
       >
         Include:
         <ul
-          className="TranscriptPage__Legend-sc-1i4bfgh-2 cTBIfH"
+          className="ChartStyles__Legend-sc-atxio9-1 mfEDY"
         >
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-cds-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-cds-regions"
                 onChange={[Function]}
@@ -9703,22 +9703,22 @@ exports[`TranscriptPageContainer with dataset gnomad_r2_1_non_topmed has no unex
               />
               Coding regions (CDS)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 hPtBuL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 dWcYqk"
                 color="#424242"
                 height={10}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-utr-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-utr-regions"
                 onChange={[Function]}
@@ -9726,22 +9726,22 @@ exports[`TranscriptPageContainer with dataset gnomad_r2_1_non_topmed has no unex
               />
               Untranslated regions (UTRs)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 cEzNst"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 lhFEQi"
                 color="#424242"
                 height={4}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-nc-regions"
             >
               <input
                 checked={true}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-nc-regions"
                 onChange={[Function]}
@@ -9749,7 +9749,7 @@ exports[`TranscriptPageContainer with dataset gnomad_r2_1_non_topmed has no unex
               />
               Non-coding regions
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 dqkCL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 fDzopB"
                 color="#bdbdbd"
                 height={4}
               />
@@ -11087,23 +11087,23 @@ exports[`TranscriptPageContainer with dataset gnomad_r3 has no unexpected change
         </div>
       </div>
       <div
-        className="TranscriptPage__ControlPanel-sc-1i4bfgh-1 litgDe"
+        className="ChartStyles__ControlPanel-sc-atxio9-0 iLJjwA"
         width={814}
       >
         Include:
         <ul
-          className="TranscriptPage__Legend-sc-1i4bfgh-2 cTBIfH"
+          className="ChartStyles__Legend-sc-atxio9-1 mfEDY"
         >
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-cds-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-cds-regions"
                 onChange={[Function]}
@@ -11111,22 +11111,22 @@ exports[`TranscriptPageContainer with dataset gnomad_r3 has no unexpected change
               />
               Coding regions (CDS)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 hPtBuL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 dWcYqk"
                 color="#424242"
                 height={10}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-utr-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-utr-regions"
                 onChange={[Function]}
@@ -11134,22 +11134,22 @@ exports[`TranscriptPageContainer with dataset gnomad_r3 has no unexpected change
               />
               Untranslated regions (UTRs)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 cEzNst"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 lhFEQi"
                 color="#424242"
                 height={4}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-nc-regions"
             >
               <input
                 checked={true}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-nc-regions"
                 onChange={[Function]}
@@ -11157,7 +11157,7 @@ exports[`TranscriptPageContainer with dataset gnomad_r3 has no unexpected change
               />
               Non-coding regions
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 dqkCL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 fDzopB"
                 color="#bdbdbd"
                 height={4}
               />
@@ -12495,23 +12495,23 @@ exports[`TranscriptPageContainer with dataset gnomad_r3_controls_and_biobanks ha
         </div>
       </div>
       <div
-        className="TranscriptPage__ControlPanel-sc-1i4bfgh-1 litgDe"
+        className="ChartStyles__ControlPanel-sc-atxio9-0 iLJjwA"
         width={814}
       >
         Include:
         <ul
-          className="TranscriptPage__Legend-sc-1i4bfgh-2 cTBIfH"
+          className="ChartStyles__Legend-sc-atxio9-1 mfEDY"
         >
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-cds-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-cds-regions"
                 onChange={[Function]}
@@ -12519,22 +12519,22 @@ exports[`TranscriptPageContainer with dataset gnomad_r3_controls_and_biobanks ha
               />
               Coding regions (CDS)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 hPtBuL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 dWcYqk"
                 color="#424242"
                 height={10}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-utr-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-utr-regions"
                 onChange={[Function]}
@@ -12542,22 +12542,22 @@ exports[`TranscriptPageContainer with dataset gnomad_r3_controls_and_biobanks ha
               />
               Untranslated regions (UTRs)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 cEzNst"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 lhFEQi"
                 color="#424242"
                 height={4}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-nc-regions"
             >
               <input
                 checked={true}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-nc-regions"
                 onChange={[Function]}
@@ -12565,7 +12565,7 @@ exports[`TranscriptPageContainer with dataset gnomad_r3_controls_and_biobanks ha
               />
               Non-coding regions
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 dqkCL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 fDzopB"
                 color="#bdbdbd"
                 height={4}
               />
@@ -13903,23 +13903,23 @@ exports[`TranscriptPageContainer with dataset gnomad_r3_non_cancer has no unexpe
         </div>
       </div>
       <div
-        className="TranscriptPage__ControlPanel-sc-1i4bfgh-1 litgDe"
+        className="ChartStyles__ControlPanel-sc-atxio9-0 iLJjwA"
         width={814}
       >
         Include:
         <ul
-          className="TranscriptPage__Legend-sc-1i4bfgh-2 cTBIfH"
+          className="ChartStyles__Legend-sc-atxio9-1 mfEDY"
         >
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-cds-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-cds-regions"
                 onChange={[Function]}
@@ -13927,22 +13927,22 @@ exports[`TranscriptPageContainer with dataset gnomad_r3_non_cancer has no unexpe
               />
               Coding regions (CDS)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 hPtBuL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 dWcYqk"
                 color="#424242"
                 height={10}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-utr-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-utr-regions"
                 onChange={[Function]}
@@ -13950,22 +13950,22 @@ exports[`TranscriptPageContainer with dataset gnomad_r3_non_cancer has no unexpe
               />
               Untranslated regions (UTRs)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 cEzNst"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 lhFEQi"
                 color="#424242"
                 height={4}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-nc-regions"
             >
               <input
                 checked={true}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-nc-regions"
                 onChange={[Function]}
@@ -13973,7 +13973,7 @@ exports[`TranscriptPageContainer with dataset gnomad_r3_non_cancer has no unexpe
               />
               Non-coding regions
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 dqkCL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 fDzopB"
                 color="#bdbdbd"
                 height={4}
               />
@@ -15311,23 +15311,23 @@ exports[`TranscriptPageContainer with dataset gnomad_r3_non_neuro has no unexpec
         </div>
       </div>
       <div
-        className="TranscriptPage__ControlPanel-sc-1i4bfgh-1 litgDe"
+        className="ChartStyles__ControlPanel-sc-atxio9-0 iLJjwA"
         width={814}
       >
         Include:
         <ul
-          className="TranscriptPage__Legend-sc-1i4bfgh-2 cTBIfH"
+          className="ChartStyles__Legend-sc-atxio9-1 mfEDY"
         >
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-cds-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-cds-regions"
                 onChange={[Function]}
@@ -15335,22 +15335,22 @@ exports[`TranscriptPageContainer with dataset gnomad_r3_non_neuro has no unexpec
               />
               Coding regions (CDS)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 hPtBuL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 dWcYqk"
                 color="#424242"
                 height={10}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-utr-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-utr-regions"
                 onChange={[Function]}
@@ -15358,22 +15358,22 @@ exports[`TranscriptPageContainer with dataset gnomad_r3_non_neuro has no unexpec
               />
               Untranslated regions (UTRs)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 cEzNst"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 lhFEQi"
                 color="#424242"
                 height={4}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-nc-regions"
             >
               <input
                 checked={true}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-nc-regions"
                 onChange={[Function]}
@@ -15381,7 +15381,7 @@ exports[`TranscriptPageContainer with dataset gnomad_r3_non_neuro has no unexpec
               />
               Non-coding regions
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 dqkCL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 fDzopB"
                 color="#bdbdbd"
                 height={4}
               />
@@ -16719,23 +16719,23 @@ exports[`TranscriptPageContainer with dataset gnomad_r3_non_topmed has no unexpe
         </div>
       </div>
       <div
-        className="TranscriptPage__ControlPanel-sc-1i4bfgh-1 litgDe"
+        className="ChartStyles__ControlPanel-sc-atxio9-0 iLJjwA"
         width={814}
       >
         Include:
         <ul
-          className="TranscriptPage__Legend-sc-1i4bfgh-2 cTBIfH"
+          className="ChartStyles__Legend-sc-atxio9-1 mfEDY"
         >
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-cds-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-cds-regions"
                 onChange={[Function]}
@@ -16743,22 +16743,22 @@ exports[`TranscriptPageContainer with dataset gnomad_r3_non_topmed has no unexpe
               />
               Coding regions (CDS)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 hPtBuL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 dWcYqk"
                 color="#424242"
                 height={10}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-utr-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-utr-regions"
                 onChange={[Function]}
@@ -16766,22 +16766,22 @@ exports[`TranscriptPageContainer with dataset gnomad_r3_non_topmed has no unexpe
               />
               Untranslated regions (UTRs)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 cEzNst"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 lhFEQi"
                 color="#424242"
                 height={4}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-nc-regions"
             >
               <input
                 checked={true}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-nc-regions"
                 onChange={[Function]}
@@ -16789,7 +16789,7 @@ exports[`TranscriptPageContainer with dataset gnomad_r3_non_topmed has no unexpe
               />
               Non-coding regions
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 dqkCL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 fDzopB"
                 color="#bdbdbd"
                 height={4}
               />
@@ -18127,23 +18127,23 @@ exports[`TranscriptPageContainer with dataset gnomad_r3_non_v2 has no unexpected
         </div>
       </div>
       <div
-        className="TranscriptPage__ControlPanel-sc-1i4bfgh-1 litgDe"
+        className="ChartStyles__ControlPanel-sc-atxio9-0 iLJjwA"
         width={814}
       >
         Include:
         <ul
-          className="TranscriptPage__Legend-sc-1i4bfgh-2 cTBIfH"
+          className="ChartStyles__Legend-sc-atxio9-1 mfEDY"
         >
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-cds-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-cds-regions"
                 onChange={[Function]}
@@ -18151,22 +18151,22 @@ exports[`TranscriptPageContainer with dataset gnomad_r3_non_v2 has no unexpected
               />
               Coding regions (CDS)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 hPtBuL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 dWcYqk"
                 color="#424242"
                 height={10}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-utr-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-utr-regions"
                 onChange={[Function]}
@@ -18174,22 +18174,22 @@ exports[`TranscriptPageContainer with dataset gnomad_r3_non_v2 has no unexpected
               />
               Untranslated regions (UTRs)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 cEzNst"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 lhFEQi"
                 color="#424242"
                 height={4}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-nc-regions"
             >
               <input
                 checked={true}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-nc-regions"
                 onChange={[Function]}
@@ -18197,7 +18197,7 @@ exports[`TranscriptPageContainer with dataset gnomad_r3_non_v2 has no unexpected
               />
               Non-coding regions
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 dqkCL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 fDzopB"
                 color="#bdbdbd"
                 height={4}
               />
@@ -19534,23 +19534,23 @@ exports[`TranscriptPageContainer with dataset gnomad_r4 has no unexpected change
         </div>
       </div>
       <div
-        className="TranscriptPage__ControlPanel-sc-1i4bfgh-1 litgDe"
+        className="ChartStyles__ControlPanel-sc-atxio9-0 iLJjwA"
         width={814}
       >
         Include:
         <ul
-          className="TranscriptPage__Legend-sc-1i4bfgh-2 cTBIfH"
+          className="ChartStyles__Legend-sc-atxio9-1 mfEDY"
         >
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-cds-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-cds-regions"
                 onChange={[Function]}
@@ -19558,22 +19558,22 @@ exports[`TranscriptPageContainer with dataset gnomad_r4 has no unexpected change
               />
               Coding regions (CDS)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 hPtBuL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 dWcYqk"
                 color="#424242"
                 height={10}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-utr-regions"
             >
               <input
                 checked={false}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-utr-regions"
                 onChange={[Function]}
@@ -19581,22 +19581,22 @@ exports[`TranscriptPageContainer with dataset gnomad_r4 has no unexpected change
               />
               Untranslated regions (UTRs)
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 cEzNst"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 lhFEQi"
                 color="#424242"
                 height={4}
               />
             </label>
           </li>
           <li
-            className="TranscriptPage__LegendItemWrapper-sc-1i4bfgh-3 cXlOox"
+            className="ChartStyles__LegendItemWrapper-sc-atxio9-2 fBsdzH"
           >
             <label
-              className="TranscriptPage__Label-sc-1i4bfgh-4 dUJxeL"
+              className="ChartStyles__Label-sc-atxio9-3 fwkrzD"
               htmlFor="include-nc-regions"
             >
               <input
                 checked={true}
-                className="TranscriptPage__CheckboxInput-sc-1i4bfgh-5 leeEsn"
+                className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
                 disabled={true}
                 id="include-nc-regions"
                 onChange={[Function]}
@@ -19604,7 +19604,7 @@ exports[`TranscriptPageContainer with dataset gnomad_r4 has no unexpected change
               />
               Non-coding regions
               <span
-                className="TranscriptPage__LegendSwatch-sc-1i4bfgh-6 dqkCL"
+                className="ChartStyles__LegendSwatch-sc-atxio9-5 fDzopB"
                 color="#bdbdbd"
                 height={4}
               />


### PR DESCRIPTION
Another PR addressing an item from the list of copy/paste sections on issue #1154. Moves some styled-components that were defined in two places, in to a separate file. Styled components are then imported where needed.

This one did require updating snapshots due to the `className` changes.

Passes tests locally.

FYI @rileyhgrant 