### PR TITLE
Remove returned error when variant has no ClinVar entry

### DIFF
--- a/graphql-api/src/graphql/resolvers/clinvar-variants.ts
+++ b/graphql-api/src/graphql/resolvers/clinvar-variants.ts
@@ -24,8 +24,11 @@ const resolveClinVarVariant = async (_: any, args: any, ctx: any) => {
 
   const variant = await fetchClinvarVariantById(ctx.esClient, args.reference_genome, variantId)
 
+  // Previously, we would return an error from the API if a variant was not found in ClinVar
+  //   This interefered with our nginx cache, as it uniformly does not cache responses that include
+  //   an error. Now we instead return null.
   if (!variant) {
-    throw new UserVisibleError('ClinVar variant not found')
+    return null
   }
 
   return variant


### PR DESCRIPTION
Our API prevents nginx caching when an error is returned, since variants can, and often do, legitimately do not have a ClinVar entry for the given variant id, this removes the error from the response to allow caching of many more variants.