### PR TITLE
Modify ES indices for v4.1 deployment

### DIFF
--- a/graphql-api/src/queries/copy-number-variant-queries.ts
+++ b/graphql-api/src/queries/copy-number-variant-queries.ts
@@ -1,6 +1,6 @@
 import { fetchAllSearchResults } from './helpers/elasticsearch-helpers'
 
-const GNOMAD_COPY_NUMBER_VARIANTS_V4_INDEX = 'gnomad_v4_cnvs'
+const GNOMAD_COPY_NUMBER_VARIANTS_V4_INDEX = 'v4p1_gnomad_v4_cnvs'
 
 type CnvDatasetId = 'gnomad_cnv_r4'
 type DatasetDependentQueryParams = {

--- a/graphql-api/src/queries/gene-queries.ts
+++ b/graphql-api/src/queries/gene-queries.ts
@@ -4,7 +4,7 @@ import { fetchAllSearchResults } from './helpers/elasticsearch-helpers'
 
 const GENE_INDICES = {
   GRCh37: 'genes_grch37',
-  GRCh38: 'genes_grch38',
+  GRCh38: 'v4p1_genes_grch38',
 }
 
 const _fetchGeneById = async (esClient: any, geneId: any, referenceGenome: any) => {

--- a/graphql-api/src/queries/structural-variant-queries.spec.ts
+++ b/graphql-api/src/queries/structural-variant-queries.spec.ts
@@ -54,7 +54,9 @@ const makeMockClient = (response: any) => {
 }
 
 const expectedIndex = (datasetId: SvDatasetId) =>
-  datasetId === 'gnomad_sv_r4' ? 'gnomad_structural_variants_v3' : 'gnomad_structural_variants_v2'
+  datasetId === 'gnomad_sv_r4'
+    ? 'v4p1_gnomad_structural_variants_v3'
+    : 'gnomad_structural_variants_v2'
 
 describe('fetchStructuralVariantById', () => {
   const variantId = 'dummy-variant'

--- a/graphql-api/src/queries/structural-variant-queries.ts
+++ b/graphql-api/src/queries/structural-variant-queries.ts
@@ -3,7 +3,7 @@ import { isEmpty } from 'lodash'
 import { fetchAllSearchResults } from './helpers/elasticsearch-helpers'
 
 const GNOMAD_STRUCTURAL_VARIANTS_V2_INDEX = 'gnomad_structural_variants_v2'
-const GNOMAD_STRUCTURAL_VARIANTS_V3_INDEX = 'gnomad_structural_variants_v3'
+const GNOMAD_STRUCTURAL_VARIANTS_V3_INDEX = 'v4p1_gnomad_structural_variants_v3'
 
 type SvDatasetId =
   | 'gnomad_sv_r2_1'

--- a/graphql-api/src/queries/variant-datasets/gnomad-v4-variant-queries.ts
+++ b/graphql-api/src/queries/variant-datasets/gnomad-v4-variant-queries.ts
@@ -259,9 +259,9 @@ const shapeVariantSummary = (subset: Subset, context: any) => {
     const genomeFilters = variant.genome.filters || []
     const jointFilters = variant.joint.filter || []
 
-    const subsetJointFreq = variant.joint.freq[subset].ac_raw
-
     const subsetGenomeFreq = variant.genome.freq[subset] || {}
+    const subsetJointFreq = variant.joint.freq[subset] || {}
+
     const hasExomeVariant = variant.exome.freq[subset].ac_raw
     const hasGenomeVariant = subsetGenomeFreq.ac_raw
     const hasJointVariant = subsetJointFreq.ac_raw

--- a/graphql-api/src/queries/variant-datasets/gnomad-v4-variant-queries.ts
+++ b/graphql-api/src/queries/variant-datasets/gnomad-v4-variant-queries.ts
@@ -12,7 +12,7 @@ import { getFlagsForContext } from './shared/flags'
 import { getConsequenceForContext } from './shared/transcriptConsequence'
 import largeGenes from '../helpers/large-genes'
 
-const GNOMAD_V4_VARIANT_INDEX = 'gnomad_v4_variants'
+const GNOMAD_V4_VARIANT_INDEX = 'v4p1_gnomad_v4_variants'
 
 type Subset = 'all' | 'non_ukb'
 


### PR DESCRIPTION
Temporarily add new graphql aliases to allow a v4.1 deployment to exist at the same time as a v4.0 deployment