### PR TITLE
Update genes and short variants for v4.1

### DIFF
--- a/browser/src/GenePage/VariantsInGene.tsx
+++ b/browser/src/GenePage/VariantsInGene.tsx
@@ -260,6 +260,26 @@ query ${operationName}($geneId: String!, $datasetId: DatasetId!, $referenceGenom
           ac_hom
         }
       }
+      joint {
+        ac
+        hemizygote_count
+        homozygote_count
+        fafmax {
+          faf95_max
+          faf95_max_gen_anc
+          faf99_max
+          faf99_max_gen_anc
+        }
+        an
+        filters
+        populations {
+          id
+          ac
+          an
+          homozygote_count
+          hemizygote_count
+        }
+      }
       in_silico_predictors {
         id
         value

--- a/browser/src/QCFilter.tsx
+++ b/browser/src/QCFilter.tsx
@@ -53,7 +53,13 @@ const renderFilterDescription = (filter: Filter, data: any) => {
   let description = FILTER_DISPLAY_MAPPING[filter].description
 
   if (filter === 'discrepant_frequencies') {
-    description = description.concat(`, with a p value of ${data.cochran_p_value}`)
+    description = description.concat(
+      `, with a ${
+        data.testName === 'cochran_mantel_haenszel_test'
+          ? 'Cochran Mantel Haenszel test'
+          : 'Contingency Table test'
+      } p-value of ${data.pValue.toExponential(2)}`
+    )
   }
 
   return description

--- a/browser/src/QCFilter.tsx
+++ b/browser/src/QCFilter.tsx
@@ -19,7 +19,8 @@ type DisplayData = {
 const FILTER_DISPLAY_MAPPING: Record<Filter, DisplayData> = {
   AC0: {
     name: 'AC0',
-    description: 'Allele count is zero (i.e.e no high-confidence genotype)',
+    description:
+      'Allele count is zero due to removal of low quality genotypes (GQ < 20; DP < 10; and AB < 0.2 for het calls) at this site',
   },
   AS_VQSR: {
     name: 'AS VSQR',
@@ -34,18 +35,18 @@ const FILTER_DISPLAY_MAPPING: Record<Filter, DisplayData> = {
     description: 'Failed random forest filters',
   },
   discrepant_frequencies: {
-    name: 'Discrepant Frequencies',
+    name: 'Discrepant frequencies',
     description: 'Has discrepant frequencies between genomes and exomes',
   },
   not_called_in_exomes: {
-    name: 'Not in Exomes',
+    name: 'Not in exomes',
     description:
-      'This variant was not called in the gnomAD exome callset; no samples had any exome call (no samples had reference or alternate calls).',
+      'This variant was not called in the gnomAD exome callset; no exome samples had any genotype call (no reference or alternate calls)',
   },
   not_called_in_genomes: {
-    name: 'Not in gemomes',
+    name: 'Not in genomes',
     description:
-      'This variant was not called in the gnomAD genome callset; no samples had any genome call (no samples had reference or alternate calls).',
+      'This variant was not called in the gnomAD genome callset; no genome samples had any genotype call (no reference or alternate calls)',
   },
 }
 

--- a/browser/src/QCFilter.tsx
+++ b/browser/src/QCFilter.tsx
@@ -2,20 +2,71 @@ import React from 'react'
 
 import { Badge } from '@gnomad/ui'
 
-const FILTER_DESCRIPTIONS = {
-  AC0: 'Allele count is zero (i.e. no high-confidence genotype)',
-  AS_VQSR: 'Failed allele-specific VQSR filter',
-  InbreedingCoeff: 'Has an inbreeding coefficient < -0.3',
-  RF: 'Failed random forest filters',
+export type Filter =
+  | 'AC0'
+  | 'AS_VQSR'
+  | 'InbreedingCoeff'
+  | 'RF'
+  | 'discrepant_frequencies'
+  | 'not_called_in_exomes'
+  | 'not_called_in_genomes'
+
+type DisplayData = {
+  name: string
+  description: string
+}
+
+const FILTER_DISPLAY_MAPPING: Record<Filter, DisplayData> = {
+  AC0: {
+    name: 'AC0',
+    description: 'Allele count is zero (i.e.e no high-confidence genotype)',
+  },
+  AS_VQSR: {
+    name: 'AS VSQR',
+    description: 'Failed allele-specific VQSR filter',
+  },
+  InbreedingCoeff: {
+    name: 'Inbreeding Coeff',
+    description: 'Has an inbreeding coefficient < -0.3',
+  },
+  RF: {
+    name: 'RF',
+    description: 'Failed random forest filters',
+  },
+  discrepant_frequencies: {
+    name: 'Discrepant Frequencies',
+    description: 'Has discrepant frequencies between genomes and exomes',
+  },
+  not_called_in_exomes: {
+    name: 'Not in Exomes',
+    description:
+      'This variant was not called in the gnomAD exome callset; no samples had any exome call (no samples had reference or alternate calls).',
+  },
+  not_called_in_genomes: {
+    name: 'Not in gemomes',
+    description:
+      'This variant was not called in the gnomAD genome callset; no samples had any genome call (no samples had reference or alternate calls).',
+  },
+}
+
+const renderFilterDescription = (filter: Filter, data: any) => {
+  let description = FILTER_DISPLAY_MAPPING[filter].description
+
+  if (filter === 'discrepant_frequencies') {
+    description = description.concat(`, with a p value of ${data.cochran_p_value}`)
+  }
+
+  return description
 }
 
 type Props = {
-  filter: 'AC0' | 'AS_VQSR' | 'InbreedingCoeff' | 'RF'
+  filter: Filter
+  data?: any
 }
 
-const QCFilter = ({ filter }: Props) => (
-  <Badge level="warning" tooltip={FILTER_DESCRIPTIONS[filter]}>
-    {filter}
+const QCFilter = ({ filter, data }: Props) => (
+  <Badge level="warning" tooltip={renderFilterDescription(filter, data)}>
+    {FILTER_DISPLAY_MAPPING[filter].name}
   </Badge>
 )
 

--- a/browser/src/RegionPage/VariantsInRegion.tsx
+++ b/browser/src/RegionPage/VariantsInRegion.tsx
@@ -169,6 +169,26 @@ query ${operationName}($chrom: String!, $start: Int!, $stop: Int!, $datasetId: D
           ac_hom
         }
       }
+      joint {
+        ac
+        hemizygote_count
+        homozygote_count
+        fafmax {
+          faf95_max
+          faf95_max_gen_anc
+          faf99_max
+          faf99_max_gen_anc
+        }
+        an
+        filters
+        populations {
+          id
+          ac
+          an
+          homozygote_count
+          hemizygote_count
+        }
+      }
       in_silico_predictors {
         id
         value

--- a/browser/src/TranscriptPage/VariantsInTranscript.tsx
+++ b/browser/src/TranscriptPage/VariantsInTranscript.tsx
@@ -201,6 +201,26 @@ query ${operationName}($transcriptId: String!, $datasetId: DatasetId!, $referenc
           ac_hom
         }
       }
+      joint {
+        ac
+        hemizygote_count
+        homozygote_count
+        fafmax {
+          faf95_max
+          faf95_max_gen_anc
+          faf99_max
+          faf99_max_gen_anc
+        }
+        an
+        filters
+        populations {
+          id
+          ac
+          an
+          homozygote_count
+          hemizygote_count
+        }
+      }
       in_silico_predictors {
         id
         value

--- a/browser/src/VariantList/ExportVariantsButton.tsx
+++ b/browser/src/VariantList/ExportVariantsButton.tsx
@@ -86,11 +86,18 @@ export const createVersionSpecificColumns = (datasetId: DatasetId) => {
   if (isV4(datasetId)) {
     versionSpecificColumns = [
       {
+        label: 'Filters - joint',
+        getValue: (variant) => {
+          const v4Variant = variant as V4VariantTableVariant
+          return v4Variant.joint.filters.length === 0 ? 'PASS' : v4Variant.joint.filters.join(',')
+        },
+      },
+      {
         label: 'GroupMax FAF group',
         getValue: (variant) => {
           const v4Variant = variant as V4VariantTableVariant
-          return v4Variant.faf95_joint.popmax_population !== null
-            ? v4Variant.faf95_joint.popmax_population
+          return v4Variant.joint.fafmax.faf95_max_gen_anc !== null
+            ? v4Variant.joint.fafmax.faf95_max_gen_anc
             : ''
         },
       },
@@ -98,8 +105,8 @@ export const createVersionSpecificColumns = (datasetId: DatasetId) => {
         label: 'GroupMax FAF frequency',
         getValue: (variant) => {
           const v4Variant = variant as V4VariantTableVariant
-          return v4Variant.faf95_joint.popmax !== null
-            ? JSON.stringify(v4Variant.faf95_joint.popmax)
+          return v4Variant.joint.fafmax.faf95_max !== null
+            ? JSON.stringify(v4Variant.joint.fafmax.faf95_max)
             : ''
         },
       },
@@ -371,7 +378,13 @@ type V2VariantTableVariant = VariantTableVariant & {
 }
 
 type V4VariantTableVariant = VariantTableVariant & {
-  faf95_joint: FilteredAlleleFrequency
+  joint: {
+    filters: string[]
+    fafmax: {
+      faf95_max: number | null
+      faf95_max_gen_anc: string | null
+    }
+  }
   in_silico_predictors: {
     id: string
     value: string

--- a/browser/src/VariantList/mergeExomeAndGenomeData.ts
+++ b/browser/src/VariantList/mergeExomeAndGenomeData.ts
@@ -61,21 +61,39 @@ const mergeExomeAndGenomeData = (variants: any) =>
       }
     }
 
-    const totalAC = add(exome.ac, genome.ac)
-    const totalAN = add(exome.an, genome.an)
-    const totalAF = totalAN ? totalAC / totalAN : 0
+    const jointAC = variant.joint ? variant.joint.ac : add(exome.ac, genome.ac)
+    const jointAN = variant.joint ? variant.joint.an : add(exome.an, genome.an)
+    const jointAF = jointAC ? jointAC / jointAN : 0
 
-    return {
+    const jointHemizygoteCount = variant.joint
+      ? variant.joint.hemizygote_count
+      : add(exome.ac_hemi, genome.ac_hemi)
+    const jointHomozygoteCount = variant.joint
+      ? variant.joint.homozygote_count
+      : add(exome.ac_hom, genome.ac_hom)
+
+    const exomeAndGenomeFilters = exome.filters.concat(genome.filters)
+    const jointFilters = variant.joint
+      ? exomeAndGenomeFilters.concat(variant.joint.filters)
+      : exomeAndGenomeFilters
+
+    const jointPopulations = variant.join
+      ? variant.joint.populations
+      : mergeExomeAndGenomePopulationData(exome!, genome!)
+
+    const jointVariantData = {
       ...variant,
-      ac: totalAC,
-      an: totalAN,
-      af: totalAF,
-      allele_freq: totalAF, // hack for variant track which expects allele_freq field
-      ac_hemi: add(exome.ac_hemi, genome.ac_hemi),
-      ac_hom: add(exome.ac_hom, genome.ac_hom),
-      filters: exome.filters.concat(genome.filters),
-      populations: mergeExomeAndGenomePopulationData(exome!, genome!),
+      ac: jointAC,
+      an: jointAN,
+      af: jointAF,
+      allele_freq: jointAF, // hack for variant track which expects allele_freq field
+      ac_hemi: jointHemizygoteCount,
+      ac_hom: jointHomozygoteCount,
+      filters: jointFilters,
+      populations: jointPopulations,
     }
+
+    return jointVariantData
   })
 
 export default mergeExomeAndGenomeData

--- a/browser/src/VariantPage/VariantOccurrenceTable.tsx
+++ b/browser/src/VariantPage/VariantOccurrenceTable.tsx
@@ -43,15 +43,25 @@ const NoWrap = styled.span`
 type VariantContext = 'exome' | 'genome' | 'joint'
 const renderGnomadVariantFlag = (variant: Variant, context: VariantContext) => {
   if (!variant[context]) {
-    return <Badge level="error">No variant</Badge>
+    return context === 'joint' ? <div /> : <Badge level="error">No variant</Badge>
   }
   const { filters } = variant[context]!
 
   if (filters.length === 0) {
-    return <Badge level="success">Pass</Badge>
+    return context === 'joint' ? <div /> : <Badge level="success">Pass</Badge>
   }
 
-  return filters.map((filter: any) => <QCFilter key={filter} filter={filter} />)
+  return filters.map((filter) => {
+    const data =
+      filter === 'discrepant_frequencies'
+        ? {
+            pValue: variant.joint!.freq_comparison_stats.stat_union.p_value,
+            testName: variant.joint!.freq_comparison_stats.stat_union.stat_test_name,
+          }
+        : {}
+
+    return <QCFilter key={filter} filter={filter} data={data} />
+  })
 }
 
 const FilteringAlleleFrequencyPopulation = styled.div`
@@ -264,12 +274,14 @@ export const GnomadVariantOccurrenceTable = ({
               {/* @ts-expect-error TS(2322) FIXME: Type '{ children: Element; tooltip: string; }' is ... Remove this comment to see the full error message */}
               <TooltipAnchor tooltip="Quality control filters that this variant failed (if any)">
                 {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
-                <TooltipHint>Filters</TooltipHint>
+                <TooltipHint>
+                  Filters <InfoButton topic="what-do-the-flags-on-the-browser-mean" />
+                </TooltipHint>
               </TooltipAnchor>
             </th>
             {showExomes && <td>{renderGnomadVariantFlag(variant, 'exome')}</td>}
             {showGenomes && <td>{renderGnomadVariantFlag(variant, 'genome')}</td>}
-            {showTotal && <td />}
+            {showTotal && <td>{renderGnomadVariantFlag(variant, 'joint')}</td>}
           </tr>
           <tr>
             <th scope="row">

--- a/browser/src/VariantPage/VariantOccurrenceTable.tsx
+++ b/browser/src/VariantPage/VariantOccurrenceTable.tsx
@@ -463,29 +463,6 @@ export const GnomadVariantOccurrenceTable = ({
               {showTotal && <td />}
             </tr>
           )}
-          {isV4(datasetId) && (
-            <tr>
-              <th scope="row">
-                {/* @ts-expect-error TS(2322) FIXME: Type '{ children: Element; tooltip: string; }' is ... Remove this comment to see the full error message */}
-                <TooltipAnchor tooltip="Fraction of individuals with >20x coverage at this variant's locus">
-                  {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
-                  <TooltipHint>Fraction of individuals with &gt;20x coverage</TooltipHint>
-                </TooltipAnchor>
-              </th>
-              {/* TODO: this logic can be extracted into a helper, and cleaned for clarity, todo after V4 mvp launch */}
-              {variant.exome ? (
-                <td>{exomeCoverage.over20 !== null ? exomeCoverage.over20.toFixed(1) : '–'}</td>
-              ) : (
-                <td />
-              )}
-              {variant.genome ? (
-                <td>{genomeCoverage.over20 !== null ? genomeCoverage.over20.toFixed(1) : '–'}</td>
-              ) : (
-                <td />
-              )}
-              {showTotal && <td />}
-            </tr>
-          )}
         </tbody>
       </Table>
       {(hasLowAlleleNumberInExomes || hasLowAlleleNumberInGenomes) && (

--- a/browser/src/VariantPage/VariantPage.tsx
+++ b/browser/src/VariantPage/VariantPage.tsx
@@ -465,10 +465,6 @@ query ${operationName}($variantId: String!, $datasetId: DatasetId!, $referenceGe
     alt
     caid
     colocated_variants
-    faf95_joint {
-      popmax
-      popmax_population
-    }
     coverage {
       exome {
         mean
@@ -640,6 +636,53 @@ query ${operationName}($variantId: String!, $datasetId: DatasetId!, $referenceGe
         site_quality_metrics {
           metric
           value
+        }
+      }
+    }
+    joint {
+      ac
+      an
+      homozygote_count
+      hemizygote_count
+      faf95 {
+        popmax
+        popmax_population
+      }
+      filters
+      populations {
+        id
+        ac
+        an
+        homozygote_count
+        hemizygote_count
+      }
+      age_distribution {
+        het {
+          bin_edges
+          bin_freq
+          n_smaller
+          n_larger
+        }
+        hom {
+          bin_edges
+          bin_freq
+          n_smaller
+          n_larger
+        }
+      }
+      freq_comparison_stats {
+        contingency_table_test {
+          p_value
+          odds_ratio
+        }
+        cochran_mantel_haenszel_test {
+          chisq
+          odds_ratio
+        }
+        stat_union {
+          p_value
+          stat_test_name
+          gen_ancs
         }
       }
     }

--- a/browser/src/VariantPage/__snapshots__/VariantPage.spec.tsx.snap
+++ b/browser/src/VariantPage/__snapshots__/VariantPage.spec.tsx.snap
@@ -421,7 +421,35 @@ exports[`VariantPage with the dataset "gnomad_r3" has no unexpected changes 1`] 
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
-                    Filters
+                    Filters 
+                    <button
+                      className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <img
+                        alt=""
+                        aria-hidden="true"
+                        src="test-file-stub"
+                      />
+                      <span
+                        style={
+                          {
+                            "border": "0",
+                            "clip": "rect(0 0 0 0)",
+                            "height": "1px",
+                            "margin": "-1px",
+                            "overflow": "hidden",
+                            "padding": "0",
+                            "position": "absolute",
+                            "whiteSpace": "nowrap",
+                            "width": "1px",
+                          }
+                        }
+                      >
+                        More information
+                      </span>
+                    </button>
                   </span>
                 </th>
                 <td>
@@ -9835,7 +9863,35 @@ exports[`VariantPage with the dataset "gnomad_r3_controls_and_biobanks" has no u
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
-                    Filters
+                    Filters 
+                    <button
+                      className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <img
+                        alt=""
+                        aria-hidden="true"
+                        src="test-file-stub"
+                      />
+                      <span
+                        style={
+                          {
+                            "border": "0",
+                            "clip": "rect(0 0 0 0)",
+                            "height": "1px",
+                            "margin": "-1px",
+                            "overflow": "hidden",
+                            "padding": "0",
+                            "position": "absolute",
+                            "whiteSpace": "nowrap",
+                            "width": "1px",
+                          }
+                        }
+                      >
+                        More information
+                      </span>
+                    </button>
                   </span>
                 </th>
                 <td>
@@ -19252,7 +19308,35 @@ exports[`VariantPage with the dataset "gnomad_r3_non_cancer" has no unexpected c
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
-                    Filters
+                    Filters 
+                    <button
+                      className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <img
+                        alt=""
+                        aria-hidden="true"
+                        src="test-file-stub"
+                      />
+                      <span
+                        style={
+                          {
+                            "border": "0",
+                            "clip": "rect(0 0 0 0)",
+                            "height": "1px",
+                            "margin": "-1px",
+                            "overflow": "hidden",
+                            "padding": "0",
+                            "position": "absolute",
+                            "whiteSpace": "nowrap",
+                            "width": "1px",
+                          }
+                        }
+                      >
+                        More information
+                      </span>
+                    </button>
                   </span>
                 </th>
                 <td>
@@ -28669,7 +28753,35 @@ exports[`VariantPage with the dataset "gnomad_r3_non_neuro" has no unexpected ch
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
-                    Filters
+                    Filters 
+                    <button
+                      className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <img
+                        alt=""
+                        aria-hidden="true"
+                        src="test-file-stub"
+                      />
+                      <span
+                        style={
+                          {
+                            "border": "0",
+                            "clip": "rect(0 0 0 0)",
+                            "height": "1px",
+                            "margin": "-1px",
+                            "overflow": "hidden",
+                            "padding": "0",
+                            "position": "absolute",
+                            "whiteSpace": "nowrap",
+                            "width": "1px",
+                          }
+                        }
+                      >
+                        More information
+                      </span>
+                    </button>
                   </span>
                 </th>
                 <td>
@@ -38086,7 +38198,35 @@ exports[`VariantPage with the dataset "gnomad_r3_non_topmed" has no unexpected c
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
-                    Filters
+                    Filters 
+                    <button
+                      className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <img
+                        alt=""
+                        aria-hidden="true"
+                        src="test-file-stub"
+                      />
+                      <span
+                        style={
+                          {
+                            "border": "0",
+                            "clip": "rect(0 0 0 0)",
+                            "height": "1px",
+                            "margin": "-1px",
+                            "overflow": "hidden",
+                            "padding": "0",
+                            "position": "absolute",
+                            "whiteSpace": "nowrap",
+                            "width": "1px",
+                          }
+                        }
+                      >
+                        More information
+                      </span>
+                    </button>
                   </span>
                 </th>
                 <td>
@@ -47503,7 +47643,35 @@ exports[`VariantPage with the dataset "gnomad_r3_non_v2" has no unexpected chang
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
-                    Filters
+                    Filters 
+                    <button
+                      className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <img
+                        alt=""
+                        aria-hidden="true"
+                        src="test-file-stub"
+                      />
+                      <span
+                        style={
+                          {
+                            "border": "0",
+                            "clip": "rect(0 0 0 0)",
+                            "height": "1px",
+                            "margin": "-1px",
+                            "overflow": "hidden",
+                            "padding": "0",
+                            "position": "absolute",
+                            "whiteSpace": "nowrap",
+                            "width": "1px",
+                          }
+                        }
+                      >
+                        More information
+                      </span>
+                    </button>
                   </span>
                 </th>
                 <td>
@@ -64422,7 +64590,35 @@ exports[`VariantPage with the dataset gnomad_r2_1 has no unexpected changes 1`] 
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
-                    Filters
+                    Filters 
+                    <button
+                      className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <img
+                        alt=""
+                        aria-hidden="true"
+                        src="test-file-stub"
+                      />
+                      <span
+                        style={
+                          {
+                            "border": "0",
+                            "clip": "rect(0 0 0 0)",
+                            "height": "1px",
+                            "margin": "-1px",
+                            "overflow": "hidden",
+                            "padding": "0",
+                            "position": "absolute",
+                            "whiteSpace": "nowrap",
+                            "width": "1px",
+                          }
+                        }
+                      >
+                        More information
+                      </span>
+                    </button>
                   </span>
                 </th>
                 <td>
@@ -74052,7 +74248,35 @@ exports[`VariantPage with the dataset gnomad_r2_1_controls has no unexpected cha
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
-                    Filters
+                    Filters 
+                    <button
+                      className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <img
+                        alt=""
+                        aria-hidden="true"
+                        src="test-file-stub"
+                      />
+                      <span
+                        style={
+                          {
+                            "border": "0",
+                            "clip": "rect(0 0 0 0)",
+                            "height": "1px",
+                            "margin": "-1px",
+                            "overflow": "hidden",
+                            "padding": "0",
+                            "position": "absolute",
+                            "whiteSpace": "nowrap",
+                            "width": "1px",
+                          }
+                        }
+                      >
+                        More information
+                      </span>
+                    </button>
                   </span>
                 </th>
                 <td>
@@ -83682,7 +83906,35 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_cancer has no unexpected c
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
-                    Filters
+                    Filters 
+                    <button
+                      className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <img
+                        alt=""
+                        aria-hidden="true"
+                        src="test-file-stub"
+                      />
+                      <span
+                        style={
+                          {
+                            "border": "0",
+                            "clip": "rect(0 0 0 0)",
+                            "height": "1px",
+                            "margin": "-1px",
+                            "overflow": "hidden",
+                            "padding": "0",
+                            "position": "absolute",
+                            "whiteSpace": "nowrap",
+                            "width": "1px",
+                          }
+                        }
+                      >
+                        More information
+                      </span>
+                    </button>
                   </span>
                 </th>
                 <td>
@@ -93312,7 +93564,35 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_neuro has no unexpected ch
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
-                    Filters
+                    Filters 
+                    <button
+                      className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <img
+                        alt=""
+                        aria-hidden="true"
+                        src="test-file-stub"
+                      />
+                      <span
+                        style={
+                          {
+                            "border": "0",
+                            "clip": "rect(0 0 0 0)",
+                            "height": "1px",
+                            "margin": "-1px",
+                            "overflow": "hidden",
+                            "padding": "0",
+                            "position": "absolute",
+                            "whiteSpace": "nowrap",
+                            "width": "1px",
+                          }
+                        }
+                      >
+                        More information
+                      </span>
+                    </button>
                   </span>
                 </th>
                 <td>
@@ -102942,7 +103222,35 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_topmed has no unexpected c
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
-                    Filters
+                    Filters 
+                    <button
+                      className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <img
+                        alt=""
+                        aria-hidden="true"
+                        src="test-file-stub"
+                      />
+                      <span
+                        style={
+                          {
+                            "border": "0",
+                            "clip": "rect(0 0 0 0)",
+                            "height": "1px",
+                            "margin": "-1px",
+                            "overflow": "hidden",
+                            "padding": "0",
+                            "position": "absolute",
+                            "whiteSpace": "nowrap",
+                            "width": "1px",
+                          }
+                        }
+                      >
+                        More information
+                      </span>
+                    </button>
                   </span>
                 </th>
                 <td>

--- a/browser/src/VariantPage/__snapshots__/VariantPage.spec.tsx.snap
+++ b/browser/src/VariantPage/__snapshots__/VariantPage.spec.tsx.snap
@@ -64439,7 +64439,9 @@ exports[`VariantPage with the dataset gnomad_r2_1 has no unexpected changes 1`] 
                     No variant
                   </span>
                 </td>
-                <td />
+                <td>
+                  <div />
+                </td>
               </tr>
               <tr>
                 <th
@@ -64560,22 +64562,7 @@ exports[`VariantPage with the dataset gnomad_r2_1 has no unexpected changes 1`] 
                   </span>
                 </td>
                 <td />
-                <td>
-                  <span>
-                    <span
-                      className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
-                    >
-                      1.000
-                    </span>
-                    <div
-                      className="VariantOccurrenceTable__FilteringAlleleFrequencyPopulation-sc-8b13g7-2 fRZHhe"
-                    >
-                      European (non-Finnish)
-                    </div>
-                  </span>
-                </td>
+                <td />
               </tr>
               <tr>
                 <th
@@ -74082,7 +74069,9 @@ exports[`VariantPage with the dataset gnomad_r2_1_controls has no unexpected cha
                     No variant
                   </span>
                 </td>
-                <td />
+                <td>
+                  <div />
+                </td>
               </tr>
               <tr>
                 <th
@@ -74203,22 +74192,7 @@ exports[`VariantPage with the dataset gnomad_r2_1_controls has no unexpected cha
                   </span>
                 </td>
                 <td />
-                <td>
-                  <span>
-                    <span
-                      className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
-                    >
-                      1.000
-                    </span>
-                    <div
-                      className="VariantOccurrenceTable__FilteringAlleleFrequencyPopulation-sc-8b13g7-2 fRZHhe"
-                    >
-                      European (non-Finnish)
-                    </div>
-                  </span>
-                </td>
+                <td />
               </tr>
               <tr>
                 <th
@@ -83725,7 +83699,9 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_cancer has no unexpected c
                     No variant
                   </span>
                 </td>
-                <td />
+                <td>
+                  <div />
+                </td>
               </tr>
               <tr>
                 <th
@@ -83846,22 +83822,7 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_cancer has no unexpected c
                   </span>
                 </td>
                 <td />
-                <td>
-                  <span>
-                    <span
-                      className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
-                    >
-                      1.000
-                    </span>
-                    <div
-                      className="VariantOccurrenceTable__FilteringAlleleFrequencyPopulation-sc-8b13g7-2 fRZHhe"
-                    >
-                      European (non-Finnish)
-                    </div>
-                  </span>
-                </td>
+                <td />
               </tr>
               <tr>
                 <th
@@ -93368,7 +93329,9 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_neuro has no unexpected ch
                     No variant
                   </span>
                 </td>
-                <td />
+                <td>
+                  <div />
+                </td>
               </tr>
               <tr>
                 <th
@@ -93489,22 +93452,7 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_neuro has no unexpected ch
                   </span>
                 </td>
                 <td />
-                <td>
-                  <span>
-                    <span
-                      className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
-                    >
-                      1.000
-                    </span>
-                    <div
-                      className="VariantOccurrenceTable__FilteringAlleleFrequencyPopulation-sc-8b13g7-2 fRZHhe"
-                    >
-                      European (non-Finnish)
-                    </div>
-                  </span>
-                </td>
+                <td />
               </tr>
               <tr>
                 <th
@@ -103011,7 +102959,9 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_topmed has no unexpected c
                     No variant
                   </span>
                 </td>
-                <td />
+                <td>
+                  <div />
+                </td>
               </tr>
               <tr>
                 <th
@@ -103132,22 +103082,7 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_topmed has no unexpected c
                   </span>
                 </td>
                 <td />
-                <td>
-                  <span>
-                    <span
-                      className="TooltipHint-sc-1wwbc8j-0 cXXQWi"
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
-                    >
-                      1.000
-                    </span>
-                    <div
-                      className="VariantOccurrenceTable__FilteringAlleleFrequencyPopulation-sc-8b13g7-2 fRZHhe"
-                    >
-                      European (non-Finnish)
-                    </div>
-                  </span>
-                </td>
+                <td />
               </tr>
               <tr>
                 <th

--- a/browser/src/__factories__/Variant.ts
+++ b/browser/src/__factories__/Variant.ts
@@ -89,6 +89,7 @@ export const variantFactory = Factory.define<Variant>(({ params, associations })
   const {
     exome = null,
     genome = null,
+    joint = null,
     non_coding_constraint = null,
     clinvar = null,
     coverage = { exome: null, genome: null },
@@ -110,6 +111,7 @@ export const variantFactory = Factory.define<Variant>(({ params, associations })
     clinvar,
     exome,
     genome,
+    joint,
     lof_curations,
     in_silico_predictors,
     non_coding_constraint,
@@ -195,8 +197,8 @@ export const sequencingFactory = Factory.define<SequencingType>(({ params, assoc
   const {
     ac = 1,
     an = 1,
-    homozygote_count = null,
-    hemizygote_count = null,
+    homozygote_count = 0,
+    hemizygote_count = 0,
     filters = [],
     populations = [],
     local_ancestry_populations = [],

--- a/data-pipeline/src/data_pipeline/data_types/variant/annotate_variants.py
+++ b/data-pipeline/src/data_pipeline/data_types/variant/annotate_variants.py
@@ -7,10 +7,10 @@ def annotate_variants(variants_path, exome_coverage_path=None, genome_coverage_p
     ds = ds.annotate(coverage=hl.struct())
     if exome_coverage_path:
         exome_coverage = hl.read_table(exome_coverage_path)
-        ds = ds.annotate(coverage=ds.coverage.annotate(exome=exome_coverage[ds.locus].drop("xpos")))
+        ds = ds.annotate(coverage=ds.coverage.annotate(exome=exome_coverage[ds.locus]))
     if genome_coverage_path:
         genome_coverage = hl.read_table(genome_coverage_path)
-        ds = ds.annotate(coverage=ds.coverage.annotate(genome=genome_coverage[ds.locus].drop("xpos")))
+        ds = ds.annotate(coverage=ds.coverage.annotate(genome=genome_coverage[ds.locus]))
 
     return ds
 

--- a/data-pipeline/src/data_pipeline/datasets/gnomad_v4/gnomad_v4_constraint.py
+++ b/data-pipeline/src/data_pipeline/datasets/gnomad_v4/gnomad_v4_constraint.py
@@ -11,7 +11,6 @@ def prepare_gnomad_v4_constraint(path):
     ds = ds.select(
         # ID
         transcript_id=ds.transcript,
-        gene_id=ds.gene,
         # Expected
         exp_lof=ds.lof.exp,
         exp_mis=ds.mis.exp,

--- a/data-pipeline/src/data_pipeline/pipelines/genes.py
+++ b/data-pipeline/src/data_pipeline/pipelines/genes.py
@@ -220,7 +220,7 @@ pipeline.add_task(
     "prepare_gnomad_v4_constraint",
     prepare_gnomad_v4_constraint,
     f"/{constraint_subdir}/gnomad_v4_constraint.ht",
-    {"path": "gs://gcp-public-data--gnomad/release/v4.0/constraint/gnomad.v4.0.constraint_metrics.ht"},
+    {"path": "gs://gcp-public-data--gnomad/release/v4.1/constraint/gnomad.v4.1.constraint_metrics.ht"},
 )
 
 pipeline.add_task(

--- a/data-pipeline/src/data_pipeline/pipelines/gnomad_v4_variants.py
+++ b/data-pipeline/src/data_pipeline/pipelines/gnomad_v4_variants.py
@@ -50,8 +50,9 @@ pipeline.add_task(
     task_function=prepare_gnomad_v4_variants,
     output_path=f"{output_sub_dir}/gnomad_v4_variants_base.ht",
     inputs={
-        "exome_variants_path": "gs://gcp-public-data--gnomad/release/4.0/ht/exomes/gnomad.exomes.v4.0.sites.ht",
-        "genome_variants_path": "gs://gcp-public-data--gnomad/release/4.0/ht/genomes/gnomad.genomes.v4.0.sites.ht/",
+        "exome_variants_path": "gs://gcp-public-data--gnomad/release/4.1/ht/exomes/gnomad.exomes.v4.1.sites.ht",
+        "genome_variants_path": "gs://gcp-public-data--gnomad/release/4.1/ht/genomes/gnomad.genomes.v4.1.sites.ht",
+        "variants_joint_frequency_path": "gs://gcp-public-data--gnomad/release/4.1/ht/joint/gnomad.joint.v4.1.sites.ht",
     },
 )
 

--- a/dataset-metadata/gnomadPopulations.ts
+++ b/dataset-metadata/gnomadPopulations.ts
@@ -12,6 +12,7 @@ export const GNOMAD_POPULATION_NAMES = {
   fin: 'European (Finnish)',
   oth: 'Remaining individuals',
   sas: 'South Asian',
+  rmi: 'Remaining',
   remaining: 'Remaining',
 
   // EAS subpopulations

--- a/graphql-api/src/graphql/types/variant.graphql
+++ b/graphql-api/src/graphql/types/variant.graphql
@@ -117,6 +117,23 @@ type VariantSequencingTypeData {
   ac_hemi: Int
 }
 
+type JointFafmax {
+  faf95_max: Float
+  faf95_max_gen_anc: String
+  faf99_max: Float
+  faf99_max_gen_anc: String
+}
+
+type VariantJointSequencingTypeData {
+  ac: Int
+  an: Int
+  homozygote_count: Int
+  hemizygote_count: Int
+  filters: [String!]
+  populations: [VariantPopulation]
+  fafmax: JointFafmax
+}
+
 type NonCodingConstraintRegion {
   chrom: String!
   start: Int!
@@ -139,6 +156,7 @@ type Variant {
   rsids: [String!]
   exome: VariantSequencingTypeData
   genome: VariantSequencingTypeData
+  joint: VariantJointSequencingTypeData
   flags: [String!]
   lof_curation: LoFCurationInGene
   transcript_consequence: TranscriptConsequence
@@ -247,8 +265,6 @@ type VariantDetails {
   flags: [String!]
   transcript_consequences: [TranscriptConsequence!]
   in_silico_predictors: [VariantInSilicoPredictor!]
-  faf95_joint: VariantFilteringAlleleFrequency
-  faf99_joint: VariantFilteringAlleleFrequency
 
   non_coding_constraint: NonCodingConstraintRegion
 

--- a/graphql-api/src/graphql/types/variant.graphql
+++ b/graphql-api/src/graphql/types/variant.graphql
@@ -234,6 +234,42 @@ type VariantDetailsSequencingTypeData {
   ac_hemi: Int
 }
 
+type ContingencyTableTest {
+  p_value: Float
+  odds_ratio: Float
+}
+
+type CochranMantelHaenszelTest {
+  chisq: Float
+  p_value: Float
+}
+
+type StatUnion {
+  p_value: Float
+  stat_test_name: String
+  gen_ancs: [String]
+}
+
+type VariantJointFrequencyComparisonStats {
+  contingency_table_test: [ContingencyTableTest]
+  cochran_mantel_haenszel_test: CochranMantelHaenszelTest
+  stat_union: StatUnion
+}
+
+type VariantDetailsJointSequencingTypeData {
+  ac: Int
+  an: Int
+  homozygote_count: Int
+  hemizygote_count: Int
+  faf95: VariantFilteringAlleleFrequency
+  faf99: VariantFilteringAlleleFrequency
+  filters: [String!]
+  populations: [VariantPopulation]
+  age_distribution: VariantAgeDistribution
+  quality_metrics: VariantQualityMetrics
+  freq_comparison_stats: VariantJointFrequencyComparisonStats
+}
+
 type MultiNucleotideVariantSummary {
   combined_variant_id: String!
   changes_amino_acids: Boolean!
@@ -262,6 +298,7 @@ type VariantDetails {
   multi_nucleotide_variants: [MultiNucleotideVariantSummary!]
   exome: VariantDetailsSequencingTypeData
   genome: VariantDetailsSequencingTypeData
+  joint: VariantDetailsJointSequencingTypeData
   flags: [String!]
   transcript_consequences: [TranscriptConsequence!]
   in_silico_predictors: [VariantInSilicoPredictor!]

--- a/graphql-api/src/queries/variant-datasets/gnomad-v4-variant-queries.ts
+++ b/graphql-api/src/queries/variant-datasets/gnomad-v4-variant-queries.ts
@@ -344,6 +344,31 @@ const shapeVariantSummary = (subset: any, context: any) => {
   }
 }
 
+const getMultiVariantSourceFields = (
+  exomeSubset: string,
+  genomeSubset: string,
+  jointSubset: string
+): string[] => {
+  const commonMultiVariantQuerySourceFields = [
+    `value.exome.freq.${exomeSubset}`,
+    `value.genome.freq.${genomeSubset}`,
+    `value.joint.freq.${jointSubset}`,
+    'value.exome.filters',
+    'value.genome.filters',
+    'value.joint.filters',
+    'value.alleles',
+    // 'value.caid',
+    'value.locus',
+    'value.flags',
+    'value.rsids',
+    'value.transcript_consequences',
+    'value.variant_id',
+    'value.joint.fafmax',
+    'value.in_silico_predictors',
+  ]
+  return commonMultiVariantQuerySourceFields
+}
+
 // ================================================================================================
 // Gene query
 // ================================================================================================
@@ -385,23 +410,7 @@ const fetchVariantsByGene = async (esClient: any, gene: any, _subset: any) => {
       index: GNOMAD_V4_VARIANT_INDEX,
       type: '_doc',
       size: pageSize,
-      _source: [
-        `value.exome.freq.${exomeSubset}`,
-        `value.genome.freq.${genomeSubset}`,
-        `value.joint.freq.${jointSubset}`,
-        'value.exome.filters',
-        'value.genome.filters',
-        'value.joint.filters',
-        'value.alleles',
-        // 'value.caid',
-        'value.locus',
-        'value.flags',
-        'value.rsids',
-        'value.transcript_consequences',
-        'value.variant_id',
-        'value.joint.fafmax',
-        'value.in_silico_predictors',
-      ],
+      _source: getMultiVariantSourceFields(exomeSubset, genomeSubset, jointSubset),
       body: {
         query: {
           bool: {
@@ -434,27 +443,13 @@ const fetchVariantsByRegion = async (esClient: any, region: any, _subset: any) =
   const subset = 'all'
   const exomeSubset = 'all'
   const genomeSubset = 'all'
+  const jointSubset = 'all'
 
   const hits = await fetchAllSearchResults(esClient, {
     index: GNOMAD_V4_VARIANT_INDEX,
     type: '_doc',
     size: 10000,
-    _source: [
-      `value.exome.freq.${exomeSubset}`,
-      `value.genome.freq.${genomeSubset}`,
-      'value.exome.filters',
-      'value.genome.filters',
-      'value.alleles',
-      // 'value.caid',
-      'value.locus',
-      'value.flags',
-      'value.rsids',
-      'value.transcript_consequences',
-      'value.variant_id',
-      'value.faf95_joint',
-      'value.faf99_joint',
-      'value.in_silico_predictors',
-    ],
+    _source: getMultiVariantSourceFields(exomeSubset, genomeSubset, jointSubset),
     body: {
       query: {
         bool: {
@@ -492,6 +487,7 @@ const fetchVariantsByTranscript = async (esClient: any, transcript: any, _subset
   const subset = 'all'
   const exomeSubset = 'all'
   const genomeSubset = 'all'
+  const jointSubset = 'all'
 
   if (transcript.gene.symbol === 'TTN') {
     throw new UserVisibleError(
@@ -525,23 +521,7 @@ const fetchVariantsByTranscript = async (esClient: any, transcript: any, _subset
     index: GNOMAD_V4_VARIANT_INDEX,
     type: '_doc',
     size: 10000,
-    _source: [
-      `value.exome.freq.${exomeSubset}`,
-      `value.genome.freq.${genomeSubset}`,
-      'value.exome.filters',
-      'value.genome.filters',
-      'value.genome.filters',
-      'value.alleles',
-      // 'value.caid',
-      'value.locus',
-      'value.flags',
-      'value.rsids',
-      'value.transcript_consequences',
-      'value.variant_id',
-      'value.faf95_joint',
-      'value.faf99_joint',
-      'value.in_silico_predictors',
-    ],
+    _source: getMultiVariantSourceFields(exomeSubset, genomeSubset, jointSubset),
     body: {
       query: {
         bool: {


### PR DESCRIPTION
Resolves #1423, 
Resolves #1442, 
Resolves #1475,
Resolves #1491,

Updates:
- **pipelines**
  - genes pipeline now uses v4.1 constraint data (minor update to one task to not drop a field)
  - v4 variants pipeline annotates variants with `joint` frequency data from the new release hailtable
- **graphql-api**
  - add typing for new `joint` frequency data being returned
  - minor refactors to DRY error prone code
- **frontend** 
  - query and use new `joint` frequency data
  - minor refactors to DRY error prone code