### PR TITLE
V4 variants data pipeline: add task for CAIDs annotation

### DIFF
--- a/data-pipeline/src/data_pipeline/data_types/variant/__init__.py
+++ b/data-pipeline/src/data_pipeline/data_types/variant/__init__.py
@@ -1,10 +1,11 @@
-from .annotate_variants import annotate_variants
+from .annotate_variants import annotate_variants, annotate_caids
 from .transcript_consequence.annotate_transcript_consequences import annotate_transcript_consequences
 from .variant_id import variant_id, variant_ids, compressed_variant_id
 
 __all__ = [
     "annotate_variants",
     "annotate_transcript_consequences",
+    "annotate_caids",
     "variant_id",
     "variant_ids",
     "compressed_variant_id",

--- a/data-pipeline/src/data_pipeline/data_types/variant/annotate_variants.py
+++ b/data-pipeline/src/data_pipeline/data_types/variant/annotate_variants.py
@@ -1,7 +1,7 @@
 import hail as hl
 
 
-def annotate_variants(variants_path, exome_coverage_path=None, genome_coverage_path=None, caids_path=None):
+def annotate_variants(variants_path, exome_coverage_path=None, genome_coverage_path=None):
     ds = hl.read_table(variants_path)
 
     ds = ds.annotate(coverage=hl.struct())
@@ -11,6 +11,12 @@ def annotate_variants(variants_path, exome_coverage_path=None, genome_coverage_p
     if genome_coverage_path:
         genome_coverage = hl.read_table(genome_coverage_path)
         ds = ds.annotate(coverage=ds.coverage.annotate(genome=genome_coverage[ds.locus].drop("xpos")))
+
+    return ds
+
+
+def annotate_caids(variants_path, caids_path=None):
+    ds = hl.read_table(variants_path)
 
     if caids_path:
         caids = hl.read_table(caids_path)

--- a/data-pipeline/src/data_pipeline/datasets/gnomad_v4/gnomad_v4_validation.py
+++ b/data-pipeline/src/data_pipeline/datasets/gnomad_v4/gnomad_v4_validation.py
@@ -17,6 +17,7 @@ from data_pipeline.datasets.gnomad_v4.types.initial_variant import InitialVarian
 from data_pipeline.datasets.gnomad_v4.types.prepare_variants_step1 import Variant as Step1Variant
 from data_pipeline.datasets.gnomad_v4.types.prepare_variants_step2 import Variant as Step2Variant
 from data_pipeline.datasets.gnomad_v4.types.prepare_variants_step3 import Variant as Step3Variant
+from data_pipeline.datasets.gnomad_v4.types.prepare_variants_step4 import Variant as Step4Variant
 
 c = Converter(forbid_extra_keys=True)
 
@@ -114,3 +115,11 @@ def validate_step3_output(pipeline: Pipeline):
     ht = ht.sample(0.001, 1337)
     validate_rows(ht, Step3Variant)
     logger.info("Validated annotate_gnomad_v4_transcript_consequences (step 3) output")
+
+
+def validate_step4_output(pipeline: Pipeline):
+    output_path = pipeline.get_task("annotate_gnomad_v4_caids").get_output_path()
+    ht = hl.read_table(output_path)
+    ht = ht.sample(0.001, 1337)
+    validate_rows(ht, Step4Variant)
+    logger.info("Validated annotate_gnomad_v4_caids (step 4) output")

--- a/data-pipeline/src/data_pipeline/datasets/gnomad_v4/types/prepare_variants_step2.py
+++ b/data-pipeline/src/data_pipeline/datasets/gnomad_v4/types/prepare_variants_step2.py
@@ -27,4 +27,3 @@ class Coverage:
 @attr.define
 class Variant(Step1Variant):
     coverage: Coverage
-    # caids go here too

--- a/data-pipeline/src/data_pipeline/datasets/gnomad_v4/types/prepare_variants_step4.py
+++ b/data-pipeline/src/data_pipeline/datasets/gnomad_v4/types/prepare_variants_step4.py
@@ -1,0 +1,8 @@
+import attr
+
+from data_pipeline.datasets.gnomad_v4.types.prepare_variants_step3 import Variant as Step3Variant
+
+
+@attr.define
+class Variant(Step3Variant):
+    caid: str

--- a/data-pipeline/src/data_pipeline/pipelines/gnomad_v4_variants.py
+++ b/data-pipeline/src/data_pipeline/pipelines/gnomad_v4_variants.py
@@ -21,11 +21,13 @@ from data_pipeline.datasets.gnomad_v4.gnomad_v4_validation import (
     validate_step1_output,
     validate_step2_output,
     validate_step3_output,
+    validate_step4_output,
 )
 
 from data_pipeline.data_types.variant import (
     annotate_variants,
     annotate_transcript_consequences,
+    annotate_caids,
 )
 
 RUN = True
@@ -62,7 +64,6 @@ pipeline.add_task(
             "variants_path": pipeline.get_task("prepare_gnomad_v4_variants"),
             "exome_coverage_path": "gs://gcp-public-data--gnomad/release/4.0/coverage/exomes/gnomad.exomes.v4.0.coverage.ht",
             "genome_coverage_path": "gs://gcp-public-data--gnomad/release/3.0.1/coverage/genomes/gnomad.genomes.r3.0.1.coverage.ht",
-            # "caids_path": "gs://gnomad-browser-data-pipeline/caids/gnomad_v4_caids.ht",
         }
     ),
 )
@@ -78,11 +79,21 @@ pipeline.add_task(
     },
 )
 
+pipeline.add_task(
+    name="annotate_gnomad_v4_caids",
+    task_function=annotate_caids,
+    output_path=f"{output_sub_dir}/gnomad_v4_variants_annotated_3.ht",
+    inputs={
+        "variants_path": pipeline.get_task("annotate_gnomad_v4_transcript_consequences"),
+        "caids_path": "gs://gnomad-browser-data-pipeline/caids/gnomad_v4_caids.ht",
+    },
+)
+
 ###############################################
 # Outputs
 ###############################################
 
-pipeline.set_outputs({"variants": "annotate_gnomad_v4_transcript_consequences"})
+pipeline.set_outputs({"variants": "annotate_gnomad_v4_caids"})
 
 ###############################################
 # Run
@@ -99,6 +110,7 @@ if __name__ == "__main__":
                 "prepare_gnomad_v4_variants",
                 "annotate_gnomad_v4_variants",
                 "annotate_gnomad_v4_transcript_consequences",
+                "annotate_gnomad_v4_caids",
             ],
         )
         # copy locally using:
@@ -113,3 +125,4 @@ if __name__ == "__main__":
     validate_step1_output(pipeline)
     validate_step2_output(pipeline)
     validate_step3_output(pipeline)
+    validate_step4_output(pipeline)


### PR DESCRIPTION
This PR is a continuation of the work started in #1419. It adds a task to the V4 variants pipeline to add ClinGen Canonical Allele IDs (CAIDs) to the variants dataset. It uses the output CAIDs Hail table from #1419 to do so.

Originally, the pipeline was written to do this work in step 2 of the pipeline, but the adding of CAIDs was bypassed during the V4 release because the CAIDs Hail table was not yet created.

Now that the table is ready to use for annotating the variants dataset, it would be easier to do by adding a new step (4) to the end of the pipeline to simply use the output of step 3 (current state of the variants dataset). Alternatively, re-running the pipeline as originally written (add CAIDs in step 2) would require running more steps and overwriting the existing outputs, specifically steps 2 and 3.
