### PR TITLE
maint: flop back to standard disks for ES

### DIFF
--- a/deploy/manifests/elasticsearch/elasticsearch.yaml.jinja2
+++ b/deploy/manifests/elasticsearch/elasticsearch.yaml.jinja2
@@ -92,7 +92,7 @@ spec:
               command: ['sh', '-c', 'sysctl -w vm.max_map_count=262144']
             - name: install-plugins
               command: ['sh', '-c', 'bin/elasticsearch-plugin install --batch repository-gcs']
-    - name: data-green
+    - name: data-blue
       count: 4
       config:  # https://www.elastic.co/guide/en/elasticsearch/reference/current/settings.html
         node.roles: ["data"]
@@ -141,7 +141,7 @@ spec:
           spec:
             accessModes:
               - ReadWriteOnce
-            storageClassName: premium-rwo
+            storageClassName: standard
             resources:
               requests:
                 storage: 1750Gi


### PR DESCRIPTION
This moves us back to standard class disks for the cost savings, which required us to deploy a new nodeSet (changing storageclass on an existing nodeset is not allowed in the ECK operator).

The migration flow here works as follows:
- spin up additional GKE nodes in the es-data pool to handle new ES nodeSet
- apply a manifest with both blue and green data nodeSets
- set the shard allocation filters to move all data from green -> blue
- after data is done relocating, apply the ES manifest with only the blue nodeset to remove the green one
- scale down the GKE node pool.