### PR TITLE
Update region page snapshot with v4 genomic constraint

### DIFF
--- a/.github/workflows/browser-ci.yml
+++ b/.github/workflows/browser-ci.yml
@@ -5,11 +5,13 @@ on:
       - main
     paths:
       - 'browser/**'
+      - 'dataset-metadata/**'
       - 'package.json'
       - 'pnpm-lock.yaml'
   pull_request:
     paths:
       - 'browser/**'
+      - 'dataset-metadata/**'
       - 'package.json'
       - 'pnpm-lock.yaml'
 jobs:

--- a/.github/workflows/graphql-api-ci.yml
+++ b/.github/workflows/graphql-api-ci.yml
@@ -5,11 +5,13 @@ on:
       - main
     paths:
       - 'graphql-api/**'
+      - 'dataset-metadata/**'
       - 'package.json'
       - 'pnpm-lock.yaml'
   pull_request:
     paths:
       - 'graphql-api/**'
+      - 'dataset-metadata/**'
       - 'package.json'
       - 'pnpm-lock.yaml'
 jobs:

--- a/browser/src/RegionPage/__snapshots__/RegionPage.spec.tsx.snap
+++ b/browser/src/RegionPage/__snapshots__/RegionPage.spec.tsx.snap
@@ -3781,6 +3781,14 @@ exports[`RegionPage with "gnomad_r4" dataset has no unexpected changes for a mit
         }
       }
     />
+    <React.Fragment>
+      <RegionalGenomicConstraintTrack
+        height={45}
+        regions={[]}
+        start={345}
+        stop={456}
+      />
+    </React.Fragment>
     <MitochondrialVariantsInRegion
       datasetId="gnomad_r4"
       region={
@@ -3925,6 +3933,14 @@ exports[`RegionPage with "gnomad_r4" dataset has no unexpected changes for a non
         }
       }
     />
+    <React.Fragment>
+      <RegionalGenomicConstraintTrack
+        height={45}
+        regions={[]}
+        start={345}
+        stop={456}
+      />
+    </React.Fragment>
     <ConnectedVariantsInRegion
       datasetId="gnomad_r4"
       region={


### PR DESCRIPTION
Related #1436 

Updates the snapshot for the region page, as genomic constraint now displays on v4 region pages.

Also updates the CI so that typescript related CI (frontend and API) run when the metadata is edited, this snapshot was mistakenly missed initially as the CI didn't run since no frontend files changed in #1436.

