### PR TITLE
back to SSDs for ES

### DIFF
--- a/deploy/manifests/elasticsearch/elasticsearch.yaml.jinja2
+++ b/deploy/manifests/elasticsearch/elasticsearch.yaml.jinja2
@@ -92,6 +92,59 @@ spec:
               command: ['sh', '-c', 'sysctl -w vm.max_map_count=262144']
             - name: install-plugins
               command: ['sh', '-c', 'bin/elasticsearch-plugin install --batch repository-gcs']
+    - name: data-green
+      count: 3
+      config:  # https://www.elastic.co/guide/en/elasticsearch/reference/current/settings.html
+        node.roles: ["data"]
+        cluster.routing.allocation.disk.watermark.low: '100gb'
+        cluster.routing.allocation.disk.watermark.high: '50gb'
+        cluster.routing.allocation.disk.watermark.flood_stage: '10gb'
+        ingest.geoip.downloader.enabled: false
+      podTemplate:
+        metadata:
+          labels:
+            role: data
+        spec:
+          automountServiceAccountToken: true
+          serviceAccountName: es-snaps
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: cloud.google.com/gke-nodepool
+                        operator: In
+                        values:
+                          - es-data
+          initContainers:
+            - name: sysctl
+              securityContext:
+                privileged: true
+              command: ['sh', '-c', 'sysctl -w vm.max_map_count=262144']
+            - name: install-plugins
+              command: ['sh', '-c', 'bin/elasticsearch-plugin install --batch repository-gcs']
+          containers:
+            - name: elasticsearch
+              env:
+                - name: ES_JAVA_OPTS
+                  value: '-Xms26g -Xmx26g'
+              resources:
+                requests:
+                  cpu: 6
+                  memory: 52Gi
+                limits:
+                  cpu: 7
+                  memory: 52Gi
+      volumeClaimTemplates:
+        - metadata:
+            name: elasticsearch-data
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            storageClassName: premium-rwo
+            resources:
+              requests:
+                storage: 1750Gi
     - name: data-blue
       count: 3
       config:  # https://www.elastic.co/guide/en/elasticsearch/reference/current/settings.html

--- a/deploy/manifests/elasticsearch/elasticsearch.yaml.jinja2
+++ b/deploy/manifests/elasticsearch/elasticsearch.yaml.jinja2
@@ -145,59 +145,6 @@ spec:
             resources:
               requests:
                 storage: 1750Gi
-    - name: data-blue
-      count: 3
-      config:  # https://www.elastic.co/guide/en/elasticsearch/reference/current/settings.html
-        node.roles: ["data"]
-        cluster.routing.allocation.disk.watermark.low: '100gb'
-        cluster.routing.allocation.disk.watermark.high: '50gb'
-        cluster.routing.allocation.disk.watermark.flood_stage: '10gb'
-        ingest.geoip.downloader.enabled: false
-      podTemplate:
-        metadata:
-          labels:
-            role: data
-        spec:
-          automountServiceAccountToken: true
-          serviceAccountName: es-snaps
-          affinity:
-            nodeAffinity:
-              requiredDuringSchedulingIgnoredDuringExecution:
-                nodeSelectorTerms:
-                  - matchExpressions:
-                      - key: cloud.google.com/gke-nodepool
-                        operator: In
-                        values:
-                          - es-data
-          initContainers:
-            - name: sysctl
-              securityContext:
-                privileged: true
-              command: ['sh', '-c', 'sysctl -w vm.max_map_count=262144']
-            - name: install-plugins
-              command: ['sh', '-c', 'bin/elasticsearch-plugin install --batch repository-gcs']
-          containers:
-            - name: elasticsearch
-              env:
-                - name: ES_JAVA_OPTS
-                  value: '-Xms26g -Xmx26g'
-              resources:
-                requests:
-                  cpu: 6
-                  memory: 52Gi
-                limits:
-                  cpu: 7
-                  memory: 52Gi
-      volumeClaimTemplates:
-        - metadata:
-            name: elasticsearch-data
-          spec:
-            accessModes:
-              - ReadWriteOnce
-            storageClassName: standard
-            resources:
-              requests:
-                storage: 1750Gi
 {% if n_ingest_pods > 0 %}
     - name: ingest
       count: {{ n_ingest_pods }}


### PR DESCRIPTION
while it saved a significant cost, digging through the metrics is showing that me moving us to slower disks has degraded the user experience pretty significantly. I think the slower disks were fine with the v3 dataset, but the SSDs we put in place for v4 seem like they help quite a lot with the worst case performance on the larger dataset. This change set will create a SSD-backed ES nodeset, and then remove data-blue once i'm done moving data over to the new one.

below is a graph of our 95%-ile latency since the change in January, which now that I think more about it is probably worth paying more attention to. These queries represent our heaviest (like coverage, variantsingene, etc), and thus are very likely what many users experience on a typical uncached page load. The 50th percentile latency is probably less relevant here, since those probably represent the queries which are _always_ fast, even when things aren't going well.

![Screenshot 2024-03-12 at 1 12 35 PM](https://github.com/broadinstitute/gnomad-browser/assets/636687/d5f455b9-fded-4607-b1c8-e4c299fc9a84)

I'm still unsure what's causing the immediate pain over the last few days, since that's even worse than was typical post-slow disk change. But, I think we've been doing on average 10-15 more requests/sec on average, so this increased usage is likely pushing us over an edge we were sitting very close to before this week.