### PR TITLE
drop one node out of the ES data pool

### DIFF
--- a/deploy/manifests/elasticsearch/elasticsearch.yaml.jinja2
+++ b/deploy/manifests/elasticsearch/elasticsearch.yaml.jinja2
@@ -93,7 +93,7 @@ spec:
             - name: install-plugins
               command: ['sh', '-c', 'bin/elasticsearch-plugin install --batch repository-gcs']
     - name: data-blue
-      count: 4
+      count: 3
       config:  # https://www.elastic.co/guide/en/elasticsearch/reference/current/settings.html
         node.roles: ["data"]
         cluster.routing.allocation.disk.watermark.low: '100gb'


### PR DESCRIPTION
Now that the v4 dust has settled, and we've cleaned up some indices, I think we can actually drop one of the nodes off of our ES cluster, based on the available disk space.

```
shards disk.indices disk.used disk.avail disk.total disk.percent host        ip          node
   115          1tb       1tb    689.2gb      1.6tb           59 10.164.1.7  10.164.1.7  gnomad-es-data-blue-0
   114          1tb       1tb    688.9gb      1.6tb           59 10.164.7.7  10.164.7.7  gnomad-es-data-blue-3
   114          1tb       1tb    691.4gb      1.6tb           59 10.164.3.3  10.164.3.3  gnomad-es-data-blue-1
   115          1tb       1tb    689.2gb      1.6tb           59 10.164.2.11 10.164.2.11 gnomad-es-data-blue-2
   ```
   
   We have 4TBs of data, and 6.4TBs of total disk. If we downscale to 3 nodes, that will leave us with 4.8TBs of total disk, which should fit the live prod dataset. If my math is right, i think that leaves us with 2TBs of disk across the three remaining nodes to stash the 1TB that will need to be displaced.