### PR TITLE
Change v4.0.0 -> v4.1.0 in Dataset Selector and Metadata

### DIFF
--- a/browser/src/App.tsx
+++ b/browser/src/App.tsx
@@ -3,8 +3,6 @@ import { hot } from 'react-hot-loader/root'
 import { BrowserRouter as Router, Route, useLocation } from 'react-router-dom'
 import styled from 'styled-components'
 
-import { ExternalLink } from '@gnomad/ui'
-
 import Delayed from './Delayed'
 import ErrorBoundary from './ErrorBoundary'
 
@@ -72,16 +70,7 @@ const Banner = styled.div`
   }
 `
 
-const BANNER_CONTENT = (
-  <>
-    We are aware of an issue in the gnomAD v4.0 exomes where well covered variants have lower than
-    expected allele numbers. This issue will be fixed in the upcoming v4.1 release. For more
-    information, see our write-up {/* @ts-expect-error */}
-    <ExternalLink href="https://docs.google.com/document/d/1Xm5ZIhmkh7hv2qEfCDS6J2T0IUZYiXP8pNClTlNvCGQ/edit?usp=sharing">
-      here.
-    </ExternalLink>{' '}
-  </>
-)
+const BANNER_CONTENT = <>gnomAD v4 is now version v4.1.0</>
 
 const App = () => {
   const [isLoading, setIsLoading] = useState(true)

--- a/browser/src/GenePage/__snapshots__/GenePage.spec.tsx.snap
+++ b/browser/src/GenePage/__snapshots__/GenePage.spec.tsx.snap
@@ -91,7 +91,7 @@ exports[`GenePage with CNV dataset "gnomad_cnv_r4" has no unexpected changes 1`]
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -1609,7 +1609,7 @@ exports[`GenePage with SV dataset "gnomad_sv_r2_1" has no unexpected changes 1`]
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -3116,7 +3116,7 @@ exports[`GenePage with SV dataset "gnomad_sv_r2_1_controls" has no unexpected ch
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -4623,7 +4623,7 @@ exports[`GenePage with SV dataset "gnomad_sv_r2_1_non_neuro" has no unexpected c
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -6084,7 +6084,7 @@ exports[`GenePage with SV dataset "gnomad_sv_r4" has no unexpected changes 1`] =
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD v4.0.0
+              gnomAD v4.1.0
             </a>
           </li>
           <li
@@ -6130,7 +6130,7 @@ exports[`GenePage with SV dataset "gnomad_sv_r4" has no unexpected changes 1`] =
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -7637,7 +7637,7 @@ exports[`GenePage with non-SV dataset "exac" has no unexpected changes 1`] = `
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -9178,7 +9178,7 @@ exports[`GenePage with non-SV dataset "gnomad_cnv_r4" has no unexpected changes 
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -10696,7 +10696,7 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1" has no unexpected changes 1`
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -12332,7 +12332,7 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_controls" has no unexpected c
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -13968,7 +13968,7 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_non_cancer" has no unexpected
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -15604,7 +15604,7 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_non_neuro" has no unexpected 
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -17240,7 +17240,7 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_non_topmed" has no unexpected
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -18876,7 +18876,7 @@ exports[`GenePage with non-SV dataset "gnomad_r3" has no unexpected changes 1`] 
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -20418,7 +20418,7 @@ exports[`GenePage with non-SV dataset "gnomad_r3_controls_and_biobanks" has no u
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -21960,7 +21960,7 @@ exports[`GenePage with non-SV dataset "gnomad_r3_non_cancer" has no unexpected c
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -23502,7 +23502,7 @@ exports[`GenePage with non-SV dataset "gnomad_r3_non_neuro" has no unexpected ch
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -25044,7 +25044,7 @@ exports[`GenePage with non-SV dataset "gnomad_r3_non_topmed" has no unexpected c
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -26586,7 +26586,7 @@ exports[`GenePage with non-SV dataset "gnomad_r3_non_v2" has no unexpected chang
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -28082,7 +28082,7 @@ exports[`GenePage with non-SV dataset "gnomad_r4" has no unexpected changes 1`] 
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD v4.0.0
+              gnomAD v4.1.0
             </a>
           </li>
           <li
@@ -28128,7 +28128,7 @@ exports[`GenePage with non-SV dataset "gnomad_r4" has no unexpected changes 1`] 
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -29669,7 +29669,7 @@ exports[`GenePage with non-SV dataset "gnomad_r4_non_ukb" has no unexpected chan
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >

--- a/browser/src/MitochondrialVariantPage/__snapshots__/MitochondrialVariantPage.spec.tsx.snap
+++ b/browser/src/MitochondrialVariantPage/__snapshots__/MitochondrialVariantPage.spec.tsx.snap
@@ -109,7 +109,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_cnv_r4 has no unexpected c
                   onClick={[Function]}
                   onKeyDown={[Function]}
                 >
-                  gnomAD v4.0.0
+                  gnomAD v4.1.0
                   <div
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >
@@ -8722,7 +8722,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3 has no unexpected chang
                   onClick={[Function]}
                   onKeyDown={[Function]}
                 >
-                  gnomAD v4.0.0
+                  gnomAD v4.1.0
                   <div
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >
@@ -17245,7 +17245,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_controls_and_biobanks h
                   onClick={[Function]}
                   onKeyDown={[Function]}
                 >
-                  gnomAD v4.0.0
+                  gnomAD v4.1.0
                   <div
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >
@@ -25768,7 +25768,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_non_cancer has no unexp
                   onClick={[Function]}
                   onKeyDown={[Function]}
                 >
-                  gnomAD v4.0.0
+                  gnomAD v4.1.0
                   <div
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >
@@ -34291,7 +34291,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_non_neuro has no unexpe
                   onClick={[Function]}
                   onKeyDown={[Function]}
                 >
-                  gnomAD v4.0.0
+                  gnomAD v4.1.0
                   <div
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >
@@ -42814,7 +42814,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_non_topmed has no unexp
                   onClick={[Function]}
                   onKeyDown={[Function]}
                 >
-                  gnomAD v4.0.0
+                  gnomAD v4.1.0
                   <div
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >
@@ -51337,7 +51337,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_non_v2 has no unexpecte
                   onClick={[Function]}
                   onKeyDown={[Function]}
                 >
-                  gnomAD v4.0.0
+                  gnomAD v4.1.0
                   <div
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >
@@ -59814,7 +59814,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_r4 has no unexpected chang
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            gnomAD v4.0.0
+            gnomAD v4.1.0
           </a>
         </li>
         <li
@@ -59860,7 +59860,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_r4 has no unexpected chang
                   onClick={[Function]}
                   onKeyDown={[Function]}
                 >
-                  gnomAD v4.0.0
+                  gnomAD v4.1.0
                   <div
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >
@@ -68383,7 +68383,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_r4_non_ukb has no unexpect
                   onClick={[Function]}
                   onKeyDown={[Function]}
                 >
-                  gnomAD v4.0.0
+                  gnomAD v4.1.0
                   <div
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >
@@ -76906,7 +76906,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_sv_r2_1 has no unexpected 
                   onClick={[Function]}
                   onKeyDown={[Function]}
                 >
-                  gnomAD v4.0.0
+                  gnomAD v4.1.0
                   <div
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >
@@ -85429,7 +85429,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_sv_r2_1_controls has no un
                   onClick={[Function]}
                   onKeyDown={[Function]}
                 >
-                  gnomAD v4.0.0
+                  gnomAD v4.1.0
                   <div
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >
@@ -93952,7 +93952,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_sv_r2_1_non_neuro has no u
                   onClick={[Function]}
                   onKeyDown={[Function]}
                 >
-                  gnomAD v4.0.0
+                  gnomAD v4.1.0
                   <div
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >
@@ -102429,7 +102429,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_sv_r4 has no unexpected ch
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            gnomAD v4.0.0
+            gnomAD v4.1.0
           </a>
         </li>
         <li
@@ -102475,7 +102475,7 @@ exports[`MitochondrialVariantPage with dataset gnomad_sv_r4 has no unexpected ch
                   onClick={[Function]}
                   onKeyDown={[Function]}
                 >
-                  gnomAD v4.0.0
+                  gnomAD v4.1.0
                   <div
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >

--- a/browser/src/RegionPage/__snapshots__/RegionPage.spec.tsx.snap
+++ b/browser/src/RegionPage/__snapshots__/RegionPage.spec.tsx.snap
@@ -3699,7 +3699,7 @@ exports[`RegionPage with "gnomad_r4" dataset has no unexpected changes for a mit
 <TrackPage>
   <TrackPage__TrackPageSection>
     <DocumentTitle
-      title="M-345-456 | gnomAD v4.0.0"
+      title="M-345-456 | gnomAD v4.1.0"
     />
     <GnomadPageHeading
       datasetOptions={
@@ -3849,7 +3849,7 @@ exports[`RegionPage with "gnomad_r4" dataset has no unexpected changes for a non
 <TrackPage>
   <TrackPage__TrackPageSection>
     <DocumentTitle
-      title="12-345-456 | gnomAD v4.0.0"
+      title="12-345-456 | gnomAD v4.1.0"
     />
     <GnomadPageHeading
       datasetOptions={

--- a/browser/src/Searchbox.tsx
+++ b/browser/src/Searchbox.tsx
@@ -93,7 +93,7 @@ export default withRouter((props: any) => {
         }}
       >
         <optgroup label="GRCh38">
-          <option value="gnomad_r4">gnomAD v4.0.0</option>
+          <option value="gnomad_r4">gnomAD v4.1.0</option>
           <option value="gnomad_r3">gnomAD v3.1.2</option>
           <option value="gnomad_sv_r4">gnomAD SVs v4</option>
           <option value="gnomad_cnv_r4">gnomAD CNVs v4.0</option>

--- a/browser/src/ShortTandemRepeatPage/__snapshots__/ShortTandemRepeatPageContainer.spec.tsx.snap
+++ b/browser/src/ShortTandemRepeatPage/__snapshots__/ShortTandemRepeatPageContainer.spec.tsx.snap
@@ -1966,7 +1966,7 @@ query ShortTandemRepeat($strId: String!, $datasetId: DatasetId!) {
 exports[`ShortTandemRepeatPageContainer with dataset gnomad_r4 queries API with correct parameters 1`] = `
 <Page>
   <DocumentTitle
-    title="ATXN1 | Tandem Repeat | gnomAD v4.0.0"
+    title="ATXN1 | Tandem Repeat | gnomAD v4.1.0"
   />
   <GnomadPageHeading
     datasetOptions={

--- a/browser/src/TranscriptPage/__snapshots__/TranscriptPage.spec.tsx.snap
+++ b/browser/src/TranscriptPage/__snapshots__/TranscriptPage.spec.tsx.snap
@@ -90,7 +90,7 @@ exports[`TranscriptPage with dataset "exac" has no unexpected changes 1`] = `
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -915,7 +915,7 @@ exports[`TranscriptPage with dataset "gnomad_cnv_r4" has no unexpected changes 1
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -1740,7 +1740,7 @@ exports[`TranscriptPage with dataset "gnomad_r2_1" has no unexpected changes 1`]
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -2565,7 +2565,7 @@ exports[`TranscriptPage with dataset "gnomad_r2_1_controls" has no unexpected ch
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -3390,7 +3390,7 @@ exports[`TranscriptPage with dataset "gnomad_r2_1_non_cancer" has no unexpected 
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -4215,7 +4215,7 @@ exports[`TranscriptPage with dataset "gnomad_r2_1_non_neuro" has no unexpected c
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -5040,7 +5040,7 @@ exports[`TranscriptPage with dataset "gnomad_r2_1_non_topmed" has no unexpected 
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -5865,7 +5865,7 @@ exports[`TranscriptPage with dataset "gnomad_r3" has no unexpected changes 1`] =
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -6691,7 +6691,7 @@ exports[`TranscriptPage with dataset "gnomad_r3_controls_and_biobanks" has no un
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -7517,7 +7517,7 @@ exports[`TranscriptPage with dataset "gnomad_r3_non_cancer" has no unexpected ch
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -8343,7 +8343,7 @@ exports[`TranscriptPage with dataset "gnomad_r3_non_neuro" has no unexpected cha
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -9169,7 +9169,7 @@ exports[`TranscriptPage with dataset "gnomad_r3_non_topmed" has no unexpected ch
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -9995,7 +9995,7 @@ exports[`TranscriptPage with dataset "gnomad_r3_non_v2" has no unexpected change
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -10775,7 +10775,7 @@ exports[`TranscriptPage with dataset "gnomad_r4" has no unexpected changes 1`] =
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD v4.0.0
+              gnomAD v4.1.0
             </a>
           </li>
           <li
@@ -10821,7 +10821,7 @@ exports[`TranscriptPage with dataset "gnomad_r4" has no unexpected changes 1`] =
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -11646,7 +11646,7 @@ exports[`TranscriptPage with dataset "gnomad_r4_non_ukb" has no unexpected chang
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -12471,7 +12471,7 @@ exports[`TranscriptPage with dataset "gnomad_sv_r2_1" has no unexpected changes 
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -13296,7 +13296,7 @@ exports[`TranscriptPage with dataset "gnomad_sv_r2_1_controls" has no unexpected
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -14121,7 +14121,7 @@ exports[`TranscriptPage with dataset "gnomad_sv_r2_1_non_neuro" has no unexpecte
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -14900,7 +14900,7 @@ exports[`TranscriptPage with dataset "gnomad_sv_r4" has no unexpected changes 1`
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD v4.0.0
+              gnomAD v4.1.0
             </a>
           </li>
           <li
@@ -14946,7 +14946,7 @@ exports[`TranscriptPage with dataset "gnomad_sv_r4" has no unexpected changes 1`
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >

--- a/browser/src/TranscriptPage/__snapshots__/TranscriptPageContainer.spec.tsx.snap
+++ b/browser/src/TranscriptPage/__snapshots__/TranscriptPageContainer.spec.tsx.snap
@@ -90,7 +90,7 @@ exports[`TranscriptPageContainer with dataset exac has no unexpected changes 1`]
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -1545,7 +1545,7 @@ exports[`TranscriptPageContainer with dataset gnomad_cnv_r4 has no unexpected ch
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -3000,7 +3000,7 @@ exports[`TranscriptPageContainer with dataset gnomad_r2_1 has no unexpected chan
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -4455,7 +4455,7 @@ exports[`TranscriptPageContainer with dataset gnomad_r2_1_controls has no unexpe
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -5910,7 +5910,7 @@ exports[`TranscriptPageContainer with dataset gnomad_r2_1_non_cancer has no unex
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -7365,7 +7365,7 @@ exports[`TranscriptPageContainer with dataset gnomad_r2_1_non_neuro has no unexp
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -8820,7 +8820,7 @@ exports[`TranscriptPageContainer with dataset gnomad_r2_1_non_topmed has no unex
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -10275,7 +10275,7 @@ exports[`TranscriptPageContainer with dataset gnomad_r3 has no unexpected change
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -11731,7 +11731,7 @@ exports[`TranscriptPageContainer with dataset gnomad_r3_controls_and_biobanks ha
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -13187,7 +13187,7 @@ exports[`TranscriptPageContainer with dataset gnomad_r3_non_cancer has no unexpe
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -14643,7 +14643,7 @@ exports[`TranscriptPageContainer with dataset gnomad_r3_non_neuro has no unexpec
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -16099,7 +16099,7 @@ exports[`TranscriptPageContainer with dataset gnomad_r3_non_topmed has no unexpe
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -17555,7 +17555,7 @@ exports[`TranscriptPageContainer with dataset gnomad_r3_non_v2 has no unexpected
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -18965,7 +18965,7 @@ exports[`TranscriptPageContainer with dataset gnomad_r4 has no unexpected change
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              gnomAD v4.0.0
+              gnomAD v4.1.0
             </a>
           </li>
           <li
@@ -19011,7 +19011,7 @@ exports[`TranscriptPageContainer with dataset gnomad_r4 has no unexpected change
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -20466,7 +20466,7 @@ exports[`TranscriptPageContainer with dataset gnomad_r4_non_ukb has no unexpecte
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    gnomAD v4.0.0
+                    gnomAD v4.1.0
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >

--- a/browser/src/VariantCooccurrencePage/__snapshots__/VariantCooccurrencePage.spec.tsx.snap
+++ b/browser/src/VariantCooccurrencePage/__snapshots__/VariantCooccurrencePage.spec.tsx.snap
@@ -79,7 +79,7 @@ exports[`VariantCoocurrencePage for gnomad_r2_1 has an accuracy warning for vari
                         data-item="gnomad_r4"
                         href="/?dataset=gnomad_r4"
                       >
-                        gnomAD v4.0.0
+                        gnomAD v4.1.0
                         <div
                           class="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                         >
@@ -898,7 +898,7 @@ exports[`VariantCoocurrencePage for gnomad_r2_1 has an accuracy warning for vari
                       data-item="gnomad_r4"
                       href="/?dataset=gnomad_r4"
                     >
-                      gnomAD v4.0.0
+                      gnomAD v4.1.0
                       <div
                         class="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                       >
@@ -1779,7 +1779,7 @@ exports[`VariantCoocurrencePage for gnomad_r2_1 has no unexpected changes 1`] = 
                   onClick={[Function]}
                   onKeyDown={[Function]}
                 >
-                  gnomAD v4.0.0
+                  gnomAD v4.1.0
                   <div
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >
@@ -2712,7 +2712,7 @@ exports[`VariantCoocurrencePage for gnomad_r2_1 when the main population has a c
                         data-item="gnomad_r4"
                         href="/?dataset=gnomad_r4"
                       >
-                        gnomAD v4.0.0
+                        gnomAD v4.1.0
                         <div
                           class="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                         >
@@ -3393,7 +3393,7 @@ exports[`VariantCoocurrencePage for gnomad_r2_1 when the main population has a c
                       data-item="gnomad_r4"
                       href="/?dataset=gnomad_r4"
                     >
-                      gnomAD v4.0.0
+                      gnomAD v4.1.0
                       <div
                         class="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                       >
@@ -4131,7 +4131,7 @@ exports[`VariantCoocurrencePage for gnomad_r2_1 when the main population has cis
                         data-item="gnomad_r4"
                         href="/?dataset=gnomad_r4"
                       >
-                        gnomAD v4.0.0
+                        gnomAD v4.1.0
                         <div
                           class="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                         >
@@ -4935,7 +4935,7 @@ exports[`VariantCoocurrencePage for gnomad_r2_1 when the main population has cis
                       data-item="gnomad_r4"
                       href="/?dataset=gnomad_r4"
                     >
-                      gnomAD v4.0.0
+                      gnomAD v4.1.0
                       <div
                         class="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                       >
@@ -5796,7 +5796,7 @@ exports[`VariantCoocurrencePage for gnomad_r2_1 when the main population has hig
                         data-item="gnomad_r4"
                         href="/?dataset=gnomad_r4"
                       >
-                        gnomAD v4.0.0
+                        gnomAD v4.1.0
                         <div
                           class="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                         >
@@ -6600,7 +6600,7 @@ exports[`VariantCoocurrencePage for gnomad_r2_1 when the main population has hig
                       data-item="gnomad_r4"
                       href="/?dataset=gnomad_r4"
                     >
-                      gnomAD v4.0.0
+                      gnomAD v4.1.0
                       <div
                         class="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                       >
@@ -7461,7 +7461,7 @@ exports[`VariantCoocurrencePage for gnomad_r2_1 when the main population has low
                         data-item="gnomad_r4"
                         href="/?dataset=gnomad_r4"
                       >
-                        gnomAD v4.0.0
+                        gnomAD v4.1.0
                         <div
                           class="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                         >
@@ -8265,7 +8265,7 @@ exports[`VariantCoocurrencePage for gnomad_r2_1 when the main population has low
                       data-item="gnomad_r4"
                       href="/?dataset=gnomad_r4"
                     >
-                      gnomAD v4.0.0
+                      gnomAD v4.1.0
                       <div
                         class="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                       >
@@ -9126,7 +9126,7 @@ exports[`VariantCoocurrencePage for gnomad_r2_1 when the main population has nei
                         data-item="gnomad_r4"
                         href="/?dataset=gnomad_r4"
                       >
-                        gnomAD v4.0.0
+                        gnomAD v4.1.0
                         <div
                           class="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                         >
@@ -9902,7 +9902,7 @@ exports[`VariantCoocurrencePage for gnomad_r2_1 when the main population has nei
                       data-item="gnomad_r4"
                       href="/?dataset=gnomad_r4"
                     >
-                      gnomAD v4.0.0
+                      gnomAD v4.1.0
                       <div
                         class="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                       >
@@ -10735,7 +10735,7 @@ exports[`VariantCoocurrencePage for gnomad_r2_1 when the main population has onl
                         data-item="gnomad_r4"
                         href="/?dataset=gnomad_r4"
                       >
-                        gnomAD v4.0.0
+                        gnomAD v4.1.0
                         <div
                           class="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                         >
@@ -11511,7 +11511,7 @@ exports[`VariantCoocurrencePage for gnomad_r2_1 when the main population has onl
                       data-item="gnomad_r4"
                       href="/?dataset=gnomad_r4"
                     >
-                      gnomAD v4.0.0
+                      gnomAD v4.1.0
                       <div
                         class="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                       >
@@ -12344,7 +12344,7 @@ exports[`VariantCoocurrencePage for gnomad_r2_1 when the main population has onl
                         data-item="gnomad_r4"
                         href="/?dataset=gnomad_r4"
                       >
-                        gnomAD v4.0.0
+                        gnomAD v4.1.0
                         <div
                           class="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                         >
@@ -13120,7 +13120,7 @@ exports[`VariantCoocurrencePage for gnomad_r2_1 when the main population has onl
                       data-item="gnomad_r4"
                       href="/?dataset=gnomad_r4"
                     >
-                      gnomAD v4.0.0
+                      gnomAD v4.1.0
                       <div
                         class="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                       >
@@ -13953,7 +13953,7 @@ exports[`VariantCoocurrencePage for gnomad_r2_1 when the main population has tra
                         data-item="gnomad_r4"
                         href="/?dataset=gnomad_r4"
                       >
-                        gnomAD v4.0.0
+                        gnomAD v4.1.0
                         <div
                           class="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                         >
@@ -14757,7 +14757,7 @@ exports[`VariantCoocurrencePage for gnomad_r2_1 when the main population has tra
                       data-item="gnomad_r4"
                       href="/?dataset=gnomad_r4"
                     >
-                      gnomAD v4.0.0
+                      gnomAD v4.1.0
                       <div
                         class="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                       >
@@ -15623,7 +15623,7 @@ exports[`VariantCoocurrencePage for non-2.1 dataset exac has no unexpected chang
                   onClick={[Function]}
                   onKeyDown={[Function]}
                 >
-                  gnomAD v4.0.0
+                  gnomAD v4.1.0
                   <div
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >
@@ -15935,7 +15935,7 @@ exports[`VariantCoocurrencePage for non-2.1 dataset gnomad_cnv_r4 has no unexpec
                   onClick={[Function]}
                   onKeyDown={[Function]}
                 >
-                  gnomAD v4.0.0
+                  gnomAD v4.1.0
                   <div
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >
@@ -16247,7 +16247,7 @@ exports[`VariantCoocurrencePage for non-2.1 dataset gnomad_r2_1_controls has no 
                   onClick={[Function]}
                   onKeyDown={[Function]}
                 >
-                  gnomAD v4.0.0
+                  gnomAD v4.1.0
                   <div
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >
@@ -16559,7 +16559,7 @@ exports[`VariantCoocurrencePage for non-2.1 dataset gnomad_r2_1_non_cancer has n
                   onClick={[Function]}
                   onKeyDown={[Function]}
                 >
-                  gnomAD v4.0.0
+                  gnomAD v4.1.0
                   <div
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >
@@ -16871,7 +16871,7 @@ exports[`VariantCoocurrencePage for non-2.1 dataset gnomad_r2_1_non_neuro has no
                   onClick={[Function]}
                   onKeyDown={[Function]}
                 >
-                  gnomAD v4.0.0
+                  gnomAD v4.1.0
                   <div
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >
@@ -17183,7 +17183,7 @@ exports[`VariantCoocurrencePage for non-2.1 dataset gnomad_r2_1_non_topmed has n
                   onClick={[Function]}
                   onKeyDown={[Function]}
                 >
-                  gnomAD v4.0.0
+                  gnomAD v4.1.0
                   <div
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >
@@ -17495,7 +17495,7 @@ exports[`VariantCoocurrencePage for non-2.1 dataset gnomad_r3 has no unexpected 
                   onClick={[Function]}
                   onKeyDown={[Function]}
                 >
-                  gnomAD v4.0.0
+                  gnomAD v4.1.0
                   <div
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >
@@ -17807,7 +17807,7 @@ exports[`VariantCoocurrencePage for non-2.1 dataset gnomad_r3_controls_and_bioba
                   onClick={[Function]}
                   onKeyDown={[Function]}
                 >
-                  gnomAD v4.0.0
+                  gnomAD v4.1.0
                   <div
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >
@@ -18119,7 +18119,7 @@ exports[`VariantCoocurrencePage for non-2.1 dataset gnomad_r3_non_cancer has no 
                   onClick={[Function]}
                   onKeyDown={[Function]}
                 >
-                  gnomAD v4.0.0
+                  gnomAD v4.1.0
                   <div
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >
@@ -18431,7 +18431,7 @@ exports[`VariantCoocurrencePage for non-2.1 dataset gnomad_r3_non_neuro has no u
                   onClick={[Function]}
                   onKeyDown={[Function]}
                 >
-                  gnomAD v4.0.0
+                  gnomAD v4.1.0
                   <div
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >
@@ -18743,7 +18743,7 @@ exports[`VariantCoocurrencePage for non-2.1 dataset gnomad_r3_non_topmed has no 
                   onClick={[Function]}
                   onKeyDown={[Function]}
                 >
-                  gnomAD v4.0.0
+                  gnomAD v4.1.0
                   <div
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >
@@ -19055,7 +19055,7 @@ exports[`VariantCoocurrencePage for non-2.1 dataset gnomad_r3_non_v2 has no unex
                   onClick={[Function]}
                   onKeyDown={[Function]}
                 >
-                  gnomAD v4.0.0
+                  gnomAD v4.1.0
                   <div
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >
@@ -19321,7 +19321,7 @@ exports[`VariantCoocurrencePage for non-2.1 dataset gnomad_r4 has no unexpected 
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            gnomAD v4.0.0
+            gnomAD v4.1.0
           </a>
         </li>
         <li
@@ -19367,7 +19367,7 @@ exports[`VariantCoocurrencePage for non-2.1 dataset gnomad_r4 has no unexpected 
                   onClick={[Function]}
                   onKeyDown={[Function]}
                 >
-                  gnomAD v4.0.0
+                  gnomAD v4.1.0
                   <div
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >
@@ -19679,7 +19679,7 @@ exports[`VariantCoocurrencePage for non-2.1 dataset gnomad_r4_non_ukb has no une
                   onClick={[Function]}
                   onKeyDown={[Function]}
                 >
-                  gnomAD v4.0.0
+                  gnomAD v4.1.0
                   <div
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >
@@ -19991,7 +19991,7 @@ exports[`VariantCoocurrencePage for non-2.1 dataset gnomad_sv_r2_1_controls has 
                   onClick={[Function]}
                   onKeyDown={[Function]}
                 >
-                  gnomAD v4.0.0
+                  gnomAD v4.1.0
                   <div
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >
@@ -20303,7 +20303,7 @@ exports[`VariantCoocurrencePage for non-2.1 dataset gnomad_sv_r2_1_non_neuro has
                   onClick={[Function]}
                   onKeyDown={[Function]}
                 >
-                  gnomAD v4.0.0
+                  gnomAD v4.1.0
                   <div
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >
@@ -20569,7 +20569,7 @@ exports[`VariantCoocurrencePage for non-2.1 dataset gnomad_sv_r4 has no unexpect
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            gnomAD v4.0.0
+            gnomAD v4.1.0
           </a>
         </li>
         <li
@@ -20615,7 +20615,7 @@ exports[`VariantCoocurrencePage for non-2.1 dataset gnomad_sv_r4 has no unexpect
                   onClick={[Function]}
                   onKeyDown={[Function]}
                 >
-                  gnomAD v4.0.0
+                  gnomAD v4.1.0
                   <div
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >

--- a/browser/src/VariantPage/__snapshots__/LiftoverDisambiguationPage.spec.tsx.snap
+++ b/browser/src/VariantPage/__snapshots__/LiftoverDisambiguationPage.spec.tsx.snap
@@ -315,7 +315,7 @@ exports[`LiftoverDisambiguationPage starting from liftover target dataset gnomad
     Due to liftover, variant 
     fakevariant
      in dataset 
-    gnomAD v4.0.0
+    gnomAD v4.1.0
      may correspond to a different variant or variants in 
     GRCh37
     .
@@ -338,7 +338,7 @@ exports[`LiftoverDisambiguationPage starting from liftover target dataset gnomad
     Due to liftover, variant 
     fakevariant
      in dataset 
-    gnomAD v4.0.0
+    gnomAD v4.1.0
      may correspond to a different variant or variants in 
     GRCh37
     .

--- a/browser/src/VariantPage/__snapshots__/VariantPage.spec.tsx.snap
+++ b/browser/src/VariantPage/__snapshots__/VariantPage.spec.tsx.snap
@@ -152,7 +152,7 @@ exports[`VariantPage with the dataset "gnomad_r3" has no unexpected changes 1`] 
                   onClick={[Function]}
                   onKeyDown={[Function]}
                 >
-                  gnomAD v4.0.0
+                  gnomAD v4.1.0
                   <div
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >
@@ -9611,7 +9611,7 @@ exports[`VariantPage with the dataset "gnomad_r3_controls_and_biobanks" has no u
                   onClick={[Function]}
                   onKeyDown={[Function]}
                 >
-                  gnomAD v4.0.0
+                  gnomAD v4.1.0
                   <div
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >
@@ -19073,7 +19073,7 @@ exports[`VariantPage with the dataset "gnomad_r3_non_cancer" has no unexpected c
                   onClick={[Function]}
                   onKeyDown={[Function]}
                 >
-                  gnomAD v4.0.0
+                  gnomAD v4.1.0
                   <div
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >
@@ -28535,7 +28535,7 @@ exports[`VariantPage with the dataset "gnomad_r3_non_neuro" has no unexpected ch
                   onClick={[Function]}
                   onKeyDown={[Function]}
                 >
-                  gnomAD v4.0.0
+                  gnomAD v4.1.0
                   <div
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >
@@ -37997,7 +37997,7 @@ exports[`VariantPage with the dataset "gnomad_r3_non_topmed" has no unexpected c
                   onClick={[Function]}
                   onKeyDown={[Function]}
                 >
-                  gnomAD v4.0.0
+                  gnomAD v4.1.0
                   <div
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >
@@ -47459,7 +47459,7 @@ exports[`VariantPage with the dataset "gnomad_r3_non_v2" has no unexpected chang
                   onClick={[Function]}
                   onKeyDown={[Function]}
                 >
-                  gnomAD v4.0.0
+                  gnomAD v4.1.0
                   <div
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >
@@ -56921,7 +56921,7 @@ exports[`VariantPage with the dataset exac has no unexpected changes 1`] = `
                   onClick={[Function]}
                   onKeyDown={[Function]}
                 >
-                  gnomAD v4.0.0
+                  gnomAD v4.1.0
                   <div
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >
@@ -64413,7 +64413,7 @@ exports[`VariantPage with the dataset gnomad_r2_1 has no unexpected changes 1`] 
                   onClick={[Function]}
                   onKeyDown={[Function]}
                 >
-                  gnomAD v4.0.0
+                  gnomAD v4.1.0
                   <div
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >
@@ -74088,7 +74088,7 @@ exports[`VariantPage with the dataset gnomad_r2_1_controls has no unexpected cha
                   onClick={[Function]}
                   onKeyDown={[Function]}
                 >
-                  gnomAD v4.0.0
+                  gnomAD v4.1.0
                   <div
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >
@@ -83763,7 +83763,7 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_cancer has no unexpected c
                   onClick={[Function]}
                   onKeyDown={[Function]}
                 >
-                  gnomAD v4.0.0
+                  gnomAD v4.1.0
                   <div
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >
@@ -93438,7 +93438,7 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_neuro has no unexpected ch
                   onClick={[Function]}
                   onKeyDown={[Function]}
                 >
-                  gnomAD v4.0.0
+                  gnomAD v4.1.0
                   <div
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >
@@ -103113,7 +103113,7 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_topmed has no unexpected c
                   onClick={[Function]}
                   onKeyDown={[Function]}
                 >
-                  gnomAD v4.0.0
+                  gnomAD v4.1.0
                   <div
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >

--- a/browser/src/__snapshots__/DatasetSelector.spec.tsx.snap
+++ b/browser/src/__snapshots__/DatasetSelector.spec.tsx.snap
@@ -224,7 +224,7 @@ exports[`DataSelector with "exac" dataset selected has no unexpected changes 1`]
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            gnomAD v4.0.0
+            gnomAD v4.1.0
             <div
               className="c8"
             >
@@ -816,7 +816,7 @@ exports[`DataSelector with "exac" dataset selected has no unexpected changes whe
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            gnomAD v4.0.0
+            gnomAD v4.1.0
             <div
               className="c8"
             >
@@ -1408,7 +1408,7 @@ exports[`DataSelector with "gnomad_cnv_r4" dataset selected has no unexpected ch
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            gnomAD v4.0.0
+            gnomAD v4.1.0
             <div
               className="c8"
             >
@@ -2000,7 +2000,7 @@ exports[`DataSelector with "gnomad_cnv_r4" dataset selected has no unexpected ch
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            gnomAD v4.0.0
+            gnomAD v4.1.0
             <div
               className="c8"
             >
@@ -2592,7 +2592,7 @@ exports[`DataSelector with "gnomad_r2_1" dataset selected has no unexpected chan
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            gnomAD v4.0.0
+            gnomAD v4.1.0
             <div
               className="c8"
             >
@@ -3184,7 +3184,7 @@ exports[`DataSelector with "gnomad_r2_1" dataset selected has no unexpected chan
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            gnomAD v4.0.0
+            gnomAD v4.1.0
             <div
               className="c8"
             >
@@ -3776,7 +3776,7 @@ exports[`DataSelector with "gnomad_r2_1_controls" dataset selected has no unexpe
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            gnomAD v4.0.0
+            gnomAD v4.1.0
             <div
               className="c8"
             >
@@ -4368,7 +4368,7 @@ exports[`DataSelector with "gnomad_r2_1_controls" dataset selected has no unexpe
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            gnomAD v4.0.0
+            gnomAD v4.1.0
             <div
               className="c8"
             >
@@ -4960,7 +4960,7 @@ exports[`DataSelector with "gnomad_r2_1_non_cancer" dataset selected has no unex
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            gnomAD v4.0.0
+            gnomAD v4.1.0
             <div
               className="c8"
             >
@@ -5552,7 +5552,7 @@ exports[`DataSelector with "gnomad_r2_1_non_cancer" dataset selected has no unex
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            gnomAD v4.0.0
+            gnomAD v4.1.0
             <div
               className="c8"
             >
@@ -6144,7 +6144,7 @@ exports[`DataSelector with "gnomad_r2_1_non_neuro" dataset selected has no unexp
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            gnomAD v4.0.0
+            gnomAD v4.1.0
             <div
               className="c8"
             >
@@ -6736,7 +6736,7 @@ exports[`DataSelector with "gnomad_r2_1_non_neuro" dataset selected has no unexp
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            gnomAD v4.0.0
+            gnomAD v4.1.0
             <div
               className="c8"
             >
@@ -7328,7 +7328,7 @@ exports[`DataSelector with "gnomad_r2_1_non_topmed" dataset selected has no unex
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            gnomAD v4.0.0
+            gnomAD v4.1.0
             <div
               className="c8"
             >
@@ -7920,7 +7920,7 @@ exports[`DataSelector with "gnomad_r2_1_non_topmed" dataset selected has no unex
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            gnomAD v4.0.0
+            gnomAD v4.1.0
             <div
               className="c8"
             >
@@ -8512,7 +8512,7 @@ exports[`DataSelector with "gnomad_r3" dataset selected has no unexpected change
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            gnomAD v4.0.0
+            gnomAD v4.1.0
             <div
               className="c8"
             >
@@ -9104,7 +9104,7 @@ exports[`DataSelector with "gnomad_r3" dataset selected has no unexpected change
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            gnomAD v4.0.0
+            gnomAD v4.1.0
             <div
               className="c8"
             >
@@ -9696,7 +9696,7 @@ exports[`DataSelector with "gnomad_r3_controls_and_biobanks" dataset selected ha
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            gnomAD v4.0.0
+            gnomAD v4.1.0
             <div
               className="c8"
             >
@@ -10288,7 +10288,7 @@ exports[`DataSelector with "gnomad_r3_controls_and_biobanks" dataset selected ha
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            gnomAD v4.0.0
+            gnomAD v4.1.0
             <div
               className="c8"
             >
@@ -10880,7 +10880,7 @@ exports[`DataSelector with "gnomad_r3_non_cancer" dataset selected has no unexpe
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            gnomAD v4.0.0
+            gnomAD v4.1.0
             <div
               className="c8"
             >
@@ -11472,7 +11472,7 @@ exports[`DataSelector with "gnomad_r3_non_cancer" dataset selected has no unexpe
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            gnomAD v4.0.0
+            gnomAD v4.1.0
             <div
               className="c8"
             >
@@ -12064,7 +12064,7 @@ exports[`DataSelector with "gnomad_r3_non_neuro" dataset selected has no unexpec
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            gnomAD v4.0.0
+            gnomAD v4.1.0
             <div
               className="c8"
             >
@@ -12656,7 +12656,7 @@ exports[`DataSelector with "gnomad_r3_non_neuro" dataset selected has no unexpec
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            gnomAD v4.0.0
+            gnomAD v4.1.0
             <div
               className="c8"
             >
@@ -13248,7 +13248,7 @@ exports[`DataSelector with "gnomad_r3_non_topmed" dataset selected has no unexpe
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            gnomAD v4.0.0
+            gnomAD v4.1.0
             <div
               className="c8"
             >
@@ -13840,7 +13840,7 @@ exports[`DataSelector with "gnomad_r3_non_topmed" dataset selected has no unexpe
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            gnomAD v4.0.0
+            gnomAD v4.1.0
             <div
               className="c8"
             >
@@ -14432,7 +14432,7 @@ exports[`DataSelector with "gnomad_r3_non_v2" dataset selected has no unexpected
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            gnomAD v4.0.0
+            gnomAD v4.1.0
             <div
               className="c8"
             >
@@ -15024,7 +15024,7 @@ exports[`DataSelector with "gnomad_r3_non_v2" dataset selected has no unexpected
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            gnomAD v4.0.0
+            gnomAD v4.1.0
             <div
               className="c8"
             >
@@ -15570,7 +15570,7 @@ exports[`DataSelector with "gnomad_r4" dataset selected has no unexpected change
       onClick={[Function]}
       onKeyDown={[Function]}
     >
-      gnomAD v4.0.0
+      gnomAD v4.1.0
     </a>
   </li>
   <li
@@ -15616,7 +15616,7 @@ exports[`DataSelector with "gnomad_r4" dataset selected has no unexpected change
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            gnomAD v4.0.0
+            gnomAD v4.1.0
             <div
               className="c8"
             >
@@ -16162,7 +16162,7 @@ exports[`DataSelector with "gnomad_r4" dataset selected has no unexpected change
       onClick={[Function]}
       onKeyDown={[Function]}
     >
-      gnomAD v4.0.0
+      gnomAD v4.1.0
     </a>
   </li>
   <li
@@ -16208,7 +16208,7 @@ exports[`DataSelector with "gnomad_r4" dataset selected has no unexpected change
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            gnomAD v4.0.0
+            gnomAD v4.1.0
             <div
               className="c8"
             >
@@ -16800,7 +16800,7 @@ exports[`DataSelector with "gnomad_r4_non_ukb" dataset selected has no unexpecte
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            gnomAD v4.0.0
+            gnomAD v4.1.0
             <div
               className="c8"
             >
@@ -17392,7 +17392,7 @@ exports[`DataSelector with "gnomad_r4_non_ukb" dataset selected has no unexpecte
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            gnomAD v4.0.0
+            gnomAD v4.1.0
             <div
               className="c8"
             >
@@ -17984,7 +17984,7 @@ exports[`DataSelector with "gnomad_sv_r2_1" dataset selected has no unexpected c
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            gnomAD v4.0.0
+            gnomAD v4.1.0
             <div
               className="c8"
             >
@@ -18576,7 +18576,7 @@ exports[`DataSelector with "gnomad_sv_r2_1" dataset selected has no unexpected c
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            gnomAD v4.0.0
+            gnomAD v4.1.0
             <div
               className="c8"
             >
@@ -19168,7 +19168,7 @@ exports[`DataSelector with "gnomad_sv_r2_1_controls" dataset selected has no une
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            gnomAD v4.0.0
+            gnomAD v4.1.0
             <div
               className="c8"
             >
@@ -19760,7 +19760,7 @@ exports[`DataSelector with "gnomad_sv_r2_1_controls" dataset selected has no une
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            gnomAD v4.0.0
+            gnomAD v4.1.0
             <div
               className="c8"
             >
@@ -20352,7 +20352,7 @@ exports[`DataSelector with "gnomad_sv_r2_1_non_neuro" dataset selected has no un
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            gnomAD v4.0.0
+            gnomAD v4.1.0
             <div
               className="c8"
             >
@@ -20944,7 +20944,7 @@ exports[`DataSelector with "gnomad_sv_r2_1_non_neuro" dataset selected has no un
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            gnomAD v4.0.0
+            gnomAD v4.1.0
             <div
               className="c8"
             >
@@ -21490,7 +21490,7 @@ exports[`DataSelector with "gnomad_sv_r4" dataset selected has no unexpected cha
       onClick={[Function]}
       onKeyDown={[Function]}
     >
-      gnomAD v4.0.0
+      gnomAD v4.1.0
     </a>
   </li>
   <li
@@ -21536,7 +21536,7 @@ exports[`DataSelector with "gnomad_sv_r4" dataset selected has no unexpected cha
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            gnomAD v4.0.0
+            gnomAD v4.1.0
             <div
               className="c8"
             >
@@ -22082,7 +22082,7 @@ exports[`DataSelector with "gnomad_sv_r4" dataset selected has no unexpected cha
       onClick={[Function]}
       onKeyDown={[Function]}
     >
-      gnomAD v4.0.0
+      gnomAD v4.1.0
     </a>
   </li>
   <li
@@ -22128,7 +22128,7 @@ exports[`DataSelector with "gnomad_sv_r4" dataset selected has no unexpected cha
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            gnomAD v4.0.0
+            gnomAD v4.1.0
             <div
               className="c8"
             >

--- a/browser/src/__snapshots__/HomePage.spec.tsx.snap
+++ b/browser/src/__snapshots__/HomePage.spec.tsx.snap
@@ -203,7 +203,7 @@ exports[`Home Page has no unexpected changes 1`] = `
         <option
           value="gnomad_r4"
         >
-          gnomAD v4.0.0
+          gnomAD v4.1.0
         </option>
         <option
           value="gnomad_r3"

--- a/browser/src/__snapshots__/NavBar.spec.tsx.snap
+++ b/browser/src/__snapshots__/NavBar.spec.tsx.snap
@@ -258,7 +258,7 @@ exports[`NavBar has no unexpected changes 1`] = `
         <option
           value="gnomad_r4"
         >
-          gnomAD v4.0.0
+          gnomAD v4.1.0
         </option>
         <option
           value="gnomad_r3"

--- a/browser/src/__snapshots__/Searchbox.spec.tsx.snap
+++ b/browser/src/__snapshots__/Searchbox.spec.tsx.snap
@@ -15,7 +15,7 @@ exports[`Searchbox has no unexpected changes when no dataset specified 1`] = `
       <option
         value="gnomad_r4"
       >
-        gnomAD v4.0.0
+        gnomAD v4.1.0
       </option>
       <option
         value="gnomad_r3"
@@ -103,7 +103,7 @@ exports[`Searchbox with selected dataset exac has no unexpected changes 1`] = `
       <option
         value="gnomad_r4"
       >
-        gnomAD v4.0.0
+        gnomAD v4.1.0
       </option>
       <option
         value="gnomad_r3"
@@ -191,7 +191,7 @@ exports[`Searchbox with selected dataset gnomad_cnv_r4 has no unexpected changes
       <option
         value="gnomad_r4"
       >
-        gnomAD v4.0.0
+        gnomAD v4.1.0
       </option>
       <option
         value="gnomad_r3"
@@ -279,7 +279,7 @@ exports[`Searchbox with selected dataset gnomad_r2_1 has no unexpected changes 1
       <option
         value="gnomad_r4"
       >
-        gnomAD v4.0.0
+        gnomAD v4.1.0
       </option>
       <option
         value="gnomad_r3"
@@ -367,7 +367,7 @@ exports[`Searchbox with selected dataset gnomad_r2_1_controls has no unexpected 
       <option
         value="gnomad_r4"
       >
-        gnomAD v4.0.0
+        gnomAD v4.1.0
       </option>
       <option
         value="gnomad_r3"
@@ -455,7 +455,7 @@ exports[`Searchbox with selected dataset gnomad_r2_1_non_cancer has no unexpecte
       <option
         value="gnomad_r4"
       >
-        gnomAD v4.0.0
+        gnomAD v4.1.0
       </option>
       <option
         value="gnomad_r3"
@@ -543,7 +543,7 @@ exports[`Searchbox with selected dataset gnomad_r2_1_non_neuro has no unexpected
       <option
         value="gnomad_r4"
       >
-        gnomAD v4.0.0
+        gnomAD v4.1.0
       </option>
       <option
         value="gnomad_r3"
@@ -631,7 +631,7 @@ exports[`Searchbox with selected dataset gnomad_r2_1_non_topmed has no unexpecte
       <option
         value="gnomad_r4"
       >
-        gnomAD v4.0.0
+        gnomAD v4.1.0
       </option>
       <option
         value="gnomad_r3"
@@ -719,7 +719,7 @@ exports[`Searchbox with selected dataset gnomad_r3 has no unexpected changes 1`]
       <option
         value="gnomad_r4"
       >
-        gnomAD v4.0.0
+        gnomAD v4.1.0
       </option>
       <option
         value="gnomad_r3"
@@ -807,7 +807,7 @@ exports[`Searchbox with selected dataset gnomad_r3_controls_and_biobanks has no 
       <option
         value="gnomad_r4"
       >
-        gnomAD v4.0.0
+        gnomAD v4.1.0
       </option>
       <option
         value="gnomad_r3"
@@ -895,7 +895,7 @@ exports[`Searchbox with selected dataset gnomad_r3_non_cancer has no unexpected 
       <option
         value="gnomad_r4"
       >
-        gnomAD v4.0.0
+        gnomAD v4.1.0
       </option>
       <option
         value="gnomad_r3"
@@ -983,7 +983,7 @@ exports[`Searchbox with selected dataset gnomad_r3_non_neuro has no unexpected c
       <option
         value="gnomad_r4"
       >
-        gnomAD v4.0.0
+        gnomAD v4.1.0
       </option>
       <option
         value="gnomad_r3"
@@ -1071,7 +1071,7 @@ exports[`Searchbox with selected dataset gnomad_r3_non_topmed has no unexpected 
       <option
         value="gnomad_r4"
       >
-        gnomAD v4.0.0
+        gnomAD v4.1.0
       </option>
       <option
         value="gnomad_r3"
@@ -1159,7 +1159,7 @@ exports[`Searchbox with selected dataset gnomad_r3_non_v2 has no unexpected chan
       <option
         value="gnomad_r4"
       >
-        gnomAD v4.0.0
+        gnomAD v4.1.0
       </option>
       <option
         value="gnomad_r3"
@@ -1247,7 +1247,7 @@ exports[`Searchbox with selected dataset gnomad_r4 has no unexpected changes 1`]
       <option
         value="gnomad_r4"
       >
-        gnomAD v4.0.0
+        gnomAD v4.1.0
       </option>
       <option
         value="gnomad_r3"
@@ -1335,7 +1335,7 @@ exports[`Searchbox with selected dataset gnomad_r4_non_ukb has no unexpected cha
       <option
         value="gnomad_r4"
       >
-        gnomAD v4.0.0
+        gnomAD v4.1.0
       </option>
       <option
         value="gnomad_r3"
@@ -1423,7 +1423,7 @@ exports[`Searchbox with selected dataset gnomad_sv_r2_1 has no unexpected change
       <option
         value="gnomad_r4"
       >
-        gnomAD v4.0.0
+        gnomAD v4.1.0
       </option>
       <option
         value="gnomad_r3"
@@ -1511,7 +1511,7 @@ exports[`Searchbox with selected dataset gnomad_sv_r2_1_controls has no unexpect
       <option
         value="gnomad_r4"
       >
-        gnomAD v4.0.0
+        gnomAD v4.1.0
       </option>
       <option
         value="gnomad_r3"
@@ -1599,7 +1599,7 @@ exports[`Searchbox with selected dataset gnomad_sv_r2_1_non_neuro has no unexpec
       <option
         value="gnomad_r4"
       >
-        gnomAD v4.0.0
+        gnomAD v4.1.0
       </option>
       <option
         value="gnomad_r3"
@@ -1687,7 +1687,7 @@ exports[`Searchbox with selected dataset gnomad_sv_r4 has no unexpected changes 
       <option
         value="gnomad_r4"
       >
-        gnomAD v4.0.0
+        gnomAD v4.1.0
       </option>
       <option
         value="gnomad_r3"

--- a/dataset-metadata/metadata.ts
+++ b/dataset-metadata/metadata.ts
@@ -18,7 +18,7 @@ export const datasetLabels = {
   gnomad_sv_r2_1_non_neuro: 'gnomAD SVs v2.1 (non-neuro)',
   gnomad_sv_r4: 'gnomAD SVs v4.0',
   gnomad_cnv_r4: 'gnomAD CNVs v4.0',
-  gnomad_r4: 'gnomAD v4.0.0',
+  gnomad_r4: 'gnomAD v4.1.0',
   gnomad_r4_non_ukb: 'gnomAD v4.1.0 (non-UKB)',
 } as const
 export type DatasetId = keyof typeof datasetLabels


### PR DESCRIPTION
- Modifies the dataset selector and metadata to change `v4.0.0` -> `v4.1.0`
- Updates the banner to say v4.0 is now v4.1
