### PR TITLE
make the API pods larger

### DIFF
--- a/deploy/manifests/browser/base/api.deployment.yaml
+++ b/deploy/manifests/browser/base/api.deployment.yaml
@@ -60,17 +60,17 @@ spec:
             - name: JSON_CACHE_COMPRESSION
               value: 'true'
             - name: NODE_OPTIONS
-              value: '--max-old-space-size=3072'
+              value: '--max-old-space-size=6144'
           ports:
             - name: http
               containerPort: 8000
           resources:
             requests:
               cpu: '1'
-              memory: '2Gi'
+              memory: '7Gi'
             limits:
               cpu: '2'
-              memory: '4Gi'
+              memory: '8Gi'
           readinessProbe:
             httpGet:
               path: /health/ready


### PR DESCRIPTION
We're fairly consistently getting container restarts when pods reach their 3GB javascript heap limit. We were previously getting containers killed when they reached the pod memory limit of 4GB. We initially tried to set the JS heap limit explicitly to 3GB, because the default value wasn't causing any memory eviction before reaching the pod limits.

Now that pods are falling over because we can't allocate heap, or keep it cleaned up, @ 3GB, I think it's clear that we need more resources for these pods to service normal requests.

This doubles the memory limit for the pod to 8GBs, and sets the request to 7GBs. The heap is being set to 6GBs, which uses most of the available memory, and leaves a bit more for OS-related overhead in the container.