### PR TITLE
Improve typing on variant table CSV export

### DIFF
--- a/browser/src/VariantList/ExportVariantsButton.tsx
+++ b/browser/src/VariantList/ExportVariantsButton.tsx
@@ -348,12 +348,12 @@ export type VariantTableVariant = {
   transcript_id: string
   transcript_version: string
   variant_id: string
-  exome?: {
+  exome: {
     filters: string[]
-  }
-  genome?: {
+  } | null
+  genome: {
     filters: string[]
-  }
+  } | null
 }
 
 type FilteredAlleleFrequency = {
@@ -362,10 +362,10 @@ type FilteredAlleleFrequency = {
 }
 
 type V2VariantTableVariant = VariantTableVariant & {
-  exome?: {
+  exome: {
     faf95: FilteredAlleleFrequency
   }
-  genome?: {
+  genome: {
     faf95: FilteredAlleleFrequency
   }
 }

--- a/browser/src/VariantList/ExportVariantsButton.tsx
+++ b/browser/src/VariantList/ExportVariantsButton.tsx
@@ -87,25 +87,34 @@ export const createVersionSpecificColumns = (datasetId: DatasetId) => {
     versionSpecificColumns = [
       {
         label: 'GroupMax FAF group',
-        getValue: (variant: any) =>
-          variant.faf95_joint.popmax_population !== null
-            ? variant.faf95_joint.popmax_population
-            : '',
+        getValue: (variant) => {
+          const v4Variant = variant as V4VariantTableVariant
+          return v4Variant.faf95_joint.popmax_population !== null
+            ? v4Variant.faf95_joint.popmax_population
+            : ''
+        },
       },
       {
         label: 'GroupMax FAF frequency',
-        getValue: (variant: any) =>
-          variant.faf95_joint.popmax !== null ? JSON.stringify(variant.faf95_joint.popmax) : '',
+        getValue: (variant) => {
+          const v4Variant = variant as V4VariantTableVariant
+          return v4Variant.faf95_joint.popmax !== null
+            ? JSON.stringify(v4Variant.faf95_joint.popmax)
+            : ''
+        },
       },
     ]
 
     inSilicoPredictorIds.forEach((id) => {
       const inSilicoColumn = {
         label: id,
-        getValue: (variant: any) =>
-          variant.in_silico_predictors.filter((predictor: any) => predictor.id === id).length > 0
-            ? variant.in_silico_predictors.filter((predictor: any) => predictor.id === id)[0].value
-            : '',
+        getValue: (variant: VariantTableVariant) => {
+          const v4Variant = variant as V4VariantTableVariant
+          return v4Variant.in_silico_predictors.filter((predictor) => predictor.id === id).length >
+            0
+            ? v4Variant.in_silico_predictors.filter((predictor) => predictor.id === id)[0].value
+            : ''
+        },
       }
       versionSpecificColumns = versionSpecificColumns.concat(inSilicoColumn)
     })
@@ -115,31 +124,39 @@ export const createVersionSpecificColumns = (datasetId: DatasetId) => {
     versionSpecificColumns = [
       {
         label: 'Exome GroupMax FAF group',
-        getValue: (variant: any) =>
-          variant.exome && variant.exome.faf95.popmax_population !== null
-            ? variant.exome.faf95.popmax_population
-            : '',
+        getValue: (variant) => {
+          const v2Variant = variant as V2VariantTableVariant
+          return v2Variant.exome && v2Variant.exome.faf95.popmax_population !== null
+            ? v2Variant.exome.faf95.popmax_population
+            : ''
+        },
       },
       {
         label: 'Exome GroupMax FAF frequency',
-        getValue: (variant: any) =>
-          variant.exome && variant.exome.faf95.popmax !== null
-            ? JSON.stringify(variant.exome.faf95.popmax)
-            : '',
+        getValue: (variant) => {
+          const v2Variant = variant as V2VariantTableVariant
+          return v2Variant.exome && v2Variant.exome.faf95.popmax !== null
+            ? JSON.stringify(v2Variant.exome.faf95.popmax)
+            : ''
+        },
       },
       {
         label: 'Genome GroupMax FAF group',
-        getValue: (variant: any) =>
-          variant.genome && variant.genome?.faf95.popmax_population !== null
-            ? variant.genome?.faf95.popmax_population
-            : '',
+        getValue: (variant) => {
+          const v2Variant = variant as V2VariantTableVariant
+          return v2Variant.genome && v2Variant.genome.faf95.popmax_population !== null
+            ? v2Variant.genome.faf95.popmax_population
+            : ''
+        },
       },
       {
         label: 'Genome GroupMax FAF frequency',
-        getValue: (variant: any) =>
-          variant.genome && variant.genome?.faf95.popmax !== null
-            ? JSON.stringify(variant.genome.faf95.popmax)
-            : '',
+        getValue: (variant) => {
+          const v2Variant = variant as V2VariantTableVariant
+          return v2Variant.genome && v2Variant.genome.faf95.popmax !== null
+            ? JSON.stringify(v2Variant.genome.faf95.popmax)
+            : ''
+        },
       },
     ]
   }
@@ -149,40 +166,40 @@ export const createVersionSpecificColumns = (datasetId: DatasetId) => {
 
 const exportVariantsToCsv = (
   variants: VariantTableVariant[],
-  datasetId: any,
-  baseFileName: any
+  datasetId: DatasetId,
+  baseFileName: string
 ) => {
   const DEFAULT_COLUMNS = [
     {
       label: 'gnomAD ID',
-      getValue: (variant: any) => variant.variant_id,
+      getValue: (variant: VariantTableVariant) => variant.variant_id,
     },
     {
       label: 'Chromosome',
-      getValue: (variant: any) => variant.variant_id.split('-')[0],
+      getValue: (variant: VariantTableVariant) => variant.variant_id.split('-')[0],
     },
     {
       label: 'Position',
-      getValue: (variant: any) => JSON.stringify(variant.pos),
+      getValue: (variant: VariantTableVariant) => JSON.stringify(variant.pos),
     },
     {
       label: 'rsIDs',
-      getValue: (variant: any) => (variant.rsids || []).join(';'),
+      getValue: (variant: VariantTableVariant) => (variant.rsids || []).join(';'),
     },
     {
       label: 'Reference',
-      getValue: (variant: any) => variant.variant_id.split('-')[2],
+      getValue: (variant: VariantTableVariant) => variant.variant_id.split('-')[2],
     },
     {
       label: 'Alternate',
-      getValue: (variant: any) => variant.variant_id.split('-')[3],
+      getValue: (variant: VariantTableVariant) => variant.variant_id.split('-')[3],
     },
     {
       label: 'Source',
       getValue:
         datasetId === 'exac'
           ? () => 'ExAC'
-          : (variant: any) => {
+          : (variant: VariantTableVariant) => {
               const sources = []
               if (variant.exome) {
                 sources.push('gnomAD Exomes')
@@ -195,7 +212,7 @@ const exportVariantsToCsv = (
     },
     {
       label: 'Filters - exomes',
-      getValue: (variant: any) => {
+      getValue: (variant: VariantTableVariant) => {
         if (!variant.exome) {
           return 'NA'
         }
@@ -204,7 +221,7 @@ const exportVariantsToCsv = (
     },
     {
       label: 'Filters - genomes',
-      getValue: (variant: any) => {
+      getValue: (variant: VariantTableVariant) => {
         if (!variant.genome) {
           return 'NA'
         }
@@ -213,56 +230,56 @@ const exportVariantsToCsv = (
     },
     {
       label: 'Transcript',
-      getValue: (variant: any) =>
+      getValue: (variant: VariantTableVariant) =>
         variant.transcript_id ? `${variant.transcript_id}.${variant.transcript_version}` : '',
     },
     {
       label: 'HGVS Consequence',
-      getValue: (variant: any) => variant.hgvs || '',
+      getValue: (variant: VariantTableVariant) => variant.hgvs || '',
     },
     {
       label: 'Protein Consequence',
-      getValue: (variant: any) => variant.hgvsp || '',
+      getValue: (variant: VariantTableVariant) => variant.hgvsp || '',
     },
     {
       label: 'Transcript Consequence',
-      getValue: (variant: any) => variant.hgvsc || '',
+      getValue: (variant: VariantTableVariant) => variant.hgvsc || '',
     },
     {
       label: 'VEP Annotation',
-      getValue: (variant: any) => variant.consequence || '',
+      getValue: (variant: VariantTableVariant) => variant.consequence || '',
     },
     {
       label: 'ClinVar Clinical Significance',
-      getValue: (variant: any) => variant.clinical_significance || '',
+      getValue: (variant: VariantTableVariant) => variant.clinical_significance || '',
     },
     {
       label: 'ClinVar Variation ID',
-      getValue: (variant: any) => variant.clinvar_variation_id || '',
+      getValue: (variant: VariantTableVariant) => variant.clinvar_variation_id || '',
     },
     {
       label: 'Flags',
-      getValue: (variant: any) => variant.flags.join(','),
+      getValue: (variant: VariantTableVariant) => variant.flags.join(','),
     },
     {
       label: 'Allele Count',
-      getValue: (variant: any) => JSON.stringify(variant.ac),
+      getValue: (variant: VariantTableVariant) => JSON.stringify(variant.ac),
     },
     {
       label: 'Allele Number',
-      getValue: (variant: any) => JSON.stringify(variant.an),
+      getValue: (variant: VariantTableVariant) => JSON.stringify(variant.an),
     },
     {
       label: 'Allele Frequency',
-      getValue: (variant: any) => JSON.stringify(variant.af),
+      getValue: (variant: VariantTableVariant) => JSON.stringify(variant.af),
     },
     {
       label: 'Homozygote Count',
-      getValue: (variant: any) => JSON.stringify(variant.ac_hom),
+      getValue: (variant: VariantTableVariant) => JSON.stringify(variant.ac_hom),
     },
     {
       label: 'Hemizygote Count',
-      getValue: (variant: any) => JSON.stringify(variant.ac_hemi),
+      getValue: (variant: VariantTableVariant) => JSON.stringify(variant.ac_hemi),
     },
   ]
 
@@ -275,7 +292,7 @@ const exportVariantsToCsv = (
   const headerRow = columns.map((c) => c.label)
 
   const csv = `${headerRow}\r\n${variants
-    .map((variant: any) =>
+    .map((variant) =>
       columns
         .map((c) => c.getValue(variant))
         .map((val) =>
@@ -312,12 +329,14 @@ const exportVariantsToCsv = (
   link.click()
 }
 
-export type VariantTableVariant = {
+type VariantTableVariant = {
   ac: number
   ac_hemi: number
   ac_hom: number
   an: number
   af: number
+  clinical_significance: string
+  clinvar_variation_id: string
   consequence?: string
   flags: string[]
   hgvs?: string
@@ -326,6 +345,8 @@ export type VariantTableVariant = {
   populations: Population[]
   pos: number
   rsids?: string[]
+  transcript_id: string
+  transcript_version: string
   variant_id: string
   exome?: {
     filters: string[]
@@ -335,8 +356,31 @@ export type VariantTableVariant = {
   }
 }
 
+type FilteredAlleleFrequency = {
+  popmax: number | null
+  popmax_population: string | null
+}
+
+type V2VariantTableVariant = VariantTableVariant & {
+  exome?: {
+    faf95: FilteredAlleleFrequency
+  }
+  genome?: {
+    faf95: FilteredAlleleFrequency
+  }
+}
+
+type V4VariantTableVariant = VariantTableVariant & {
+  faf95_joint: FilteredAlleleFrequency
+  in_silico_predictors: {
+    id: string
+    value: string
+    flags: string[]
+  }[]
+}
+
 type Props = {
-  datasetId: string
+  datasetId: DatasetId
   exportFileName: string
   variants: VariantTableVariant[]
 }

--- a/browser/src/VariantList/ExportVariantsButton.tsx
+++ b/browser/src/VariantList/ExportVariantsButton.tsx
@@ -329,7 +329,7 @@ const exportVariantsToCsv = (
   link.click()
 }
 
-type VariantTableVariant = {
+export type VariantTableVariant = {
   ac: number
   ac_hemi: number
   ac_hom: number

--- a/browser/src/__factories__/Variant.ts
+++ b/browser/src/__factories__/Variant.ts
@@ -152,8 +152,11 @@ export const variantTableVariantFactory = Factory.define<VariantTableVariant>(
       pos = 1,
       rsids = [],
       variant_id = '',
+      clinical_significance = 'benign',
+      clinvar_variation_id = '12345',
+      transcript_id = 'ENST00012345',
+      transcript_version = '1',
     } = params
-
     const {
       exome = {
         filters: [],
@@ -180,6 +183,10 @@ export const variantTableVariantFactory = Factory.define<VariantTableVariant>(
       variant_id,
       exome,
       genome,
+      clinical_significance,
+      clinvar_variation_id,
+      transcript_id,
+      transcript_version,
     }
   }
 )


### PR DESCRIPTION
Resolves: #1412 

Improves typing on the CSV export functionality on variant tables. Per discussion with Phil, the component now utilizes several different types to characterize the differing possible fields of variants from different datasets.

For now, there is no interface that acts as an abstract base type, as the minimal
`VariantTableVariant` type serves as a concrete type for a generic variant table variant (exac and v3), in addition to two more specialized types introduced for v2 and v4 variant table variants. I'm happy to change this if we think having an interface act as the base type is a better pattern. 