### PR TITLE
Remove mid in grpmax and faf v4 help text

### DIFF
--- a/browser/help/topics/faf.md
+++ b/browser/help/topics/faf.md
@@ -7,6 +7,6 @@ This annotation can be used for filtering variants by allele frequency against a
 
 Note that the GroupMax FAF contains filtering allele frequency information from the genetic ancestry group with the highest **FAF**, not the filtering allele frequency information calculated on the genetic ancestry group with the highest **AF**.
 
-The filtering allele frequency calculation only includes non-bottlenecked genetic ancestry groups: we did not calculate this metric on the Amish (`ami`), Ashkenazi Jewish (`asj`), European Finnish (`fin`), Middle Eastern (`mid`), and "Remaining Individuals" (`rmi`) groups.
+The filtering allele frequency calculation only includes non-bottlenecked genetic ancestry groups: we did not calculate this metric on the Amish (`ami`), Ashkenazi Jewish (`asj`), European Finnish (`fin`), and "Remaining Individuals" (`rmi`) groups.
 
 On the browser, the **GroupMax FAF** annotation is directly available on the variant page. In the VCF and Hail Tables, the filtering allele frequency annotation (abbreviated "`faf`") is computed globally and for each genetic ancestry group. Filtering allele frequencies (FAFs) for each genetic ancestry group are listed separately with 95% and 99% CIs.

--- a/browser/help/topics/faf.md
+++ b/browser/help/topics/faf.md
@@ -7,6 +7,6 @@ This annotation can be used for filtering variants by allele frequency against a
 
 Note that the GroupMax FAF contains filtering allele frequency information from the genetic ancestry group with the highest **FAF**, not the filtering allele frequency information calculated on the genetic ancestry group with the highest **AF**.
 
-The filtering allele frequency calculation only includes non-bottlenecked genetic ancestry groups: we did not calculate this metric on the Amish (`ami`), Ashkenazi Jewish (`asj`), European Finnish (`fin`), and "Remaining Individuals" (`rmi`) groups.
+The filtering allele frequency calculation only includes non-bottlenecked genetic ancestry groups: we did not calculate this metric on the Amish (`ami`), Ashkenazi Jewish (`asj`), European Finnish (`fin`), and "Remaining Individuals" (`rmi`) groups. Due to small group size, we also did not include the Middle Eastern (`mid`) group in genome FAF calculations.
 
 On the browser, the **GroupMax FAF** annotation is directly available on the variant page. In the VCF and Hail Tables, the filtering allele frequency annotation (abbreviated "`faf`") is computed globally and for each genetic ancestry group. Filtering allele frequencies (FAFs) for each genetic ancestry group are listed separately with 95% and 99% CIs.

--- a/browser/help/topics/grpmax.md
+++ b/browser/help/topics/grpmax.md
@@ -5,4 +5,4 @@ title: 'Group maximum allele frequency'
 
 This annotation (abbreviated "`grpmax`") contains allele frequency information (AC, AN, AF, homozygote count) for the non-bottlenecked genetic ancestry groups with the highest **AF**. Note that `grpmax` is distinct from filtering allele frequency.
 
-For gnomAD v4, this calculation excludes Amish (`ami`), Ashkenazi Jewish (`asj`), European Finnish (`fin`), and "Remaining Individuals" (`rmi`) groups. For gnomAD v2, this calculation excludes Ashkenazi Jewish (`asj`), European Finnish (`fin`), and "Remaining Individuals" (`rmi`) groups.
+For gnomAD v4 exomes and genomes, this calculation excludes Amish (`ami`), Ashkenazi Jewish (`asj`), European Finnish (`fin`), and "Remaining Individuals" (`rmi`) groups. Due to small group size, we also did not include the Middle Eastern (`mid`) group in genome `grpmax` calculations. For gnomAD v2, this calculation excludes Ashkenazi Jewish (`asj`), European Finnish (`fin`), and "Remaining Individuals" (`rmi`) groups.

--- a/browser/help/topics/grpmax.md
+++ b/browser/help/topics/grpmax.md
@@ -5,4 +5,4 @@ title: 'Group maximum allele frequency'
 
 This annotation (abbreviated "`grpmax`") contains allele frequency information (AC, AN, AF, homozygote count) for the non-bottlenecked genetic ancestry groups with the highest **AF**. Note that `grpmax` is distinct from filtering allele frequency.
 
-For gnomAD v4, this calculation excludes Amish (`ami`), Ashkenazi Jewish (`asj`), European Finnish (`fin`), Middle Eastern (`mid`), and "Remaining Individuals" (`rmi`) groups. For gnomAD v2, this calculation excludes Ashkenazi Jewish (`asj`), European Finnish (`fin`), and "Remaining Individuals" (`rmi`) groups.
+For gnomAD v4, this calculation excludes Amish (`ami`), Ashkenazi Jewish (`asj`), European Finnish (`fin`), and "Remaining Individuals" (`rmi`) groups. For gnomAD v2, this calculation excludes Ashkenazi Jewish (`asj`), European Finnish (`fin`), and "Remaining Individuals" (`rmi`) groups.


### PR DESCRIPTION
We included Middle Eastern in GrpMax and FAF calculations in v4.1 so should remove them from the exclusion text.