### PR TITLE
Correct label of type of V4 SV checksums to crc32c

### DIFF
--- a/browser/src/DownloadsPage/GnomadV4Downloads.tsx
+++ b/browser/src/DownloadsPage/GnomadV4Downloads.tsx
@@ -69,30 +69,30 @@ const genomeChromosomeVcfs = [
 ]
 
 const svChromosomeVcfs = [
-  { chrom: '1', size: '616.33 MiB', crc32: 'f497d60f' },
-  { chrom: '2', size: '612.83 MiB', crc32: 'bee58761' },
-  { chrom: '3', size: '469.64 MiB', crc32: '00c11e03' },
-  { chrom: '4', size: '446.44 MiB', crc32: '4aa1be45' },
-  { chrom: '5', size: '418.1 MiB', crc32: 'cc78d775' },
-  { chrom: '6', size: '418.37 MiB', crc32: '8ad01764' },
-  { chrom: '7', size: '437.99 MiB', crc32: '0e78bed7' },
-  { chrom: '8', size: '332.91 MiB', crc32: '1a7974d3' },
-  { chrom: '9', size: '289.19 MiB', crc32: '693c4cc1' },
-  { chrom: '10', size: '320.36 MiB', crc32: '63dc92db' },
-  { chrom: '11', size: '312.75 MiB', crc32: 'c0016756' },
-  { chrom: '12', size: '322.33 MiB', crc32: '28396743' },
-  { chrom: '13', size: '208.4 MiB', crc32: '504d3937' },
-  { chrom: '14', size: '218.37 MiB', crc32: '06ccecf9' },
-  { chrom: '15', size: '183.5 MiB', crc32: 'c191b2ca' },
-  { chrom: '16', size: '234 MiB', crc32: '016c8e77' },
-  { chrom: '17', size: '233.1 MiB', crc32: 'f37738a4' },
-  { chrom: '18', size: '157.88 MiB', crc32: '1f802ad6' },
-  { chrom: '19', size: '227.48 MiB', crc32: '16a48cf0' },
-  { chrom: '20', size: '148.62 MiB', crc32: '7e34ac14' },
-  { chrom: '21', size: '109.55 MiB', crc32: '6805d560' },
-  { chrom: '22', size: '112.34 MiB', crc32: '3a0cce90' },
-  { chrom: 'X', size: '335.93 MiB', crc32: '1b49e5a6' },
-  { chrom: 'Y', size: '50.76 MiB', crc32: 'd8a3a636' },
+  { chrom: '1', size: '616.33 MiB', crc32c: 'f497d60f' },
+  { chrom: '2', size: '612.83 MiB', crc32c: 'bee58761' },
+  { chrom: '3', size: '469.64 MiB', crc32c: '00c11e03' },
+  { chrom: '4', size: '446.44 MiB', crc32c: '4aa1be45' },
+  { chrom: '5', size: '418.1 MiB', crc32c: 'cc78d775' },
+  { chrom: '6', size: '418.37 MiB', crc32c: '8ad01764' },
+  { chrom: '7', size: '437.99 MiB', crc32c: '0e78bed7' },
+  { chrom: '8', size: '332.91 MiB', crc32c: '1a7974d3' },
+  { chrom: '9', size: '289.19 MiB', crc32c: '693c4cc1' },
+  { chrom: '10', size: '320.36 MiB', crc32c: '63dc92db' },
+  { chrom: '11', size: '312.75 MiB', crc32c: 'c0016756' },
+  { chrom: '12', size: '322.33 MiB', crc32c: '28396743' },
+  { chrom: '13', size: '208.4 MiB', crc32c: '504d3937' },
+  { chrom: '14', size: '218.37 MiB', crc32c: '06ccecf9' },
+  { chrom: '15', size: '183.5 MiB', crc32c: 'c191b2ca' },
+  { chrom: '16', size: '234 MiB', crc32c: '016c8e77' },
+  { chrom: '17', size: '233.1 MiB', crc32c: 'f37738a4' },
+  { chrom: '18', size: '157.88 MiB', crc32c: '1f802ad6' },
+  { chrom: '19', size: '227.48 MiB', crc32c: '16a48cf0' },
+  { chrom: '20', size: '148.62 MiB', crc32c: '7e34ac14' },
+  { chrom: '21', size: '109.55 MiB', crc32c: '6805d560' },
+  { chrom: '22', size: '112.34 MiB', crc32c: '3a0cce90' },
+  { chrom: 'X', size: '335.93 MiB', crc32c: '1b49e5a6' },
+  { chrom: 'Y', size: '50.76 MiB', crc32c: 'd8a3a636' },
 ]
 
 const GnomadV4Downloads = () => {
@@ -270,14 +270,14 @@ const GnomadV4Downloads = () => {
           <Link to="/help/sv-overview">help text</Link>
         </p>
         <FileList>
-          {svChromosomeVcfs.map(({ chrom, size, crc32 }) => (
+          {svChromosomeVcfs.map(({ chrom, size, crc32c }) => (
             // @ts-expect-error TS(2769) FIXME: No overload matches this call.
             <ListItem key={chrom}>
               <DownloadLinks
                 label={`chr${chrom} VCF`}
                 path={`/release/4.0/genome_sv/gnomad.v4.0.sv.chr${chrom}.vcf.gz`}
                 size={size}
-                crc32={crc32}
+                crc32c={crc32c}
                 includeTBI
               />
             </ListItem>

--- a/browser/src/DownloadsPage/__snapshots__/DownloadsPage.spec.tsx.snap
+++ b/browser/src/DownloadsPage/__snapshots__/DownloadsPage.spec.tsx.snap
@@ -5187,7 +5187,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           <br />
           <span>
             616.33 MiB
-            , CRC32: 
+            , CRC32C: 
             f497d60f
           </span>
           <br />
@@ -5268,7 +5268,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           <br />
           <span>
             612.83 MiB
-            , CRC32: 
+            , CRC32C: 
             bee58761
           </span>
           <br />
@@ -5349,7 +5349,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           <br />
           <span>
             469.64 MiB
-            , CRC32: 
+            , CRC32C: 
             00c11e03
           </span>
           <br />
@@ -5430,7 +5430,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           <br />
           <span>
             446.44 MiB
-            , CRC32: 
+            , CRC32C: 
             4aa1be45
           </span>
           <br />
@@ -5511,7 +5511,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           <br />
           <span>
             418.1 MiB
-            , CRC32: 
+            , CRC32C: 
             cc78d775
           </span>
           <br />
@@ -5592,7 +5592,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           <br />
           <span>
             418.37 MiB
-            , CRC32: 
+            , CRC32C: 
             8ad01764
           </span>
           <br />
@@ -5673,7 +5673,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           <br />
           <span>
             437.99 MiB
-            , CRC32: 
+            , CRC32C: 
             0e78bed7
           </span>
           <br />
@@ -5754,7 +5754,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           <br />
           <span>
             332.91 MiB
-            , CRC32: 
+            , CRC32C: 
             1a7974d3
           </span>
           <br />
@@ -5835,7 +5835,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           <br />
           <span>
             289.19 MiB
-            , CRC32: 
+            , CRC32C: 
             693c4cc1
           </span>
           <br />
@@ -5916,7 +5916,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           <br />
           <span>
             320.36 MiB
-            , CRC32: 
+            , CRC32C: 
             63dc92db
           </span>
           <br />
@@ -5997,7 +5997,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           <br />
           <span>
             312.75 MiB
-            , CRC32: 
+            , CRC32C: 
             c0016756
           </span>
           <br />
@@ -6078,7 +6078,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           <br />
           <span>
             322.33 MiB
-            , CRC32: 
+            , CRC32C: 
             28396743
           </span>
           <br />
@@ -6159,7 +6159,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           <br />
           <span>
             208.4 MiB
-            , CRC32: 
+            , CRC32C: 
             504d3937
           </span>
           <br />
@@ -6240,7 +6240,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           <br />
           <span>
             218.37 MiB
-            , CRC32: 
+            , CRC32C: 
             06ccecf9
           </span>
           <br />
@@ -6321,7 +6321,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           <br />
           <span>
             183.5 MiB
-            , CRC32: 
+            , CRC32C: 
             c191b2ca
           </span>
           <br />
@@ -6402,7 +6402,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           <br />
           <span>
             234 MiB
-            , CRC32: 
+            , CRC32C: 
             016c8e77
           </span>
           <br />
@@ -6483,7 +6483,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           <br />
           <span>
             233.1 MiB
-            , CRC32: 
+            , CRC32C: 
             f37738a4
           </span>
           <br />
@@ -6564,7 +6564,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           <br />
           <span>
             157.88 MiB
-            , CRC32: 
+            , CRC32C: 
             1f802ad6
           </span>
           <br />
@@ -6645,7 +6645,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           <br />
           <span>
             227.48 MiB
-            , CRC32: 
+            , CRC32C: 
             16a48cf0
           </span>
           <br />
@@ -6726,7 +6726,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           <br />
           <span>
             148.62 MiB
-            , CRC32: 
+            , CRC32C: 
             7e34ac14
           </span>
           <br />
@@ -6807,7 +6807,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           <br />
           <span>
             109.55 MiB
-            , CRC32: 
+            , CRC32C: 
             6805d560
           </span>
           <br />
@@ -6888,7 +6888,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           <br />
           <span>
             112.34 MiB
-            , CRC32: 
+            , CRC32C: 
             3a0cce90
           </span>
           <br />
@@ -6969,7 +6969,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           <br />
           <span>
             335.93 MiB
-            , CRC32: 
+            , CRC32C: 
             1b49e5a6
           </span>
           <br />
@@ -7050,7 +7050,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           <br />
           <span>
             50.76 MiB
-            , CRC32: 
+            , CRC32C: 
             d8a3a636
           </span>
           <br />

--- a/browser/src/DownloadsPage/downloadsPageStyles.tsx
+++ b/browser/src/DownloadsPage/downloadsPageStyles.tsx
@@ -242,7 +242,7 @@ type OwnDownloadLinksProps = {
   path: string
   size?: string
   md5?: string
-  crc32?: string
+  crc32c?: string
   gcsBucket?: string
   includeGCP?: boolean
   includeAWS?: boolean
@@ -251,8 +251,7 @@ type OwnDownloadLinksProps = {
 }
 
 // @ts-expect-error TS(2456) FIXME: Type alias 'DownloadLinksProps' circula... Remove this comment to see the full error message
-type DownloadLinksProps = OwnDownloadLinksProps &
-  typeof DownloadLinks.defaultProps
+type DownloadLinksProps = OwnDownloadLinksProps & typeof DownloadLinks.defaultProps
 
 // @ts-expect-error TS(7022) FIXME: 'DownloadLinks' implicitly has type 'an... Remove this comment to see the full error message
 export const DownloadLinks = ({
@@ -260,7 +259,7 @@ export const DownloadLinks = ({
   path,
   size,
   md5,
-  crc32,
+  crc32c,
   gcsBucket,
   includeGCP,
   includeAWS,
@@ -279,10 +278,10 @@ export const DownloadLinks = ({
           <br />
         </>
       )}
-      {size && crc32 && (
+      {size && crc32c && (
         <>
           <span>
-            {size}, CRC32:&nbsp;{crc32}
+            {size}, CRC32C:&nbsp;{crc32c}
           </span>
           <br />
         </>
@@ -324,42 +323,42 @@ export const DownloadLinks = ({
       </span>
       {includeTBI && (
         <>
-        <br />
-        <span>
-          Download TBI from{' '}
-          {renderDownloadOptions([
-            includeGCP && (
-              // @ts-expect-error TS(2786) FIXME: 'ExternalLink' cannot be used as a JSX component.
-              <ExternalLink
-                key="gcp"
-                aria-label={`Download TBI file for ${label} from Google`}
-                href={`https://storage.googleapis.com/${gcsBucket}${path}.tbi`}
-              >
-                Google
-              </ExternalLink>
-            ),
-            includeAWS && (
-              // @ts-expect-error TS(2786) FIXME: 'ExternalLink' cannot be used as a JSX component.
-              <ExternalLink
-                key="aws"
-                aria-label={`Download TBI file for ${label} from Amazon`}
-                href={`https://gnomad-public-us-east-1.s3.amazonaws.com${path}.tbi`}
-              >
-                Amazon
-              </ExternalLink>
-            ),
-            includeAzure && (
-              // @ts-expect-error TS(2786) FIXME: 'ExternalLink' cannot be used as a JSX component.
-              <ExternalLink
-                key="azure"
-                aria-label={`Download TBI file for ${label} from Microsoft`}
-                href={`https://datasetgnomad.blob.core.windows.net/dataset${path}.tbi`}
-              >
-                Microsoft
-              </ExternalLink>
-            ),
-          ])}
-        </span>
+          <br />
+          <span>
+            Download TBI from{' '}
+            {renderDownloadOptions([
+              includeGCP && (
+                // @ts-expect-error TS(2786) FIXME: 'ExternalLink' cannot be used as a JSX component.
+                <ExternalLink
+                  key="gcp"
+                  aria-label={`Download TBI file for ${label} from Google`}
+                  href={`https://storage.googleapis.com/${gcsBucket}${path}.tbi`}
+                >
+                  Google
+                </ExternalLink>
+              ),
+              includeAWS && (
+                // @ts-expect-error TS(2786) FIXME: 'ExternalLink' cannot be used as a JSX component.
+                <ExternalLink
+                  key="aws"
+                  aria-label={`Download TBI file for ${label} from Amazon`}
+                  href={`https://gnomad-public-us-east-1.s3.amazonaws.com${path}.tbi`}
+                >
+                  Amazon
+                </ExternalLink>
+              ),
+              includeAzure && (
+                // @ts-expect-error TS(2786) FIXME: 'ExternalLink' cannot be used as a JSX component.
+                <ExternalLink
+                  key="azure"
+                  aria-label={`Download TBI file for ${label} from Microsoft`}
+                  href={`https://datasetgnomad.blob.core.windows.net/dataset${path}.tbi`}
+                >
+                  Microsoft
+                </ExternalLink>
+              ),
+            ])}
+          </span>
         </>
       )}
     </>


### PR DESCRIPTION
Resolves: https://discuss.gnomad.broadinstitute.org/t/unmatched-crc32-values-of-gnomad-v4-structural-variants-vcf-files/185/2

Currently, the checksums displayed for the v4 SVs are crc32c checksums, but the download page incorrectly lists them as crc32 checksums. This is a small PR that fixes the labeling of those checksums to match what they actually are.