### PR TITLE
Update metadata to render genomic constraint for v4

### DIFF
--- a/dataset-metadata/metadata.ts
+++ b/dataset-metadata/metadata.ts
@@ -207,9 +207,9 @@ const metadataForDataset = (datasetId: DatasetId): DatasetMetadata => ({
   transcriptsHaveExomeCoverage: !datasetId.startsWith('gnomad_r3') && datasetId !== 'gnomad_sv_r4',
   referenceGenome:
     datasetId.startsWith('gnomad_r3') ||
-      datasetId.startsWith('gnomad_r4') ||
-      datasetId === 'gnomad_sv_r4' ||
-      datasetId === 'gnomad_cnv_r4'
+    datasetId.startsWith('gnomad_r4') ||
+    datasetId === 'gnomad_sv_r4' ||
+    datasetId === 'gnomad_cnv_r4'
       ? 'GRCh38'
       : 'GRCh37',
   genesHaveGenomeCoverage: !datasetId.startsWith('gnomad_cnv'),
@@ -245,7 +245,10 @@ const metadataForDataset = (datasetId: DatasetId): DatasetMetadata => ({
   hasRelatedVariants: datasetId !== 'gnomad_r2_1',
   showAllIndividualsInAgeDistributionByDefault: datasetId !== 'exac',
   hasExons: !datasetId.startsWith('gnomad_sv'),
-  hasShortTandemRepeats: datasetId.startsWith('gnomad_r3') || datasetId.startsWith('gnomad_r4') || datasetId === "gnomad_sv_r4",
+  hasShortTandemRepeats:
+    datasetId.startsWith('gnomad_r3') ||
+    datasetId.startsWith('gnomad_r4') ||
+    datasetId === 'gnomad_sv_r4',
   hasMitochondrialGenomeCoverage: !(datasetId === 'exac' || datasetId.startsWith('gnomad_r2')),
   hasMitochondrialVariants: !(datasetId === 'exac' || datasetId.startsWith('gnomad_r2')),
   hasNonCodingReadData: !(datasetId === 'exac' || datasetId.startsWith('gnomad_r2')),

--- a/dataset-metadata/metadata.ts
+++ b/dataset-metadata/metadata.ts
@@ -201,7 +201,10 @@ const metadataForDataset = (datasetId: DatasetId): DatasetMetadata => ({
     datasetId.startsWith('gnomad_r2') ||
     datasetId.startsWith('gnomad_sv_r2') ||
     datasetId === 'exac',
-  hasNonCodingConstraints: datasetId.startsWith('gnomad_r3') || datasetId === 'gnomad_sv_r4',
+  hasNonCodingConstraints:
+    datasetId.startsWith('gnomad_r3') ||
+    datasetId.startsWith('gnomad_r4') ||
+    datasetId === 'gnomad_sv_r4',
   hasExome: !datasetId.startsWith('gnomad_r3') && datasetId !== 'gnomad_sv_r4',
   genesHaveExomeCoverage: !datasetId.startsWith('gnomad_r3') && datasetId !== 'gnomad_sv_r4',
   transcriptsHaveExomeCoverage: !datasetId.startsWith('gnomad_r3') && datasetId !== 'gnomad_sv_r4',

--- a/dataset-metadata/metadata.ts
+++ b/dataset-metadata/metadata.ts
@@ -209,12 +209,7 @@ const metadataForDataset = (datasetId: DatasetId): DatasetMetadata => ({
   genesHaveExomeCoverage: !datasetId.startsWith('gnomad_r3') && datasetId !== 'gnomad_sv_r4',
   transcriptsHaveExomeCoverage: !datasetId.startsWith('gnomad_r3') && datasetId !== 'gnomad_sv_r4',
   referenceGenome:
-    datasetId.startsWith('gnomad_r3') ||
-    datasetId.startsWith('gnomad_r4') ||
-    datasetId === 'gnomad_sv_r4' ||
-    datasetId === 'gnomad_cnv_r4'
-      ? 'GRCh38'
-      : 'GRCh37',
+    datasetId.startsWith('gnomad_r3') || datasetId.endsWith('r4') ? 'GRCh38' : 'GRCh37',
   genesHaveGenomeCoverage: !datasetId.startsWith('gnomad_cnv'),
   regionsHaveExomeCoverage:
     !datasetId.startsWith('gnomad_sv') && !datasetId.startsWith('gnomad_r3'),


### PR DESCRIPTION
Resolves #1421 

Updates the metadata so that non-coding constraint renders on v4 region and variant pages.

---

![Screenshot 2024-03-08 at 16 11 39](https://github.com/broadinstitute/gnomad-browser/assets/59549713/f2172c8c-6e91-4b89-944c-e4c9829963e6)
