### PR TITLE
Update banner with v4 AN warning

### DIFF
--- a/browser/src/App.tsx
+++ b/browser/src/App.tsx
@@ -74,11 +74,12 @@ const Banner = styled.div`
 
 const BANNER_CONTENT = (
   <>
-    gnomAD v4 is here! Read our {/* @ts-expect-error */}
-    <ExternalLink href="https://gnomad.broadinstitute.org/news/2023-11-gnomad-v4-0">
-      blog post
+    We are aware of an {/* @ts-expect-error */}
+    <ExternalLink href="https://docs.google.com/document/d/1Xm5ZIhmkh7hv2qEfCDS6J2T0IUZYiXP8pNClTlNvCGQ/edit?usp=sharing">
+      issue{' '}
     </ExternalLink>{' '}
-    for more details
+    in the gnomAD v4.0 exomes where well covered variants have lower than expected allele numbers.
+    This issue will be fixed in the upcoming v4.1 release.
   </>
 )
 

--- a/browser/src/App.tsx
+++ b/browser/src/App.tsx
@@ -76,8 +76,7 @@ const BANNER_CONTENT = (
   <>
     We are aware of an issue in the gnomAD v4.0 exomes where well covered variants have lower than
     expected allele numbers. This issue will be fixed in the upcoming v4.1 release. For more
-    information, see our write-up
-    {/* @ts-expect-error */}
+    information, see our write-up {/* @ts-expect-error */}
     <ExternalLink href="https://docs.google.com/document/d/1Xm5ZIhmkh7hv2qEfCDS6J2T0IUZYiXP8pNClTlNvCGQ/edit?usp=sharing">
       here.
     </ExternalLink>{' '}

--- a/browser/src/App.tsx
+++ b/browser/src/App.tsx
@@ -74,12 +74,13 @@ const Banner = styled.div`
 
 const BANNER_CONTENT = (
   <>
-    We are aware of an {/* @ts-expect-error */}
+    We are aware of an issue in the gnomAD v4.0 exomes where well covered variants have lower than
+    expected allele numbers. This issue will be fixed in the upcoming v4.1 release. For more
+    information, see our write-up
+    {/* @ts-expect-error */}
     <ExternalLink href="https://docs.google.com/document/d/1Xm5ZIhmkh7hv2qEfCDS6J2T0IUZYiXP8pNClTlNvCGQ/edit?usp=sharing">
-      issue{' '}
+      here.
     </ExternalLink>{' '}
-    in the gnomAD v4.0 exomes where well covered variants have lower than expected allele numbers.
-    This issue will be fixed in the upcoming v4.1 release.
   </>
 )
 


### PR DESCRIPTION
Resolves #1413 

Corresponding blog PR: https://github.com/broadinstitute/gnomad-blog/pull/151

Updates the banner with the warning message about the known issue with AN in v4.