### PR TITLE
fix(browser): update v4.1 genomes chr2 md5 on downloads

### DIFF
--- a/browser/src/DownloadsPage/GnomadV4Downloads.tsx
+++ b/browser/src/DownloadsPage/GnomadV4Downloads.tsx
@@ -16,7 +16,7 @@ import Link from '../Link'
 
 const exomeChromosomeVcfs = [
   { chrom: '1', size: '17.50 GiB', md5: '848be4d85c953bc73a8e4f0c97026a72' },
-  { chrom: '2', size: '13.30 GiB', md5: 'e2f5d891a3374e88d1c3136f94bed0ea' },
+  { chrom: '2', size: '13.30 GiB', md5: '518ca01e6757a68bc0abe76f85af644d' },
   { chrom: '3', size: '10.79 GiB', md5: 'a35b949b32453b4b5abd7b1de42e298a' },
   { chrom: '4', size: '7.18 GiB', md5: 'c7c7008a73acbb8fea68b82951842832' },
   { chrom: '5', size: '7.91 GiB', md5: 'c1016f56be62deb2e947fed4d31302dd' },

--- a/browser/src/DownloadsPage/__snapshots__/DownloadsPage.spec.tsx.snap
+++ b/browser/src/DownloadsPage/__snapshots__/DownloadsPage.spec.tsx.snap
@@ -866,7 +866,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               <span>
                 13.30 GiB
                 , MD5: 
-                e2f5d891a3374e88d1c3136f94bed0ea
+                518ca01e6757a68bc0abe76f85af644d
               </span>
               <br />
               <span>


### PR DESCRIPTION
Resolves #1511

Updates genome chr2's checksum to the correct one: `518ca01e6757a68bc0abe76f85af644d`