### PR TITLE
Log button clicks of pext track in GA4

### DIFF
--- a/browser/src/GenePage/TissueExpressionTrack.tsx
+++ b/browser/src/GenePage/TissueExpressionTrack.tsx
@@ -12,6 +12,8 @@ import { Badge, Button, Modal, SearchInput, Select, TooltipAnchor } from '@gnoma
 import { GTEX_TISSUE_COLORS, GTEX_TISSUE_NAMES } from '../gtex'
 import InfoButton from '../help/InfoButton'
 
+import { logAnalyticsEvent } from '../analytics'
+
 import TranscriptsTissueExpression from './TranscriptsTissueExpression'
 
 const getPlotRegions = (expressionRegions: any, getValueForRegion: any) => {
@@ -426,6 +428,13 @@ const TissueExpressionTrack = ({
                     paddingRight: '0.25em',
                   }}
                   onClick={() => {
+                    if (!isExpanded) {
+                      logAnalyticsEvent(
+                        'button_click',
+                        'User Interaction',
+                        'User expanded v2 tissue expression track'
+                      )
+                    }
                     setIsExpanded(!isExpanded)
                   }}
                 >

--- a/browser/src/analytics.ts
+++ b/browser/src/analytics.ts
@@ -1,0 +1,14 @@
+export const logAnalyticsEvent = (
+  eventName: string,
+  eventCategory: string,
+  eventLabel: string
+): void => {
+  if ((window as any).gtag) {
+    ;(window as any).gtag('event', eventName, {
+      event_category: eventCategory,
+      event_label: eventLabel,
+    })
+  }
+
+  return undefined
+}


### PR DESCRIPTION
Adds tracking to the v2 pext button to log how many times the button gets clicked

---

![Screenshot 2024-03-08 at 16 57 25](https://github.com/broadinstitute/gnomad-browser/assets/59549713/a11a43b4-e29b-455e-8ad0-852b6a263009)
