### PR TITLE
v4.1 copy edits

### DIFF
--- a/browser/src/App.tsx
+++ b/browser/src/App.tsx
@@ -9,6 +9,7 @@ import ErrorBoundary from './ErrorBoundary'
 import Notifications, { showNotification } from './Notifications'
 import StatusMessage from './StatusMessage'
 import userPreferences from './userPreferences'
+import { ExternalLink } from '@gnomad/ui'
 
 const NavBar = lazy(() => import('./NavBar'))
 const Routes = lazy(() => import('./Routes'))
@@ -70,8 +71,15 @@ const Banner = styled.div`
   }
 `
 
-const BANNER_CONTENT = <>gnomAD v4 is now version v4.1.0</>
-
+const BANNER_CONTENT = (
+  <>
+    gnomAD v4 is here! Read our {/* @ts-expect-error */}
+    <ExternalLink href="https://gnomad.broadinstitute.org/news/2024-04-gnomad-v4-1">
+      blog post
+    </ExternalLink>{' '}
+    for more details
+  </>
+)
 const App = () => {
   const [isLoading, setIsLoading] = useState(true)
   useEffect(() => {

--- a/browser/src/DownloadsPage/GnomadV4Downloads.tsx
+++ b/browser/src/DownloadsPage/GnomadV4Downloads.tsx
@@ -15,84 +15,57 @@ import {
 import Link from '../Link'
 
 const exomeChromosomeVcfs = [
-  { chrom: '1', size: '26.88 GiB', md5: '50bba514e8d4e65aef39c7baa9c29e71' },
-  { chrom: '2', size: '20.32 GiB', md5: '0bac3559c5d9442d35c72308ab4a8684' },
-  { chrom: '3', size: '16.33 GiB', md5: '4cb2b400a8dfd95711e3b20a7a166f25' },
-  { chrom: '4', size: '11.07 GiB', md5: '2d1988c3ef15027c1c978a245feb4110' },
-  { chrom: '5', size: '12.29 GiB', md5: '4e4b38e9a819748a7909684f311ebd20' },
-  { chrom: '6', size: '13.14 GiB', md5: '22bac98dcacfddcc43820e05d4a72081' },
-  { chrom: '7', size: '14.01 GiB', md5: 'bf00c8dfe5c22d6fd684b7b90be4e8ff' },
-  { chrom: '8', size: '10.38 GiB', md5: 'c10c6a7265af418cbfd7a855944bc9f2' },
-  { chrom: '9', size: '11.57 GiB', md5: 'f20000e361f3f2f4759619b3029c10ad' },
-  { chrom: '10', size: '11.23 GiB', md5: 'd85984b39664d800ec8da815004029c1' },
-  { chrom: '11', size: '16.58 GiB', md5: '882f7345687996ac5e728fe771debeb2' },
-  { chrom: '12', size: '15.21 GiB', md5: '1b11c7c60a205703a977ba03c30f2f41' },
-  { chrom: '13', size: '5.18 GiB', md5: '4611cd7c3e0a1111ba52b2ec544484b4' },
-  { chrom: '14', size: '9.54 GiB', md5: '628757952a5114929bf1150901bc34bb' },
-  { chrom: '15', size: '10.65 GiB', md5: '63574925084fa8e48dac46185c41975f' },
-  { chrom: '16', size: '13.90 GiB', md5: 'ba59445b0fb0f1a1d78df5dc623c40dd' },
-  { chrom: '17', size: '17.04 GiB', md5: '5010e1133a4153c34ae3b113c7c97280' },
-  { chrom: '18', size: '4.87 GiB', md5: 'aed2e7e455e35b97a32d4886d94ccaa0' },
-  { chrom: '19', size: '18.14 GiB', md5: '67c40daa48e50bb4ec1ec541570217b0' },
-  { chrom: '20', size: '6.9 GiB', md5: '09b0221006b59c1626d8188e909e933d' },
-  { chrom: '21', size: '3.27 GiB', md5: '206afe8d9dbe544697e1b67eee6d2f7f' },
-  { chrom: '22', size: '7.31 GiB', md5: '3084349c03194e8cf5063a1e46473248' },
-  { chrom: 'X', size: '7.96 GiB', md5: '6d33a288735eda242c473905ccb6743b' },
-  { chrom: 'Y', size: '163.66 MiB', md5: 'c8414744cf75fa498e2497a9391eb1ad' },
+  { chrom: '1', size: '17.50 GiB', md5: '848be4d85c953bc73a8e4f0c97026a72' },
+  { chrom: '2', size: '13.30 GiB', md5: 'e2f5d891a3374e88d1c3136f94bed0ea' },
+  { chrom: '3', size: '10.79 GiB', md5: 'a35b949b32453b4b5abd7b1de42e298a' },
+  { chrom: '4', size: '7.18 GiB', md5: 'c7c7008a73acbb8fea68b82951842832' },
+  { chrom: '5', size: '7.91 GiB', md5: 'c1016f56be62deb2e947fed4d31302dd' },
+  { chrom: '6', size: '8.50 GiB', md5: 'f96bc8711ed085d63b8bd5396664adbc' },
+  { chrom: '7', size: '9.01 GiB', md5: 'c41cd52571b001cf7d3e388a668e4dff' },
+  { chrom: '8', size: '6.78 GiB', md5: 'a47777fe141c01876cb170f2c2f2e6b6' },
+  { chrom: '9', size: '7.49 GiB', md5: 'c5abd4d8aff12f2bf8b4ec844769782f' },
+  { chrom: '10', size: '7.32 GiB', md5: '4befc8dc50ead888e8af24f556c9fdd6' },
+  { chrom: '11', size: '10.84 GiB', md5: '3833ce3ab046afe92c9b55df93a61ec' },
+  { chrom: '12', size: '9.90 GiB', md5: 'e530a9ed203cdcc914621ab7430774bb' },
+  { chrom: '13', size: '3.30 GiB', md5: 'af1eab40c8be47c8c7c04dc73e0333e4' },
+  { chrom: '14', size: '6.21 GiB', md5: 'd0e0fa71d94bf016a061ba4dc0bd869f' },
+  { chrom: '15', size: '6.87 GiB', md5: '01b116e34b3815cfd1d3afa53a29a41b' },
+  { chrom: '16', size: '9.10 GiB', md5: '44137843b2df39c8a654427181bda919' },
+  { chrom: '17', size: '11.19 GiB', md5: 'c61978218ab3eaa07b571eb9959f39d2' },
+  { chrom: '18', size: '3.16 GiB', md5: '1ec708d5cae9657ccee0626763ed9946' },
+  { chrom: '19', size: '11.75 GiB', md5: '50a37cfa9a9a3e030388bcf15bdabb79' },
+  { chrom: '20', size: '4.43 GiB', md5: '605680cd99e469bdf5f0045bd22359c9' },
+  { chrom: '21', size: '2.10 GiB', md5: '7ca6d51a42425b857eddb46d7bc5832d' },
+  { chrom: '22', size: '4.71 GiB', md5: 'dcf191563e69054a71bd4dc77862799a' },
+  { chrom: 'X', size: '5.35 GiB', md5: '5b7b17d3d4cff22c20480a908c861a28' },
+  { chrom: 'Y', size: '108.30 MiB', md5: ' d500cf5a73c53f02d1b95f1e092f2e49' },
 ]
 
 const genomeChromosomeVcfs = [
-  { chrom: '1', size: '64.64 GiB', md5: '722d44a602a6988c2ffd55b6ed7ca3ce' },
-  { chrom: '2', size: '68.24 GiB', md5: '2d14cb70a93d772191fa5133f5b1a129' },
-  { chrom: '3', size: '56.96 GiB', md5: 'b0c8955adcd44e8757d9bfdb01a2e180' },
-  { chrom: '4', size: '53.19 GiB', md5: '9fba0d34f3074100681b74fc489f620b' },
-  { chrom: '5', size: '48.64 GiB', md5: '007112b5d72df612dcfb3dc45606dc25' },
-  { chrom: '6', size: '46.85 GiB', md5: '9b0a289a7dc7910f1a79586b8aa62593' },
-  { chrom: '7', size: '45.95 GiB', md5: '0929e74108e1d7faab3f7e90e8af9410' },
-  { chrom: '8', size: '43.03 GiB', md5: '4c6bc15f9d1232f83e89f5305cc1fbab' },
-  { chrom: '9', size: '36.36 GiB', md5: '83c85e0d39b0bab7b8223642c8d2dab0' },
-  { chrom: '10', size: '39.16 GiB', md5: '757db8e8f1007144e6dd8dfcd697046b' },
-  { chrom: '11', size: '38.57 GiB', md5: '52c5b1e9313869dc347b55133dd5c31f' },
-  { chrom: '12', size: '37.86 GiB', md5: '19d5b3abacf1c6be990b3aa8f6ca2786' },
-  { chrom: '13', size: '25.65 GiB', md5: '94c6da5e72d87bf0a714d6b5c1c09272' },
-  { chrom: '14', size: '26.02 GiB', md5: '145c7f1710a6b3a90044f3d14912ce4b' },
-  { chrom: '15', size: '24.63 GiB', md5: '3e04c33c6a03f91b1b071dc8c3224f77' },
-  { chrom: '16', size: '27.57 GiB', md5: '572a343a3d8629e0579dbd424f5147ad' },
-  { chrom: '17', size: '25.17 GiB', md5: 'ac0003ebe2297dd4377c5045bb439c5c' },
-  { chrom: '18', size: '21.12 GiB', md5: '4e1b5b41b0bc70c23d43904dd9ff3bb1' },
-  { chrom: '19', size: '19.91 GiB', md5: '992829f49533843a5ced897d6388d5e2' },
-  { chrom: '20', size: '17.49 GiB', md5: 'd3ab3ed3c79c53a4fe15ced300b07ef5' },
-  { chrom: '21', size: '11.47 GiB', md5: '4d2e808cbaafcd2ddc7692be0a45a924' },
-  { chrom: '22', size: '12.77 GiB', md5: 'd6ba3b18b07423e3a1af56e8405a26c2' },
-  { chrom: 'X', size: '37.05 GiB', md5: 'b77d8f0219fa9a033a6f747d5fef12d9' },
-  { chrom: 'Y', size: '890.03 MiB', md5: '8c231b75745b6670555915847c9999e8' },
-]
-
-const svChromosomeVcfs = [
-  { chrom: '1', size: '616.33 MiB', crc32c: 'f497d60f' },
-  { chrom: '2', size: '612.83 MiB', crc32c: 'bee58761' },
-  { chrom: '3', size: '469.64 MiB', crc32c: '00c11e03' },
-  { chrom: '4', size: '446.44 MiB', crc32c: '4aa1be45' },
-  { chrom: '5', size: '418.1 MiB', crc32c: 'cc78d775' },
-  { chrom: '6', size: '418.37 MiB', crc32c: '8ad01764' },
-  { chrom: '7', size: '437.99 MiB', crc32c: '0e78bed7' },
-  { chrom: '8', size: '332.91 MiB', crc32c: '1a7974d3' },
-  { chrom: '9', size: '289.19 MiB', crc32c: '693c4cc1' },
-  { chrom: '10', size: '320.36 MiB', crc32c: '63dc92db' },
-  { chrom: '11', size: '312.75 MiB', crc32c: 'c0016756' },
-  { chrom: '12', size: '322.33 MiB', crc32c: '28396743' },
-  { chrom: '13', size: '208.4 MiB', crc32c: '504d3937' },
-  { chrom: '14', size: '218.37 MiB', crc32c: '06ccecf9' },
-  { chrom: '15', size: '183.5 MiB', crc32c: 'c191b2ca' },
-  { chrom: '16', size: '234 MiB', crc32c: '016c8e77' },
-  { chrom: '17', size: '233.1 MiB', crc32c: 'f37738a4' },
-  { chrom: '18', size: '157.88 MiB', crc32c: '1f802ad6' },
-  { chrom: '19', size: '227.48 MiB', crc32c: '16a48cf0' },
-  { chrom: '20', size: '148.62 MiB', crc32c: '7e34ac14' },
-  { chrom: '21', size: '109.55 MiB', crc32c: '6805d560' },
-  { chrom: '22', size: '112.34 MiB', crc32c: '3a0cce90' },
-  { chrom: 'X', size: '335.93 MiB', crc32c: '1b49e5a6' },
-  { chrom: 'Y', size: '50.76 MiB', crc32c: 'd8a3a636' },
+  { chrom: '1', size: '41.05 GiB', md5: '328b4578212afec2cde394a1b02d544f' },
+  { chrom: '2', size: '43.43 GiB', md5: '2d14cb70a93d772191fa5133f5b1a129' },
+  { chrom: '3', size: '36.56 GiB', md5: '716c181431a3c11a2eb18c5f50a3542d' },
+  { chrom: '4', size: '33.56 GiB', md5: 'd9b913f3e30c8f410f9ce7dee5dee6d4' },
+  { chrom: '5', size: '30.46 GiB', md5: 'a2a3b9014af5c8f9bbaaf743968e48f8' },
+  { chrom: '6', size: '29.61 GiB', md5: 'e65c2aa321c5e272548fb3d901bae382' },
+  { chrom: '7', size: '29.10 GiB', md5: '58ee22cf3dcc8cb8b493d218e19432cc' },
+  { chrom: '8', size: '27.28 GiB', md5: '9854d9df22977cf5bac0f9fc05f4e8f5' },
+  { chrom: '9', size: '23.06 GiB', md5: '6adfc9c47000cf66d1305392051b391d' },
+  { chrom: '10', size: '25.00 GiB', md5: 'c2cd760130d2339f7135fc70700db1e1' },
+  { chrom: '11', size: '24.58 GiB', md5: 'd1e7a4dcf3ff62eeffca57afefc5a33a' },
+  { chrom: '12', size: '24.17 GiB', md5: '644bdbc5c53d9112edbacad401a28d1a' },
+  { chrom: '13', size: '15.93 GiB', md5: '84b12f299210d2a7e390c56a234b7b68' },
+  { chrom: '14', size: '16.63 GiB', md5: '0e524b414faf5a51b74d153939b3ddcd' },
+  { chrom: '15', size: '15.74 GiB', md5: '00d1386eadbfcb653eb810a6c08ed250' },
+  { chrom: '16', size: '17.62 GiB', md5: '2b106c12ca8cca9bd58e98d2c248ef4d' },
+  { chrom: '17', size: '16.22 GiB', md5: '9d58b459e75312b487c660666ea540c4' },
+  { chrom: '18', size: '13.44 GiB', md5: 'b95d30a6f5a45242d834fc7351afd760' },
+  { chrom: '19', size: '12.74 GiB', md5: '73fa1c7c09072e8ca5e26a1443f0af2a' },
+  { chrom: '20', size: '11.03 GiB', md5: '6c6f326c67b288ec99932905da72c1e6' },
+  { chrom: '21', size: '7.23 GiB', md5: '9b6584cfe62f6e8bd0c3cea90a4ce56a' },
+  { chrom: '22', size: '8.13 GiB', md5: 'a7bcf712a6b8d29e690468bf1dd8913d' },
+  { chrom: 'X', size: '21.34 GiB', md5: '8b91766906865b0795c653af51cb73b8' },
+  { chrom: 'Y', size: '571.35 MiB', md5: '1ffb9c683674f41ff7cf524e5bb56bb8' },
 ]
 
 const GnomadV4Downloads = () => {
@@ -121,6 +94,11 @@ const GnomadV4Downloads = () => {
           <ExternalLink href="https://gnomad.broadinstitute.org/news/2023-11-gnomad-v4-0">
             gnomAD v4.0.0 blog post
           </ExternalLink>
+          and the{' '}
+          {/* @ts-expect-error TS(2786) FIXME: 'ExternalLink' cannot be used as a JSX component. */}
+          <ExternalLink href="https://gnomad.broadinstitute.org/news/2024-04-gnomad-v4-1">
+            gnomAD v4.1.0 blog post
+          </ExternalLink>
           .
         </p>
         <ColumnsWrapper>
@@ -131,7 +109,7 @@ const GnomadV4Downloads = () => {
               <ListItem>
                 <GetUrlButtons
                   label="Sites Hail Table"
-                  path="/release/4.0/ht/exomes/gnomad.exomes.v4.0.sites.ht"
+                  path="/release/4.1/ht/exomes/gnomad.exomes.v4.1.sites.ht"
                 />
               </ListItem>
               {exomeChromosomeVcfs.map(({ chrom, size, md5 }) => (
@@ -139,7 +117,7 @@ const GnomadV4Downloads = () => {
                 <ListItem key={chrom}>
                   <DownloadLinks
                     label={`chr${chrom} sites VCF`}
-                    path={`/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr${chrom}.vcf.bgz`}
+                    path={`/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr${chrom}.vcf.bgz`}
                     size={size}
                     md5={md5}
                     includeTBI
@@ -156,7 +134,7 @@ const GnomadV4Downloads = () => {
               <ListItem>
                 <GetUrlButtons
                   label="Sites Hail Table"
-                  path="/release/4.0/ht/genomes/gnomad.genomes.v4.0.sites.ht/"
+                  path="/release/4.1/ht/genomes/gnomad.genomes.v4.1.sites.ht/"
                 />
               </ListItem>
               {genomeChromosomeVcfs.map(({ chrom, size, md5 }) => (
@@ -164,13 +142,77 @@ const GnomadV4Downloads = () => {
                 <ListItem key={chrom}>
                   <DownloadLinks
                     label={`chr${chrom} sites VCF`}
-                    path={`/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr${chrom}.vcf.bgz`}
+                    path={`/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr${chrom}.vcf.bgz`}
                     size={size}
                     md5={md5}
                     includeTBI
                   />
                 </ListItem>
               ))}
+            </FileList>
+          </Column>
+        </ColumnsWrapper>
+      </DownloadsSection>
+
+      <DownloadsSection>
+        <SectionTitle id="v4-joint-freq-stats">Joint Frequency</SectionTitle>
+        <FileList>
+          {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+          <ListItem>
+            <DownloadLinks
+              label="Joint sites Hail Table"
+              path="/release/4.1/ht/joint/gnomad.joint.v4.1.site.ht"
+            />
+          </ListItem>
+        </FileList>
+      </DownloadsSection>
+
+      <DownloadsSection>
+        <SectionTitle id="v4-all-sites-allele-number">All sites allele numbers</SectionTitle>
+        <ColumnsWrapper>
+          <Column>
+            <h3>Exomes</h3>
+            <FileList>
+              {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+              <ListItem>
+                <GetUrlButtons
+                  label="Exomes all site allele number Hail Table"
+                  path="/release/4.1/ht/exomes/gnomad.exomes.v4.1.allele_number_all_sites.ht"
+                />
+              </ListItem>
+
+              {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+              <ListItem>
+                <DownloadLinks
+                  label="Exomes all site allele number TSV"
+                  path="/release/4.1/tsv/exomes/gnomad.exomes.v4.1.allele_number_all_sites.tsv.bgz"
+                  md5="ee71ce1ccfa5c1d9dd86e1ee1b1d11e2"
+                  size="1.07 GiB"
+                />
+              </ListItem>
+            </FileList>
+          </Column>
+
+          <Column>
+            <h3>Genomes</h3>
+            <FileList>
+              {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+              <ListItem>
+                <GetUrlButtons
+                  label="Genomes all site allele number Hail Table"
+                  path="/release/4.1/ht/genomes/gnomad.genomes.v4.1.allele_number_all_sites.ht"
+                />
+              </ListItem>
+
+              {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+              <ListItem>
+                <DownloadLinks
+                  label="Genomes all site allele number TSV"
+                  path="/release/4.1/tsv/genomes/gnomad.genomes.v4.1.allele_number_all_sites.tsv.bgz"
+                  md5="7101516dd79d48d10c28fa548b22884a"
+                  size="11.19 GiB"
+                />
+              </ListItem>
             </FileList>
           </Column>
         </ColumnsWrapper>
@@ -244,20 +286,20 @@ const GnomadV4Downloads = () => {
         <FileList>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
-            <DownloadLinks label="README" path="/release/4.0/constraint/README.txt" />
+            <DownloadLinks label="README" path="/release/4.1/constraint/README.txt" />
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
             <GetUrlButtons
               label="Constraint metrics Hail Table"
-              path="/release/4.0/constraint/gnomad.v4.0.constraint_metrics.ht"
+              path="/release/4.1/constraint/gnomad.v4.1.constraint_metrics.ht"
             />
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
             <DownloadLinks
               label="Constraint metrics TSV"
-              path="/release/4.0/constraint/gnomad.v4.0.constraint_metrics.tsv"
+              path="/release/4.1/constraint/gnomad.v4.1.constraint_metrics.tsv"
             />
           </ListItem>
         </FileList>
@@ -270,18 +312,26 @@ const GnomadV4Downloads = () => {
           <Link to="/help/sv-overview">help text</Link>
         </p>
         <FileList>
-          {svChromosomeVcfs.map(({ chrom, size, crc32c }) => (
-            // @ts-expect-error TS(2769) FIXME: No overload matches this call.
-            <ListItem key={chrom}>
-              <DownloadLinks
-                label={`chr${chrom} VCF`}
-                path={`/release/4.0/genome_sv/gnomad.v4.0.sv.chr${chrom}.vcf.gz`}
-                size={size}
-                crc32c={crc32c}
-                includeTBI
-              />
-            </ListItem>
-          ))}
+          {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+          <ListItem>
+            <DownloadLinks
+              label="Genome SV VCF"
+              path="/release/4.1/genome_sv/gnomad.v4.1.sv.sites.vcf.gz"
+              size="1.62 GiB"
+              hash="3ee614951c2f0c36659842876f7ce0ba"
+              includeTBI
+            />
+          </ListItem>
+          {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+          <ListItem>
+            <DownloadLinks
+              label="Genome SV non neuro controls VCF"
+              path="/release/4.1/genome_sv/gnomad.v4.1.sv.non_neuro_controls.sites.vcf.gz"
+              size="3.12 GiB"
+              hash="eb9eae81e32923829d256695731e899a"
+              includeTBI
+            />
+          </ListItem>
         </FileList>
       </DownloadsSection>
 
@@ -296,21 +346,27 @@ const GnomadV4Downloads = () => {
           <ListItem>
             <DownloadLinks
               label="Exome CNV VCF"
-              path="/release/4.0/exome_cnv/gnomad.v4.0.cnv.all.vcf.gz"
+              path="/release/4.1/exome_cnv/gnomad.v4.1.cnv.all.vcf.gz"
+              size="8.51 MiB"
+              hash="a662f9c838eeda60c4b9918e437bee89"
             />
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
             <DownloadLinks
               label="Exome CNV non neuro VCF"
-              path="/release/4.0/exome_cnv/gnomad.v4.0.cnv.non_neuro.vcf.gz"
+              path="/release/4.1/exome_cnv/gnomad.v4.1.cnv.non_neuro.vcf.gz"
+              size="7.90 MiB"
+              hash="532c77b717f7d67d4424c76c1f4ea0f2"
             />
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <ListItem>
             <DownloadLinks
-              label="Exome CNV non-neuro controls VCF"
-              path="/release/4.0/exome_cnv/gnomad.v4.0.cnv.non_neuro_controls.vcf.gz"
+              label="Exome CNV non neuro controls VCF"
+              path="/release/4.1/exome_cnv/gnomad.v4.1.cnv.non_neuro_controls.vcf.gz"
+              size="5.33 MiB"
+              hash="e75e0ee3f5b7fb6e174a3fa7637a3d6d"
             />
           </ListItem>
         </FileList>
@@ -338,6 +394,27 @@ const GnomadV4Downloads = () => {
             <DownloadLinks
               label="Exome calling intervals flat file"
               path="/resources/grch38/intervals/ukb.pad50.broad.pad50.union.intervals"
+            />
+          </ListItem>
+          {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+          <ListItem>
+            <DownloadLinks
+              label="REVEL v4.1 README"
+              path="/release/4.1/tsv/revel_for_2414_unmatched_transcripts_README.md"
+            />
+          </ListItem>
+          {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+          <ListItem>
+            <DownloadLinks
+              label="Exomes REVEL supplementary TSV"
+              path="/release/4.1/tsv/exomes/gnomad.v4.1.exomes.revel_for_2414_unmatched_transcripts.tsv.bgz"
+            />
+          </ListItem>
+          {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+          <ListItem>
+            <DownloadLinks
+              label="Genomes REVEL supplementary TSV"
+              path="/release/4.1/tsv/genomes/gnomad.v4.1.genomes.revel_for_2414_unmatched_transcripts.tsv.bgz"
             />
           </ListItem>
         </FileList>

--- a/browser/src/DownloadsPage/__snapshots__/DownloadsPage.spec.tsx.snap
+++ b/browser/src/DownloadsPage/__snapshots__/DownloadsPage.spec.tsx.snap
@@ -714,6 +714,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
         >
           gnomAD v4.0.0 blog post
         </a>
+        and the
+         
+        <a
+          className="c10"
+          href="https://gnomad.broadinstitute.org/news/2024-04-gnomad-v4-1"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          gnomAD v4.1.0 blog post
+        </a>
         .
       </p>
       <div
@@ -772,9 +782,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                26.88 GiB
+                17.50 GiB
                 , MD5: 
-                50bba514e8d4e65aef39c7baa9c29e71
+                848be4d85c953bc73a8e4f0c97026a72
               </span>
               <br />
               <span>
@@ -783,7 +793,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr1 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr1.vcf.bgz"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr1.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -793,7 +803,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr1 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr1.vcf.bgz"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr1.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -803,7 +813,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr1 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr1.vcf.bgz"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr1.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -817,7 +827,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr1 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr1.vcf.bgz.tbi"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr1.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -827,7 +837,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr1 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr1.vcf.bgz.tbi"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr1.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -837,7 +847,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr1 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr1.vcf.bgz.tbi"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr1.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -853,9 +863,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                20.32 GiB
+                13.30 GiB
                 , MD5: 
-                0bac3559c5d9442d35c72308ab4a8684
+                e2f5d891a3374e88d1c3136f94bed0ea
               </span>
               <br />
               <span>
@@ -864,7 +874,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr2 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr2.vcf.bgz"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr2.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -874,7 +884,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr2 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr2.vcf.bgz"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr2.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -884,7 +894,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr2 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr2.vcf.bgz"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr2.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -898,7 +908,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr2 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr2.vcf.bgz.tbi"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr2.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -908,7 +918,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr2 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr2.vcf.bgz.tbi"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr2.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -918,7 +928,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr2 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr2.vcf.bgz.tbi"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr2.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -934,9 +944,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                16.33 GiB
+                10.79 GiB
                 , MD5: 
-                4cb2b400a8dfd95711e3b20a7a166f25
+                a35b949b32453b4b5abd7b1de42e298a
               </span>
               <br />
               <span>
@@ -945,7 +955,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr3 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr3.vcf.bgz"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr3.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -955,7 +965,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr3 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr3.vcf.bgz"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr3.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -965,7 +975,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr3 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr3.vcf.bgz"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr3.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -979,7 +989,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr3 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr3.vcf.bgz.tbi"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr3.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -989,7 +999,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr3 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr3.vcf.bgz.tbi"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr3.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -999,7 +1009,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr3 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr3.vcf.bgz.tbi"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr3.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1015,9 +1025,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                11.07 GiB
+                7.18 GiB
                 , MD5: 
-                2d1988c3ef15027c1c978a245feb4110
+                c7c7008a73acbb8fea68b82951842832
               </span>
               <br />
               <span>
@@ -1026,7 +1036,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr4 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr4.vcf.bgz"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr4.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1036,7 +1046,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr4 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr4.vcf.bgz"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr4.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1046,7 +1056,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr4 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr4.vcf.bgz"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr4.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1060,7 +1070,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr4 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr4.vcf.bgz.tbi"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr4.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1070,7 +1080,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr4 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr4.vcf.bgz.tbi"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr4.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1080,7 +1090,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr4 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr4.vcf.bgz.tbi"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr4.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1096,9 +1106,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                12.29 GiB
+                7.91 GiB
                 , MD5: 
-                4e4b38e9a819748a7909684f311ebd20
+                c1016f56be62deb2e947fed4d31302dd
               </span>
               <br />
               <span>
@@ -1107,7 +1117,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr5 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr5.vcf.bgz"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr5.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1117,7 +1127,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr5 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr5.vcf.bgz"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr5.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1127,7 +1137,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr5 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr5.vcf.bgz"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr5.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1141,7 +1151,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr5 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr5.vcf.bgz.tbi"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr5.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1151,7 +1161,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr5 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr5.vcf.bgz.tbi"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr5.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1161,7 +1171,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr5 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr5.vcf.bgz.tbi"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr5.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1177,9 +1187,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                13.14 GiB
+                8.50 GiB
                 , MD5: 
-                22bac98dcacfddcc43820e05d4a72081
+                f96bc8711ed085d63b8bd5396664adbc
               </span>
               <br />
               <span>
@@ -1188,7 +1198,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr6 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr6.vcf.bgz"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr6.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1198,7 +1208,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr6 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr6.vcf.bgz"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr6.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1208,7 +1218,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr6 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr6.vcf.bgz"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr6.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1222,7 +1232,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr6 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr6.vcf.bgz.tbi"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr6.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1232,7 +1242,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr6 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr6.vcf.bgz.tbi"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr6.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1242,7 +1252,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr6 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr6.vcf.bgz.tbi"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr6.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1258,9 +1268,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                14.01 GiB
+                9.01 GiB
                 , MD5: 
-                bf00c8dfe5c22d6fd684b7b90be4e8ff
+                c41cd52571b001cf7d3e388a668e4dff
               </span>
               <br />
               <span>
@@ -1269,7 +1279,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr7 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr7.vcf.bgz"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr7.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1279,7 +1289,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr7 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr7.vcf.bgz"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr7.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1289,7 +1299,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr7 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr7.vcf.bgz"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr7.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1303,7 +1313,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr7 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr7.vcf.bgz.tbi"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr7.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1313,7 +1323,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr7 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr7.vcf.bgz.tbi"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr7.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1323,7 +1333,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr7 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr7.vcf.bgz.tbi"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr7.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1339,9 +1349,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                10.38 GiB
+                6.78 GiB
                 , MD5: 
-                c10c6a7265af418cbfd7a855944bc9f2
+                a47777fe141c01876cb170f2c2f2e6b6
               </span>
               <br />
               <span>
@@ -1350,7 +1360,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr8 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr8.vcf.bgz"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr8.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1360,7 +1370,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr8 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr8.vcf.bgz"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr8.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1370,7 +1380,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr8 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr8.vcf.bgz"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr8.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1384,7 +1394,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr8 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr8.vcf.bgz.tbi"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr8.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1394,7 +1404,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr8 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr8.vcf.bgz.tbi"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr8.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1404,7 +1414,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr8 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr8.vcf.bgz.tbi"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr8.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1420,9 +1430,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                11.57 GiB
+                7.49 GiB
                 , MD5: 
-                f20000e361f3f2f4759619b3029c10ad
+                c5abd4d8aff12f2bf8b4ec844769782f
               </span>
               <br />
               <span>
@@ -1431,7 +1441,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr9 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr9.vcf.bgz"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr9.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1441,7 +1451,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr9 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr9.vcf.bgz"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr9.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1451,7 +1461,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr9 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr9.vcf.bgz"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr9.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1465,7 +1475,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr9 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr9.vcf.bgz.tbi"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr9.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1475,7 +1485,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr9 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr9.vcf.bgz.tbi"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr9.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1485,7 +1495,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr9 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr9.vcf.bgz.tbi"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr9.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1501,9 +1511,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                11.23 GiB
+                7.32 GiB
                 , MD5: 
-                d85984b39664d800ec8da815004029c1
+                4befc8dc50ead888e8af24f556c9fdd6
               </span>
               <br />
               <span>
@@ -1512,7 +1522,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr10 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr10.vcf.bgz"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr10.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1522,7 +1532,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr10 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr10.vcf.bgz"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr10.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1532,7 +1542,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr10 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr10.vcf.bgz"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr10.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1546,7 +1556,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr10 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr10.vcf.bgz.tbi"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr10.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1556,7 +1566,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr10 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr10.vcf.bgz.tbi"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr10.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1566,7 +1576,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr10 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr10.vcf.bgz.tbi"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr10.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1582,9 +1592,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                16.58 GiB
+                10.84 GiB
                 , MD5: 
-                882f7345687996ac5e728fe771debeb2
+                3833ce3ab046afe92c9b55df93a61ec
               </span>
               <br />
               <span>
@@ -1593,7 +1603,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr11 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr11.vcf.bgz"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr11.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1603,7 +1613,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr11 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr11.vcf.bgz"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr11.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1613,7 +1623,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr11 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr11.vcf.bgz"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr11.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1627,7 +1637,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr11 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr11.vcf.bgz.tbi"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr11.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1637,7 +1647,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr11 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr11.vcf.bgz.tbi"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr11.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1647,7 +1657,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr11 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr11.vcf.bgz.tbi"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr11.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1663,9 +1673,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                15.21 GiB
+                9.90 GiB
                 , MD5: 
-                1b11c7c60a205703a977ba03c30f2f41
+                e530a9ed203cdcc914621ab7430774bb
               </span>
               <br />
               <span>
@@ -1674,7 +1684,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr12 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr12.vcf.bgz"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr12.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1684,7 +1694,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr12 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr12.vcf.bgz"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr12.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1694,7 +1704,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr12 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr12.vcf.bgz"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr12.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1708,7 +1718,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr12 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr12.vcf.bgz.tbi"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr12.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1718,7 +1728,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr12 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr12.vcf.bgz.tbi"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr12.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1728,7 +1738,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr12 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr12.vcf.bgz.tbi"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr12.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1744,9 +1754,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                5.18 GiB
+                3.30 GiB
                 , MD5: 
-                4611cd7c3e0a1111ba52b2ec544484b4
+                af1eab40c8be47c8c7c04dc73e0333e4
               </span>
               <br />
               <span>
@@ -1755,7 +1765,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr13 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr13.vcf.bgz"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr13.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1765,7 +1775,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr13 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr13.vcf.bgz"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr13.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1775,7 +1785,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr13 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr13.vcf.bgz"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr13.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1789,7 +1799,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr13 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr13.vcf.bgz.tbi"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr13.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1799,7 +1809,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr13 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr13.vcf.bgz.tbi"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr13.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1809,7 +1819,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr13 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr13.vcf.bgz.tbi"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr13.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1825,9 +1835,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                9.54 GiB
+                6.21 GiB
                 , MD5: 
-                628757952a5114929bf1150901bc34bb
+                d0e0fa71d94bf016a061ba4dc0bd869f
               </span>
               <br />
               <span>
@@ -1836,7 +1846,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr14 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr14.vcf.bgz"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr14.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1846,7 +1856,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr14 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr14.vcf.bgz"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr14.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1856,7 +1866,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr14 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr14.vcf.bgz"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr14.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1870,7 +1880,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr14 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr14.vcf.bgz.tbi"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr14.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1880,7 +1890,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr14 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr14.vcf.bgz.tbi"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr14.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1890,7 +1900,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr14 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr14.vcf.bgz.tbi"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr14.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1906,9 +1916,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                10.65 GiB
+                6.87 GiB
                 , MD5: 
-                63574925084fa8e48dac46185c41975f
+                01b116e34b3815cfd1d3afa53a29a41b
               </span>
               <br />
               <span>
@@ -1917,7 +1927,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr15 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr15.vcf.bgz"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr15.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1927,7 +1937,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr15 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr15.vcf.bgz"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr15.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1937,7 +1947,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr15 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr15.vcf.bgz"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr15.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1951,7 +1961,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr15 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr15.vcf.bgz.tbi"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr15.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1961,7 +1971,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr15 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr15.vcf.bgz.tbi"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr15.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1971,7 +1981,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr15 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr15.vcf.bgz.tbi"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr15.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -1987,9 +1997,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                13.90 GiB
+                9.10 GiB
                 , MD5: 
-                ba59445b0fb0f1a1d78df5dc623c40dd
+                44137843b2df39c8a654427181bda919
               </span>
               <br />
               <span>
@@ -1998,7 +2008,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr16 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr16.vcf.bgz"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr16.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2008,7 +2018,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr16 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr16.vcf.bgz"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr16.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2018,7 +2028,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr16 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr16.vcf.bgz"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr16.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2032,7 +2042,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr16 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr16.vcf.bgz.tbi"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr16.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2042,7 +2052,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr16 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr16.vcf.bgz.tbi"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr16.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2052,7 +2062,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr16 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr16.vcf.bgz.tbi"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr16.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2068,9 +2078,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                17.04 GiB
+                11.19 GiB
                 , MD5: 
-                5010e1133a4153c34ae3b113c7c97280
+                c61978218ab3eaa07b571eb9959f39d2
               </span>
               <br />
               <span>
@@ -2079,7 +2089,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr17 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr17.vcf.bgz"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr17.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2089,7 +2099,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr17 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr17.vcf.bgz"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr17.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2099,7 +2109,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr17 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr17.vcf.bgz"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr17.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2113,7 +2123,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr17 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr17.vcf.bgz.tbi"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr17.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2123,7 +2133,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr17 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr17.vcf.bgz.tbi"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr17.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2133,7 +2143,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr17 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr17.vcf.bgz.tbi"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr17.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2149,9 +2159,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                4.87 GiB
+                3.16 GiB
                 , MD5: 
-                aed2e7e455e35b97a32d4886d94ccaa0
+                1ec708d5cae9657ccee0626763ed9946
               </span>
               <br />
               <span>
@@ -2160,7 +2170,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr18 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr18.vcf.bgz"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr18.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2170,7 +2180,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr18 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr18.vcf.bgz"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr18.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2180,7 +2190,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr18 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr18.vcf.bgz"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr18.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2194,7 +2204,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr18 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr18.vcf.bgz.tbi"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr18.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2204,7 +2214,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr18 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr18.vcf.bgz.tbi"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr18.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2214,7 +2224,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr18 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr18.vcf.bgz.tbi"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr18.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2230,9 +2240,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                18.14 GiB
+                11.75 GiB
                 , MD5: 
-                67c40daa48e50bb4ec1ec541570217b0
+                50a37cfa9a9a3e030388bcf15bdabb79
               </span>
               <br />
               <span>
@@ -2241,7 +2251,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr19 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr19.vcf.bgz"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr19.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2251,7 +2261,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr19 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr19.vcf.bgz"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr19.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2261,7 +2271,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr19 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr19.vcf.bgz"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr19.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2275,7 +2285,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr19 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr19.vcf.bgz.tbi"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr19.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2285,7 +2295,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr19 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr19.vcf.bgz.tbi"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr19.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2295,7 +2305,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr19 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr19.vcf.bgz.tbi"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr19.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2311,9 +2321,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                6.9 GiB
+                4.43 GiB
                 , MD5: 
-                09b0221006b59c1626d8188e909e933d
+                605680cd99e469bdf5f0045bd22359c9
               </span>
               <br />
               <span>
@@ -2322,7 +2332,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr20 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr20.vcf.bgz"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr20.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2332,7 +2342,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr20 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr20.vcf.bgz"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr20.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2342,7 +2352,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr20 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr20.vcf.bgz"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr20.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2356,7 +2366,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr20 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr20.vcf.bgz.tbi"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr20.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2366,7 +2376,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr20 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr20.vcf.bgz.tbi"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr20.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2376,7 +2386,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr20 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr20.vcf.bgz.tbi"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr20.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2392,9 +2402,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                3.27 GiB
+                2.10 GiB
                 , MD5: 
-                206afe8d9dbe544697e1b67eee6d2f7f
+                7ca6d51a42425b857eddb46d7bc5832d
               </span>
               <br />
               <span>
@@ -2403,7 +2413,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr21 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr21.vcf.bgz"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr21.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2413,7 +2423,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr21 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr21.vcf.bgz"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr21.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2423,7 +2433,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr21 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr21.vcf.bgz"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr21.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2437,7 +2447,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr21 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr21.vcf.bgz.tbi"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr21.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2447,7 +2457,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr21 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr21.vcf.bgz.tbi"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr21.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2457,7 +2467,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr21 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr21.vcf.bgz.tbi"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr21.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2473,9 +2483,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                7.31 GiB
+                4.71 GiB
                 , MD5: 
-                3084349c03194e8cf5063a1e46473248
+                dcf191563e69054a71bd4dc77862799a
               </span>
               <br />
               <span>
@@ -2484,7 +2494,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr22 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr22.vcf.bgz"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr22.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2494,7 +2504,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr22 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr22.vcf.bgz"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr22.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2504,7 +2514,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr22 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr22.vcf.bgz"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr22.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2518,7 +2528,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr22 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr22.vcf.bgz.tbi"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr22.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2528,7 +2538,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr22 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr22.vcf.bgz.tbi"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr22.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2538,7 +2548,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr22 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr22.vcf.bgz.tbi"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr22.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2554,9 +2564,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                7.96 GiB
+                5.35 GiB
                 , MD5: 
-                6d33a288735eda242c473905ccb6743b
+                5b7b17d3d4cff22c20480a908c861a28
               </span>
               <br />
               <span>
@@ -2565,7 +2575,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chrX sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chrX.vcf.bgz"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chrX.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2575,7 +2585,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chrX sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chrX.vcf.bgz"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chrX.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2585,7 +2595,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chrX sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chrX.vcf.bgz"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chrX.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2599,7 +2609,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chrX sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chrX.vcf.bgz.tbi"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chrX.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2609,7 +2619,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chrX sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chrX.vcf.bgz.tbi"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chrX.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2619,7 +2629,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chrX sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chrX.vcf.bgz.tbi"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chrX.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2635,9 +2645,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                163.66 MiB
+                108.30 MiB
                 , MD5: 
-                c8414744cf75fa498e2497a9391eb1ad
+                 d500cf5a73c53f02d1b95f1e092f2e49
               </span>
               <br />
               <span>
@@ -2646,7 +2656,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chrY sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chrY.vcf.bgz"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chrY.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2656,7 +2666,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chrY sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chrY.vcf.bgz"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chrY.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2666,7 +2676,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chrY sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chrY.vcf.bgz"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chrY.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2680,7 +2690,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chrY sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chrY.vcf.bgz.tbi"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chrY.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2690,7 +2700,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chrY sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chrY.vcf.bgz.tbi"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chrY.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2700,7 +2710,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chrY sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chrY.vcf.bgz.tbi"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chrY.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2763,9 +2773,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                64.64 GiB
+                41.05 GiB
                 , MD5: 
-                722d44a602a6988c2ffd55b6ed7ca3ce
+                328b4578212afec2cde394a1b02d544f
               </span>
               <br />
               <span>
@@ -2774,7 +2784,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr1 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr1.vcf.bgz"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr1.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2784,7 +2794,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr1 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr1.vcf.bgz"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr1.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2794,7 +2804,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr1 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr1.vcf.bgz"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr1.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2808,7 +2818,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr1 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr1.vcf.bgz.tbi"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr1.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2818,7 +2828,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr1 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr1.vcf.bgz.tbi"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr1.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2828,7 +2838,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr1 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr1.vcf.bgz.tbi"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr1.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2844,7 +2854,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                68.24 GiB
+                43.43 GiB
                 , MD5: 
                 2d14cb70a93d772191fa5133f5b1a129
               </span>
@@ -2855,7 +2865,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr2 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr2.vcf.bgz"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr2.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2865,7 +2875,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr2 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr2.vcf.bgz"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr2.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2875,7 +2885,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr2 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr2.vcf.bgz"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr2.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2889,7 +2899,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr2 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr2.vcf.bgz.tbi"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr2.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2899,7 +2909,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr2 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr2.vcf.bgz.tbi"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr2.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2909,7 +2919,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr2 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr2.vcf.bgz.tbi"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr2.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2925,9 +2935,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                56.96 GiB
+                36.56 GiB
                 , MD5: 
-                b0c8955adcd44e8757d9bfdb01a2e180
+                716c181431a3c11a2eb18c5f50a3542d
               </span>
               <br />
               <span>
@@ -2936,7 +2946,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr3 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr3.vcf.bgz"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr3.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2946,7 +2956,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr3 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr3.vcf.bgz"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr3.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2956,7 +2966,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr3 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr3.vcf.bgz"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr3.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2970,7 +2980,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr3 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr3.vcf.bgz.tbi"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr3.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2980,7 +2990,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr3 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr3.vcf.bgz.tbi"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr3.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -2990,7 +3000,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr3 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr3.vcf.bgz.tbi"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr3.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3006,9 +3016,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                53.19 GiB
+                33.56 GiB
                 , MD5: 
-                9fba0d34f3074100681b74fc489f620b
+                d9b913f3e30c8f410f9ce7dee5dee6d4
               </span>
               <br />
               <span>
@@ -3017,7 +3027,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr4 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr4.vcf.bgz"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr4.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3027,7 +3037,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr4 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr4.vcf.bgz"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr4.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3037,7 +3047,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr4 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr4.vcf.bgz"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr4.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3051,7 +3061,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr4 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr4.vcf.bgz.tbi"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr4.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3061,7 +3071,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr4 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr4.vcf.bgz.tbi"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr4.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3071,7 +3081,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr4 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr4.vcf.bgz.tbi"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr4.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3087,9 +3097,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                48.64 GiB
+                30.46 GiB
                 , MD5: 
-                007112b5d72df612dcfb3dc45606dc25
+                a2a3b9014af5c8f9bbaaf743968e48f8
               </span>
               <br />
               <span>
@@ -3098,7 +3108,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr5 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr5.vcf.bgz"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr5.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3108,7 +3118,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr5 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr5.vcf.bgz"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr5.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3118,7 +3128,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr5 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr5.vcf.bgz"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr5.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3132,7 +3142,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr5 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr5.vcf.bgz.tbi"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr5.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3142,7 +3152,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr5 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr5.vcf.bgz.tbi"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr5.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3152,7 +3162,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr5 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr5.vcf.bgz.tbi"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr5.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3168,9 +3178,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                46.85 GiB
+                29.61 GiB
                 , MD5: 
-                9b0a289a7dc7910f1a79586b8aa62593
+                e65c2aa321c5e272548fb3d901bae382
               </span>
               <br />
               <span>
@@ -3179,7 +3189,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr6 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr6.vcf.bgz"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr6.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3189,7 +3199,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr6 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr6.vcf.bgz"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr6.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3199,7 +3209,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr6 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr6.vcf.bgz"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr6.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3213,7 +3223,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr6 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr6.vcf.bgz.tbi"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr6.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3223,7 +3233,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr6 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr6.vcf.bgz.tbi"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr6.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3233,7 +3243,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr6 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr6.vcf.bgz.tbi"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr6.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3249,9 +3259,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                45.95 GiB
+                29.10 GiB
                 , MD5: 
-                0929e74108e1d7faab3f7e90e8af9410
+                58ee22cf3dcc8cb8b493d218e19432cc
               </span>
               <br />
               <span>
@@ -3260,7 +3270,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr7 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr7.vcf.bgz"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr7.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3270,7 +3280,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr7 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr7.vcf.bgz"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr7.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3280,7 +3290,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr7 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr7.vcf.bgz"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr7.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3294,7 +3304,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr7 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr7.vcf.bgz.tbi"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr7.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3304,7 +3314,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr7 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr7.vcf.bgz.tbi"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr7.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3314,7 +3324,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr7 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr7.vcf.bgz.tbi"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr7.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3330,9 +3340,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                43.03 GiB
+                27.28 GiB
                 , MD5: 
-                4c6bc15f9d1232f83e89f5305cc1fbab
+                9854d9df22977cf5bac0f9fc05f4e8f5
               </span>
               <br />
               <span>
@@ -3341,7 +3351,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr8 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr8.vcf.bgz"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr8.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3351,7 +3361,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr8 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr8.vcf.bgz"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr8.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3361,7 +3371,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr8 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr8.vcf.bgz"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr8.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3375,7 +3385,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr8 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr8.vcf.bgz.tbi"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr8.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3385,7 +3395,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr8 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr8.vcf.bgz.tbi"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr8.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3395,7 +3405,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr8 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr8.vcf.bgz.tbi"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr8.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3411,9 +3421,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                36.36 GiB
+                23.06 GiB
                 , MD5: 
-                83c85e0d39b0bab7b8223642c8d2dab0
+                6adfc9c47000cf66d1305392051b391d
               </span>
               <br />
               <span>
@@ -3422,7 +3432,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr9 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr9.vcf.bgz"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr9.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3432,7 +3442,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr9 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr9.vcf.bgz"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr9.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3442,7 +3452,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr9 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr9.vcf.bgz"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr9.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3456,7 +3466,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr9 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr9.vcf.bgz.tbi"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr9.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3466,7 +3476,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr9 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr9.vcf.bgz.tbi"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr9.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3476,7 +3486,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr9 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr9.vcf.bgz.tbi"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr9.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3492,9 +3502,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                39.16 GiB
+                25.00 GiB
                 , MD5: 
-                757db8e8f1007144e6dd8dfcd697046b
+                c2cd760130d2339f7135fc70700db1e1
               </span>
               <br />
               <span>
@@ -3503,7 +3513,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr10 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr10.vcf.bgz"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr10.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3513,7 +3523,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr10 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr10.vcf.bgz"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr10.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3523,7 +3533,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr10 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr10.vcf.bgz"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr10.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3537,7 +3547,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr10 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr10.vcf.bgz.tbi"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr10.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3547,7 +3557,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr10 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr10.vcf.bgz.tbi"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr10.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3557,7 +3567,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr10 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr10.vcf.bgz.tbi"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr10.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3573,9 +3583,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                38.57 GiB
+                24.58 GiB
                 , MD5: 
-                52c5b1e9313869dc347b55133dd5c31f
+                d1e7a4dcf3ff62eeffca57afefc5a33a
               </span>
               <br />
               <span>
@@ -3584,7 +3594,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr11 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr11.vcf.bgz"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr11.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3594,7 +3604,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr11 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr11.vcf.bgz"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr11.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3604,7 +3614,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr11 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr11.vcf.bgz"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr11.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3618,7 +3628,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr11 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr11.vcf.bgz.tbi"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr11.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3628,7 +3638,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr11 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr11.vcf.bgz.tbi"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr11.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3638,7 +3648,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr11 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr11.vcf.bgz.tbi"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr11.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3654,9 +3664,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                37.86 GiB
+                24.17 GiB
                 , MD5: 
-                19d5b3abacf1c6be990b3aa8f6ca2786
+                644bdbc5c53d9112edbacad401a28d1a
               </span>
               <br />
               <span>
@@ -3665,7 +3675,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr12 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr12.vcf.bgz"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr12.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3675,7 +3685,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr12 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr12.vcf.bgz"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr12.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3685,7 +3695,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr12 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr12.vcf.bgz"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr12.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3699,7 +3709,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr12 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr12.vcf.bgz.tbi"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr12.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3709,7 +3719,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr12 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr12.vcf.bgz.tbi"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr12.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3719,7 +3729,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr12 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr12.vcf.bgz.tbi"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr12.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3735,9 +3745,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                25.65 GiB
+                15.93 GiB
                 , MD5: 
-                94c6da5e72d87bf0a714d6b5c1c09272
+                84b12f299210d2a7e390c56a234b7b68
               </span>
               <br />
               <span>
@@ -3746,7 +3756,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr13 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr13.vcf.bgz"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr13.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3756,7 +3766,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr13 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr13.vcf.bgz"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr13.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3766,7 +3776,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr13 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr13.vcf.bgz"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr13.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3780,7 +3790,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr13 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr13.vcf.bgz.tbi"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr13.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3790,7 +3800,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr13 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr13.vcf.bgz.tbi"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr13.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3800,7 +3810,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr13 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr13.vcf.bgz.tbi"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr13.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3816,9 +3826,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                26.02 GiB
+                16.63 GiB
                 , MD5: 
-                145c7f1710a6b3a90044f3d14912ce4b
+                0e524b414faf5a51b74d153939b3ddcd
               </span>
               <br />
               <span>
@@ -3827,7 +3837,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr14 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr14.vcf.bgz"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr14.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3837,7 +3847,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr14 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr14.vcf.bgz"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr14.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3847,7 +3857,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr14 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr14.vcf.bgz"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr14.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3861,7 +3871,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr14 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr14.vcf.bgz.tbi"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr14.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3871,7 +3881,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr14 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr14.vcf.bgz.tbi"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr14.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3881,7 +3891,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr14 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr14.vcf.bgz.tbi"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr14.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3897,9 +3907,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                24.63 GiB
+                15.74 GiB
                 , MD5: 
-                3e04c33c6a03f91b1b071dc8c3224f77
+                00d1386eadbfcb653eb810a6c08ed250
               </span>
               <br />
               <span>
@@ -3908,7 +3918,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr15 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr15.vcf.bgz"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr15.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3918,7 +3928,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr15 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr15.vcf.bgz"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr15.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3928,7 +3938,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr15 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr15.vcf.bgz"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr15.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3942,7 +3952,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr15 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr15.vcf.bgz.tbi"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr15.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3952,7 +3962,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr15 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr15.vcf.bgz.tbi"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr15.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3962,7 +3972,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr15 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr15.vcf.bgz.tbi"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr15.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3978,9 +3988,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                27.57 GiB
+                17.62 GiB
                 , MD5: 
-                572a343a3d8629e0579dbd424f5147ad
+                2b106c12ca8cca9bd58e98d2c248ef4d
               </span>
               <br />
               <span>
@@ -3989,7 +3999,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr16 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr16.vcf.bgz"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr16.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -3999,7 +4009,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr16 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr16.vcf.bgz"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr16.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4009,7 +4019,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr16 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr16.vcf.bgz"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr16.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4023,7 +4033,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr16 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr16.vcf.bgz.tbi"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr16.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4033,7 +4043,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr16 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr16.vcf.bgz.tbi"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr16.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4043,7 +4053,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr16 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr16.vcf.bgz.tbi"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr16.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4059,9 +4069,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                25.17 GiB
+                16.22 GiB
                 , MD5: 
-                ac0003ebe2297dd4377c5045bb439c5c
+                9d58b459e75312b487c660666ea540c4
               </span>
               <br />
               <span>
@@ -4070,7 +4080,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr17 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr17.vcf.bgz"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr17.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4080,7 +4090,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr17 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr17.vcf.bgz"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr17.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4090,7 +4100,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr17 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr17.vcf.bgz"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr17.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4104,7 +4114,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr17 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr17.vcf.bgz.tbi"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr17.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4114,7 +4124,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr17 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr17.vcf.bgz.tbi"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr17.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4124,7 +4134,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr17 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr17.vcf.bgz.tbi"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr17.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4140,9 +4150,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                21.12 GiB
+                13.44 GiB
                 , MD5: 
-                4e1b5b41b0bc70c23d43904dd9ff3bb1
+                b95d30a6f5a45242d834fc7351afd760
               </span>
               <br />
               <span>
@@ -4151,7 +4161,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr18 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr18.vcf.bgz"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr18.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4161,7 +4171,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr18 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr18.vcf.bgz"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr18.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4171,7 +4181,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr18 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr18.vcf.bgz"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr18.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4185,7 +4195,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr18 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr18.vcf.bgz.tbi"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr18.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4195,7 +4205,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr18 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr18.vcf.bgz.tbi"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr18.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4205,7 +4215,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr18 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr18.vcf.bgz.tbi"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr18.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4221,9 +4231,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                19.91 GiB
+                12.74 GiB
                 , MD5: 
-                992829f49533843a5ced897d6388d5e2
+                73fa1c7c09072e8ca5e26a1443f0af2a
               </span>
               <br />
               <span>
@@ -4232,7 +4242,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr19 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr19.vcf.bgz"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr19.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4242,7 +4252,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr19 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr19.vcf.bgz"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr19.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4252,7 +4262,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr19 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr19.vcf.bgz"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr19.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4266,7 +4276,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr19 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr19.vcf.bgz.tbi"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr19.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4276,7 +4286,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr19 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr19.vcf.bgz.tbi"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr19.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4286,7 +4296,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr19 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr19.vcf.bgz.tbi"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr19.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4302,9 +4312,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                17.49 GiB
+                11.03 GiB
                 , MD5: 
-                d3ab3ed3c79c53a4fe15ced300b07ef5
+                6c6f326c67b288ec99932905da72c1e6
               </span>
               <br />
               <span>
@@ -4313,7 +4323,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr20 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr20.vcf.bgz"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr20.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4323,7 +4333,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr20 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr20.vcf.bgz"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr20.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4333,7 +4343,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr20 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr20.vcf.bgz"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr20.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4347,7 +4357,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr20 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr20.vcf.bgz.tbi"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr20.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4357,7 +4367,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr20 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr20.vcf.bgz.tbi"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr20.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4367,7 +4377,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr20 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr20.vcf.bgz.tbi"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr20.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4383,9 +4393,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                11.47 GiB
+                7.23 GiB
                 , MD5: 
-                4d2e808cbaafcd2ddc7692be0a45a924
+                9b6584cfe62f6e8bd0c3cea90a4ce56a
               </span>
               <br />
               <span>
@@ -4394,7 +4404,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr21 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr21.vcf.bgz"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr21.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4404,7 +4414,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr21 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr21.vcf.bgz"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr21.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4414,7 +4424,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr21 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr21.vcf.bgz"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr21.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4428,7 +4438,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr21 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr21.vcf.bgz.tbi"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr21.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4438,7 +4448,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr21 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr21.vcf.bgz.tbi"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr21.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4448,7 +4458,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr21 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr21.vcf.bgz.tbi"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr21.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4464,9 +4474,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                12.77 GiB
+                8.13 GiB
                 , MD5: 
-                d6ba3b18b07423e3a1af56e8405a26c2
+                a7bcf712a6b8d29e690468bf1dd8913d
               </span>
               <br />
               <span>
@@ -4475,7 +4485,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr22 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr22.vcf.bgz"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr22.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4485,7 +4495,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr22 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr22.vcf.bgz"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr22.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4495,7 +4505,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chr22 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr22.vcf.bgz"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr22.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4509,7 +4519,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr22 sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr22.vcf.bgz.tbi"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr22.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4519,7 +4529,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr22 sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr22.vcf.bgz.tbi"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr22.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4529,7 +4539,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chr22 sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr22.vcf.bgz.tbi"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr22.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4545,9 +4555,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                37.05 GiB
+                21.34 GiB
                 , MD5: 
-                b77d8f0219fa9a033a6f747d5fef12d9
+                8b91766906865b0795c653af51cb73b8
               </span>
               <br />
               <span>
@@ -4556,7 +4566,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chrX sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chrX.vcf.bgz"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chrX.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4566,7 +4576,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chrX sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chrX.vcf.bgz"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chrX.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4576,7 +4586,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chrX sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chrX.vcf.bgz"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chrX.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4590,7 +4600,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chrX sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chrX.vcf.bgz.tbi"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chrX.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4600,7 +4610,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chrX sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chrX.vcf.bgz.tbi"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chrX.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4610,7 +4620,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chrX sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chrX.vcf.bgz.tbi"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chrX.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4626,9 +4636,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                890.03 MiB
+                571.35 MiB
                 , MD5: 
-                8c231b75745b6670555915847c9999e8
+                1ffb9c683674f41ff7cf524e5bb56bb8
               </span>
               <br />
               <span>
@@ -4637,7 +4647,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chrY sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chrY.vcf.bgz"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chrY.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4647,7 +4657,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chrY sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chrY.vcf.bgz"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chrY.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4657,7 +4667,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download chrY sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chrY.vcf.bgz"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chrY.vcf.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4671,7 +4681,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chrY sites VCF from Google"
                   className="c10"
-                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chrY.vcf.bgz.tbi"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chrY.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4681,7 +4691,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chrY sites VCF from Amazon"
                   className="c10"
-                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chrY.vcf.bgz.tbi"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chrY.vcf.bgz.tbi"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -4691,7 +4701,298 @@ exports[`Downloads Page has no unexpected changes 1`] = `
                 <a
                   aria-label="Download TBI file for chrY sites VCF from Microsoft"
                   className="c10"
-                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chrY.vcf.bgz.tbi"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chrY.vcf.bgz.tbi"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </section>
+    <section
+      className="c15"
+    >
+      <span
+        className="c6"
+      >
+        <h2
+          className="c16"
+        >
+          <a
+            aria-hidden="true"
+            className="c8 c9"
+            href="#v4-joint-freq-stats"
+            id="v4-joint-freq-stats"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Joint Frequency
+        </h2>
+      </span>
+      <ul
+        className="c19"
+      >
+        <li
+          className="c20"
+        >
+          <span>
+            Joint sites Hail Table
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download Joint sites Hail Table from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/ht/joint/gnomad.joint.v4.1.site.ht"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download Joint sites Hail Table from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/ht/joint/gnomad.joint.v4.1.site.ht"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download Joint sites Hail Table from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/ht/joint/gnomad.joint.v4.1.site.ht"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+      </ul>
+    </section>
+    <section
+      className="c15"
+    >
+      <span
+        className="c6"
+      >
+        <h2
+          className="c16"
+        >
+          <a
+            aria-hidden="true"
+            className="c8 c9"
+            href="#v4-all-sites-allele-number"
+            id="v4-all-sites-allele-number"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          All sites allele numbers
+        </h2>
+      </span>
+      <div
+        className="c17"
+      >
+        <div
+          className="c18"
+        >
+          <h3>
+            Exomes
+          </h3>
+          <ul
+            className="c19"
+          >
+            <li
+              className="c20"
+            >
+              <span>
+                Exomes all site allele number Hail Table
+              </span>
+              <br />
+              Show URL for
+               
+              <button
+                aria-label="Show Google URL for Exomes all site allele number Hail Table"
+                className="c21"
+                onClick={[Function]}
+                type="button"
+              >
+                Google
+              </button>
+               / 
+              <button
+                aria-label="Show Amazon URL for Exomes all site allele number Hail Table"
+                className="c21"
+                onClick={[Function]}
+                type="button"
+              >
+                Amazon
+              </button>
+               / 
+              <button
+                aria-label="Show Microsoft URL for Exomes all site allele number Hail Table"
+                className="c21"
+                onClick={[Function]}
+                type="button"
+              >
+                Microsoft
+              </button>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                Exomes all site allele number TSV
+              </span>
+              <br />
+              <span>
+                1.07 GiB
+                , MD5: 
+                ee71ce1ccfa5c1d9dd86e1ee1b1d11e2
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download Exomes all site allele number TSV from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/tsv/exomes/gnomad.exomes.v4.1.allele_number_all_sites.tsv.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download Exomes all site allele number TSV from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/tsv/exomes/gnomad.exomes.v4.1.allele_number_all_sites.tsv.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download Exomes all site allele number TSV from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/tsv/exomes/gnomad.exomes.v4.1.allele_number_all_sites.tsv.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Microsoft
+                </a>
+              </span>
+            </li>
+          </ul>
+        </div>
+        <div
+          className="c18"
+        >
+          <h3>
+            Genomes
+          </h3>
+          <ul
+            className="c19"
+          >
+            <li
+              className="c20"
+            >
+              <span>
+                Genomes all site allele number Hail Table
+              </span>
+              <br />
+              Show URL for
+               
+              <button
+                aria-label="Show Google URL for Genomes all site allele number Hail Table"
+                className="c21"
+                onClick={[Function]}
+                type="button"
+              >
+                Google
+              </button>
+               / 
+              <button
+                aria-label="Show Amazon URL for Genomes all site allele number Hail Table"
+                className="c21"
+                onClick={[Function]}
+                type="button"
+              >
+                Amazon
+              </button>
+               / 
+              <button
+                aria-label="Show Microsoft URL for Genomes all site allele number Hail Table"
+                className="c21"
+                onClick={[Function]}
+                type="button"
+              >
+                Microsoft
+              </button>
+            </li>
+            <li
+              className="c20"
+            >
+              <span>
+                Genomes all site allele number TSV
+              </span>
+              <br />
+              <span>
+                11.19 GiB
+                , MD5: 
+                7101516dd79d48d10c28fa548b22884a
+              </span>
+              <br />
+              <span>
+                Download from
+                 
+                <a
+                  aria-label="Download Genomes all site allele number TSV from Google"
+                  className="c10"
+                  href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/tsv/genomes/gnomad.genomes.v4.1.allele_number_all_sites.tsv.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Google
+                </a>
+                 / 
+                <a
+                  aria-label="Download Genomes all site allele number TSV from Amazon"
+                  className="c10"
+                  href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/tsv/genomes/gnomad.genomes.v4.1.allele_number_all_sites.tsv.bgz"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Amazon
+                </a>
+                 / 
+                <a
+                  aria-label="Download Genomes all site allele number TSV from Microsoft"
+                  className="c10"
+                  href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/tsv/genomes/gnomad.genomes.v4.1.allele_number_all_sites.tsv.bgz"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -5031,7 +5332,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             <a
               aria-label="Download README from Google"
               className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/constraint/README.txt"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/constraint/README.txt"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -5041,7 +5342,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             <a
               aria-label="Download README from Amazon"
               className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/constraint/README.txt"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/constraint/README.txt"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -5051,7 +5352,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             <a
               aria-label="Download README from Microsoft"
               className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/constraint/README.txt"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/constraint/README.txt"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -5108,7 +5409,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             <a
               aria-label="Download Constraint metrics TSV from Google"
               className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/constraint/gnomad.v4.0.constraint_metrics.tsv"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/constraint/gnomad.v4.1.constraint_metrics.tsv"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -5118,7 +5419,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             <a
               aria-label="Download Constraint metrics TSV from Amazon"
               className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/constraint/gnomad.v4.0.constraint_metrics.tsv"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/constraint/gnomad.v4.1.constraint_metrics.tsv"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -5128,7 +5429,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             <a
               aria-label="Download Constraint metrics TSV from Microsoft"
               className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/constraint/gnomad.v4.0.constraint_metrics.tsv"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/constraint/gnomad.v4.1.constraint_metrics.tsv"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -5182,22 +5483,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           className="c20"
         >
           <span>
-            chr1 VCF
-          </span>
-          <br />
-          <span>
-            616.33 MiB
-            , CRC32C: 
-            f497d60f
+            Genome SV VCF
           </span>
           <br />
           <span>
             Download from
              
             <a
-              aria-label="Download chr1 VCF from Google"
+              aria-label="Download Genome SV VCF from Google"
               className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr1.vcf.gz"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/genome_sv/gnomad.v4.1.sv.sites.vcf.gz"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -5205,9 +5500,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             </a>
              / 
             <a
-              aria-label="Download chr1 VCF from Amazon"
+              aria-label="Download Genome SV VCF from Amazon"
               className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/genome_sv/gnomad.v4.0.sv.chr1.vcf.gz"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/genome_sv/gnomad.v4.1.sv.sites.vcf.gz"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -5215,9 +5510,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             </a>
              / 
             <a
-              aria-label="Download chr1 VCF from Microsoft"
+              aria-label="Download Genome SV VCF from Microsoft"
               className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr1.vcf.gz"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/genome_sv/gnomad.v4.1.sv.sites.vcf.gz"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -5229,9 +5524,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             Download TBI from
              
             <a
-              aria-label="Download TBI file for chr1 VCF from Google"
+              aria-label="Download TBI file for Genome SV VCF from Google"
               className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr1.vcf.gz.tbi"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/genome_sv/gnomad.v4.1.sv.sites.vcf.gz.tbi"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -5239,9 +5534,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             </a>
              / 
             <a
-              aria-label="Download TBI file for chr1 VCF from Amazon"
+              aria-label="Download TBI file for Genome SV VCF from Amazon"
               className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/genome_sv/gnomad.v4.0.sv.chr1.vcf.gz.tbi"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/genome_sv/gnomad.v4.1.sv.sites.vcf.gz.tbi"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -5249,9 +5544,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             </a>
              / 
             <a
-              aria-label="Download TBI file for chr1 VCF from Microsoft"
+              aria-label="Download TBI file for Genome SV VCF from Microsoft"
               className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr1.vcf.gz.tbi"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/genome_sv/gnomad.v4.1.sv.sites.vcf.gz.tbi"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -5263,22 +5558,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           className="c20"
         >
           <span>
-            chr2 VCF
-          </span>
-          <br />
-          <span>
-            612.83 MiB
-            , CRC32C: 
-            bee58761
+            Genome SV non neuro controls VCF
           </span>
           <br />
           <span>
             Download from
              
             <a
-              aria-label="Download chr2 VCF from Google"
+              aria-label="Download Genome SV non neuro controls VCF from Google"
               className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr2.vcf.gz"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/genome_sv/gnomad.v4.1.sv.non_neuro_controls.sites.vcf.gz"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -5286,9 +5575,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             </a>
              / 
             <a
-              aria-label="Download chr2 VCF from Amazon"
+              aria-label="Download Genome SV non neuro controls VCF from Amazon"
               className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/genome_sv/gnomad.v4.0.sv.chr2.vcf.gz"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/genome_sv/gnomad.v4.1.sv.non_neuro_controls.sites.vcf.gz"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -5296,9 +5585,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             </a>
              / 
             <a
-              aria-label="Download chr2 VCF from Microsoft"
+              aria-label="Download Genome SV non neuro controls VCF from Microsoft"
               className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr2.vcf.gz"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/genome_sv/gnomad.v4.1.sv.non_neuro_controls.sites.vcf.gz"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -5310,9 +5599,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             Download TBI from
              
             <a
-              aria-label="Download TBI file for chr2 VCF from Google"
+              aria-label="Download TBI file for Genome SV non neuro controls VCF from Google"
               className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr2.vcf.gz.tbi"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/genome_sv/gnomad.v4.1.sv.non_neuro_controls.sites.vcf.gz.tbi"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -5320,9 +5609,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             </a>
              / 
             <a
-              aria-label="Download TBI file for chr2 VCF from Amazon"
+              aria-label="Download TBI file for Genome SV non neuro controls VCF from Amazon"
               className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/genome_sv/gnomad.v4.0.sv.chr2.vcf.gz.tbi"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/genome_sv/gnomad.v4.1.sv.non_neuro_controls.sites.vcf.gz.tbi"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -5330,1791 +5619,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             </a>
              / 
             <a
-              aria-label="Download TBI file for chr2 VCF from Microsoft"
+              aria-label="Download TBI file for Genome SV non neuro controls VCF from Microsoft"
               className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr2.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c20"
-        >
-          <span>
-            chr3 VCF
-          </span>
-          <br />
-          <span>
-            469.64 MiB
-            , CRC32C: 
-            00c11e03
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr3 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr3.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr3 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/genome_sv/gnomad.v4.0.sv.chr3.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr3 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr3.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr3 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr3.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr3 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/genome_sv/gnomad.v4.0.sv.chr3.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr3 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr3.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c20"
-        >
-          <span>
-            chr4 VCF
-          </span>
-          <br />
-          <span>
-            446.44 MiB
-            , CRC32C: 
-            4aa1be45
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr4 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr4.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr4 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/genome_sv/gnomad.v4.0.sv.chr4.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr4 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr4.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr4 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr4.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr4 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/genome_sv/gnomad.v4.0.sv.chr4.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr4 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr4.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c20"
-        >
-          <span>
-            chr5 VCF
-          </span>
-          <br />
-          <span>
-            418.1 MiB
-            , CRC32C: 
-            cc78d775
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr5 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr5.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr5 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/genome_sv/gnomad.v4.0.sv.chr5.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr5 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr5.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr5 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr5.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr5 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/genome_sv/gnomad.v4.0.sv.chr5.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr5 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr5.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c20"
-        >
-          <span>
-            chr6 VCF
-          </span>
-          <br />
-          <span>
-            418.37 MiB
-            , CRC32C: 
-            8ad01764
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr6 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr6.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr6 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/genome_sv/gnomad.v4.0.sv.chr6.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr6 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr6.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr6 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr6.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr6 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/genome_sv/gnomad.v4.0.sv.chr6.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr6 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr6.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c20"
-        >
-          <span>
-            chr7 VCF
-          </span>
-          <br />
-          <span>
-            437.99 MiB
-            , CRC32C: 
-            0e78bed7
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr7 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr7.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr7 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/genome_sv/gnomad.v4.0.sv.chr7.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr7 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr7.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr7 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr7.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr7 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/genome_sv/gnomad.v4.0.sv.chr7.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr7 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr7.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c20"
-        >
-          <span>
-            chr8 VCF
-          </span>
-          <br />
-          <span>
-            332.91 MiB
-            , CRC32C: 
-            1a7974d3
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr8 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr8.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr8 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/genome_sv/gnomad.v4.0.sv.chr8.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr8 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr8.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr8 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr8.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr8 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/genome_sv/gnomad.v4.0.sv.chr8.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr8 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr8.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c20"
-        >
-          <span>
-            chr9 VCF
-          </span>
-          <br />
-          <span>
-            289.19 MiB
-            , CRC32C: 
-            693c4cc1
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr9 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr9.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr9 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/genome_sv/gnomad.v4.0.sv.chr9.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr9 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr9.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr9 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr9.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr9 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/genome_sv/gnomad.v4.0.sv.chr9.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr9 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr9.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c20"
-        >
-          <span>
-            chr10 VCF
-          </span>
-          <br />
-          <span>
-            320.36 MiB
-            , CRC32C: 
-            63dc92db
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr10 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr10.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr10 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/genome_sv/gnomad.v4.0.sv.chr10.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr10 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr10.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr10 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr10.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr10 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/genome_sv/gnomad.v4.0.sv.chr10.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr10 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr10.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c20"
-        >
-          <span>
-            chr11 VCF
-          </span>
-          <br />
-          <span>
-            312.75 MiB
-            , CRC32C: 
-            c0016756
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr11 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr11.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr11 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/genome_sv/gnomad.v4.0.sv.chr11.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr11 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr11.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr11 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr11.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr11 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/genome_sv/gnomad.v4.0.sv.chr11.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr11 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr11.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c20"
-        >
-          <span>
-            chr12 VCF
-          </span>
-          <br />
-          <span>
-            322.33 MiB
-            , CRC32C: 
-            28396743
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr12 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr12.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr12 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/genome_sv/gnomad.v4.0.sv.chr12.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr12 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr12.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr12 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr12.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr12 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/genome_sv/gnomad.v4.0.sv.chr12.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr12 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr12.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c20"
-        >
-          <span>
-            chr13 VCF
-          </span>
-          <br />
-          <span>
-            208.4 MiB
-            , CRC32C: 
-            504d3937
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr13 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr13.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr13 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/genome_sv/gnomad.v4.0.sv.chr13.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr13 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr13.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr13 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr13.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr13 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/genome_sv/gnomad.v4.0.sv.chr13.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr13 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr13.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c20"
-        >
-          <span>
-            chr14 VCF
-          </span>
-          <br />
-          <span>
-            218.37 MiB
-            , CRC32C: 
-            06ccecf9
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr14 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr14.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr14 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/genome_sv/gnomad.v4.0.sv.chr14.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr14 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr14.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr14 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr14.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr14 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/genome_sv/gnomad.v4.0.sv.chr14.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr14 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr14.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c20"
-        >
-          <span>
-            chr15 VCF
-          </span>
-          <br />
-          <span>
-            183.5 MiB
-            , CRC32C: 
-            c191b2ca
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr15 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr15.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr15 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/genome_sv/gnomad.v4.0.sv.chr15.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr15 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr15.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr15 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr15.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr15 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/genome_sv/gnomad.v4.0.sv.chr15.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr15 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr15.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c20"
-        >
-          <span>
-            chr16 VCF
-          </span>
-          <br />
-          <span>
-            234 MiB
-            , CRC32C: 
-            016c8e77
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr16 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr16.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr16 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/genome_sv/gnomad.v4.0.sv.chr16.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr16 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr16.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr16 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr16.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr16 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/genome_sv/gnomad.v4.0.sv.chr16.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr16 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr16.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c20"
-        >
-          <span>
-            chr17 VCF
-          </span>
-          <br />
-          <span>
-            233.1 MiB
-            , CRC32C: 
-            f37738a4
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr17 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr17.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr17 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/genome_sv/gnomad.v4.0.sv.chr17.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr17 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr17.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr17 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr17.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr17 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/genome_sv/gnomad.v4.0.sv.chr17.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr17 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr17.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c20"
-        >
-          <span>
-            chr18 VCF
-          </span>
-          <br />
-          <span>
-            157.88 MiB
-            , CRC32C: 
-            1f802ad6
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr18 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr18.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr18 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/genome_sv/gnomad.v4.0.sv.chr18.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr18 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr18.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr18 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr18.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr18 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/genome_sv/gnomad.v4.0.sv.chr18.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr18 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr18.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c20"
-        >
-          <span>
-            chr19 VCF
-          </span>
-          <br />
-          <span>
-            227.48 MiB
-            , CRC32C: 
-            16a48cf0
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr19 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr19.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr19 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/genome_sv/gnomad.v4.0.sv.chr19.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr19 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr19.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr19 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr19.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr19 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/genome_sv/gnomad.v4.0.sv.chr19.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr19 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr19.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c20"
-        >
-          <span>
-            chr20 VCF
-          </span>
-          <br />
-          <span>
-            148.62 MiB
-            , CRC32C: 
-            7e34ac14
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr20 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr20.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr20 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/genome_sv/gnomad.v4.0.sv.chr20.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr20 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr20.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr20 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr20.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr20 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/genome_sv/gnomad.v4.0.sv.chr20.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr20 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr20.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c20"
-        >
-          <span>
-            chr21 VCF
-          </span>
-          <br />
-          <span>
-            109.55 MiB
-            , CRC32C: 
-            6805d560
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr21 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr21.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr21 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/genome_sv/gnomad.v4.0.sv.chr21.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr21 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr21.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr21 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr21.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr21 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/genome_sv/gnomad.v4.0.sv.chr21.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr21 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr21.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c20"
-        >
-          <span>
-            chr22 VCF
-          </span>
-          <br />
-          <span>
-            112.34 MiB
-            , CRC32C: 
-            3a0cce90
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chr22 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr22.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chr22 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/genome_sv/gnomad.v4.0.sv.chr22.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chr22 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr22.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chr22 VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chr22.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr22 VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/genome_sv/gnomad.v4.0.sv.chr22.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chr22 VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chr22.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c20"
-        >
-          <span>
-            chrX VCF
-          </span>
-          <br />
-          <span>
-            335.93 MiB
-            , CRC32C: 
-            1b49e5a6
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chrX VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chrX.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chrX VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/genome_sv/gnomad.v4.0.sv.chrX.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chrX VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chrX.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chrX VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chrX.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chrX VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/genome_sv/gnomad.v4.0.sv.chrX.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chrX VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chrX.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-        </li>
-        <li
-          className="c20"
-        >
-          <span>
-            chrY VCF
-          </span>
-          <br />
-          <span>
-            50.76 MiB
-            , CRC32C: 
-            d8a3a636
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download chrY VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chrY.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download chrY VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/genome_sv/gnomad.v4.0.sv.chrY.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download chrY VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chrY.vcf.gz"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Microsoft
-            </a>
-          </span>
-          <br />
-          <span>
-            Download TBI from
-             
-            <a
-              aria-label="Download TBI file for chrY VCF from Google"
-              className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/genome_sv/gnomad.v4.0.sv.chrY.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chrY VCF from Amazon"
-              className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/genome_sv/gnomad.v4.0.sv.chrY.vcf.gz.tbi"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-             / 
-            <a
-              aria-label="Download TBI file for chrY VCF from Microsoft"
-              className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/genome_sv/gnomad.v4.0.sv.chrY.vcf.gz.tbi"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/genome_sv/gnomad.v4.1.sv.non_neuro_controls.sites.vcf.gz.tbi"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -7177,7 +5684,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             <a
               aria-label="Download Exome CNV VCF from Google"
               className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/exome_cnv/gnomad.v4.0.cnv.all.vcf.gz"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/exome_cnv/gnomad.v4.1.cnv.all.vcf.gz"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -7187,7 +5694,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             <a
               aria-label="Download Exome CNV VCF from Amazon"
               className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/exome_cnv/gnomad.v4.0.cnv.all.vcf.gz"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/exome_cnv/gnomad.v4.1.cnv.all.vcf.gz"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -7197,7 +5704,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             <a
               aria-label="Download Exome CNV VCF from Microsoft"
               className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/exome_cnv/gnomad.v4.0.cnv.all.vcf.gz"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/exome_cnv/gnomad.v4.1.cnv.all.vcf.gz"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -7218,7 +5725,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             <a
               aria-label="Download Exome CNV non neuro VCF from Google"
               className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/exome_cnv/gnomad.v4.0.cnv.non_neuro.vcf.gz"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/exome_cnv/gnomad.v4.1.cnv.non_neuro.vcf.gz"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -7228,7 +5735,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             <a
               aria-label="Download Exome CNV non neuro VCF from Amazon"
               className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/exome_cnv/gnomad.v4.0.cnv.non_neuro.vcf.gz"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/exome_cnv/gnomad.v4.1.cnv.non_neuro.vcf.gz"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -7238,7 +5745,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             <a
               aria-label="Download Exome CNV non neuro VCF from Microsoft"
               className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/exome_cnv/gnomad.v4.0.cnv.non_neuro.vcf.gz"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/exome_cnv/gnomad.v4.1.cnv.non_neuro.vcf.gz"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -7250,16 +5757,16 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           className="c20"
         >
           <span>
-            Exome CNV non-neuro controls VCF
+            Exome CNV non neuro controls VCF
           </span>
           <br />
           <span>
             Download from
              
             <a
-              aria-label="Download Exome CNV non-neuro controls VCF from Google"
+              aria-label="Download Exome CNV non neuro controls VCF from Google"
               className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.0/exome_cnv/gnomad.v4.0.cnv.non_neuro_controls.vcf.gz"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/exome_cnv/gnomad.v4.1.cnv.non_neuro_controls.vcf.gz"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -7267,9 +5774,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             </a>
              / 
             <a
-              aria-label="Download Exome CNV non-neuro controls VCF from Amazon"
+              aria-label="Download Exome CNV non neuro controls VCF from Amazon"
               className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/exome_cnv/gnomad.v4.0.cnv.non_neuro_controls.vcf.gz"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/exome_cnv/gnomad.v4.1.cnv.non_neuro_controls.vcf.gz"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -7277,9 +5784,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             </a>
              / 
             <a
-              aria-label="Download Exome CNV non-neuro controls VCF from Microsoft"
+              aria-label="Download Exome CNV non neuro controls VCF from Microsoft"
               className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.0/exome_cnv/gnomad.v4.0.cnv.non_neuro_controls.vcf.gz"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/exome_cnv/gnomad.v4.1.cnv.non_neuro_controls.vcf.gz"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -7429,6 +5936,129 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               aria-label="Download Exome calling intervals flat file from Microsoft"
               className="c10"
               href="https://datasetgnomad.blob.core.windows.net/dataset/resources/grch38/intervals/ukb.pad50.broad.pad50.union.intervals"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            REVEL v4.1 README
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download REVEL v4.1 README from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/tsv/revel_for_2414_unmatched_transcripts_README.md"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download REVEL v4.1 README from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/tsv/revel_for_2414_unmatched_transcripts_README.md"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download REVEL v4.1 README from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/tsv/revel_for_2414_unmatched_transcripts_README.md"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            Exomes REVEL supplementary TSV
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download Exomes REVEL supplementary TSV from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/tsv/exomes/gnomad.v4.1.exomes.revel_for_2414_unmatched_transcripts.tsv.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download Exomes REVEL supplementary TSV from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/tsv/exomes/gnomad.v4.1.exomes.revel_for_2414_unmatched_transcripts.tsv.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download Exomes REVEL supplementary TSV from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/tsv/exomes/gnomad.v4.1.exomes.revel_for_2414_unmatched_transcripts.tsv.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            Genomes REVEL supplementary TSV
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download Genomes REVEL supplementary TSV from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/tsv/genomes/gnomad.v4.1.genomes.revel_for_2414_unmatched_transcripts.tsv.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download Genomes REVEL supplementary TSV from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/tsv/genomes/gnomad.v4.1.genomes.revel_for_2414_unmatched_transcripts.tsv.bgz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download Genomes REVEL supplementary TSV from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/tsv/genomes/gnomad.v4.1.genomes.revel_for_2414_unmatched_transcripts.tsv.bgz"
               rel="noopener noreferrer"
               target="_blank"
             >

--- a/browser/src/HomePage.tsx
+++ b/browser/src/HomePage.tsx
@@ -88,6 +88,12 @@ export default () => (
           Browse tandem repeats in gnomAD
         </Link>
       </ListItem>
+      {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+      <ListItem>
+        <Link to="/help/what-features-are-not-yet-in-v4-and-where-can-i-find-them">
+          Locate features not yet in gnomAD v4
+        </Link>
+      </ListItem>
     </List>
 
     <p>

--- a/browser/src/StatsPage/NumberOfVariantsInGnomadList.tsx
+++ b/browser/src/StatsPage/NumberOfVariantsInGnomadList.tsx
@@ -14,7 +14,7 @@ const SectionHeader = styled.div`
   font-weight: bold;
 `
 
-const SectionList = styled.ul`
+export const SectionList = styled.ul`
   margin-top: 0.5em;
 
   li {

--- a/browser/src/StatsPage/StatsPage.tsx
+++ b/browser/src/StatsPage/StatsPage.tsx
@@ -22,7 +22,7 @@ import Link from '../Link'
 import gnomadExomeGenomeCountsByVersion from './BarGraphData/gnomADExomeGenomeCountsByVersion.json'
 import gnomadV4GeneticAncestryCounts from './BarGraphData/gnomadV4GeneticAncestryCounts.json'
 import gnomadV4GeneticDiversityCounts from './BarGraphData/gnomadV4GeneticDiversityCounts.json'
-import NumberOfVariantsInGnomadList from './NumberOfVariantsInGnomadList'
+import NumberOfVariantsInGnomadList, { SectionList } from './NumberOfVariantsInGnomadList'
 import StackedBarGraph from './StackedBarGraph'
 import GeneticAncestryGroupsByVersionTable from './StatsPageTables/GeneticAncestryGroupsByVersionTable'
 import V4GeneticAncestryTable from './StatsPageTables/V4GeneticAncestryTable'
@@ -185,14 +185,17 @@ const StatsPage = () => {
           <TwoColumnLayout>
             <div>
               <h2>gnomAD v4 includes 807,162 individuals</h2>
-              <ul>
+              <SectionList>
                 <li>
                   730,947 <span style={{ color: gnomadBlue }}>exomes</span>
+                  <SectionList>
+                    <li>314,392 in the non-UKB subset</li>
+                  </SectionList>
                 </li>
                 <li>
                   76,215 <span style={{ color: gnomadGreen }}>genomes</span>
                 </li>
-              </ul>
+              </SectionList>
               <h2>v4 variants</h2>
               <NumberOfVariantsInGnomadList />
             </div>

--- a/browser/src/StatsPage/__snapshots__/StatsPage.spec.tsx.snap
+++ b/browser/src/StatsPage/__snapshots__/StatsPage.spec.tsx.snap
@@ -115,24 +115,24 @@ exports[`Stats Page has no unexpected changes 1`] = `
   line-height: 1.4;
 }
 
-.c5 {
+.c6 {
   margin-left: 2rem;
 }
 
-.c6 {
+.c7 {
   margin-bottom: 1em;
 }
 
-.c7 {
+.c8 {
   font-size: 1.1em;
   font-weight: bold;
 }
 
-.c8 {
+.c5 {
   margin-top: 0.5em;
 }
 
-.c8 li {
+.c5 li {
   margin-bottom: 0.5em;
 }
 
@@ -556,7 +556,9 @@ exports[`Stats Page has no unexpected changes 1`] = `
           <h2>
             gnomAD v4 includes 807,162 individuals
           </h2>
-          <ul>
+          <ul
+            className="c5"
+          >
             <li>
               730,947 
               <span
@@ -568,6 +570,13 @@ exports[`Stats Page has no unexpected changes 1`] = `
               >
                 exomes
               </span>
+              <ul
+                className="c5"
+              >
+                <li>
+                  314,392 in the non-UKB subset
+                </li>
+              </ul>
             </li>
             <li>
               76,215 
@@ -586,18 +595,18 @@ exports[`Stats Page has no unexpected changes 1`] = `
             v4 variants
           </h2>
           <div
-            className="c5"
+            className="c6"
           >
             <div
-              className="c6"
+              className="c7"
             >
               <div
-                className="c7"
+                className="c8"
               >
                 Short variants
               </div>
               <ul
-                className="c8"
+                className="c5"
               >
                 <li>
                   Total SNVs: 786,500,648
@@ -608,7 +617,7 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 <li>
                   Variant type* counts
                   <ul
-                    className="c8"
+                    className="c5"
                   >
                     <li>
                       Synonymous: 9,643,254
@@ -641,20 +650,20 @@ exports[`Stats Page has no unexpected changes 1`] = `
               </div>
             </div>
             <div
-              className="c6"
+              className="c7"
             >
               <div
-                className="c7"
+                className="c8"
               >
                 Structural variants
               </div>
               <ul
-                className="c8"
+                className="c5"
               >
                 <li>
                   1,199,117 genome SVs
                   <ul
-                    className="c8"
+                    className="c5"
                   >
                     <li>
                       627,947 Deletions
@@ -682,7 +691,7 @@ exports[`Stats Page has no unexpected changes 1`] = `
                 <li>
                   66,903 rare (&lt;1% site frequency (SF)) exome CNVs
                   <ul
-                    className="c8"
+                    className="c5"
                   >
                     <li>
                       30,877 Deletions
@@ -695,15 +704,15 @@ exports[`Stats Page has no unexpected changes 1`] = `
               </ul>
             </div>
             <div
-              className="c6"
+              className="c7"
             >
               <div
-                className="c7"
+                className="c8"
               >
                 Average number of variants per person
               </div>
               <ul
-                className="c8"
+                className="c5"
               >
                 <li>
                   SNVs per person (

--- a/browser/src/VariantPage/VariantOccurrenceTable.tsx
+++ b/browser/src/VariantPage/VariantOccurrenceTable.tsx
@@ -376,8 +376,18 @@ export const GnomadVariantOccurrenceTable = ({
                 <TooltipHint>Allele Frequency</TooltipHint>
               </TooltipAnchor>
             </th>
-            {showExomes && <td>{isPresentInExome && exomeAlleleFrequency.toPrecision(4)}</td>}
-            {showGenomes && <td>{isPresentInGenome && genomeAlleleFrequency.toPrecision(4)}</td>}
+            {showExomes && (
+              <td>
+                {isPresentInExome && exomeAlleleFrequency.toPrecision(4)}
+                {notCalledInExomes && '-'}
+              </td>
+            )}
+            {showGenomes && (
+              <td>
+                {isPresentInGenome && genomeAlleleFrequency.toPrecision(4)}
+                {notCalledInGenomes && '-'}
+              </td>
+            )}
             {showTotal && <td>{totalAlleleFrequency.toPrecision(4)}</td>}
           </tr>
           <tr>
@@ -389,11 +399,15 @@ export const GnomadVariantOccurrenceTable = ({
               (95% confidence)
             </th>
             {showExomes && (
-              <td>{isPresentInExome && <FilteringAlleleFrequency {...variant.exome!.faf95} />}</td>
+              <td>
+                {isPresentInExome && <FilteringAlleleFrequency {...variant.exome!.faf95} />}
+                {notCalledInExomes && '-'}
+              </td>
             )}
             {showGenomes && (
               <td>
                 {isPresentInGenome && <FilteringAlleleFrequency {...variant.genome!.faf95} />}
+                {notCalledInGenomes && '-'}
               </td>
             )}
             {showTotal && (
@@ -414,12 +428,14 @@ export const GnomadVariantOccurrenceTable = ({
               {showExomes && (
                 <td>
                   {isPresentInExome && exomeHomozygoteCount}
+                  {notCalledInExomes && '-'}
                   {showExomeHighAlleleBalanceWarning && ' *'}
                 </td>
               )}
               {showGenomes && (
                 <td>
                   {isPresentInGenome && genomeHomozygoteCount}
+                  {notCalledInGenomes && '-'}
                   {showGenomeHighAlleleBalanceWarning && ' *'}
                 </td>
               )}

--- a/browser/src/VariantPage/VariantOccurrenceTable.tsx
+++ b/browser/src/VariantPage/VariantOccurrenceTable.tsx
@@ -44,7 +44,8 @@ type VariantContext = 'exome' | 'genome' | 'joint'
 const renderGnomadVariantFlag = (variant: Variant, context: VariantContext) => {
   if (!variant[context]) {
     let badgeName = 'No variant'
-    let badgeDescription
+    let badgeDescription =
+      'Variant is not present in this data type. All called sample genotypes from this data type are homozygous reference'
 
     if (variant.joint) {
       if (

--- a/browser/src/VariantPage/__snapshots__/VariantPage.spec.tsx.snap
+++ b/browser/src/VariantPage/__snapshots__/VariantPage.spec.tsx.snap
@@ -64767,6 +64767,8 @@ exports[`VariantPage with the dataset gnomad_r2_1 has no unexpected changes 1`] 
                 <td>
                   <span
                     className="Badge__BadgeWrapper-sc-j4izdp-1 hcZQTs"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
                   >
                     No variant
                   </span>
@@ -74442,6 +74444,8 @@ exports[`VariantPage with the dataset gnomad_r2_1_controls has no unexpected cha
                 <td>
                   <span
                     className="Badge__BadgeWrapper-sc-j4izdp-1 hcZQTs"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
                   >
                     No variant
                   </span>
@@ -84117,6 +84121,8 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_cancer has no unexpected c
                 <td>
                   <span
                     className="Badge__BadgeWrapper-sc-j4izdp-1 hcZQTs"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
                   >
                     No variant
                   </span>
@@ -93792,6 +93798,8 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_neuro has no unexpected ch
                 <td>
                   <span
                     className="Badge__BadgeWrapper-sc-j4izdp-1 hcZQTs"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
                   >
                     No variant
                   </span>
@@ -103467,6 +103475,8 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_topmed has no unexpected c
                 <td>
                   <span
                     className="Badge__BadgeWrapper-sc-j4izdp-1 hcZQTs"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
                   >
                     No variant
                   </span>

--- a/browser/src/__snapshots__/HomePage.spec.tsx.snap
+++ b/browser/src/__snapshots__/HomePage.spec.tsx.snap
@@ -349,6 +349,17 @@ exports[`Home Page has no unexpected changes 1`] = `
         Browse tandem repeats in gnomAD
       </a>
     </li>
+    <li
+      className="c7"
+    >
+      <a
+        className="-Link c8"
+        href="/help/what-features-are-not-yet-in-v4-and-where-can-i-find-them"
+        onClick={[Function]}
+      >
+        Locate features not yet in gnomAD v4
+      </a>
+    </li>
   </ul>
   <p>
     Please note that the gnomAD v3 genomes are now part of gnomAD v4. For more information, see


### PR DESCRIPTION
Various cleanup commits being stuffed into the aforementioned single potpourri commit

The commits address, in order:
- render "`-`" for every row in variant occurrence table if "no data" flag
- reword 4.1 banner
- Resolves #1498
- Resolves #1440 
- Resolves #1487
- Resolves #1443 

