### PR TITLE
Update v2 exome sample number on stats page

### DIFF
--- a/browser/src/StatsPage/BarGraphData/gnomADExomeGenomeCountsByVersion.json
+++ b/browser/src/StatsPage/BarGraphData/gnomADExomeGenomeCountsByVersion.json
@@ -5,7 +5,7 @@
   },
   "data": [
     { "label": "ExAC", "Exomes": 60706, "Genomes": 0 },
-    { "label": "gnomAD v2", "Exomes": 125758, "Genomes": 15708 },
+    { "label": "gnomAD v2", "Exomes": 125748, "Genomes": 15708 },
     { "label": "gnomAD v3", "Exomes": 0, "Genomes": 76156 },
     { "label": "gnomAD v4", "Exomes": 730947, "Genomes": 76215 }
   ]

--- a/browser/src/StatsPage/__snapshots__/StatsPage.spec.tsx.snap
+++ b/browser/src/StatsPage/__snapshots__/StatsPage.spec.tsx.snap
@@ -1442,11 +1442,11 @@ exports[`Stats Page has no unexpected changes 1`] = `
                         />
                         <rect
                           fill="#0e6fbf"
-                          height={56.088963553784765}
+                          height={56.084503482572245}
                           stroke="#333"
                           width={39.6}
                           x={-64.8}
-                          y={303.91103644621523}
+                          y={303.91549651742775}
                         />
                         <text
                           dy={4}
@@ -1454,9 +1454,9 @@ exports[`Stats Page has no unexpected changes 1`] = `
                           fontSize={12}
                           textAnchor="middle"
                           x={-45}
-                          y={331.9555182231076}
+                          y={331.9577482587139}
                         >
-                          125,758
+                          125,748
                         </text>
                         <rect
                           className="c16"
@@ -1473,7 +1473,7 @@ exports[`Stats Page has no unexpected changes 1`] = `
                           stroke="#333"
                           width={39.6}
                           x={-64.8}
-                          y={296.9051565856668}
+                          y={296.90961665687934}
                         />
                         <rect
                           className="c16"


### PR DESCRIPTION
Resolves #1406 

Updates the v2 exome sample count on the Stats page from 125,758 (incorrect) to 125,748.