### PR TITLE
Update RMC track to display region coordinates

### DIFF
--- a/browser/src/RegionalMissenseConstraintTrack.spec.tsx
+++ b/browser/src/RegionalMissenseConstraintTrack.spec.tsx
@@ -47,6 +47,22 @@ describe('RegionaMissenseConstraintTrack', () => {
           { start: 6, stop: 8, i: 2, j: 3 },
         ],
       },
+      {
+        regions1: [
+          { start: 2, stop: 4, region_start: 2, region_stop: 4 },
+          { start: 6, stop: 8, region_start: 6, region_stop: 8 },
+        ],
+        regions2: [
+          { start: 1, stop: 3, j: 1 },
+          { start: 3, stop: 5, j: 2 },
+          { start: 5, stop: 9, j: 3 },
+        ],
+        expected: [
+          { start: 2, stop: 3, region_start: 2, region_stop: 4, j: 1 },
+          { start: 3, stop: 4, region_start: 2, region_stop: 4, j: 2 },
+          { start: 6, stop: 8, region_start: 6, region_stop: 8, j: 3 },
+        ],
+      },
     ]
 
     testCases.forEach(({ regions1, regions2, expected }) => {

--- a/browser/src/RegionalMissenseConstraintTrack.tsx
+++ b/browser/src/RegionalMissenseConstraintTrack.tsx
@@ -14,6 +14,8 @@ type RegionalMissenseConstraintRegion = {
   chrom: string
   start: number
   stop: number
+  region_start: number
+  region_stop: number
   aa_start: string | null
   aa_stop: string | null
   obs_mis: number | undefined
@@ -55,7 +57,9 @@ const RegionAttributeList = styled.dl`
   }
 `
 
-export const regionIntersections = (regionArrays: { start: number; stop: number }[][]) => {
+export const regionIntersections = (
+  regionArrays: { start: number; stop: number }[][]
+): RegionalMissenseConstraintRegion[] => {
   const sortedRegionsArrays = regionArrays.map((regions) =>
     [...regions].sort((a, b) => a.start - b.start)
   )
@@ -212,7 +216,7 @@ const RegionTooltip = ({ region, isTranscriptWide }: RegionTooltipProps) => {
     <RegionAttributeList>
       <div>
         <dt>Coordinates:</dt>
-        <dd>{`${region.chrom}:${region.start}-${region.stop}`}</dd>
+        <dd>{`${region.chrom}:${region.region_start}-${region.region_stop}`}</dd>
       </div>
       <div>
         <dt>Amino acids:</dt>
@@ -315,6 +319,8 @@ const RegionalMissenseConstraintTrack = ({ regionalMissenseConstraint, gene }: P
           chrom: gene.chrom,
           start: Math.min(gene.start, gene.stop),
           stop: Math.max(gene.start, gene.stop),
+          region_start: Math.min(gene.start, gene.stop),
+          region_stop: Math.max(gene.start, gene.stop),
           obs_mis: gene.gnomad_constraint.obs_mis,
           exp_mis: gene.gnomad_constraint.exp_mis,
           obs_exp: gene.gnomad_constraint.oe_mis,
@@ -329,7 +335,13 @@ const RegionalMissenseConstraintTrack = ({ regionalMissenseConstraint, gene }: P
   }
 
   const constrainedExons = regionIntersections([
-    regionalMissenseConstraint.regions,
+    regionalMissenseConstraint.regions.map((region) => {
+      return {
+        ...region,
+        region_start: region.start,
+        region_stop: region.stop,
+      }
+    }),
     gene.exons.filter((exon) => exon.feature_type === 'CDS'),
   ])
 


### PR DESCRIPTION
Resolves #1417 

Updates the RMC track to display the coordinates for the respective RMC region when one hovers over an exon shadow, rather than displaying the coordinates of the exon.

--- 

Per the issue, if the first two regions on BAP1 are hovered over, they now both display the coordinates for the region (`3:52436307-52436831`).

- <img src="https://github.com/broadinstitute/gnomad-browser/assets/59549713/642c00ad-ebbe-4b20-8513-a390af2c9ae1" width="500">

- <img src="https://github.com/broadinstitute/gnomad-browser/assets/59549713/2edf5613-2f56-4a99-8558-ec0e388ed402" width="500">


