### PR TITLE
Update remaining count in v4 stats table

### DIFF
--- a/browser/src/StatsPage/StatsPageTables/GeneticAncestryGroupsByVersionTable.tsx
+++ b/browser/src/StatsPage/StatsPageTables/GeneticAncestryGroupsByVersionTable.tsx
@@ -96,7 +96,7 @@ const GeneticAncestryGroupsByVersionTable = () => {
             <td>454</td>
             <td>3,614</td>
             <td>1,503</td>
-            <td>31,172</td>
+            <td>31,712</td>
             <td>3.93%</td>
             <td>8.8x</td>
           </tr>

--- a/browser/src/StatsPage/__snapshots__/StatsPage.spec.tsx.snap
+++ b/browser/src/StatsPage/__snapshots__/StatsPage.spec.tsx.snap
@@ -4427,7 +4427,7 @@ exports[`Stats Page has no unexpected changes 1`] = `
                   1,503
                 </td>
                 <td>
-                  31,172
+                  31,712
                 </td>
                 <td>
                   3.93%


### PR DESCRIPTION
Resolves #1382 

Corrects the count of remaining individuals in the gnomad v4 population count table from 31,172 (incorrect), to 31,712 (correct).