### PR TITLE
Increase redis memory request/limit to prevent OOMKills when we use the entirety of redis 'maxmemory'

### DIFF
--- a/deploy/manifests/redis/redis-values.yaml
+++ b/deploy/manifests/redis/redis-values.yaml
@@ -21,10 +21,10 @@ master:
   resources: &podresources
     requests:
       cpu: 1
-      memory: '36Gi'
+      memory: '39Gi'
     limits:
       cpu: 2
-      memory: '36Gi'
+      memory: '39Gi'
   nodeSelector: *nodeselector
 replica:
   persistence: *podpersistence

--- a/deploy/manifests/redis/redis.statefulset.yaml
+++ b/deploy/manifests/redis/redis.statefulset.yaml
@@ -42,10 +42,10 @@ spec:
           resources:
             requests:
               cpu: '500m'
-              memory: '36Gi'
+              memory: '39Gi'
             limits:
               cpu: 1
-              memory: '36Gi'
+              memory: '39Gi'
           volumeMounts:
             - mountPath: /data
               name: redis-data


### PR DESCRIPTION
I think we're hitting an edge case where redis is getting OOMKilled when it allocates exactly 36GiB of ram to cache... or exceeds whatever the precision value for '36Gi' is in kubernete's mind.

This bumps the pod request/limit to 39GiB -- my understanding is that. We have around ~6GiB allocatable on the redis GKE node right now, so 39 should keep us under that limit without other infra changes.