### PR TITLE
Update pipeline to generate caids: add gnomAD v4 and update Hail usage

### DIFF
--- a/data-pipeline/caids/README.md
+++ b/data-pipeline/caids/README.md
@@ -5,6 +5,7 @@
    ```
    hailctl dataproc start my-cluster
 
+   hailctl dataproc submit my-cluster export_vcfs.py "gnomAD v4.0" gs://my-bucket/path/to/gnomad_v4.vcf.gz
    hailctl dataproc submit my-cluster export_vcfs.py "gnomAD v3.1.1" gs://my-bucket/path/to/gnomad_v3.vcf.gz
    hailctl dataproc submit my-cluster export_vcfs.py "gnomAD v2.1.1" gs://my-bucket/path/to/gnomad_v2.vcf.gz
    hailctl dataproc submit my-cluster export_vcfs.py "ExAC" gs://my-bucket/path/to/exac.vcf.gz
@@ -19,7 +20,8 @@
    ```
    gcloud compute instances create my-instance \
       --machine-type=e2-standard-2 \
-      --scopes=default,storage-rw
+      --scopes=default,storage-rw \
+      --subnet=my-subnet
    ```
 
    -  Connect to the instance.

--- a/data-pipeline/caids/export_vcfs.py
+++ b/data-pipeline/caids/export_vcfs.py
@@ -5,6 +5,15 @@ import argparse
 import hail as hl
 
 
+def get_gnomad_v4_variants() -> hl.Table:
+    """Get locus/alleles for all gnomAD v4 variants."""
+    ds = hl.read_table("gs://gcp-public-data--gnomad/release/4.0/ht/genomes/gnomad.genomes.v4.0.sites.ht")
+    ds = ds.select_globals()
+    ds = ds.select()
+    ds = ds.repartition(5000, shuffle=True)
+    return ds
+
+
 def get_gnomad_v3_variants() -> hl.Table:
     """Get locus/alleles for all gnomAD v3 variants."""
     ds = hl.read_table("gs://gcp-public-data--gnomad/release/3.1.1/ht/genomes/gnomad.genomes.v3.1.1.sites.ht")
@@ -45,6 +54,8 @@ def get_exac_variants() -> hl.Table:
 
 def get_variants(dataset: str) -> hl.Table:
     """Get locus/alleles for all variants in the given dataset."""
+    if dataset == "gnomAD v4.0":
+        return get_gnomad_v4_variants()
     if dataset == "gnomAD v3.1.1":
         return get_gnomad_v3_variants()
     if dataset == "gnomAD v2.1.1":
@@ -76,7 +87,7 @@ def export_vcfs(ds: hl.Table, output_url: str) -> None:
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("dataset", choices=("ExAC", "gnomAD v2.1.1", "gnomAD v3.1.1"))
+    parser.add_argument("dataset", choices=("ExAC", "gnomAD v2.1.1", "gnomAD v3.1.1", "gnomAD v4.0"))
     parser.add_argument("output_url")
     args = parser.parse_args()
 


### PR DESCRIPTION
This PR includes 2 updates to the data pipeline that generates a Hail table for `caids`:

1. Add gnomAD v4 to the pipeline
2. Update Hail imports and their usage to be compatible with newer versions of Hail
    * The `get_caids` module uses a number of Hail utils that have either been changed, removed or replaced since its last update
