### PR TITLE
Add inferred sex tables to stats page

### DIFF
--- a/browser/src/StatsPage/StatsPage.tsx
+++ b/browser/src/StatsPage/StatsPage.tsx
@@ -384,10 +384,12 @@ const StatsPage = () => {
             Inferred sex in gnomAD v4 per genetic ancestry group
           </h3>
 
+          <h4 style={{ marginBottom: '2em' }}>gnomAD v4</h4>
           <ResponsiveTable style={{ marginBottom: '6em' }}>
             <InferredSexAllV4Table />
           </ResponsiveTable>
 
+          <h4 style={{ marginBottom: '2em' }}>gnomAD v4 non-UKB</h4>
           <ResponsiveTable style={{ marginBottom: '3em' }}>
             <InferredSexNonUKBV4Table />
           </ResponsiveTable>

--- a/browser/src/StatsPage/StatsPage.tsx
+++ b/browser/src/StatsPage/StatsPage.tsx
@@ -320,7 +320,7 @@ const StatsPage = () => {
         <StatsSection>
           <SectionHeading id="diversity">Diversity in gnomAD</SectionHeading>
 
-          <h3 style={{ marginBottom: '2em' }}>Genetic Ancestry Groups in gnomAD by version</h3>
+          <h3 style={{ marginBottom: '2em' }}>Genetic ancestry groups in gnomAD by version</h3>
 
           <TwoColumnLayout style={{ marginBottom: '5em' }}>
             <img
@@ -381,7 +381,7 @@ const StatsPage = () => {
           </DiversityBarGraphContainer>
 
           <h3 style={{ marginBottom: '2em' }}>
-            Inferred sex in gnomAD v4 per Genetic Ancestry Group
+            Inferred sex in gnomAD v4 per genetic ancestry group
           </h3>
 
           <ResponsiveTable style={{ marginBottom: '6em' }}>
@@ -395,7 +395,7 @@ const StatsPage = () => {
 
         <StatsSection>
           <SectionHeading id="study-provided-labels">
-            Study-provided labels and Genetic Ancestry Groups
+            Study-provided labels and genetic ancestry groups
           </SectionHeading>
 
           <p>

--- a/browser/src/StatsPage/StatsPage.tsx
+++ b/browser/src/StatsPage/StatsPage.tsx
@@ -380,6 +380,10 @@ const StatsPage = () => {
             </DiversityBarGraph>
           </DiversityBarGraphContainer>
 
+          <h3 style={{ marginBottom: '2em' }}>
+            Inferred sex in gnomAD v4 per Genetic Ancestry Group
+          </h3>
+
           <ResponsiveTable style={{ marginBottom: '6em' }}>
             <InferredSexAllV4Table />
           </ResponsiveTable>

--- a/browser/src/StatsPage/StatsPage.tsx
+++ b/browser/src/StatsPage/StatsPage.tsx
@@ -28,6 +28,11 @@ import GeneticAncestryGroupsByVersionTable from './StatsPageTables/GeneticAncest
 import V4GeneticAncestryTable from './StatsPageTables/V4GeneticAncestryTable'
 import StudyDiseasesInGnomadTable from './StatsPageTables/StudyDiseasesInGnomadTable'
 
+import {
+  InferredSexAllV4Table,
+  InferredSexNonUKBV4Table,
+} from './StatsPageTables/InferredSexPerGeneticAncestryTables'
+
 const TwoColumnLayout = styled.div`
   display: flex;
   justify-content: space-around;
@@ -360,7 +365,7 @@ const StatsPage = () => {
             </DiversityBarGraph>
           </DiversityBarGraphContainer>
 
-          <DiversityBarGraphContainer style={{ marginBottom: '0.5em' }}>
+          <DiversityBarGraphContainer style={{ marginBottom: '6em' }}>
             <DiversityBarGraph style={{ marginTop: '1em', marginBottom: '0' }}>
               <StackedBarGraph
                 title="Per genetic ancestry group count of non-synonymous coding variants in canonical transcripts with a overall gnomAD (within version) AF >0.1"
@@ -374,6 +379,14 @@ const StatsPage = () => {
               />
             </DiversityBarGraph>
           </DiversityBarGraphContainer>
+
+          <ResponsiveTable style={{ marginBottom: '6em' }}>
+            <InferredSexAllV4Table />
+          </ResponsiveTable>
+
+          <ResponsiveTable style={{ marginBottom: '3em' }}>
+            <InferredSexNonUKBV4Table />
+          </ResponsiveTable>
         </StatsSection>
 
         <StatsSection>

--- a/browser/src/StatsPage/StatsPageTables/GeneticAncestryGroupsByVersionData.json
+++ b/browser/src/StatsPage/StatsPageTables/GeneticAncestryGroupsByVersionData.json
@@ -1,0 +1,166 @@
+{
+  "data": [
+    {
+      "geneticAncestryGroup": "amr",
+      "optionalSymbol": "",
+      "EXaC": {
+        "sampleCount": 5789
+      },
+      "gnomADV2": {
+        "sampleCount": 17720
+      },
+      "gnomADV3": {
+        "sampleCount": 7647
+      },
+      "gnomADV4": {
+        "sampleCount": 30019,
+        "percentOfSamples": 3.72,
+        "foldIncreaseFromV2": 1.7
+      }
+    },
+    {
+      "geneticAncestryGroup": "afr",
+      "optionalSymbol": "",
+      "EXaC": {
+        "sampleCount": 5203
+      },
+      "gnomADV2": {
+        "sampleCount": 12487
+      },
+      "gnomADV3": {
+        "sampleCount": 20744
+      },
+      "gnomADV4": {
+        "sampleCount": 37545,
+        "percentOfSamples": 4.65,
+        "foldIncreaseFromV2": 3
+      }
+    },
+    {
+      "geneticAncestryGroup": "asj",
+      "optionalSymbol": "",
+      "EXaC": {
+        "sampleCount": 0
+      },
+      "gnomADV2": {
+        "sampleCount": 5185
+      },
+      "gnomADV3": {
+        "sampleCount": 1736
+      },
+      "gnomADV4": {
+        "sampleCount": 14804,
+        "percentOfSamples": 1.83,
+        "foldIncreaseFromV2": 2.9
+      }
+    },
+    {
+      "geneticAncestryGroup": "eas",
+      "optionalSymbol": "",
+      "EXaC": {
+        "sampleCount": 4327
+      },
+      "gnomADV2": {
+        "sampleCount": 9977
+      },
+      "gnomADV3": {
+        "sampleCount": 2604
+      },
+      "gnomADV4": {
+        "sampleCount": 22448,
+        "percentOfSamples": 2.78,
+        "foldIncreaseFromV2": 2.3
+      }
+    },
+    {
+      "geneticAncestryGroup": "eur",
+      "optionalSymbol": "^",
+      "EXaC": {
+        "sampleCount": 36667
+      },
+      "gnomADV2": {
+        "sampleCount": 77165
+      },
+      "gnomADV3": {
+        "sampleCount": 39345
+      },
+      "gnomADV4": {
+        "sampleCount": 622057,
+        "percentOfSamples": 77.07,
+        "foldIncreaseFromV2": 8.1
+      }
+    },
+    {
+      "geneticAncestryGroup": "mid",
+      "optionalSymbol": "",
+      "EXaC": {
+        "sampleCount": 0
+      },
+      "gnomADV2": {
+        "sampleCount": 0
+      },
+      "gnomADV3": {
+        "sampleCount": 158
+      },
+      "gnomADV4": {
+        "sampleCount": 3031,
+        "percentOfSamples": 0.38,
+        "foldIncreaseFromV2": 19.2
+      }
+    },
+    {
+      "geneticAncestryGroup": "remaining",
+      "optionalSymbol": "^",
+      "EXaC": {
+        "sampleCount": 454
+      },
+      "gnomADV2": {
+        "sampleCount": 3614
+      },
+      "gnomADV3": {
+        "sampleCount": 1503
+      },
+      "gnomADV4": {
+        "sampleCount": 31712,
+        "percentOfSamples": 3.93,
+        "foldIncreaseFromV2": 8.8
+      }
+    },
+    {
+      "geneticAncestryGroup": "sas",
+      "optionalSymbol": "",
+      "EXaC": {
+        "sampleCount": 8256
+      },
+      "gnomADV2": {
+        "sampleCount": 15308
+      },
+      "gnomADV3": {
+        "sampleCount": 2419
+      },
+      "gnomADV4": {
+        "sampleCount": 45546,
+        "percentOfSamples": 5.64,
+        "foldIncreaseFromV2": 3
+      }
+    },
+    {
+      "geneticAncestryGroup": "total",
+      "optionalSymbol": "",
+      "EXaC": {
+        "sampleCount": 60706
+      },
+      "gnomADV2": {
+        "sampleCount": 141456
+      },
+      "gnomADV3": {
+        "sampleCount": 76156
+      },
+      "gnomADV4": {
+        "sampleCount": 807162,
+        "percentOfSamples": 0,
+        "foldIncreaseFromV2": 0
+      }
+    }
+  ]
+}

--- a/browser/src/StatsPage/StatsPageTables/GeneticAncestryGroupsByVersionData.json
+++ b/browser/src/StatsPage/StatsPageTables/GeneticAncestryGroupsByVersionData.json
@@ -14,8 +14,6 @@
       },
       "gnomADV4": {
         "sampleCount": 30019,
-        "sampleCountXX": 16244,
-        "sampleCountXY": 13775,
         "percentOfSamples": 3.72,
         "foldIncreaseFromV2": 1.7
       }
@@ -34,8 +32,6 @@
       },
       "gnomADV4": {
         "sampleCount": 37545,
-        "sampleCountXX": 20757,
-        "sampleCountXY": 16788,
         "percentOfSamples": 4.65,
         "foldIncreaseFromV2": 3
       }
@@ -54,8 +50,6 @@
       },
       "gnomADV4": {
         "sampleCount": 14804,
-        "sampleCountXX": 7252,
-        "sampleCountXY": 7552,
         "percentOfSamples": 1.83,
         "foldIncreaseFromV2": 2.9
       }
@@ -74,8 +68,6 @@
       },
       "gnomADV4": {
         "sampleCount": 22448,
-        "sampleCountXX": 11492,
-        "sampleCountXY": 10956,
         "percentOfSamples": 2.78,
         "foldIncreaseFromV2": 2.3
       }
@@ -94,8 +86,6 @@
       },
       "gnomADV4": {
         "sampleCount": 622057,
-        "sampleCountXX": 320938,
-        "sampleCountXY": 301119,
         "percentOfSamples": 77.07,
         "foldIncreaseFromV2": 8.1
       }
@@ -114,8 +104,6 @@
       },
       "gnomADV4": {
         "sampleCount": 3031,
-        "sampleCountXX": 1325,
-        "sampleCountXY": 1706,
         "percentOfSamples": 0.38,
         "foldIncreaseFromV2": 19.2
       }
@@ -134,8 +122,6 @@
       },
       "gnomADV4": {
         "sampleCount": 31712,
-        "sampleCountXX": 16660,
-        "sampleCountXY": 15052,
         "percentOfSamples": 3.93,
         "foldIncreaseFromV2": 8.8
       }
@@ -154,8 +140,6 @@
       },
       "gnomADV4": {
         "sampleCount": 45546,
-        "sampleCountXX": 11597,
-        "sampleCountXY": 33949,
         "percentOfSamples": 5.64,
         "foldIncreaseFromV2": 3
       }
@@ -174,8 +158,6 @@
       },
       "gnomADV4": {
         "sampleCount": 807162,
-        "sampleCountXX": 406265,
-        "sampleCountXY": 400897,
         "percentOfSamples": 0,
         "foldIncreaseFromV2": 0
       }

--- a/browser/src/StatsPage/StatsPageTables/GeneticAncestryGroupsByVersionData.json
+++ b/browser/src/StatsPage/StatsPageTables/GeneticAncestryGroupsByVersionData.json
@@ -14,6 +14,8 @@
       },
       "gnomADV4": {
         "sampleCount": 30019,
+        "sampleCountXX": 16244,
+        "sampleCountXY": 13775,
         "percentOfSamples": 3.72,
         "foldIncreaseFromV2": 1.7
       }
@@ -32,6 +34,8 @@
       },
       "gnomADV4": {
         "sampleCount": 37545,
+        "sampleCountXX": 20757,
+        "sampleCountXY": 16788,
         "percentOfSamples": 4.65,
         "foldIncreaseFromV2": 3
       }
@@ -50,6 +54,8 @@
       },
       "gnomADV4": {
         "sampleCount": 14804,
+        "sampleCountXX": 7252,
+        "sampleCountXY": 7552,
         "percentOfSamples": 1.83,
         "foldIncreaseFromV2": 2.9
       }
@@ -68,6 +74,8 @@
       },
       "gnomADV4": {
         "sampleCount": 22448,
+        "sampleCountXX": 11492,
+        "sampleCountXY": 10956,
         "percentOfSamples": 2.78,
         "foldIncreaseFromV2": 2.3
       }
@@ -86,6 +94,8 @@
       },
       "gnomADV4": {
         "sampleCount": 622057,
+        "sampleCountXX": 320938,
+        "sampleCountXY": 301119,
         "percentOfSamples": 77.07,
         "foldIncreaseFromV2": 8.1
       }
@@ -104,6 +114,8 @@
       },
       "gnomADV4": {
         "sampleCount": 3031,
+        "sampleCountXX": 1325,
+        "sampleCountXY": 1706,
         "percentOfSamples": 0.38,
         "foldIncreaseFromV2": 19.2
       }
@@ -122,6 +134,8 @@
       },
       "gnomADV4": {
         "sampleCount": 31712,
+        "sampleCountXX": 16660,
+        "sampleCountXY": 15052,
         "percentOfSamples": 3.93,
         "foldIncreaseFromV2": 8.8
       }
@@ -140,6 +154,8 @@
       },
       "gnomADV4": {
         "sampleCount": 45546,
+        "sampleCountXX": 11597,
+        "sampleCountXY": 33949,
         "percentOfSamples": 5.64,
         "foldIncreaseFromV2": 3
       }
@@ -158,6 +174,8 @@
       },
       "gnomADV4": {
         "sampleCount": 807162,
+        "sampleCountXX": 406265,
+        "sampleCountXY": 400897,
         "percentOfSamples": 0,
         "foldIncreaseFromV2": 0
       }

--- a/browser/src/StatsPage/StatsPageTables/GeneticAncestryGroupsByVersionTable.tsx
+++ b/browser/src/StatsPage/StatsPageTables/GeneticAncestryGroupsByVersionTable.tsx
@@ -5,6 +5,7 @@ import { DownloadElementAsPNGButton } from '../DownloadFigure'
 import versionData from './GeneticAncestryGroupsByVersionData.json'
 
 import {
+  renderNumberOrDash,
   StatsTable,
   StatsTableHeaderRow,
   StatsTableSubHeaderRow,
@@ -16,10 +17,6 @@ import { populationName } from '@gnomad/dataset-metadata/gnomadPopulations'
 
 const GeneticAncestryGroupsByVersionTable = () => {
   const elementId = 'genetic-ancestry-group-size-by-version-table'
-
-  const renderNumberOrDash = (number: number): string => {
-    return number ? number.toLocaleString() : '-'
-  }
 
   return (
     <div>

--- a/browser/src/StatsPage/StatsPageTables/GeneticAncestryGroupsByVersionTable.tsx
+++ b/browser/src/StatsPage/StatsPageTables/GeneticAncestryGroupsByVersionTable.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 
 import { DownloadElementAsPNGButton } from '../DownloadFigure'
 
+import tableData from './GeneticAncestryGroupsByVersionData.json'
+
 import {
   StatsTable,
   StatsTableHeaderRow,
@@ -10,9 +12,14 @@ import {
   StatsTableCaption,
   StatsTableFooter,
 } from './TableStyles'
+import { populationName } from '@gnomad/dataset-metadata/gnomadPopulations'
 
 const GeneticAncestryGroupsByVersionTable = () => {
   const elementId = 'genetic-ancestry-group-size-by-version-table'
+
+  const renderNumberOrDash = (number: number): string => {
+    return number ? number.toLocaleString() : '-'
+  }
 
   return (
     <div>
@@ -36,91 +43,41 @@ const GeneticAncestryGroupsByVersionTable = () => {
           </StatsTableSubHeaderRow>
         </thead>
         <StatsTableBody>
-          <tr>
-            <td>Admixed American</td>
-            <td>5,789</td>
-            <td>17,720</td>
-            <td>7,647</td>
-            <td>30,019</td>
-            <td>3.72%</td>
-            <td>1.7x</td>
-          </tr>
-          <tr>
-            <td>African</td>
-            <td>5,203</td>
-            <td>12,487</td>
-            <td>20,744</td>
-            <td>37,545</td>
-            <td>4.65%</td>
-            <td>3x</td>
-          </tr>
-          <tr>
-            <td>Ashkenazi Jewish</td>
-            <td>-</td>
-            <td>5,185</td>
-            <td>1,736</td>
-            <td>14,804</td>
-            <td>1.83%</td>
-            <td>2.9x</td>
-          </tr>
-          <tr>
-            <td>East Asian</td>
-            <td>4,327</td>
-            <td>9,977</td>
-            <td>2,604</td>
-            <td>22,448</td>
-            <td>2.78%</td>
-            <td>2.3x</td>
-          </tr>
-          <tr>
-            <td>European^</td>
-            <td>36,667</td>
-            <td>77,165</td>
-            <td>39,345</td>
-            <td>622,057</td>
-            <td>77.07%</td>
-            <td>8.1x</td>
-          </tr>
-          <tr>
-            <td>Middle Eastern</td>
-            <td>-</td>
-            <td>-</td>
-            <td>158</td>
-            <td>3,031</td>
-            <td>0.38%</td>
-            <td>19.2x</td>
-          </tr>
-          <tr>
-            <td>Remaining Individuals^</td>
-            <td>454</td>
-            <td>3,614</td>
-            <td>1,503</td>
-            <td>31,712</td>
-            <td>3.93%</td>
-            <td>8.8x</td>
-          </tr>
-          <tr>
-            <td>South Asian</td>
-            <td>8,256</td>
-            <td>15,308</td>
-            <td>2,419</td>
-            <td>45,546</td>
-            <td>5.64%</td>
-            <td>3x</td>
-          </tr>
+          {tableData.data
+            .filter((tableRow) => tableRow.geneticAncestryGroup !== 'total')
+            .map((tableRow) => {
+              return (
+                <tr>
+                  <td>{`${populationName(tableRow.geneticAncestryGroup)}${
+                    tableRow.optionalSymbol
+                  }`}</td>
+                  <td>{renderNumberOrDash(tableRow.EXaC.sampleCount)}</td>
+                  <td>{renderNumberOrDash(tableRow.gnomADV2.sampleCount)}</td>
+                  <td>{renderNumberOrDash(tableRow.gnomADV3.sampleCount)}</td>
+                  <td>{renderNumberOrDash(tableRow.gnomADV4.sampleCount)}</td>
+                  <td>{`${tableRow.gnomADV4.percentOfSamples}%`}</td>
+                  <td>{`${tableRow.gnomADV4.foldIncreaseFromV2}x`}</td>
+                </tr>
+              )
+            })}
         </StatsTableBody>
         <StatsTableFooter>
-          <tr>
-            <td>Total</td>
-            <td>60,706</td>
-            <td>141,456</td>
-            <td>76,156</td>
-            <td>-</td>
-            <td>807,162</td>
-            <td>-</td>
-          </tr>
+          {tableData.data
+            .filter((tableRow) => tableRow.geneticAncestryGroup === 'total')
+            .map((tableRow) => {
+              return (
+                <tr>
+                  <td>Total</td>
+                  <td>{renderNumberOrDash(tableRow.EXaC.sampleCount)}</td>
+                  <td>{renderNumberOrDash(tableRow.gnomADV2.sampleCount)}</td>
+                  <td>{renderNumberOrDash(tableRow.gnomADV3.sampleCount)}</td>
+                  <td>{renderNumberOrDash(tableRow.gnomADV4.sampleCount)}</td>
+                  <td>-</td>
+                  <td>-</td>
+                </tr>
+              )
+            })}
         </StatsTableFooter>
-
         <StatsTableCaption>
           <div>*v4 includes all v3 samples.</div>
           <div>

--- a/browser/src/StatsPage/StatsPageTables/GeneticAncestryGroupsByVersionTable.tsx
+++ b/browser/src/StatsPage/StatsPageTables/GeneticAncestryGroupsByVersionTable.tsx
@@ -35,8 +35,6 @@ const GeneticAncestryGroupsByVersionTable = () => {
             <th className="rb">Sample count</th>
             <th className="rb">Sample count</th>
             <th>Sample count</th>
-            <th>XX</th>
-            <th>XY</th>
             <th>%</th>
             <th>Increase from v2</th>
           </StatsTableSubHeaderRow>
@@ -54,8 +52,6 @@ const GeneticAncestryGroupsByVersionTable = () => {
                   <td className="rb">{renderNumberOrDash(tableRow.gnomADV2.sampleCount)}</td>
                   <td className="rb">{renderNumberOrDash(tableRow.gnomADV3.sampleCount)}</td>
                   <td>{renderNumberOrDash(tableRow.gnomADV4.sampleCount)}</td>
-                  <td>{renderNumberOrDash(tableRow.gnomADV4.sampleCountXX)}</td>
-                  <td>{renderNumberOrDash(tableRow.gnomADV4.sampleCountXY)}</td>
                   <td>{`${tableRow.gnomADV4.percentOfSamples}%`}</td>
                   <td>{`${tableRow.gnomADV4.foldIncreaseFromV2}x`}</td>
                 </tr>
@@ -73,8 +69,6 @@ const GeneticAncestryGroupsByVersionTable = () => {
                   <td>{renderNumberOrDash(tableRow.gnomADV2.sampleCount)}</td>
                   <td>{renderNumberOrDash(tableRow.gnomADV3.sampleCount)}</td>
                   <td>{renderNumberOrDash(tableRow.gnomADV4.sampleCount)}</td>
-                  <td>{renderNumberOrDash(tableRow.gnomADV4.sampleCountXX)}</td>
-                  <td>{renderNumberOrDash(tableRow.gnomADV4.sampleCountXY)}</td>
                   <td>-</td>
                   <td>-</td>
                 </tr>

--- a/browser/src/StatsPage/StatsPageTables/GeneticAncestryGroupsByVersionTable.tsx
+++ b/browser/src/StatsPage/StatsPageTables/GeneticAncestryGroupsByVersionTable.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { DownloadElementAsPNGButton } from '../DownloadFigure'
 
-import tableData from './GeneticAncestryGroupsByVersionData.json'
+import versionData from './GeneticAncestryGroupsByVersionData.json'
 
 import {
   StatsTable,
@@ -30,7 +30,7 @@ const GeneticAncestryGroupsByVersionTable = () => {
             <th>ExAC</th>
             <th>gnomAD v2</th>
             <th>gnomAD v3</th>
-            <th colSpan={3}>gnomAD v4*</th>
+            <th colSpan={5}>gnomAD v4*</th>
           </StatsTableHeaderRow>
           <StatsTableSubHeaderRow>
             <th>&nbsp;</th>
@@ -38,12 +38,14 @@ const GeneticAncestryGroupsByVersionTable = () => {
             <th>#</th>
             <th>#</th>
             <th>#</th>
+            <th># XX</th>
+            <th># XY</th>
             <th>%</th>
             <th>Fold increase from v2</th>
           </StatsTableSubHeaderRow>
         </thead>
         <StatsTableBody>
-          {tableData.data
+          {versionData.data
             .filter((tableRow) => tableRow.geneticAncestryGroup !== 'total')
             .map((tableRow) => {
               return (
@@ -55,6 +57,8 @@ const GeneticAncestryGroupsByVersionTable = () => {
                   <td>{renderNumberOrDash(tableRow.gnomADV2.sampleCount)}</td>
                   <td>{renderNumberOrDash(tableRow.gnomADV3.sampleCount)}</td>
                   <td>{renderNumberOrDash(tableRow.gnomADV4.sampleCount)}</td>
+                  <td>{renderNumberOrDash(tableRow.gnomADV4.sampleCountXX)}</td>
+                  <td>{renderNumberOrDash(tableRow.gnomADV4.sampleCountXY)}</td>
                   <td>{`${tableRow.gnomADV4.percentOfSamples}%`}</td>
                   <td>{`${tableRow.gnomADV4.foldIncreaseFromV2}x`}</td>
                 </tr>
@@ -62,7 +66,7 @@ const GeneticAncestryGroupsByVersionTable = () => {
             })}
         </StatsTableBody>
         <StatsTableFooter>
-          {tableData.data
+          {versionData.data
             .filter((tableRow) => tableRow.geneticAncestryGroup === 'total')
             .map((tableRow) => {
               return (
@@ -72,6 +76,8 @@ const GeneticAncestryGroupsByVersionTable = () => {
                   <td>{renderNumberOrDash(tableRow.gnomADV2.sampleCount)}</td>
                   <td>{renderNumberOrDash(tableRow.gnomADV3.sampleCount)}</td>
                   <td>{renderNumberOrDash(tableRow.gnomADV4.sampleCount)}</td>
+                  <td>{renderNumberOrDash(tableRow.gnomADV4.sampleCountXX)}</td>
+                  <td>{renderNumberOrDash(tableRow.gnomADV4.sampleCountXY)}</td>
                   <td>-</td>
                   <td>-</td>
                 </tr>

--- a/browser/src/StatsPage/StatsPageTables/GeneticAncestryGroupsByVersionTable.tsx
+++ b/browser/src/StatsPage/StatsPageTables/GeneticAncestryGroupsByVersionTable.tsx
@@ -31,12 +31,12 @@ const GeneticAncestryGroupsByVersionTable = () => {
           </StatsTableHeaderRow>
           <StatsTableSubHeaderRow>
             <th className="rb">&nbsp;</th>
-            <th className="rb">#</th>
-            <th className="rb">#</th>
-            <th className="rb">#</th>
-            <th>#</th>
-            <th># XX</th>
-            <th># XY</th>
+            <th className="rb">Sample count</th>
+            <th className="rb">Sample count</th>
+            <th className="rb">Sample count</th>
+            <th>Sample count</th>
+            <th>XX</th>
+            <th>XY</th>
             <th>%</th>
             <th>Increase from v2</th>
           </StatsTableSubHeaderRow>

--- a/browser/src/StatsPage/StatsPageTables/GeneticAncestryGroupsByVersionTable.tsx
+++ b/browser/src/StatsPage/StatsPageTables/GeneticAncestryGroupsByVersionTable.tsx
@@ -33,15 +33,15 @@ const GeneticAncestryGroupsByVersionTable = () => {
             <th colSpan={5}>gnomAD v4*</th>
           </StatsTableHeaderRow>
           <StatsTableSubHeaderRow>
-            <th>&nbsp;</th>
-            <th>#</th>
-            <th>#</th>
-            <th>#</th>
+            <th className="rb">&nbsp;</th>
+            <th className="rb">#</th>
+            <th className="rb">#</th>
+            <th className="rb">#</th>
             <th>#</th>
             <th># XX</th>
             <th># XY</th>
             <th>%</th>
-            <th>Fold increase from v2</th>
+            <th>Increase from v2</th>
           </StatsTableSubHeaderRow>
         </thead>
         <StatsTableBody>
@@ -50,12 +50,12 @@ const GeneticAncestryGroupsByVersionTable = () => {
             .map((tableRow) => {
               return (
                 <tr>
-                  <td>{`${populationName(tableRow.geneticAncestryGroup)}${
+                  <td className="rb">{`${populationName(tableRow.geneticAncestryGroup)}${
                     tableRow.optionalSymbol
                   }`}</td>
-                  <td>{renderNumberOrDash(tableRow.EXaC.sampleCount)}</td>
-                  <td>{renderNumberOrDash(tableRow.gnomADV2.sampleCount)}</td>
-                  <td>{renderNumberOrDash(tableRow.gnomADV3.sampleCount)}</td>
+                  <td className="rb">{renderNumberOrDash(tableRow.EXaC.sampleCount)}</td>
+                  <td className="rb">{renderNumberOrDash(tableRow.gnomADV2.sampleCount)}</td>
+                  <td className="rb">{renderNumberOrDash(tableRow.gnomADV3.sampleCount)}</td>
                   <td>{renderNumberOrDash(tableRow.gnomADV4.sampleCount)}</td>
                   <td>{renderNumberOrDash(tableRow.gnomADV4.sampleCountXX)}</td>
                   <td>{renderNumberOrDash(tableRow.gnomADV4.sampleCountXY)}</td>

--- a/browser/src/StatsPage/StatsPageTables/InferredSexPerGeneticAncestryData.json
+++ b/browser/src/StatsPage/StatsPageTables/InferredSexPerGeneticAncestryData.json
@@ -1,0 +1,217 @@
+{
+  "gnomADV4": [
+    {
+      "geneticAncestryGroup": "amr",
+      "exomes": {
+        "XX": 12845,
+        "XY": 9517
+      },
+      "genomes": {
+        "XX": 3399,
+        "XY": 4258
+      }
+    },
+
+    {
+      "geneticAncestryGroup": "afr",
+      "exomes": {
+        "XX": 9663,
+        "XY": 7077
+      },
+      "genomes": {
+        "XX": 11094,
+        "XY": 9711
+      }
+    },
+
+    {
+      "geneticAncestryGroup": "asj",
+      "exomes": {
+        "XX": 6318,
+        "XY": 6750
+      },
+      "genomes": {
+        "XX": 934,
+        "XY": 802
+      }
+    },
+
+    {
+      "geneticAncestryGroup": "ami",
+      "exomes": {
+        "XX": 0,
+        "XY": 0
+      },
+      "genomes": {
+        "XX": 235,
+        "XY": 221
+      }
+    },
+
+    {
+      "geneticAncestryGroup": "eas",
+      "exomes": {
+        "XX": 10356,
+        "XY": 9494
+      },
+      "genomes": {
+        "XX": 1136,
+        "XY": 1462
+      }
+    },
+
+    {
+      "geneticAncestryGroup": "fin",
+      "exomes": {
+        "XX": 13824,
+        "XY": 12886
+      },
+      "genomes": {
+        "XX": 1287,
+        "XY": 4029
+      }
+    },
+
+    {
+      "geneticAncestryGroup": "nfe",
+      "exomes": {
+        "XX": 286144,
+        "XY": 269862
+      },
+      "genomes": {
+        "XX": 19683,
+        "XY": 14342
+      }
+    },
+
+    {
+      "geneticAncestryGroup": "mid",
+      "exomes": {
+        "XX": 1253,
+        "XY": 1631
+      },
+      "genomes": {
+        "XX": 72,
+        "XY": 75
+      }
+    },
+
+    {
+      "geneticAncestryGroup": "remaining",
+      "exomes": {
+        "XX": 15900,
+        "XY": 14298
+      },
+      "genomes": {
+        "XX": 525,
+        "XY": 533
+      }
+    },
+
+    {
+      "geneticAncestryGroup": "sas",
+      "exomes": {
+        "XX": 11020,
+        "XY": 32109
+      },
+      "genomes": {
+        "XX": 577,
+        "XY": 1840
+      }
+    },
+
+    {
+      "geneticAncestryGroup": "total",
+      "exomes": {
+        "XX": 367323,
+        "XY": 363624
+      },
+      "genomes": {
+        "XX": 38942,
+        "XY": 37273
+      }
+    }
+  ],
+
+  "gnomADV4NonUkb": [
+    {
+      "geneticAncestryGroup": "amr",
+      "exomes": {
+        "XX": 12520,
+        "XY": 9350
+      }
+    },
+
+    {
+      "geneticAncestryGroup": "afr",
+      "exomes": {
+        "XX": 5143,
+        "XY": 3704
+      }
+    },
+
+    {
+      "geneticAncestryGroup": "asj",
+      "exomes": {
+        "XX": 4919,
+        "XY": 5573
+      }
+    },
+
+    {
+      "geneticAncestryGroup": "eas",
+      "exomes": {
+        "XX": 9149,
+        "XY": 8886
+      }
+    },
+
+    {
+      "geneticAncestryGroup": "fin",
+      "exomes": {
+        "XX": 13699,
+        "XY": 12873
+      }
+    },
+
+    {
+      "geneticAncestryGroup": "nfe",
+      "exomes": {
+        "XX": 81110,
+        "XY": 93944
+      }
+    },
+
+    {
+      "geneticAncestryGroup": "mid",
+      "exomes": {
+        "XX": 958,
+        "XY": 1116
+      }
+    },
+
+    {
+      "geneticAncestryGroup": "remaining",
+      "exomes": {
+        "XX": 8376,
+        "XY": 8173
+      }
+    },
+
+    {
+      "geneticAncestryGroup": "sas",
+      "exomes": {
+        "XX": 7251,
+        "XY": 27648
+      }
+    },
+
+    {
+      "geneticAncestryGroup": "total",
+      "exomes": {
+        "XX": 143125,
+        "XY": 171267
+      }
+    }
+  ]
+}

--- a/browser/src/StatsPage/StatsPageTables/InferredSexPerGeneticAncestryTables.tsx
+++ b/browser/src/StatsPage/StatsPageTables/InferredSexPerGeneticAncestryTables.tsx
@@ -89,7 +89,7 @@ export const InferredSexAllV4Table = () => {
             })}
         </StatsTableFooter>
         <StatsTableCaption>
-          <div>Inferred sex counts of gnomAD v4 samples per Genetic Ancestry Group</div>
+          <div>Inferred sex counts of gnomAD v4 samples per genetic ancestry group</div>
         </StatsTableCaption>
       </StatsTable>
       <div>
@@ -146,7 +146,7 @@ export const InferredSexNonUKBV4Table = () => {
         </StatsTableFooter>
         <StatsTableCaption>
           <div>
-            Inferred sex counts of the gnomAD v4 samples per Genetic Ancestry Group not including UK
+            Inferred sex counts of the gnomAD v4 samples per genetic ancestry group not including UK
             Bio Bank samples
           </div>
         </StatsTableCaption>

--- a/browser/src/StatsPage/StatsPageTables/InferredSexPerGeneticAncestryTables.tsx
+++ b/browser/src/StatsPage/StatsPageTables/InferredSexPerGeneticAncestryTables.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 
 import { DownloadElementAsPNGButton } from '../DownloadFigure'
 
+import inferredSexAllV4Data from './InferredSexPerGeneticAncestryData.json'
+
 import {
   StatsTable,
   StatsTableHeaderRow,
@@ -10,13 +12,14 @@ import {
   StatsTableCaption,
   StatsTableFooter,
 } from './TableStyles'
+import { populationName } from '@gnomad/dataset-metadata/gnomadPopulations'
 
 export const InferredSexAllV4Table = () => {
   const elementId = 'inferred-sex-by-genetic-ancestry-group-table'
 
   return (
     <div>
-      <StatsTable>
+      <StatsTable id={elementId}>
         <thead>
           <StatsTableHeaderRow>
             <th colSpan={2}>Genetic Ancestry</th>
@@ -39,154 +42,51 @@ export const InferredSexAllV4Table = () => {
           </StatsTableSubHeaderRow>
         </thead>
         <StatsTableBody>
-          <tr>
-            {/* <td rowSpan={11}>All</td> */}
-            <td>African/African American</td>
-            <td>AFR</td>
-            <td>16740</td>
-            <td>9663</td>
-            <td>7077</td>
-            <td>20805</td>
-            <td>11094</td>
-            <td>9711</td>
-            <td>37545</td>
-            <td>20757</td>
-            <td>16788</td>
-          </tr>
-          <tr>
-            <td>Amish</td>
-            <td>AMI</td>
-            <td>-</td>
-            <td>-</td>
-            <td>-</td>
-            <td>456</td>
-            <td>235</td>
-            <td>221</td>
-            <td>456</td>
-            <td>235</td>
-            <td>221</td>
-          </tr>
-          <tr>
-            <td>Admixed American</td>
-            <td>AMR</td>
-            <td>22362</td>
-            <td>12845</td>
-            <td>9517</td>
-            <td>7657</td>
-            <td>3399</td>
-            <td>4258</td>
-            <td>30019</td>
-            <td>16244</td>
-            <td>13775</td>
-          </tr>
-          <tr>
-            <td>Ashkenazi Jewish</td>
-            <td>ASJ</td>
-            <td>13068</td>
-            <td>6318</td>
-            <td>6750</td>
-            <td>1736</td>
-            <td>934</td>
-            <td>802</td>
-            <td>14804</td>
-            <td>7252</td>
-            <td>7552</td>
-          </tr>
-          <tr>
-            <td>East Asian</td>
-            <td>EAS</td>
-            <td>19850</td>
-            <td>10356</td>
-            <td>9494</td>
-            <td>2598</td>
-            <td>1136</td>
-            <td>1462</td>
-            <td>22448</td>
-            <td>11492</td>
-            <td>10956</td>
-          </tr>
-          <tr>
-            <td>European (Finnish)</td>
-            <td>FIN</td>
-            <td>26710</td>
-            <td>13824</td>
-            <td>12886</td>
-            <td>5316</td>
-            <td>1287</td>
-            <td>4029</td>
-            <td>32026</td>
-            <td>15111</td>
-            <td>16915</td>
-          </tr>
-          <tr>
-            <td>Middle Eastern</td>
-            <td>MID</td>
-            <td>2884</td>
-            <td>1253</td>
-            <td>1631</td>
-            <td>147</td>
-            <td>72</td>
-            <td>75</td>
-            <td>3031</td>
-            <td>1325</td>
-            <td>1706</td>
-          </tr>
-          <tr>
-            <td>European (non-Finnish)</td>
-            <td>NFE</td>
-            <td>556006</td>
-            <td>286144</td>
-            <td>269862</td>
-            <td>34025</td>
-            <td>19683</td>
-            <td>14342</td>
-            <td>590031</td>
-            <td>305827</td>
-            <td>284204</td>
-          </tr>
-          <tr>
-            <td>Remaining</td>
-            <td>Remaining</td>
-            <td>30198</td>
-            <td>15900</td>
-            <td>14298</td>
-            <td>1058</td>
-            <td>525</td>
-            <td>533</td>
-            <td>31256</td>
-            <td>16425</td>
-            <td>14831</td>
-          </tr>
-          <tr>
-            <td>South Asian</td>
-            <td>SAS</td>
-            <td>43129</td>
-            <td>11020</td>
-            <td>32109</td>
-            <td>2417</td>
-            <td>577</td>
-            <td>1840</td>
-            <td>45546</td>
-            <td>11597</td>
-            <td>33949</td>
-          </tr>
+          {inferredSexAllV4Data.gnomADV4
+            .filter((tableRowData) => tableRowData.geneticAncestryGroup !== 'total')
+            .map((tableRowData) => {
+              const exomesCombined = tableRowData.exomes.XX + tableRowData.exomes.XY
+              const genomesCombined = tableRowData.genomes.XX + tableRowData.genomes.XY
+              return (
+                <tr>
+                  <td>{populationName(tableRowData.geneticAncestryGroup)}</td>
+                  <td>{tableRowData.geneticAncestryGroup}</td>
+                  <td>{exomesCombined.toLocaleString()}</td>
+                  <td>{tableRowData.exomes.XX.toLocaleString()}</td>
+                  <td>{tableRowData.exomes.XY.toLocaleString()}</td>
+                  <td>{genomesCombined.toLocaleString()}</td>
+                  <td>{tableRowData.genomes.XX.toLocaleString()}</td>
+                  <td>{tableRowData.genomes.XY.toLocaleString()}</td>
+                  <td>{(exomesCombined + genomesCombined).toLocaleString()}</td>
+                  <td>{(tableRowData.exomes.XX + tableRowData.genomes.XX).toLocaleString()}</td>
+                  <td>{(tableRowData.exomes.XY + tableRowData.genomes.XY).toLocaleString()}</td>
+                </tr>
+              )
+            })}
         </StatsTableBody>
         <StatsTableFooter>
-          <tr>
-            <td>Total</td>
-            <td />
-            <td>730947</td>
-            <td>367323</td>
-            <td>363624</td>
-            <td>76215</td>
-            <td>38942</td>
-            <td>37273</td>
-            <td>807162</td>
-            <td>406265</td>
-            <td>400897</td>
-          </tr>
+          {inferredSexAllV4Data.gnomADV4
+            .filter((tableRowData) => tableRowData.geneticAncestryGroup === 'total')
+            .map((tableRowData) => {
+              const exomesCombined = tableRowData.exomes.XX + tableRowData.exomes.XY
+              const genomesCombined = tableRowData.genomes.XX + tableRowData.genomes.XY
+              return (
+                <tr>
+                  <td>Total</td>
+                  <td />
+                  <td>{exomesCombined.toLocaleString()}</td>
+                  <td>{tableRowData.exomes.XX.toLocaleString()}</td>
+                  <td>{tableRowData.exomes.XY.toLocaleString()}</td>
+                  <td>{genomesCombined.toLocaleString()}</td>
+                  <td>{tableRowData.genomes.XX.toLocaleString()}</td>
+                  <td>{tableRowData.genomes.XY.toLocaleString()}</td>
+                  <td>{(exomesCombined + genomesCombined).toLocaleString()}</td>
+                  <td>{(tableRowData.exomes.XX + tableRowData.genomes.XX).toLocaleString()}</td>
+                  <td>{(tableRowData.exomes.XY + tableRowData.genomes.XY).toLocaleString()}</td>
+                </tr>
+              )
+            })}
         </StatsTableFooter>
-
         <StatsTableCaption>
           <div>Inferred sex counts of gnomAD v4 samples per Genetic Ancestry Group</div>
         </StatsTableCaption>
@@ -203,13 +103,11 @@ export const InferredSexNonUKBV4Table = () => {
 
   return (
     <div>
-      <StatsTable>
+      <StatsTable id={elementId}>
         <thead>
           <StatsTableHeaderRow>
             <th colSpan={2}>Genetic Ancestry</th>
             <th colSpan={3}>v4 Exomes</th>
-            <th colSpan={3}>v4 Genomes</th>
-            <th colSpan={3}>Combined</th>
           </StatsTableHeaderRow>
           <StatsTableSubHeaderRow>
             <th>Genetic Ancestry</th>
@@ -217,147 +115,33 @@ export const InferredSexNonUKBV4Table = () => {
             <th>Sample Count</th>
             <th>XX</th>
             <th>XY</th>
-            <th>Sample Count</th>
-            <th>XX</th>
-            <th>XY</th>
-            <th>Sample Count</th>
-            <th>XX</th>
-            <th>XY</th>
           </StatsTableSubHeaderRow>
         </thead>
         <StatsTableBody>
-          <tr>
-            <td>African/African American</td>
-            <td>AFR</td>
-            <td>8847</td>
-            <td>5143</td>
-            <td>3704</td>
-            <td />
-            <td />
-            <td />
-            <td />
-            <td />
-            <td />
-          </tr>
-          <tr>
-            <td>Admixed American</td>
-            <td>AMR</td>
-            <td>21870</td>
-            <td>12520</td>
-            <td>9350</td>
-            <td />
-            <td />
-            <td />
-            <td />
-            <td />
-            <td />
-          </tr>
-          <tr>
-            <td>Ashkenazi Jewish</td>
-            <td>ASJ</td>
-            <td>10492</td>
-            <td>4919</td>
-            <td>5573</td>
-            <td />
-            <td />
-            <td />
-            <td />
-            <td />
-            <td />
-          </tr>
-          <tr>
-            <td>East Asian</td>
-            <td>EAS</td>
-            <td>18035</td>
-            <td>9149</td>
-            <td>8886</td>
-            <td />
-            <td />
-            <td />
-            <td />
-            <td />
-            <td />
-          </tr>
-          <tr>
-            <td>European (Finnish)</td>
-            <td>FIN</td>
-            <td>26572</td>
-            <td>13699</td>
-            <td>12873</td>
-            <td />
-            <td />
-            <td />
-            <td />
-            <td />
-            <td />
-          </tr>
-          <tr>
-            <td>Middle Eastern</td>
-            <td>MID</td>
-            <td>2074</td>
-            <td>958</td>
-            <td>1116</td>
-            <td />
-            <td />
-            <td />
-            <td />
-            <td />
-            <td />
-          </tr>
-          <tr>
-            <td>European (non-Finnish)</td>
-            <td>NFE</td>
-            <td>175054</td>
-            <td>81110</td>
-            <td>93944</td>
-            <td />
-            <td />
-            <td />
-            <td />
-            <td />
-            <td />
-          </tr>
-          <tr>
-            <td>Remaining</td>
-            <td>Remaining</td>
-            <td>16549</td>
-            <td>8376</td>
-            <td>8173</td>
-            <td />
-            <td />
-            <td />
-            <td />
-            <td />
-            <td />
-          </tr>
-          <tr>
-            <td>South Asian</td>
-            <td>SAS</td>
-            <td>34899</td>
-            <td>7251</td>
-            <td>27648</td>
-            <td />
-            <td />
-            <td />
-            <td />
-            <td />
-            <td />
-          </tr>
+          {inferredSexAllV4Data.gnomADV4NonUkb
+            .filter((tableRowData) => tableRowData.geneticAncestryGroup !== 'total')
+            .map((tableRowData) => (
+              <tr>
+                <td>{populationName(tableRowData.geneticAncestryGroup)}</td>
+                <td>{tableRowData.geneticAncestryGroup}</td>
+                <td>{(tableRowData.exomes.XX + tableRowData.exomes.XY).toLocaleString()}</td>
+                <td>{tableRowData.exomes.XX.toLocaleString()}</td>
+                <td>{tableRowData.exomes.XY.toLocaleString()}</td>
+              </tr>
+            ))}
         </StatsTableBody>
         <StatsTableFooter>
-          <tr>
-            <td>Total</td>
-            <td />
-            <td>314392</td>
-            <td>143125</td>
-            <td>171267</td>
-            <td />
-            <td />
-            <td />
-            <td />
-            <td />
-            <td />
-          </tr>
+          {inferredSexAllV4Data.gnomADV4NonUkb
+            .filter((tableRowData) => tableRowData.geneticAncestryGroup === 'total')
+            .map((tableRowData) => (
+              <tr>
+                <td>Total</td>
+                <td />
+                <td>{(tableRowData.exomes.XX + tableRowData.exomes.XY).toLocaleString()}</td>
+                <td>{tableRowData.exomes.XX.toLocaleString()}</td>
+                <td>{tableRowData.exomes.XY.toLocaleString()}</td>
+              </tr>
+            ))}
         </StatsTableFooter>
         <StatsTableCaption>
           <div>

--- a/browser/src/StatsPage/StatsPageTables/InferredSexPerGeneticAncestryTables.tsx
+++ b/browser/src/StatsPage/StatsPageTables/InferredSexPerGeneticAncestryTables.tsx
@@ -1,0 +1,364 @@
+import React from 'react'
+
+import { DownloadElementAsPNGButton } from '../DownloadFigure'
+
+import {
+  StatsTable,
+  StatsTableHeaderRow,
+  StatsTableSubHeaderRow,
+  StatsTableBody,
+  StatsTableCaption,
+  StatsTableFooter,
+} from './TableStyles'
+
+export const InferredSexAllV4Table = () => {
+  const elementId = 'inferred-sex-by-genetic-ancestry-group-table'
+
+  return (
+    <div>
+      <StatsTable>
+        <thead>
+          <StatsTableHeaderRow>
+            <th colSpan={2}>Genetic Ancestry</th>
+            <th colSpan={3}>v4 Exomes</th>
+            <th colSpan={3}>v4 Genomes</th>
+            <th colSpan={3}>Combined</th>
+          </StatsTableHeaderRow>
+          <StatsTableSubHeaderRow>
+            <th>Genetic Ancestry</th>
+            <th>Genetic Ancestry </th>
+            <th>Sample Count</th>
+            <th>XX</th>
+            <th>XY</th>
+            <th>Sample Count</th>
+            <th>XX</th>
+            <th>XY</th>
+            <th>Sample Count</th>
+            <th>XX</th>
+            <th>XY</th>
+          </StatsTableSubHeaderRow>
+        </thead>
+        <StatsTableBody>
+          <tr>
+            {/* <td rowSpan={11}>All</td> */}
+            <td>African/African American</td>
+            <td>AFR</td>
+            <td>16740</td>
+            <td>9663</td>
+            <td>7077</td>
+            <td>20805</td>
+            <td>11094</td>
+            <td>9711</td>
+            <td>37545</td>
+            <td>20757</td>
+            <td>16788</td>
+          </tr>
+          <tr>
+            <td>Amish</td>
+            <td>AMI</td>
+            <td>-</td>
+            <td>-</td>
+            <td>-</td>
+            <td>456</td>
+            <td>235</td>
+            <td>221</td>
+            <td>456</td>
+            <td>235</td>
+            <td>221</td>
+          </tr>
+          <tr>
+            <td>Admixed American</td>
+            <td>AMR</td>
+            <td>22362</td>
+            <td>12845</td>
+            <td>9517</td>
+            <td>7657</td>
+            <td>3399</td>
+            <td>4258</td>
+            <td>30019</td>
+            <td>16244</td>
+            <td>13775</td>
+          </tr>
+          <tr>
+            <td>Ashkenazi Jewish</td>
+            <td>ASJ</td>
+            <td>13068</td>
+            <td>6318</td>
+            <td>6750</td>
+            <td>1736</td>
+            <td>934</td>
+            <td>802</td>
+            <td>14804</td>
+            <td>7252</td>
+            <td>7552</td>
+          </tr>
+          <tr>
+            <td>East Asian</td>
+            <td>EAS</td>
+            <td>19850</td>
+            <td>10356</td>
+            <td>9494</td>
+            <td>2598</td>
+            <td>1136</td>
+            <td>1462</td>
+            <td>22448</td>
+            <td>11492</td>
+            <td>10956</td>
+          </tr>
+          <tr>
+            <td>European (Finnish)</td>
+            <td>FIN</td>
+            <td>26710</td>
+            <td>13824</td>
+            <td>12886</td>
+            <td>5316</td>
+            <td>1287</td>
+            <td>4029</td>
+            <td>32026</td>
+            <td>15111</td>
+            <td>16915</td>
+          </tr>
+          <tr>
+            <td>Middle Eastern</td>
+            <td>MID</td>
+            <td>2884</td>
+            <td>1253</td>
+            <td>1631</td>
+            <td>147</td>
+            <td>72</td>
+            <td>75</td>
+            <td>3031</td>
+            <td>1325</td>
+            <td>1706</td>
+          </tr>
+          <tr>
+            <td>European (non-Finnish)</td>
+            <td>NFE</td>
+            <td>556006</td>
+            <td>286144</td>
+            <td>269862</td>
+            <td>34025</td>
+            <td>19683</td>
+            <td>14342</td>
+            <td>590031</td>
+            <td>305827</td>
+            <td>284204</td>
+          </tr>
+          <tr>
+            <td>Remaining</td>
+            <td>Remaining</td>
+            <td>30198</td>
+            <td>15900</td>
+            <td>14298</td>
+            <td>1058</td>
+            <td>525</td>
+            <td>533</td>
+            <td>31256</td>
+            <td>16425</td>
+            <td>14831</td>
+          </tr>
+          <tr>
+            <td>South Asian</td>
+            <td>SAS</td>
+            <td>43129</td>
+            <td>11020</td>
+            <td>32109</td>
+            <td>2417</td>
+            <td>577</td>
+            <td>1840</td>
+            <td>45546</td>
+            <td>11597</td>
+            <td>33949</td>
+          </tr>
+        </StatsTableBody>
+        <StatsTableFooter>
+          <tr>
+            <td>Total</td>
+            <td />
+            <td>730947</td>
+            <td>367323</td>
+            <td>363624</td>
+            <td>76215</td>
+            <td>38942</td>
+            <td>37273</td>
+            <td>807162</td>
+            <td>406265</td>
+            <td>400897</td>
+          </tr>
+        </StatsTableFooter>
+      </StatsTable>
+      <div>
+        <DownloadElementAsPNGButton elementId={elementId} />
+      </div>
+    </div>
+  )
+}
+
+export const InferredSexNonUKBV4Table = () => {
+  const elementId = 'non-ukb-inferred-sex-by-genetic-ancestry-group-table'
+
+  return (
+    <div>
+      <StatsTable>
+        <thead>
+          <StatsTableHeaderRow>
+            <th colSpan={2}>Genetic Ancestry</th>
+            <th colSpan={3}>v4 Exomes</th>
+            <th colSpan={3}>v4 Genomes</th>
+            <th colSpan={3}>Combined</th>
+          </StatsTableHeaderRow>
+          <StatsTableSubHeaderRow>
+            <th>Genetic Ancestry</th>
+            <th>Genetic Ancestry </th>
+            <th>Sample Count</th>
+            <th>XX</th>
+            <th>XY</th>
+            <th>Sample Count</th>
+            <th>XX</th>
+            <th>XY</th>
+            <th>Sample Count</th>
+            <th>XX</th>
+            <th>XY</th>
+          </StatsTableSubHeaderRow>
+        </thead>
+        <StatsTableBody>
+          <tr>
+            <td>African/African American</td>
+            <td>AFR</td>
+            <td>8847</td>
+            <td>5143</td>
+            <td>3704</td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+          </tr>
+          <tr>
+            <td>Admixed American</td>
+            <td>AMR</td>
+            <td>21870</td>
+            <td>12520</td>
+            <td>9350</td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+          </tr>
+          <tr>
+            <td>Ashkenazi Jewish</td>
+            <td>ASJ</td>
+            <td>10492</td>
+            <td>4919</td>
+            <td>5573</td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+          </tr>
+          <tr>
+            <td>East Asian</td>
+            <td>EAS</td>
+            <td>18035</td>
+            <td>9149</td>
+            <td>8886</td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+          </tr>
+          <tr>
+            <td>European (Finnish)</td>
+            <td>FIN</td>
+            <td>26572</td>
+            <td>13699</td>
+            <td>12873</td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+          </tr>
+          <tr>
+            <td>Middle Eastern</td>
+            <td>MID</td>
+            <td>2074</td>
+            <td>958</td>
+            <td>1116</td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+          </tr>
+          <tr>
+            <td>European (non-Finnish)</td>
+            <td>NFE</td>
+            <td>175054</td>
+            <td>81110</td>
+            <td>93944</td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+          </tr>
+          <tr>
+            <td>Remaining</td>
+            <td>Remaining</td>
+            <td>16549</td>
+            <td>8376</td>
+            <td>8173</td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+          </tr>
+          <tr>
+            <td>South Asian</td>
+            <td>SAS</td>
+            <td>34899</td>
+            <td>7251</td>
+            <td>27648</td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+          </tr>
+        </StatsTableBody>
+        <StatsTableFooter>
+          <tr>
+            <td>Total</td>
+            <td />
+            <td>314392</td>
+            <td>143125</td>
+            <td>171267</td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+          </tr>
+        </StatsTableFooter>
+      </StatsTable>
+      <div>
+        <DownloadElementAsPNGButton elementId={elementId} />
+      </div>
+    </div>
+  )
+}

--- a/browser/src/StatsPage/StatsPageTables/InferredSexPerGeneticAncestryTables.tsx
+++ b/browser/src/StatsPage/StatsPageTables/InferredSexPerGeneticAncestryTables.tsx
@@ -5,6 +5,7 @@ import { DownloadElementAsPNGButton } from '../DownloadFigure'
 import inferredSexAllV4Data from './InferredSexPerGeneticAncestryData.json'
 
 import {
+  renderNumberOrDash,
   StatsTable,
   StatsTableHeaderRow,
   StatsTableSubHeaderRow,
@@ -29,13 +30,13 @@ export const InferredSexAllV4Table = () => {
           </StatsTableHeaderRow>
           <StatsTableSubHeaderRow>
             <th>Genetic Ancestry</th>
-            <th>Genetic Ancestry </th>
+            <th className="rb">Genetic Ancestry </th>
             <th>Sample Count</th>
             <th>XX</th>
-            <th>XY</th>
+            <th className="rb">XY</th>
             <th>Sample Count</th>
             <th>XX</th>
-            <th>XY</th>
+            <th className="rb">XY</th>
             <th>Sample Count</th>
             <th>XX</th>
             <th>XY</th>
@@ -50,16 +51,16 @@ export const InferredSexAllV4Table = () => {
               return (
                 <tr>
                   <td>{populationName(tableRowData.geneticAncestryGroup)}</td>
-                  <td>{tableRowData.geneticAncestryGroup}</td>
-                  <td>{exomesCombined.toLocaleString()}</td>
-                  <td>{tableRowData.exomes.XX.toLocaleString()}</td>
-                  <td>{tableRowData.exomes.XY.toLocaleString()}</td>
-                  <td>{genomesCombined.toLocaleString()}</td>
-                  <td>{tableRowData.genomes.XX.toLocaleString()}</td>
-                  <td>{tableRowData.genomes.XY.toLocaleString()}</td>
-                  <td>{(exomesCombined + genomesCombined).toLocaleString()}</td>
-                  <td>{(tableRowData.exomes.XX + tableRowData.genomes.XX).toLocaleString()}</td>
-                  <td>{(tableRowData.exomes.XY + tableRowData.genomes.XY).toLocaleString()}</td>
+                  <td className="rb">{tableRowData.geneticAncestryGroup}</td>
+                  <td>{renderNumberOrDash(exomesCombined)}</td>
+                  <td>{renderNumberOrDash(tableRowData.exomes.XX)}</td>
+                  <td className="rb">{renderNumberOrDash(tableRowData.exomes.XY)}</td>
+                  <td>{renderNumberOrDash(genomesCombined)}</td>
+                  <td>{renderNumberOrDash(tableRowData.genomes.XX)}</td>
+                  <td className="rb">{renderNumberOrDash(tableRowData.genomes.XY)}</td>
+                  <td>{renderNumberOrDash(exomesCombined + genomesCombined)}</td>
+                  <td>{renderNumberOrDash(tableRowData.exomes.XX + tableRowData.genomes.XX)}</td>
+                  <td>{renderNumberOrDash(tableRowData.exomes.XY + tableRowData.genomes.XY)}</td>
                 </tr>
               )
             })}
@@ -74,15 +75,15 @@ export const InferredSexAllV4Table = () => {
                 <tr>
                   <td>Total</td>
                   <td />
-                  <td>{exomesCombined.toLocaleString()}</td>
-                  <td>{tableRowData.exomes.XX.toLocaleString()}</td>
-                  <td>{tableRowData.exomes.XY.toLocaleString()}</td>
-                  <td>{genomesCombined.toLocaleString()}</td>
-                  <td>{tableRowData.genomes.XX.toLocaleString()}</td>
-                  <td>{tableRowData.genomes.XY.toLocaleString()}</td>
-                  <td>{(exomesCombined + genomesCombined).toLocaleString()}</td>
-                  <td>{(tableRowData.exomes.XX + tableRowData.genomes.XX).toLocaleString()}</td>
-                  <td>{(tableRowData.exomes.XY + tableRowData.genomes.XY).toLocaleString()}</td>
+                  <td>{renderNumberOrDash(exomesCombined)}</td>
+                  <td>{renderNumberOrDash(tableRowData.exomes.XX)}</td>
+                  <td>{renderNumberOrDash(tableRowData.exomes.XY)}</td>
+                  <td>{renderNumberOrDash(genomesCombined)}</td>
+                  <td>{renderNumberOrDash(tableRowData.genomes.XX)}</td>
+                  <td>{renderNumberOrDash(tableRowData.genomes.XY)}</td>
+                  <td>{renderNumberOrDash(exomesCombined + genomesCombined)}</td>
+                  <td>{renderNumberOrDash(tableRowData.exomes.XX + tableRowData.genomes.XX)}</td>
+                  <td>{renderNumberOrDash(tableRowData.exomes.XY + tableRowData.genomes.XY)}</td>
                 </tr>
               )
             })}
@@ -111,7 +112,7 @@ export const InferredSexNonUKBV4Table = () => {
           </StatsTableHeaderRow>
           <StatsTableSubHeaderRow>
             <th>Genetic Ancestry</th>
-            <th>Genetic Ancestry </th>
+            <th className="rb">Genetic Ancestry </th>
             <th>Sample Count</th>
             <th>XX</th>
             <th>XY</th>
@@ -123,7 +124,7 @@ export const InferredSexNonUKBV4Table = () => {
             .map((tableRowData) => (
               <tr>
                 <td>{populationName(tableRowData.geneticAncestryGroup)}</td>
-                <td>{tableRowData.geneticAncestryGroup}</td>
+                <td className="rb">{tableRowData.geneticAncestryGroup}</td>
                 <td>{(tableRowData.exomes.XX + tableRowData.exomes.XY).toLocaleString()}</td>
                 <td>{tableRowData.exomes.XX.toLocaleString()}</td>
                 <td>{tableRowData.exomes.XY.toLocaleString()}</td>

--- a/browser/src/StatsPage/StatsPageTables/InferredSexPerGeneticAncestryTables.tsx
+++ b/browser/src/StatsPage/StatsPageTables/InferredSexPerGeneticAncestryTables.tsx
@@ -186,6 +186,10 @@ export const InferredSexAllV4Table = () => {
             <td>400897</td>
           </tr>
         </StatsTableFooter>
+
+        <StatsTableCaption>
+          <div>Inferred sex counts of gnomAD v4 samples per Genetic Ancestry Group</div>
+        </StatsTableCaption>
       </StatsTable>
       <div>
         <DownloadElementAsPNGButton elementId={elementId} />
@@ -228,12 +232,12 @@ export const InferredSexNonUKBV4Table = () => {
             <td>8847</td>
             <td>5143</td>
             <td>3704</td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
+            <td />
+            <td />
+            <td />
+            <td />
+            <td />
+            <td />
           </tr>
           <tr>
             <td>Admixed American</td>
@@ -241,12 +245,12 @@ export const InferredSexNonUKBV4Table = () => {
             <td>21870</td>
             <td>12520</td>
             <td>9350</td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
+            <td />
+            <td />
+            <td />
+            <td />
+            <td />
+            <td />
           </tr>
           <tr>
             <td>Ashkenazi Jewish</td>
@@ -254,12 +258,12 @@ export const InferredSexNonUKBV4Table = () => {
             <td>10492</td>
             <td>4919</td>
             <td>5573</td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
+            <td />
+            <td />
+            <td />
+            <td />
+            <td />
+            <td />
           </tr>
           <tr>
             <td>East Asian</td>
@@ -267,12 +271,12 @@ export const InferredSexNonUKBV4Table = () => {
             <td>18035</td>
             <td>9149</td>
             <td>8886</td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
+            <td />
+            <td />
+            <td />
+            <td />
+            <td />
+            <td />
           </tr>
           <tr>
             <td>European (Finnish)</td>
@@ -280,12 +284,12 @@ export const InferredSexNonUKBV4Table = () => {
             <td>26572</td>
             <td>13699</td>
             <td>12873</td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
+            <td />
+            <td />
+            <td />
+            <td />
+            <td />
+            <td />
           </tr>
           <tr>
             <td>Middle Eastern</td>
@@ -293,12 +297,12 @@ export const InferredSexNonUKBV4Table = () => {
             <td>2074</td>
             <td>958</td>
             <td>1116</td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
+            <td />
+            <td />
+            <td />
+            <td />
+            <td />
+            <td />
           </tr>
           <tr>
             <td>European (non-Finnish)</td>
@@ -306,12 +310,12 @@ export const InferredSexNonUKBV4Table = () => {
             <td>175054</td>
             <td>81110</td>
             <td>93944</td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
+            <td />
+            <td />
+            <td />
+            <td />
+            <td />
+            <td />
           </tr>
           <tr>
             <td>Remaining</td>
@@ -319,12 +323,12 @@ export const InferredSexNonUKBV4Table = () => {
             <td>16549</td>
             <td>8376</td>
             <td>8173</td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
+            <td />
+            <td />
+            <td />
+            <td />
+            <td />
+            <td />
           </tr>
           <tr>
             <td>South Asian</td>
@@ -332,12 +336,12 @@ export const InferredSexNonUKBV4Table = () => {
             <td>34899</td>
             <td>7251</td>
             <td>27648</td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
+            <td />
+            <td />
+            <td />
+            <td />
+            <td />
+            <td />
           </tr>
         </StatsTableBody>
         <StatsTableFooter>
@@ -347,14 +351,20 @@ export const InferredSexNonUKBV4Table = () => {
             <td>314392</td>
             <td>143125</td>
             <td>171267</td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
+            <td />
+            <td />
+            <td />
+            <td />
+            <td />
+            <td />
           </tr>
         </StatsTableFooter>
+        <StatsTableCaption>
+          <div>
+            Inferred sex counts of the gnomAD v4 samples per Genetic Ancestry Group not including UK
+            Bio Bank samples
+          </div>
+        </StatsTableCaption>
       </StatsTable>
       <div>
         <DownloadElementAsPNGButton elementId={elementId} />

--- a/browser/src/StatsPage/StatsPageTables/InferredSexPerGeneticAncestryTables.tsx
+++ b/browser/src/StatsPage/StatsPageTables/InferredSexPerGeneticAncestryTables.tsx
@@ -147,7 +147,7 @@ export const InferredSexNonUKBV4Table = () => {
         <StatsTableCaption>
           <div>
             Inferred sex counts of the gnomAD v4 samples per genetic ancestry group not including UK
-            Bio Bank samples
+            Biobank samples
           </div>
         </StatsTableCaption>
       </StatsTable>

--- a/browser/src/StatsPage/StatsPageTables/TableStyles.tsx
+++ b/browser/src/StatsPage/StatsPageTables/TableStyles.tsx
@@ -36,6 +36,7 @@ export const StatsTableSubHeaderRow = styled.tr`
   th {
     font-weight: normal;
   }
+
   th.rb {
     border-right: 1px solid #0e6fbf;
   }

--- a/browser/src/StatsPage/StatsPageTables/TableStyles.tsx
+++ b/browser/src/StatsPage/StatsPageTables/TableStyles.tsx
@@ -32,6 +32,9 @@ export const StatsTableSubHeaderRow = styled.tr`
   th {
     font-weight: normal;
   }
+  th.rb {
+    border-right: 1px solid #0e6fbf;
+  }
 `
 
 export const StatsTableFooter = styled.tfoot`
@@ -53,6 +56,10 @@ export const StatsTableBody = styled.tbody`
 
   tr:nth-of-type(even) {
     background-color: #f3f3f3;
+  }
+
+  td.rb {
+    border-right: 1px solid #bbb;
   }
 `
 

--- a/browser/src/StatsPage/StatsPageTables/TableStyles.tsx
+++ b/browser/src/StatsPage/StatsPageTables/TableStyles.tsx
@@ -1,5 +1,9 @@
 import styled from 'styled-components'
 
+export const renderNumberOrDash = (number: number): string => {
+  return number ? number.toLocaleString() : '-'
+}
+
 export const StatsTable = styled.table`
   border-collapse: collapse;
   min-width: 400px;

--- a/browser/src/StatsPage/__snapshots__/StatsPage.spec.tsx.snap
+++ b/browser/src/StatsPage/__snapshots__/StatsPage.spec.tsx.snap
@@ -282,6 +282,10 @@ exports[`Stats Page has no unexpected changes 1`] = `
   font-weight: normal;
 }
 
+.c39 th.rb {
+  border-right: 1px solid #0e6fbf;
+}
+
 .c41 tr {
   background-color: #508a14;
   color: #fafafa;
@@ -298,6 +302,10 @@ exports[`Stats Page has no unexpected changes 1`] = `
 
 .c40 tr:nth-of-type(even) {
   background-color: #f3f3f3;
+}
+
+.c40 td.rb {
+  border-right: 1px solid #bbb;
 }
 
 .c42 {
@@ -4468,16 +4476,24 @@ exports[`Stats Page has no unexpected changes 1`] = `
               <tr
                 className="c39"
               >
-                <th>
+                <th
+                  className="rb"
+                >
                    
                 </th>
-                <th>
+                <th
+                  className="rb"
+                >
                   #
                 </th>
-                <th>
+                <th
+                  className="rb"
+                >
                   #
                 </th>
-                <th>
+                <th
+                  className="rb"
+                >
                   #
                 </th>
                 <th>
@@ -4493,7 +4509,7 @@ exports[`Stats Page has no unexpected changes 1`] = `
                   %
                 </th>
                 <th>
-                  Fold increase from v2
+                  Increase from v2
                 </th>
               </tr>
             </thead>
@@ -4501,16 +4517,24 @@ exports[`Stats Page has no unexpected changes 1`] = `
               className="c40"
             >
               <tr>
-                <td>
+                <td
+                  className="rb"
+                >
                   Admixed American
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   5,789
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   17,720
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   7,647
                 </td>
                 <td>
@@ -4530,16 +4554,24 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 </td>
               </tr>
               <tr>
-                <td>
+                <td
+                  className="rb"
+                >
                   African/African American
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   5,203
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   12,487
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   20,744
                 </td>
                 <td>
@@ -4559,16 +4591,24 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 </td>
               </tr>
               <tr>
-                <td>
+                <td
+                  className="rb"
+                >
                   Ashkenazi Jewish
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   -
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   5,185
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   1,736
                 </td>
                 <td>
@@ -4588,16 +4628,24 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 </td>
               </tr>
               <tr>
-                <td>
+                <td
+                  className="rb"
+                >
                   East Asian
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   4,327
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   9,977
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   2,604
                 </td>
                 <td>
@@ -4617,16 +4665,24 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 </td>
               </tr>
               <tr>
-                <td>
+                <td
+                  className="rb"
+                >
                   European^
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   36,667
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   77,165
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   39,345
                 </td>
                 <td>
@@ -4646,16 +4702,24 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 </td>
               </tr>
               <tr>
-                <td>
+                <td
+                  className="rb"
+                >
                   Middle Eastern
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   -
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   -
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   158
                 </td>
                 <td>
@@ -4675,16 +4739,24 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 </td>
               </tr>
               <tr>
-                <td>
+                <td
+                  className="rb"
+                >
                   Remaining^
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   454
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   3,614
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   1,503
                 </td>
                 <td>
@@ -4704,16 +4776,24 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 </td>
               </tr>
               <tr>
-                <td>
+                <td
+                  className="rb"
+                >
                   South Asian
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   8,256
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   15,308
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   2,419
                 </td>
                 <td>

--- a/browser/src/StatsPage/__snapshots__/StatsPage.spec.tsx.snap
+++ b/browser/src/StatsPage/__snapshots__/StatsPage.spec.tsx.snap
@@ -4500,12 +4500,6 @@ exports[`Stats Page has no unexpected changes 1`] = `
                   Sample count
                 </th>
                 <th>
-                  XX
-                </th>
-                <th>
-                  XY
-                </th>
-                <th>
                   %
                 </th>
                 <th>
@@ -4541,12 +4535,6 @@ exports[`Stats Page has no unexpected changes 1`] = `
                   30,019
                 </td>
                 <td>
-                  16,244
-                </td>
-                <td>
-                  13,775
-                </td>
-                <td>
                   3.72%
                 </td>
                 <td>
@@ -4576,12 +4564,6 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 </td>
                 <td>
                   37,545
-                </td>
-                <td>
-                  20,757
-                </td>
-                <td>
-                  16,788
                 </td>
                 <td>
                   4.65%
@@ -4615,12 +4597,6 @@ exports[`Stats Page has no unexpected changes 1`] = `
                   14,804
                 </td>
                 <td>
-                  7,252
-                </td>
-                <td>
-                  7,552
-                </td>
-                <td>
                   1.83%
                 </td>
                 <td>
@@ -4650,12 +4626,6 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 </td>
                 <td>
                   22,448
-                </td>
-                <td>
-                  11,492
-                </td>
-                <td>
-                  10,956
                 </td>
                 <td>
                   2.78%
@@ -4689,12 +4659,6 @@ exports[`Stats Page has no unexpected changes 1`] = `
                   622,057
                 </td>
                 <td>
-                  320,938
-                </td>
-                <td>
-                  301,119
-                </td>
-                <td>
                   77.07%
                 </td>
                 <td>
@@ -4724,12 +4688,6 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 </td>
                 <td>
                   3,031
-                </td>
-                <td>
-                  1,325
-                </td>
-                <td>
-                  1,706
                 </td>
                 <td>
                   0.38%
@@ -4763,12 +4721,6 @@ exports[`Stats Page has no unexpected changes 1`] = `
                   31,712
                 </td>
                 <td>
-                  16,660
-                </td>
-                <td>
-                  15,052
-                </td>
-                <td>
                   3.93%
                 </td>
                 <td>
@@ -4800,12 +4752,6 @@ exports[`Stats Page has no unexpected changes 1`] = `
                   45,546
                 </td>
                 <td>
-                  11,597
-                </td>
-                <td>
-                  33,949
-                </td>
-                <td>
                   5.64%
                 </td>
                 <td>
@@ -4831,12 +4777,6 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 </td>
                 <td>
                   807,162
-                </td>
-                <td>
-                  406,265
-                </td>
-                <td>
-                  400,897
                 </td>
                 <td>
                   -

--- a/browser/src/StatsPage/__snapshots__/StatsPage.spec.tsx.snap
+++ b/browser/src/StatsPage/__snapshots__/StatsPage.spec.tsx.snap
@@ -4484,26 +4484,26 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 <th
                   className="rb"
                 >
-                  #
+                  Sample count
                 </th>
                 <th
                   className="rb"
                 >
-                  #
+                  Sample count
                 </th>
                 <th
                   className="rb"
                 >
-                  #
+                  Sample count
                 </th>
                 <th>
-                  #
+                  Sample count
                 </th>
                 <th>
-                  # XX
+                  XX
                 </th>
                 <th>
-                  # XY
+                  XY
                 </th>
                 <th>
                   %

--- a/browser/src/StatsPage/__snapshots__/StatsPage.spec.tsx.snap
+++ b/browser/src/StatsPage/__snapshots__/StatsPage.spec.tsx.snap
@@ -7527,6 +7527,7 @@ exports[`Stats Page has no unexpected changes 1`] = `
         <div>
           <table
             className="c37"
+            id="inferred-sex-by-genetic-ancestry-group-table"
           >
             <thead>
               <tr
@@ -7596,107 +7597,72 @@ exports[`Stats Page has no unexpected changes 1`] = `
             >
               <tr>
                 <td>
-                  African/African American
-                </td>
-                <td>
-                  AFR
-                </td>
-                <td>
-                  16740
-                </td>
-                <td>
-                  9663
-                </td>
-                <td>
-                  7077
-                </td>
-                <td>
-                  20805
-                </td>
-                <td>
-                  11094
-                </td>
-                <td>
-                  9711
-                </td>
-                <td>
-                  37545
-                </td>
-                <td>
-                  20757
-                </td>
-                <td>
-                  16788
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  Amish
-                </td>
-                <td>
-                  AMI
-                </td>
-                <td>
-                  -
-                </td>
-                <td>
-                  -
-                </td>
-                <td>
-                  -
-                </td>
-                <td>
-                  456
-                </td>
-                <td>
-                  235
-                </td>
-                <td>
-                  221
-                </td>
-                <td>
-                  456
-                </td>
-                <td>
-                  235
-                </td>
-                <td>
-                  221
-                </td>
-              </tr>
-              <tr>
-                <td>
                   Admixed American
                 </td>
                 <td>
-                  AMR
+                  amr
                 </td>
                 <td>
-                  22362
+                  22,362
                 </td>
                 <td>
-                  12845
+                  12,845
                 </td>
                 <td>
-                  9517
+                  9,517
                 </td>
                 <td>
-                  7657
+                  7,657
                 </td>
                 <td>
-                  3399
+                  3,399
                 </td>
                 <td>
-                  4258
+                  4,258
                 </td>
                 <td>
-                  30019
+                  30,019
                 </td>
                 <td>
-                  16244
+                  16,244
                 </td>
                 <td>
-                  13775
+                  13,775
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  African/African American
+                </td>
+                <td>
+                  afr
+                </td>
+                <td>
+                  16,740
+                </td>
+                <td>
+                  9,663
+                </td>
+                <td>
+                  7,077
+                </td>
+                <td>
+                  20,805
+                </td>
+                <td>
+                  11,094
+                </td>
+                <td>
+                  9,711
+                </td>
+                <td>
+                  37,545
+                </td>
+                <td>
+                  20,757
+                </td>
+                <td>
+                  16,788
                 </td>
               </tr>
               <tr>
@@ -7704,19 +7670,19 @@ exports[`Stats Page has no unexpected changes 1`] = `
                   Ashkenazi Jewish
                 </td>
                 <td>
-                  ASJ
+                  asj
                 </td>
                 <td>
-                  13068
+                  13,068
                 </td>
                 <td>
-                  6318
+                  6,318
                 </td>
                 <td>
-                  6750
+                  6,750
                 </td>
                 <td>
-                  1736
+                  1,736
                 </td>
                 <td>
                   934
@@ -7725,13 +7691,48 @@ exports[`Stats Page has no unexpected changes 1`] = `
                   802
                 </td>
                 <td>
-                  14804
+                  14,804
                 </td>
                 <td>
-                  7252
+                  7,252
                 </td>
                 <td>
-                  7552
+                  7,552
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  Amish
+                </td>
+                <td>
+                  ami
+                </td>
+                <td>
+                  0
+                </td>
+                <td>
+                  0
+                </td>
+                <td>
+                  0
+                </td>
+                <td>
+                  456
+                </td>
+                <td>
+                  235
+                </td>
+                <td>
+                  221
+                </td>
+                <td>
+                  456
+                </td>
+                <td>
+                  235
+                </td>
+                <td>
+                  221
                 </td>
               </tr>
               <tr>
@@ -7739,34 +7740,34 @@ exports[`Stats Page has no unexpected changes 1`] = `
                   East Asian
                 </td>
                 <td>
-                  EAS
+                  eas
                 </td>
                 <td>
-                  19850
+                  19,850
                 </td>
                 <td>
-                  10356
+                  10,356
                 </td>
                 <td>
-                  9494
+                  9,494
                 </td>
                 <td>
-                  2598
+                  2,598
                 </td>
                 <td>
-                  1136
+                  1,136
                 </td>
                 <td>
-                  1462
+                  1,462
                 </td>
                 <td>
-                  22448
+                  22,448
                 </td>
                 <td>
-                  11492
+                  11,492
                 </td>
                 <td>
-                  10956
+                  10,956
                 </td>
               </tr>
               <tr>
@@ -7774,34 +7775,69 @@ exports[`Stats Page has no unexpected changes 1`] = `
                   European (Finnish)
                 </td>
                 <td>
-                  FIN
+                  fin
                 </td>
                 <td>
-                  26710
+                  26,710
                 </td>
                 <td>
-                  13824
+                  13,824
                 </td>
                 <td>
-                  12886
+                  12,886
                 </td>
                 <td>
-                  5316
+                  5,316
                 </td>
                 <td>
-                  1287
+                  1,287
                 </td>
                 <td>
-                  4029
+                  4,029
                 </td>
                 <td>
-                  32026
+                  32,026
                 </td>
                 <td>
-                  15111
+                  15,111
                 </td>
                 <td>
-                  16915
+                  16,915
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  European (non-Finnish)
+                </td>
+                <td>
+                  nfe
+                </td>
+                <td>
+                  556,006
+                </td>
+                <td>
+                  286,144
+                </td>
+                <td>
+                  269,862
+                </td>
+                <td>
+                  34,025
+                </td>
+                <td>
+                  19,683
+                </td>
+                <td>
+                  14,342
+                </td>
+                <td>
+                  590,031
+                </td>
+                <td>
+                  305,827
+                </td>
+                <td>
+                  284,204
                 </td>
               </tr>
               <tr>
@@ -7809,16 +7845,16 @@ exports[`Stats Page has no unexpected changes 1`] = `
                   Middle Eastern
                 </td>
                 <td>
-                  MID
+                  mid
                 </td>
                 <td>
-                  2884
+                  2,884
                 </td>
                 <td>
-                  1253
+                  1,253
                 </td>
                 <td>
-                  1631
+                  1,631
                 </td>
                 <td>
                   147
@@ -7830,48 +7866,13 @@ exports[`Stats Page has no unexpected changes 1`] = `
                   75
                 </td>
                 <td>
-                  3031
+                  3,031
                 </td>
                 <td>
-                  1325
+                  1,325
                 </td>
                 <td>
-                  1706
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  European (non-Finnish)
-                </td>
-                <td>
-                  NFE
-                </td>
-                <td>
-                  556006
-                </td>
-                <td>
-                  286144
-                </td>
-                <td>
-                  269862
-                </td>
-                <td>
-                  34025
-                </td>
-                <td>
-                  19683
-                </td>
-                <td>
-                  14342
-                </td>
-                <td>
-                  590031
-                </td>
-                <td>
-                  305827
-                </td>
-                <td>
-                  284204
+                  1,706
                 </td>
               </tr>
               <tr>
@@ -7879,19 +7880,19 @@ exports[`Stats Page has no unexpected changes 1`] = `
                   Remaining
                 </td>
                 <td>
-                  Remaining
+                  remaining
                 </td>
                 <td>
-                  30198
+                  30,198
                 </td>
                 <td>
-                  15900
+                  15,900
                 </td>
                 <td>
-                  14298
+                  14,298
                 </td>
                 <td>
-                  1058
+                  1,058
                 </td>
                 <td>
                   525
@@ -7900,13 +7901,13 @@ exports[`Stats Page has no unexpected changes 1`] = `
                   533
                 </td>
                 <td>
-                  31256
+                  31,256
                 </td>
                 <td>
-                  16425
+                  16,425
                 </td>
                 <td>
-                  14831
+                  14,831
                 </td>
               </tr>
               <tr>
@@ -7914,34 +7915,34 @@ exports[`Stats Page has no unexpected changes 1`] = `
                   South Asian
                 </td>
                 <td>
-                  SAS
+                  sas
                 </td>
                 <td>
-                  43129
+                  43,129
                 </td>
                 <td>
-                  11020
+                  11,020
                 </td>
                 <td>
-                  32109
+                  32,109
                 </td>
                 <td>
-                  2417
+                  2,417
                 </td>
                 <td>
                   577
                 </td>
                 <td>
-                  1840
+                  1,840
                 </td>
                 <td>
-                  45546
+                  45,546
                 </td>
                 <td>
-                  11597
+                  11,597
                 </td>
                 <td>
-                  33949
+                  33,949
                 </td>
               </tr>
             </tbody>
@@ -7954,31 +7955,31 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 </td>
                 <td />
                 <td>
-                  730947
+                  730,947
                 </td>
                 <td>
-                  367323
+                  367,323
                 </td>
                 <td>
-                  363624
+                  363,624
                 </td>
                 <td>
-                  76215
+                  76,215
                 </td>
                 <td>
-                  38942
+                  38,942
                 </td>
                 <td>
-                  37273
+                  37,273
                 </td>
                 <td>
-                  807162
+                  807,162
                 </td>
                 <td>
-                  406265
+                  406,265
                 </td>
                 <td>
-                  400897
+                  400,897
                 </td>
               </tr>
             </tfoot>
@@ -8019,6 +8020,7 @@ exports[`Stats Page has no unexpected changes 1`] = `
         <div>
           <table
             className="c37"
+            id="non-ukb-inferred-sex-by-genetic-ancestry-group-table"
           >
             <thead>
               <tr
@@ -8033,16 +8035,6 @@ exports[`Stats Page has no unexpected changes 1`] = `
                   colSpan={3}
                 >
                   v4 Exomes
-                </th>
-                <th
-                  colSpan={3}
-                >
-                  v4 Genomes
-                </th>
-                <th
-                  colSpan={3}
-                >
-                  Combined
                 </th>
               </tr>
               <tr
@@ -8063,24 +8055,6 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 <th>
                   XY
                 </th>
-                <th>
-                  Sample Count
-                </th>
-                <th>
-                  XX
-                </th>
-                <th>
-                  XY
-                </th>
-                <th>
-                  Sample Count
-                </th>
-                <th>
-                  XX
-                </th>
-                <th>
-                  XY
-                </th>
               </tr>
             </thead>
             <tbody
@@ -8088,210 +8062,156 @@ exports[`Stats Page has no unexpected changes 1`] = `
             >
               <tr>
                 <td>
-                  African/African American
-                </td>
-                <td>
-                  AFR
-                </td>
-                <td>
-                  8847
-                </td>
-                <td>
-                  5143
-                </td>
-                <td>
-                  3704
-                </td>
-                <td />
-                <td />
-                <td />
-                <td />
-                <td />
-                <td />
-              </tr>
-              <tr>
-                <td>
                   Admixed American
                 </td>
                 <td>
-                  AMR
+                  amr
                 </td>
                 <td>
-                  21870
+                  21,870
                 </td>
                 <td>
-                  12520
+                  12,520
                 </td>
                 <td>
-                  9350
+                  9,350
                 </td>
-                <td />
-                <td />
-                <td />
-                <td />
-                <td />
-                <td />
+              </tr>
+              <tr>
+                <td>
+                  African/African American
+                </td>
+                <td>
+                  afr
+                </td>
+                <td>
+                  8,847
+                </td>
+                <td>
+                  5,143
+                </td>
+                <td>
+                  3,704
+                </td>
               </tr>
               <tr>
                 <td>
                   Ashkenazi Jewish
                 </td>
                 <td>
-                  ASJ
+                  asj
                 </td>
                 <td>
-                  10492
+                  10,492
                 </td>
                 <td>
-                  4919
+                  4,919
                 </td>
                 <td>
-                  5573
+                  5,573
                 </td>
-                <td />
-                <td />
-                <td />
-                <td />
-                <td />
-                <td />
               </tr>
               <tr>
                 <td>
                   East Asian
                 </td>
                 <td>
-                  EAS
+                  eas
                 </td>
                 <td>
-                  18035
+                  18,035
                 </td>
                 <td>
-                  9149
+                  9,149
                 </td>
                 <td>
-                  8886
+                  8,886
                 </td>
-                <td />
-                <td />
-                <td />
-                <td />
-                <td />
-                <td />
               </tr>
               <tr>
                 <td>
                   European (Finnish)
                 </td>
                 <td>
-                  FIN
+                  fin
                 </td>
                 <td>
-                  26572
+                  26,572
                 </td>
                 <td>
-                  13699
+                  13,699
                 </td>
                 <td>
-                  12873
+                  12,873
                 </td>
-                <td />
-                <td />
-                <td />
-                <td />
-                <td />
-                <td />
-              </tr>
-              <tr>
-                <td>
-                  Middle Eastern
-                </td>
-                <td>
-                  MID
-                </td>
-                <td>
-                  2074
-                </td>
-                <td>
-                  958
-                </td>
-                <td>
-                  1116
-                </td>
-                <td />
-                <td />
-                <td />
-                <td />
-                <td />
-                <td />
               </tr>
               <tr>
                 <td>
                   European (non-Finnish)
                 </td>
                 <td>
-                  NFE
+                  nfe
                 </td>
                 <td>
-                  175054
+                  175,054
                 </td>
                 <td>
-                  81110
+                  81,110
                 </td>
                 <td>
-                  93944
+                  93,944
                 </td>
-                <td />
-                <td />
-                <td />
-                <td />
-                <td />
-                <td />
+              </tr>
+              <tr>
+                <td>
+                  Middle Eastern
+                </td>
+                <td>
+                  mid
+                </td>
+                <td>
+                  2,074
+                </td>
+                <td>
+                  958
+                </td>
+                <td>
+                  1,116
+                </td>
               </tr>
               <tr>
                 <td>
                   Remaining
                 </td>
                 <td>
-                  Remaining
+                  remaining
                 </td>
                 <td>
-                  16549
+                  16,549
                 </td>
                 <td>
-                  8376
+                  8,376
                 </td>
                 <td>
-                  8173
+                  8,173
                 </td>
-                <td />
-                <td />
-                <td />
-                <td />
-                <td />
-                <td />
               </tr>
               <tr>
                 <td>
                   South Asian
                 </td>
                 <td>
-                  SAS
+                  sas
                 </td>
                 <td>
-                  34899
+                  34,899
                 </td>
                 <td>
-                  7251
+                  7,251
                 </td>
                 <td>
-                  27648
+                  27,648
                 </td>
-                <td />
-                <td />
-                <td />
-                <td />
-                <td />
-                <td />
               </tr>
             </tbody>
             <tfoot
@@ -8303,20 +8223,14 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 </td>
                 <td />
                 <td>
-                  314392
+                  314,392
                 </td>
                 <td>
-                  143125
+                  143,125
                 </td>
                 <td>
-                  171267
+                  171,267
                 </td>
-                <td />
-                <td />
-                <td />
-                <td />
-                <td />
-                <td />
               </tr>
             </tfoot>
             <caption

--- a/browser/src/StatsPage/__snapshots__/StatsPage.spec.tsx.snap
+++ b/browser/src/StatsPage/__snapshots__/StatsPage.spec.tsx.snap
@@ -4460,7 +4460,7 @@ exports[`Stats Page has no unexpected changes 1`] = `
                   gnomAD v3
                 </th>
                 <th
-                  colSpan={3}
+                  colSpan={5}
                 >
                   gnomAD v4*
                 </th>
@@ -4482,6 +4482,12 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 </th>
                 <th>
                   #
+                </th>
+                <th>
+                  # XX
+                </th>
+                <th>
+                  # XY
                 </th>
                 <th>
                   %
@@ -4511,6 +4517,12 @@ exports[`Stats Page has no unexpected changes 1`] = `
                   30,019
                 </td>
                 <td>
+                  16,244
+                </td>
+                <td>
+                  13,775
+                </td>
+                <td>
                   3.72%
                 </td>
                 <td>
@@ -4532,6 +4544,12 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 </td>
                 <td>
                   37,545
+                </td>
+                <td>
+                  20,757
+                </td>
+                <td>
+                  16,788
                 </td>
                 <td>
                   4.65%
@@ -4557,6 +4575,12 @@ exports[`Stats Page has no unexpected changes 1`] = `
                   14,804
                 </td>
                 <td>
+                  7,252
+                </td>
+                <td>
+                  7,552
+                </td>
+                <td>
                   1.83%
                 </td>
                 <td>
@@ -4578,6 +4602,12 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 </td>
                 <td>
                   22,448
+                </td>
+                <td>
+                  11,492
+                </td>
+                <td>
+                  10,956
                 </td>
                 <td>
                   2.78%
@@ -4603,6 +4633,12 @@ exports[`Stats Page has no unexpected changes 1`] = `
                   622,057
                 </td>
                 <td>
+                  320,938
+                </td>
+                <td>
+                  301,119
+                </td>
+                <td>
                   77.07%
                 </td>
                 <td>
@@ -4624,6 +4660,12 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 </td>
                 <td>
                   3,031
+                </td>
+                <td>
+                  1,325
+                </td>
+                <td>
+                  1,706
                 </td>
                 <td>
                   0.38%
@@ -4649,6 +4691,12 @@ exports[`Stats Page has no unexpected changes 1`] = `
                   31,712
                 </td>
                 <td>
+                  16,660
+                </td>
+                <td>
+                  15,052
+                </td>
+                <td>
                   3.93%
                 </td>
                 <td>
@@ -4670,6 +4718,12 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 </td>
                 <td>
                   45,546
+                </td>
+                <td>
+                  11,597
+                </td>
+                <td>
+                  33,949
                 </td>
                 <td>
                   5.64%
@@ -4697,6 +4751,12 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 </td>
                 <td>
                   807,162
+                </td>
+                <td>
+                  406,265
+                </td>
+                <td>
+                  400,897
                 </td>
                 <td>
                   -

--- a/browser/src/StatsPage/__snapshots__/StatsPage.spec.tsx.snap
+++ b/browser/src/StatsPage/__snapshots__/StatsPage.spec.tsx.snap
@@ -6197,7 +6197,7 @@ exports[`Stats Page has no unexpected changes 1`] = `
         className="c43"
         style={
           {
-            "marginBottom": "0.5em",
+            "marginBottom": "6em",
           }
         }
       >
@@ -7504,6 +7504,844 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 </div>
               </div>
             </div>
+          </div>
+        </div>
+      </div>
+      <h3
+        style={
+          {
+            "marginBottom": "2em",
+          }
+        }
+      >
+        Inferred sex in gnomAD v4 per Genetic Ancestry Group
+      </h3>
+      <div
+        className="c36"
+        style={
+          {
+            "marginBottom": "6em",
+          }
+        }
+      >
+        <div>
+          <table
+            className="c37"
+          >
+            <thead>
+              <tr
+                className="c38"
+              >
+                <th
+                  colSpan={2}
+                >
+                  Genetic Ancestry
+                </th>
+                <th
+                  colSpan={3}
+                >
+                  v4 Exomes
+                </th>
+                <th
+                  colSpan={3}
+                >
+                  v4 Genomes
+                </th>
+                <th
+                  colSpan={3}
+                >
+                  Combined
+                </th>
+              </tr>
+              <tr
+                className="c39"
+              >
+                <th>
+                  Genetic Ancestry
+                </th>
+                <th>
+                  Genetic Ancestry 
+                </th>
+                <th>
+                  Sample Count
+                </th>
+                <th>
+                  XX
+                </th>
+                <th>
+                  XY
+                </th>
+                <th>
+                  Sample Count
+                </th>
+                <th>
+                  XX
+                </th>
+                <th>
+                  XY
+                </th>
+                <th>
+                  Sample Count
+                </th>
+                <th>
+                  XX
+                </th>
+                <th>
+                  XY
+                </th>
+              </tr>
+            </thead>
+            <tbody
+              className="c40"
+            >
+              <tr>
+                <td>
+                  African/African American
+                </td>
+                <td>
+                  AFR
+                </td>
+                <td>
+                  16740
+                </td>
+                <td>
+                  9663
+                </td>
+                <td>
+                  7077
+                </td>
+                <td>
+                  20805
+                </td>
+                <td>
+                  11094
+                </td>
+                <td>
+                  9711
+                </td>
+                <td>
+                  37545
+                </td>
+                <td>
+                  20757
+                </td>
+                <td>
+                  16788
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  Amish
+                </td>
+                <td>
+                  AMI
+                </td>
+                <td>
+                  -
+                </td>
+                <td>
+                  -
+                </td>
+                <td>
+                  -
+                </td>
+                <td>
+                  456
+                </td>
+                <td>
+                  235
+                </td>
+                <td>
+                  221
+                </td>
+                <td>
+                  456
+                </td>
+                <td>
+                  235
+                </td>
+                <td>
+                  221
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  Admixed American
+                </td>
+                <td>
+                  AMR
+                </td>
+                <td>
+                  22362
+                </td>
+                <td>
+                  12845
+                </td>
+                <td>
+                  9517
+                </td>
+                <td>
+                  7657
+                </td>
+                <td>
+                  3399
+                </td>
+                <td>
+                  4258
+                </td>
+                <td>
+                  30019
+                </td>
+                <td>
+                  16244
+                </td>
+                <td>
+                  13775
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  Ashkenazi Jewish
+                </td>
+                <td>
+                  ASJ
+                </td>
+                <td>
+                  13068
+                </td>
+                <td>
+                  6318
+                </td>
+                <td>
+                  6750
+                </td>
+                <td>
+                  1736
+                </td>
+                <td>
+                  934
+                </td>
+                <td>
+                  802
+                </td>
+                <td>
+                  14804
+                </td>
+                <td>
+                  7252
+                </td>
+                <td>
+                  7552
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  East Asian
+                </td>
+                <td>
+                  EAS
+                </td>
+                <td>
+                  19850
+                </td>
+                <td>
+                  10356
+                </td>
+                <td>
+                  9494
+                </td>
+                <td>
+                  2598
+                </td>
+                <td>
+                  1136
+                </td>
+                <td>
+                  1462
+                </td>
+                <td>
+                  22448
+                </td>
+                <td>
+                  11492
+                </td>
+                <td>
+                  10956
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  European (Finnish)
+                </td>
+                <td>
+                  FIN
+                </td>
+                <td>
+                  26710
+                </td>
+                <td>
+                  13824
+                </td>
+                <td>
+                  12886
+                </td>
+                <td>
+                  5316
+                </td>
+                <td>
+                  1287
+                </td>
+                <td>
+                  4029
+                </td>
+                <td>
+                  32026
+                </td>
+                <td>
+                  15111
+                </td>
+                <td>
+                  16915
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  Middle Eastern
+                </td>
+                <td>
+                  MID
+                </td>
+                <td>
+                  2884
+                </td>
+                <td>
+                  1253
+                </td>
+                <td>
+                  1631
+                </td>
+                <td>
+                  147
+                </td>
+                <td>
+                  72
+                </td>
+                <td>
+                  75
+                </td>
+                <td>
+                  3031
+                </td>
+                <td>
+                  1325
+                </td>
+                <td>
+                  1706
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  European (non-Finnish)
+                </td>
+                <td>
+                  NFE
+                </td>
+                <td>
+                  556006
+                </td>
+                <td>
+                  286144
+                </td>
+                <td>
+                  269862
+                </td>
+                <td>
+                  34025
+                </td>
+                <td>
+                  19683
+                </td>
+                <td>
+                  14342
+                </td>
+                <td>
+                  590031
+                </td>
+                <td>
+                  305827
+                </td>
+                <td>
+                  284204
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  Remaining
+                </td>
+                <td>
+                  Remaining
+                </td>
+                <td>
+                  30198
+                </td>
+                <td>
+                  15900
+                </td>
+                <td>
+                  14298
+                </td>
+                <td>
+                  1058
+                </td>
+                <td>
+                  525
+                </td>
+                <td>
+                  533
+                </td>
+                <td>
+                  31256
+                </td>
+                <td>
+                  16425
+                </td>
+                <td>
+                  14831
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  South Asian
+                </td>
+                <td>
+                  SAS
+                </td>
+                <td>
+                  43129
+                </td>
+                <td>
+                  11020
+                </td>
+                <td>
+                  32109
+                </td>
+                <td>
+                  2417
+                </td>
+                <td>
+                  577
+                </td>
+                <td>
+                  1840
+                </td>
+                <td>
+                  45546
+                </td>
+                <td>
+                  11597
+                </td>
+                <td>
+                  33949
+                </td>
+              </tr>
+            </tbody>
+            <tfoot
+              className="c41"
+            >
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td />
+                <td>
+                  730947
+                </td>
+                <td>
+                  367323
+                </td>
+                <td>
+                  363624
+                </td>
+                <td>
+                  76215
+                </td>
+                <td>
+                  38942
+                </td>
+                <td>
+                  37273
+                </td>
+                <td>
+                  807162
+                </td>
+                <td>
+                  406265
+                </td>
+                <td>
+                  400897
+                </td>
+              </tr>
+            </tfoot>
+            <caption
+              className="c42"
+            >
+              <div>
+                Inferred sex counts of gnomAD v4 samples per Genetic Ancestry Group
+              </div>
+            </caption>
+          </table>
+          <div>
+            <span>
+              <button
+                className="c12"
+                onClick={[Function]}
+                type="button"
+              >
+                <img
+                  alt="Download figure"
+                  height={15}
+                  src="test-file-stub"
+                  width={15}
+                />
+              </button>
+            </span>
+          </div>
+        </div>
+      </div>
+      <div
+        className="c36"
+        style={
+          {
+            "marginBottom": "3em",
+          }
+        }
+      >
+        <div>
+          <table
+            className="c37"
+          >
+            <thead>
+              <tr
+                className="c38"
+              >
+                <th
+                  colSpan={2}
+                >
+                  Genetic Ancestry
+                </th>
+                <th
+                  colSpan={3}
+                >
+                  v4 Exomes
+                </th>
+                <th
+                  colSpan={3}
+                >
+                  v4 Genomes
+                </th>
+                <th
+                  colSpan={3}
+                >
+                  Combined
+                </th>
+              </tr>
+              <tr
+                className="c39"
+              >
+                <th>
+                  Genetic Ancestry
+                </th>
+                <th>
+                  Genetic Ancestry 
+                </th>
+                <th>
+                  Sample Count
+                </th>
+                <th>
+                  XX
+                </th>
+                <th>
+                  XY
+                </th>
+                <th>
+                  Sample Count
+                </th>
+                <th>
+                  XX
+                </th>
+                <th>
+                  XY
+                </th>
+                <th>
+                  Sample Count
+                </th>
+                <th>
+                  XX
+                </th>
+                <th>
+                  XY
+                </th>
+              </tr>
+            </thead>
+            <tbody
+              className="c40"
+            >
+              <tr>
+                <td>
+                  African/African American
+                </td>
+                <td>
+                  AFR
+                </td>
+                <td>
+                  8847
+                </td>
+                <td>
+                  5143
+                </td>
+                <td>
+                  3704
+                </td>
+                <td />
+                <td />
+                <td />
+                <td />
+                <td />
+                <td />
+              </tr>
+              <tr>
+                <td>
+                  Admixed American
+                </td>
+                <td>
+                  AMR
+                </td>
+                <td>
+                  21870
+                </td>
+                <td>
+                  12520
+                </td>
+                <td>
+                  9350
+                </td>
+                <td />
+                <td />
+                <td />
+                <td />
+                <td />
+                <td />
+              </tr>
+              <tr>
+                <td>
+                  Ashkenazi Jewish
+                </td>
+                <td>
+                  ASJ
+                </td>
+                <td>
+                  10492
+                </td>
+                <td>
+                  4919
+                </td>
+                <td>
+                  5573
+                </td>
+                <td />
+                <td />
+                <td />
+                <td />
+                <td />
+                <td />
+              </tr>
+              <tr>
+                <td>
+                  East Asian
+                </td>
+                <td>
+                  EAS
+                </td>
+                <td>
+                  18035
+                </td>
+                <td>
+                  9149
+                </td>
+                <td>
+                  8886
+                </td>
+                <td />
+                <td />
+                <td />
+                <td />
+                <td />
+                <td />
+              </tr>
+              <tr>
+                <td>
+                  European (Finnish)
+                </td>
+                <td>
+                  FIN
+                </td>
+                <td>
+                  26572
+                </td>
+                <td>
+                  13699
+                </td>
+                <td>
+                  12873
+                </td>
+                <td />
+                <td />
+                <td />
+                <td />
+                <td />
+                <td />
+              </tr>
+              <tr>
+                <td>
+                  Middle Eastern
+                </td>
+                <td>
+                  MID
+                </td>
+                <td>
+                  2074
+                </td>
+                <td>
+                  958
+                </td>
+                <td>
+                  1116
+                </td>
+                <td />
+                <td />
+                <td />
+                <td />
+                <td />
+                <td />
+              </tr>
+              <tr>
+                <td>
+                  European (non-Finnish)
+                </td>
+                <td>
+                  NFE
+                </td>
+                <td>
+                  175054
+                </td>
+                <td>
+                  81110
+                </td>
+                <td>
+                  93944
+                </td>
+                <td />
+                <td />
+                <td />
+                <td />
+                <td />
+                <td />
+              </tr>
+              <tr>
+                <td>
+                  Remaining
+                </td>
+                <td>
+                  Remaining
+                </td>
+                <td>
+                  16549
+                </td>
+                <td>
+                  8376
+                </td>
+                <td>
+                  8173
+                </td>
+                <td />
+                <td />
+                <td />
+                <td />
+                <td />
+                <td />
+              </tr>
+              <tr>
+                <td>
+                  South Asian
+                </td>
+                <td>
+                  SAS
+                </td>
+                <td>
+                  34899
+                </td>
+                <td>
+                  7251
+                </td>
+                <td>
+                  27648
+                </td>
+                <td />
+                <td />
+                <td />
+                <td />
+                <td />
+                <td />
+              </tr>
+            </tbody>
+            <tfoot
+              className="c41"
+            >
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td />
+                <td>
+                  314392
+                </td>
+                <td>
+                  143125
+                </td>
+                <td>
+                  171267
+                </td>
+                <td />
+                <td />
+                <td />
+                <td />
+                <td />
+                <td />
+              </tr>
+            </tfoot>
+            <caption
+              className="c42"
+            >
+              <div>
+                Inferred sex counts of the gnomAD v4 samples per Genetic Ancestry Group not including UK Bio Bank samples
+              </div>
+            </caption>
+          </table>
+          <div>
+            <span>
+              <button
+                className="c12"
+                onClick={[Function]}
+                type="button"
+              >
+                <img
+                  alt="Download figure"
+                  height={15}
+                  src="test-file-stub"
+                  width={15}
+                />
+              </button>
+            </span>
           </div>
         </div>
       </div>

--- a/browser/src/StatsPage/__snapshots__/StatsPage.spec.tsx.snap
+++ b/browser/src/StatsPage/__snapshots__/StatsPage.spec.tsx.snap
@@ -7700,7 +7700,9 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 <th>
                   Genetic Ancestry
                 </th>
-                <th>
+                <th
+                  className="rb"
+                >
                   Genetic Ancestry 
                 </th>
                 <th>
@@ -7709,7 +7711,9 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 <th>
                   XX
                 </th>
-                <th>
+                <th
+                  className="rb"
+                >
                   XY
                 </th>
                 <th>
@@ -7718,7 +7722,9 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 <th>
                   XX
                 </th>
-                <th>
+                <th
+                  className="rb"
+                >
                   XY
                 </th>
                 <th>
@@ -7739,7 +7745,9 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 <td>
                   Admixed American
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   amr
                 </td>
                 <td>
@@ -7748,7 +7756,9 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 <td>
                   12,845
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   9,517
                 </td>
                 <td>
@@ -7757,7 +7767,9 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 <td>
                   3,399
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   4,258
                 </td>
                 <td>
@@ -7774,7 +7786,9 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 <td>
                   African/African American
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   afr
                 </td>
                 <td>
@@ -7783,7 +7797,9 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 <td>
                   9,663
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   7,077
                 </td>
                 <td>
@@ -7792,7 +7808,9 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 <td>
                   11,094
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   9,711
                 </td>
                 <td>
@@ -7809,7 +7827,9 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 <td>
                   Ashkenazi Jewish
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   asj
                 </td>
                 <td>
@@ -7818,7 +7838,9 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 <td>
                   6,318
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   6,750
                 </td>
                 <td>
@@ -7827,7 +7849,9 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 <td>
                   934
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   802
                 </td>
                 <td>
@@ -7844,17 +7868,21 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 <td>
                   Amish
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   ami
                 </td>
                 <td>
-                  0
+                  -
                 </td>
                 <td>
-                  0
+                  -
                 </td>
-                <td>
-                  0
+                <td
+                  className="rb"
+                >
+                  -
                 </td>
                 <td>
                   456
@@ -7862,7 +7890,9 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 <td>
                   235
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   221
                 </td>
                 <td>
@@ -7879,7 +7909,9 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 <td>
                   East Asian
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   eas
                 </td>
                 <td>
@@ -7888,7 +7920,9 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 <td>
                   10,356
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   9,494
                 </td>
                 <td>
@@ -7897,7 +7931,9 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 <td>
                   1,136
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   1,462
                 </td>
                 <td>
@@ -7914,7 +7950,9 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 <td>
                   European (Finnish)
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   fin
                 </td>
                 <td>
@@ -7923,7 +7961,9 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 <td>
                   13,824
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   12,886
                 </td>
                 <td>
@@ -7932,7 +7972,9 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 <td>
                   1,287
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   4,029
                 </td>
                 <td>
@@ -7949,7 +7991,9 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 <td>
                   European (non-Finnish)
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   nfe
                 </td>
                 <td>
@@ -7958,7 +8002,9 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 <td>
                   286,144
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   269,862
                 </td>
                 <td>
@@ -7967,7 +8013,9 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 <td>
                   19,683
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   14,342
                 </td>
                 <td>
@@ -7984,7 +8032,9 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 <td>
                   Middle Eastern
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   mid
                 </td>
                 <td>
@@ -7993,7 +8043,9 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 <td>
                   1,253
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   1,631
                 </td>
                 <td>
@@ -8002,7 +8054,9 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 <td>
                   72
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   75
                 </td>
                 <td>
@@ -8019,7 +8073,9 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 <td>
                   Remaining
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   remaining
                 </td>
                 <td>
@@ -8028,7 +8084,9 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 <td>
                   15,900
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   14,298
                 </td>
                 <td>
@@ -8037,7 +8095,9 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 <td>
                   525
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   533
                 </td>
                 <td>
@@ -8054,7 +8114,9 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 <td>
                   South Asian
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   sas
                 </td>
                 <td>
@@ -8063,7 +8125,9 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 <td>
                   11,020
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   32,109
                 </td>
                 <td>
@@ -8072,7 +8136,9 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 <td>
                   577
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   1,840
                 </td>
                 <td>
@@ -8183,7 +8249,9 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 <th>
                   Genetic Ancestry
                 </th>
-                <th>
+                <th
+                  className="rb"
+                >
                   Genetic Ancestry 
                 </th>
                 <th>
@@ -8204,7 +8272,9 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 <td>
                   Admixed American
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   amr
                 </td>
                 <td>
@@ -8221,7 +8291,9 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 <td>
                   African/African American
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   afr
                 </td>
                 <td>
@@ -8238,7 +8310,9 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 <td>
                   Ashkenazi Jewish
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   asj
                 </td>
                 <td>
@@ -8255,7 +8329,9 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 <td>
                   East Asian
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   eas
                 </td>
                 <td>
@@ -8272,7 +8348,9 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 <td>
                   European (Finnish)
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   fin
                 </td>
                 <td>
@@ -8289,7 +8367,9 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 <td>
                   European (non-Finnish)
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   nfe
                 </td>
                 <td>
@@ -8306,7 +8386,9 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 <td>
                   Middle Eastern
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   mid
                 </td>
                 <td>
@@ -8323,7 +8405,9 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 <td>
                   Remaining
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   remaining
                 </td>
                 <td>
@@ -8340,7 +8424,9 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 <td>
                   South Asian
                 </td>
-                <td>
+                <td
+                  className="rb"
+                >
                   sas
                 </td>
                 <td>

--- a/browser/src/StatsPage/__snapshots__/StatsPage.spec.tsx.snap
+++ b/browser/src/StatsPage/__snapshots__/StatsPage.spec.tsx.snap
@@ -7596,6 +7596,15 @@ exports[`Stats Page has no unexpected changes 1`] = `
       >
         Inferred sex in gnomAD v4 per genetic ancestry group
       </h3>
+      <h4
+        style={
+          {
+            "marginBottom": "2em",
+          }
+        }
+      >
+        gnomAD v4
+      </h4>
       <div
         className="c36"
         style={
@@ -8155,6 +8164,15 @@ exports[`Stats Page has no unexpected changes 1`] = `
           </div>
         </div>
       </div>
+      <h4
+        style={
+          {
+            "marginBottom": "2em",
+          }
+        }
+      >
+        gnomAD v4 non-UKB
+      </h4>
       <div
         className="c36"
         style={
@@ -8403,7 +8421,7 @@ exports[`Stats Page has no unexpected changes 1`] = `
               className="c42"
             >
               <div>
-                Inferred sex counts of the gnomAD v4 samples per genetic ancestry group not including UK Bio Bank samples
+                Inferred sex counts of the gnomAD v4 samples per genetic ancestry group not including UK Biobank samples
               </div>
             </caption>
           </table>

--- a/browser/src/StatsPage/__snapshots__/StatsPage.spec.tsx.snap
+++ b/browser/src/StatsPage/__snapshots__/StatsPage.spec.tsx.snap
@@ -4392,7 +4392,7 @@ exports[`Stats Page has no unexpected changes 1`] = `
           }
         }
       >
-        Genetic Ancestry Groups in gnomAD by version
+        Genetic ancestry groups in gnomAD by version
       </h3>
       <div
         className="c4"
@@ -7594,7 +7594,7 @@ exports[`Stats Page has no unexpected changes 1`] = `
           }
         }
       >
-        Inferred sex in gnomAD v4 per Genetic Ancestry Group
+        Inferred sex in gnomAD v4 per genetic ancestry group
       </h3>
       <div
         className="c36"
@@ -8133,7 +8133,7 @@ exports[`Stats Page has no unexpected changes 1`] = `
               className="c42"
             >
               <div>
-                Inferred sex counts of gnomAD v4 samples per Genetic Ancestry Group
+                Inferred sex counts of gnomAD v4 samples per genetic ancestry group
               </div>
             </caption>
           </table>
@@ -8403,7 +8403,7 @@ exports[`Stats Page has no unexpected changes 1`] = `
               className="c42"
             >
               <div>
-                Inferred sex counts of the gnomAD v4 samples per Genetic Ancestry Group not including UK Bio Bank samples
+                Inferred sex counts of the gnomAD v4 samples per genetic ancestry group not including UK Bio Bank samples
               </div>
             </caption>
           </table>
@@ -8449,7 +8449,7 @@ exports[`Stats Page has no unexpected changes 1`] = `
               width={12}
             />
           </a>
-          Study-provided labels and Genetic Ancestry Groups
+          Study-provided labels and genetic ancestry groups
         </h2>
       </span>
       <p>

--- a/browser/src/StatsPage/__snapshots__/StatsPage.spec.tsx.snap
+++ b/browser/src/StatsPage/__snapshots__/StatsPage.spec.tsx.snap
@@ -4519,7 +4519,7 @@ exports[`Stats Page has no unexpected changes 1`] = `
               </tr>
               <tr>
                 <td>
-                  African
+                  African/African American
                 </td>
                 <td>
                   5,203
@@ -4634,7 +4634,7 @@ exports[`Stats Page has no unexpected changes 1`] = `
               </tr>
               <tr>
                 <td>
-                  Remaining Individuals^
+                  Remaining^
                 </td>
                 <td>
                   454
@@ -4696,10 +4696,10 @@ exports[`Stats Page has no unexpected changes 1`] = `
                   76,156
                 </td>
                 <td>
-                  -
+                  807,162
                 </td>
                 <td>
-                  807,162
+                  -
                 </td>
                 <td>
                   -


### PR DESCRIPTION
Resolves #1355 

Adds 2 tables to the stats page that display the number of inferred sex sample per genetic ancestry group in v4