### PR TITLE
Fix regressions introduced by #1397

### DIFF
--- a/browser/src/GenePage/VariantsInGene.tsx
+++ b/browser/src/GenePage/VariantsInGene.tsx
@@ -222,10 +222,6 @@ query ${operationName}($geneId: String!, $datasetId: DatasetId!, $referenceGenom
         popmax
         popmax_population
       }
-      faf99_joint {
-        popmax
-        popmax_population
-      }
       exome {
         ac
         ac_hemi

--- a/browser/src/RegionPage/VariantsInRegion.tsx
+++ b/browser/src/RegionPage/VariantsInRegion.tsx
@@ -127,10 +127,18 @@ query ${operationName}($chrom: String!, $start: Int!, $stop: Int!, $datasetId: D
       transcript_id
       transcript_version
       variant_id
+      faf95_joint {
+        popmax
+        popmax_population
+      }
       exome {
         ac
         ac_hemi
         ac_hom
+        faf95 {
+          popmax
+          popmax_population
+        }
         an
         af
         filters
@@ -146,6 +154,10 @@ query ${operationName}($chrom: String!, $start: Int!, $stop: Int!, $datasetId: D
         ac
         ac_hemi
         ac_hom
+        faf95 {
+          popmax
+          popmax_population
+        }
         an
         af
         filters
@@ -156,6 +168,11 @@ query ${operationName}($chrom: String!, $start: Int!, $stop: Int!, $datasetId: D
           ac_hemi
           ac_hom
         }
+      }
+      in_silico_predictors {
+        id
+        value
+        flags
       }
       lof_curation {
         verdict

--- a/browser/src/TranscriptPage/VariantsInTranscript.tsx
+++ b/browser/src/TranscriptPage/VariantsInTranscript.tsx
@@ -159,10 +159,18 @@ query ${operationName}($transcriptId: String!, $datasetId: DatasetId!, $referenc
       transcript_id
       transcript_version
       variant_id
+      faf95_joint {
+        popmax
+        popmax_population
+      }
       exome {
         ac
         ac_hemi
         ac_hom
+        faf95 {
+          popmax
+          popmax_population
+        }
         an
         af
         filters
@@ -178,6 +186,10 @@ query ${operationName}($transcriptId: String!, $datasetId: DatasetId!, $referenc
         ac
         ac_hemi
         ac_hom
+        faf95 {
+          popmax
+          popmax_population
+        }
         an
         af
         filters
@@ -188,6 +200,15 @@ query ${operationName}($transcriptId: String!, $datasetId: DatasetId!, $referenc
           ac_hemi
           ac_hom
         }
+      }
+      in_silico_predictors {
+        id
+        value
+        flags
+      }
+      lof_curation {
+        verdict
+        flags
       }
     }
   }

--- a/browser/src/VariantList/ExportVariantsButton.tsx
+++ b/browser/src/VariantList/ExportVariantsButton.tsx
@@ -116,26 +116,30 @@ export const createVersionSpecificColumns = (datasetId: DatasetId) => {
       {
         label: 'Exome GroupMax FAF group',
         getValue: (variant: any) =>
-          variant.exome.faf95.popmax_population !== null
+          variant.exome && variant.exome.faf95.popmax_population !== null
             ? variant.exome.faf95.popmax_population
             : '',
       },
       {
         label: 'Exome GroupMax FAF frequency',
         getValue: (variant: any) =>
-          variant.exome.faf95.popmax !== null ? JSON.stringify(variant.exome.faf95.popmax) : '',
+          variant.exome && variant.exome.faf95.popmax !== null
+            ? JSON.stringify(variant.exome.faf95.popmax)
+            : '',
       },
       {
         label: 'Genome GroupMax FAF group',
         getValue: (variant: any) =>
-          variant.genome.faf95.popmax_population !== null
-            ? variant.genome.faf95.popmax_population
+          variant.genome && variant.genome?.faf95.popmax_population !== null
+            ? variant.genome?.faf95.popmax_population
             : '',
       },
       {
         label: 'Genome GroupMax FAF frequency',
         getValue: (variant: any) =>
-          variant.genome.faf95.popmax !== null ? JSON.stringify(variant.genome.faf95.popmax) : '',
+          variant.genome && variant.genome?.faf95.popmax !== null
+            ? JSON.stringify(variant.genome.faf95.popmax)
+            : '',
       },
     ]
   }

--- a/graphql-api/src/queries/variant-datasets/gnomad-v4-variant-queries.ts
+++ b/graphql-api/src/queries/variant-datasets/gnomad-v4-variant-queries.ts
@@ -381,6 +381,7 @@ const fetchVariantsByGene = async (esClient: any, gene: any, _subset: any) => {
         'value.exome.filters',
         'value.genome.filters',
         'value.alleles',
+        // 'value.caid',
         'value.locus',
         'value.flags',
         'value.rsids',
@@ -439,6 +440,9 @@ const fetchVariantsByRegion = async (esClient: any, region: any, _subset: any) =
       'value.rsids',
       'value.transcript_consequences',
       'value.variant_id',
+      'value.faf95_joint',
+      'value.faf99_joint',
+      'value.in_silico_predictors',
     ],
     body: {
       query: {
@@ -523,6 +527,9 @@ const fetchVariantsByTranscript = async (esClient: any, transcript: any, _subset
       'value.rsids',
       'value.transcript_consequences',
       'value.variant_id',
+      'value.faf95_joint',
+      'value.faf99_joint',
+      'value.in_silico_predictors',
     ],
     body: {
       query: {


### PR DESCRIPTION
Fixes a few bugs introduced by #1397:
- v4 transcript pages not loading variants
- v4 region pages not loading variants
- v2 gene, region, transcript pages not exporting CSV table when there are samples present in only exomes or only genomes