### PR TITLE
Move to artifact registry

### DIFF
--- a/deploy/deployctl/config.py
+++ b/deploy/deployctl/config.py
@@ -82,27 +82,27 @@ class Configuration:
 
     @property
     def api_image_repository(self):
-        return f"gcr.io/{self.project}/gnomad-api"
+        return f"us-docker.pkg.dev/{self.project}/gnomad/gnomad-api"
 
     @property
     def browser_image_repository(self):
-        return f"gcr.io/{self.project}/gnomad-browser"
+        return f"us-docker.pkg.dev/{self.project}/gnomad/gnomad-browser"
 
     @property
     def reads_server_image_repository(self):
-        return f"gcr.io/{self.project}/gnomad-reads-server"
+        return f"us-docker.pkg.dev/{self.project}/gnomad/gnomad-reads-server"
 
     @property
     def reads_api_image_repository(self):
-        return f"gcr.io/{self.project}/gnomad-reads-api"
+        return f"us-docker.pkg.dev/{self.project}/gnomad/gnomad-reads-api"
 
     @property
     def blog_image_repository(self):
-        return f"gcr.io/{self.project}/gnomad-blog"
+        return f"us-docker.pkg.dev/{self.project}/gnomad/gnomad-blog"
 
     @property
     def blog_auth_image_repository(self):
-        return f"gcr.io/{self.project}/gnomad-blog-auth"
+        return f"us-docker.pkg.dev/{self.project}/gnomad/gnomad-blog-auth"
 
 
 config = Configuration(_CONFIG_PATH)  # pylint: disable=invalid-name


### PR DESCRIPTION
with https://github.com/broadinstitute/tgg-terraform-modules/pull/39, update our deployctl config so that images are built and tagged with an artifact registry URL.

The intention is that each of our GCP projects will end up with a "gnomad" namespace / registry, with multiple images inside of it. So we'll have a `$LOCATION-docker.pkg.dev/$PROJECT/gnomad/gnomad-api`, `$LOCATION-docker.pkg.dev/$PROJECT/gnomad/gnomad-browser`, etc.

Note that one side effect of this change, is that you may need to add additional credential helper lines to your `~/.docker/config.json` to handle additional non-gcr.io URLs. See https://cloud.google.com/artifact-registry/docs/docker/pushing-and-pulling#cred-helper

My credHelpers config looks like

```
  "credHelpers": {
    "gcr.io": "gcloud",
    "us-central1-docker.pkg.dev": "gcloud",
    "us-east1-docker.pkg.dev": "gcloud",
    "us-docker.pkg.dev": "gcloud",
    "us-west1-docker.pkg.dev": "gcloud",
    "us.gcr.io": "gcloud"
  },
```