### PR TITLE
Add new variant flag descriptions to help text

### DIFF
--- a/browser/help/faq/technical-details/what-do-the-flags-on-the-browser-mean.md
+++ b/browser/help/faq/technical-details/what-do-the-flags-on-the-browser-mean.md
@@ -8,6 +8,9 @@ Flags that will appear on variant pages:
 - AS-VQSR: Failed GATK Allele-Specific Variant Quality Recalibration (AS-VQSR)
   InbreedingCoeff: The Inbreeding Coefficient is < -0.3
 - RF (gnomAD v2 only): Failed random forest filtering thresholds of 0.055 for exome SNVs, 0.206 for exome indels, 0.263 for genome SNVs, and 0.222 for genome indels
+- Not in exomes: Variant was not called in the gnomAD exomes, i.e. no gnomAD exome sample had a reference or non-reference genotype call. Any loci outside of the [exome capture regions](https://gnomad.broadinstitute.org/help/exome-capture-tech) will have this flag.
+- Not in genomes: Variant was not called in the gnomAD genomes, i.e., no gnomAD genome sample had a reference or non-reference genotype call.
+- Discrepant Frequencies: Variant has highly discordant frequencies in the gnomAD exomes and genomes. Variants are flagged using a Cochran–Mantel–Haenszel (CMH) test. For more information, see our combined frequency [help page](https://gnomad.broadinstitute.org/help/combined-freq-stats).
 
 Flags that will appear in the variant table on gene/region pages:
 

--- a/browser/src/help/__snapshots__/HelpPage.spec.tsx.snap
+++ b/browser/src/help/__snapshots__/HelpPage.spec.tsx.snap
@@ -9828,6 +9828,9 @@ Flags that will appear on variant pages:
 - AS-VQSR: Failed GATK Allele-Specific Variant Quality Recalibration (AS-VQSR)
   InbreedingCoeff: The Inbreeding Coefficient is < -0.3
 - RF (gnomAD v2 only): Failed random forest filtering thresholds of 0.055 for exome SNVs, 0.206 for exome indels, 0.263 for genome SNVs, and 0.222 for genome indels
+- Not in exomes: Variant was not called in the gnomAD exomes, i.e. no gnomAD exome sample had a reference or non-reference genotype call. Any loci outside of the [exome capture regions](https://gnomad.broadinstitute.org/help/exome-capture-tech) will have this flag.
+- Not in genomes: Variant was not called in the gnomAD genomes, i.e., no gnomAD genome sample had a reference or non-reference genotype call.
+- Discrepant Frequencies: Variant has highly discordant frequencies in the gnomAD exomes and genomes. Variants are flagged using a Cochran–Mantel–Haenszel (CMH) test. For more information, see our combined frequency [help page](https://gnomad.broadinstitute.org/help/combined-freq-stats).
 
 Flags that will appear in the variant table on gene/region pages:
 


### PR DESCRIPTION
Update flags page to include description for two new flags on the variant page: the no variant called flags (in exomes or genomes) and discordant frequency flag