### PR TITLE
Update frontend and graphql-api CI to run on dependency updates

### DIFF
--- a/.github/workflows/browser-ci.yml
+++ b/.github/workflows/browser-ci.yml
@@ -5,9 +5,13 @@ on:
       - main
     paths:
       - 'browser/**'
+      - 'package.json'
+      - 'yarn.lock'
   pull_request:
     paths:
       - 'browser/**'
+      - 'package.json'
+      - 'yarn.lock'
 jobs:
   checks:
     name: Checks

--- a/.github/workflows/graphql-api-ci.yml
+++ b/.github/workflows/graphql-api-ci.yml
@@ -5,9 +5,13 @@ on:
       - main
     paths:
       - 'graphql-api/**'
+      - 'package.json'
+      - 'yarn.lock'
   pull_request:
     paths:
       - 'graphql-api/**'
+      - 'package.json'
+      - 'yarn.lock'
 jobs:
   checks:
     name: Checks


### PR DESCRIPTION
Updates the frontend and graphql-api github CI yml files to also trigger a run when either the 'package.json' or 'yarn.lock' files are edited.

The primary purpose is to have CI run when dependabot opens PRs that update javascript dependencies, however I think it's also probably good in general to run the test suite whenever any PR wants to update top level javascript dependencies.