### PR TITLE
set a maximum for the JS heap that is less than the container mem limit

### DIFF
--- a/deploy/manifests/browser/base/api.deployment.yaml
+++ b/deploy/manifests/browser/base/api.deployment.yaml
@@ -57,8 +57,10 @@ spec:
               value: 'gs://gnomad-v4-gene-cache/2023-12-01'
             - name: JSON_CACHE_LARGE_GENES
               value: 'true'
-            - name: JSON_CACHE_COMPRESSION 
+            - name: JSON_CACHE_COMPRESSION
               value: 'true'
+            - name: NODE_OPTIONS
+              value: '--max-old-space-size=3072'
           ports:
             - name: http
               containerPort: 8000


### PR DESCRIPTION
I noticed that we were getting quite a few restarts on our API pods, and I started digging into why:

```
% kubectl get pods
NAME                                           READY   STATUS    RESTARTS        AGE

gnomad-api-blue-775f4c6d7d-25fwx               1/1     Running   3 (23m ago)     22h
```

It seems like things are getting killed for reaching their memory limit (of 4GiB):

```
% kubectl describe pod gnomad-api-blue-775f4c6d7d-25fwx
Name:             gnomad-api-blue-775f4c6d7d-25fwx
<snip>
    State:          Running
      Started:      Wed, 07 Feb 2024 10:15:12 -0500
    Last State:     Terminated
      Reason:       OOMKilled
      Exit Code:    137
      Started:      Wed, 07 Feb 2024 05:47:49 -0500
      Finished:     Wed, 07 Feb 2024 10:15:11 -0500
```

For the most part, the pods stay well below their memory limit, and are occasionally spiking over that limit and getting killed. Poking around the `node` internals, it looks like the default node heap size in our environment was getting set to 4.3GiB:

```
> v8.getHeapStatistics()
{
<snip>
  heap_size_limit: 4345298944,
}
```

My understanding of the way the garbage collector works, is that it won't kick in until the pod reaches the limit. I think what's happening to us is that the kubernetes hosts are killing the pod before the GC can do its job. Killing the pod in this way tends so sever in flight API requests kind of violently, and generates user-facing errors, which are puzzling/meaningless to look at from the developer perspective.

The change here sets the heap size to 3GiB, which roughly follows the recommendation in the node docs here: https://nodejs.org/docs/latest-v18.x/api/cli.html#cli_max_old_space_size_size_in_megabytes (they recommend 1.5GiB for a 2GiB RAM environment).

```
> v8.getHeapStatistics()
{
<snip>
  heap_size_limit: 3271557120,
}
```

Hoping any GC pauses or slowness result in a better experience than killing the container and being at a lower capacity for ther ~20 seconds it takes to spin the node proc back up!