### PR TITLE
Fixes to dataset labels

### DIFF
--- a/browser/src/GenePage/__snapshots__/GenePage.spec.tsx.snap
+++ b/browser/src/GenePage/__snapshots__/GenePage.spec.tsx.snap
@@ -319,7 +319,7 @@ exports[`GenePage with CNV dataset "gnomad_cnv_r4" has no unexpected changes 1`]
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -1837,7 +1837,7 @@ exports[`GenePage with SV dataset "gnomad_sv_r2_1" has no unexpected changes 1`]
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -3344,7 +3344,7 @@ exports[`GenePage with SV dataset "gnomad_sv_r2_1_controls" has no unexpected ch
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -4851,7 +4851,7 @@ exports[`GenePage with SV dataset "gnomad_sv_r2_1_non_neuro" has no unexpected c
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -6358,7 +6358,7 @@ exports[`GenePage with SV dataset "gnomad_sv_r4" has no unexpected changes 1`] =
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -7591,7 +7591,7 @@ exports[`GenePage with non-SV dataset "exac" has no unexpected changes 1`] = `
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              ExAC v1.0
+              ExAC
             </a>
           </li>
           <li
@@ -7865,7 +7865,7 @@ exports[`GenePage with non-SV dataset "exac" has no unexpected changes 1`] = `
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -9406,7 +9406,7 @@ exports[`GenePage with non-SV dataset "gnomad_cnv_r4" has no unexpected changes 
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -10924,7 +10924,7 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1" has no unexpected changes 1`
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -12560,7 +12560,7 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_controls" has no unexpected c
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -14196,7 +14196,7 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_non_cancer" has no unexpected
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -15832,7 +15832,7 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_non_neuro" has no unexpected 
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -17468,7 +17468,7 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_non_topmed" has no unexpected
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -19104,7 +19104,7 @@ exports[`GenePage with non-SV dataset "gnomad_r3" has no unexpected changes 1`] 
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -20646,7 +20646,7 @@ exports[`GenePage with non-SV dataset "gnomad_r3_controls_and_biobanks" has no u
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -22188,7 +22188,7 @@ exports[`GenePage with non-SV dataset "gnomad_r3_non_cancer" has no unexpected c
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -23730,7 +23730,7 @@ exports[`GenePage with non-SV dataset "gnomad_r3_non_neuro" has no unexpected ch
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -25272,7 +25272,7 @@ exports[`GenePage with non-SV dataset "gnomad_r3_non_topmed" has no unexpected c
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -26814,7 +26814,7 @@ exports[`GenePage with non-SV dataset "gnomad_r3_non_v2" has no unexpected chang
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -28356,7 +28356,7 @@ exports[`GenePage with non-SV dataset "gnomad_r4" has no unexpected changes 1`] 
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -29897,7 +29897,7 @@ exports[`GenePage with non-SV dataset "gnomad_r4_non_ukb" has no unexpected chan
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >

--- a/browser/src/MitochondrialVariantPage/__snapshots__/MitochondrialVariantPage.spec.tsx.snap
+++ b/browser/src/MitochondrialVariantPage/__snapshots__/MitochondrialVariantPage.spec.tsx.snap
@@ -5,7 +5,7 @@ exports[`MitochondrialVariantPage with dataset exac has no unexpected changes 1`
   className="StatusMessage-sc-neg7mh-0 hJFlwG"
 >
   Mitochondrial variants are not available in 
-  ExAC v1.0
+  ExAC
   <br />
   <br />
   <a

--- a/browser/src/RegionPage/__snapshots__/MitochondrialRegionCoverageTrack.spec.tsx.snap
+++ b/browser/src/RegionPage/__snapshots__/MitochondrialRegionCoverageTrack.spec.tsx.snap
@@ -5,7 +5,7 @@ exports[`MitochondrialRegionCoverageTrack with dataset exac has no unexpected ch
   className="StatusMessage-sc-neg7mh-0 hJFlwG"
 >
   Mitochondrial genome coverage is not available in 
-  ExAC v1.0
+  ExAC
 </div>
 `;
 

--- a/browser/src/RegionPage/__snapshots__/MitochondrialVariantsInRegion.spec.tsx.snap
+++ b/browser/src/RegionPage/__snapshots__/MitochondrialVariantsInRegion.spec.tsx.snap
@@ -5,7 +5,7 @@ exports[`MitochondrialVariantsInRegion with dataset exac has no unexpected chang
   className="StatusMessage-sc-neg7mh-0 hJFlwG"
 >
   Mitochondrial variants are not available in 
-  ExAC v1.0
+  ExAC
   <br />
   <br />
   <a

--- a/browser/src/RegionPage/__snapshots__/RegionPage.spec.tsx.snap
+++ b/browser/src/RegionPage/__snapshots__/RegionPage.spec.tsx.snap
@@ -4,7 +4,7 @@ exports[`RegionPage with "exac" dataset has no unexpected changes for a mitochon
 <TrackPage>
   <TrackPage__TrackPageSection>
     <DocumentTitle
-      title="M-345-456 | ExAC v1.0"
+      title="M-345-456 | ExAC"
     />
     <GnomadPageHeading
       datasetOptions={
@@ -146,7 +146,7 @@ exports[`RegionPage with "exac" dataset has no unexpected changes for a non-mito
 <TrackPage>
   <TrackPage__TrackPageSection>
     <DocumentTitle
-      title="12-345-456 | ExAC v1.0"
+      title="12-345-456 | ExAC"
     />
     <GnomadPageHeading
       datasetOptions={

--- a/browser/src/Searchbox.tsx
+++ b/browser/src/Searchbox.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components'
 import { Searchbox, Select } from '@gnomad/ui'
 
 import { fetchSearchResults } from './search'
-import { DatasetId } from '@gnomad/dataset-metadata/metadata'
+import { DatasetId, labelForDataset } from '@gnomad/dataset-metadata/metadata'
 
 const Wrapper = styled.div`
   display: flex;
@@ -79,6 +79,9 @@ export default withRouter((props: any) => {
 
   const innerSearchbox = useRef(null)
 
+  const grch38Datasets: DatasetId[] = ['gnomad_r4', 'gnomad_r3', 'gnomad_sv_r4', 'gnomad_cnv_r4']
+  const grch37Datasets: DatasetId[] = ['gnomad_r2_1', 'gnomad_sv_r2_1', 'exac']
+
   return (
     // @ts-expect-error TS(2769) FIXME: No overload matches this call.
     <Wrapper width={width}>
@@ -93,15 +96,14 @@ export default withRouter((props: any) => {
         }}
       >
         <optgroup label="GRCh38">
-          <option value="gnomad_r4">gnomAD v4.1.0</option>
-          <option value="gnomad_r3">gnomAD v3.1.2</option>
-          <option value="gnomad_sv_r4">gnomAD SVs v4</option>
-          <option value="gnomad_cnv_r4">gnomAD CNVs v4.0</option>
+          {grch38Datasets.map((datasetId) => (
+            <option value={datasetId}>{labelForDataset(datasetId)}</option>
+          ))}
         </optgroup>
         <optgroup label="GRCh37">
-          <option value="gnomad_r2_1">gnomAD v2.1.1</option>
-          <option value="gnomad_sv_r2_1">gnomAD SVs v2.1</option>
-          <option value="exac">ExAC</option>
+          {grch37Datasets.map((datasetId) => (
+            <option value={datasetId}>{labelForDataset(datasetId)}</option>
+          ))}
         </optgroup>
       </Select>
       <span style={{ flexGrow: 1 }}>

--- a/browser/src/ShortTandemRepeatPage/__snapshots__/ShortTandemRepeatPageContainer.spec.tsx.snap
+++ b/browser/src/ShortTandemRepeatPage/__snapshots__/ShortTandemRepeatPageContainer.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`ShortTandemRepeatPageContainer with dataset exac queries API with correct parameters 1`] = `
 <Page>
   <DocumentTitle
-    title="ATXN1 | Tandem Repeat | ExAC v1.0"
+    title="ATXN1 | Tandem Repeat | ExAC"
   />
   <GnomadPageHeading
     datasetOptions={

--- a/browser/src/TranscriptPage/__snapshots__/MitochondrialTranscriptCoverageTrack.spec.tsx.snap
+++ b/browser/src/TranscriptPage/__snapshots__/MitochondrialTranscriptCoverageTrack.spec.tsx.snap
@@ -5,7 +5,7 @@ exports[`MitochondrialTranscriptCoverageTrack with dataset exac has no unexpecte
   className="StatusMessage-sc-neg7mh-0 hJFlwG"
 >
   Mitochondrial genome coverage is not available in 
-  ExAC v1.0
+  ExAC
 </div>
 `;
 

--- a/browser/src/TranscriptPage/__snapshots__/MitochondrialVariantsInTranscript.spec.tsx.snap
+++ b/browser/src/TranscriptPage/__snapshots__/MitochondrialVariantsInTranscript.spec.tsx.snap
@@ -5,7 +5,7 @@ exports[`MitochondrialVariantsInTranscript with dataset exac has no unexpected c
   className="StatusMessage-sc-neg7mh-0 hJFlwG"
 >
   Mitochondrial variants are not available in 
-  ExAC v1.0
+  ExAC
   <br />
   <br />
   <a

--- a/browser/src/TranscriptPage/__snapshots__/TranscriptPage.spec.tsx.snap
+++ b/browser/src/TranscriptPage/__snapshots__/TranscriptPage.spec.tsx.snap
@@ -44,7 +44,7 @@ exports[`TranscriptPage with dataset "exac" has no unexpected changes 1`] = `
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              ExAC v1.0
+              ExAC
             </a>
           </li>
           <li
@@ -318,7 +318,7 @@ exports[`TranscriptPage with dataset "exac" has no unexpected changes 1`] = `
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -1143,7 +1143,7 @@ exports[`TranscriptPage with dataset "gnomad_cnv_r4" has no unexpected changes 1
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -1968,7 +1968,7 @@ exports[`TranscriptPage with dataset "gnomad_r2_1" has no unexpected changes 1`]
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -2793,7 +2793,7 @@ exports[`TranscriptPage with dataset "gnomad_r2_1_controls" has no unexpected ch
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -3618,7 +3618,7 @@ exports[`TranscriptPage with dataset "gnomad_r2_1_non_cancer" has no unexpected 
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -4443,7 +4443,7 @@ exports[`TranscriptPage with dataset "gnomad_r2_1_non_neuro" has no unexpected c
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -5268,7 +5268,7 @@ exports[`TranscriptPage with dataset "gnomad_r2_1_non_topmed" has no unexpected 
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -6093,7 +6093,7 @@ exports[`TranscriptPage with dataset "gnomad_r3" has no unexpected changes 1`] =
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -6919,7 +6919,7 @@ exports[`TranscriptPage with dataset "gnomad_r3_controls_and_biobanks" has no un
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -7745,7 +7745,7 @@ exports[`TranscriptPage with dataset "gnomad_r3_non_cancer" has no unexpected ch
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -8571,7 +8571,7 @@ exports[`TranscriptPage with dataset "gnomad_r3_non_neuro" has no unexpected cha
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -9397,7 +9397,7 @@ exports[`TranscriptPage with dataset "gnomad_r3_non_topmed" has no unexpected ch
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -10223,7 +10223,7 @@ exports[`TranscriptPage with dataset "gnomad_r3_non_v2" has no unexpected change
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -11049,7 +11049,7 @@ exports[`TranscriptPage with dataset "gnomad_r4" has no unexpected changes 1`] =
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -11874,7 +11874,7 @@ exports[`TranscriptPage with dataset "gnomad_r4_non_ukb" has no unexpected chang
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -12699,7 +12699,7 @@ exports[`TranscriptPage with dataset "gnomad_sv_r2_1" has no unexpected changes 
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -13524,7 +13524,7 @@ exports[`TranscriptPage with dataset "gnomad_sv_r2_1_controls" has no unexpected
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -14349,7 +14349,7 @@ exports[`TranscriptPage with dataset "gnomad_sv_r2_1_non_neuro" has no unexpecte
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -15174,7 +15174,7 @@ exports[`TranscriptPage with dataset "gnomad_sv_r4" has no unexpected changes 1`
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >

--- a/browser/src/TranscriptPage/__snapshots__/TranscriptPageContainer.spec.tsx.snap
+++ b/browser/src/TranscriptPage/__snapshots__/TranscriptPageContainer.spec.tsx.snap
@@ -44,7 +44,7 @@ exports[`TranscriptPageContainer with dataset exac has no unexpected changes 1`]
               onClick={[Function]}
               onKeyDown={[Function]}
             >
-              ExAC v1.0
+              ExAC
             </a>
           </li>
           <li
@@ -318,7 +318,7 @@ exports[`TranscriptPageContainer with dataset exac has no unexpected changes 1`]
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -1773,7 +1773,7 @@ exports[`TranscriptPageContainer with dataset gnomad_cnv_r4 has no unexpected ch
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -3228,7 +3228,7 @@ exports[`TranscriptPageContainer with dataset gnomad_r2_1 has no unexpected chan
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -4683,7 +4683,7 @@ exports[`TranscriptPageContainer with dataset gnomad_r2_1_controls has no unexpe
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -6138,7 +6138,7 @@ exports[`TranscriptPageContainer with dataset gnomad_r2_1_non_cancer has no unex
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -7593,7 +7593,7 @@ exports[`TranscriptPageContainer with dataset gnomad_r2_1_non_neuro has no unexp
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -9048,7 +9048,7 @@ exports[`TranscriptPageContainer with dataset gnomad_r2_1_non_topmed has no unex
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -10503,7 +10503,7 @@ exports[`TranscriptPageContainer with dataset gnomad_r3 has no unexpected change
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -11959,7 +11959,7 @@ exports[`TranscriptPageContainer with dataset gnomad_r3_controls_and_biobanks ha
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -13415,7 +13415,7 @@ exports[`TranscriptPageContainer with dataset gnomad_r3_non_cancer has no unexpe
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -14871,7 +14871,7 @@ exports[`TranscriptPageContainer with dataset gnomad_r3_non_neuro has no unexpec
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -16327,7 +16327,7 @@ exports[`TranscriptPageContainer with dataset gnomad_r3_non_topmed has no unexpe
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -17783,7 +17783,7 @@ exports[`TranscriptPageContainer with dataset gnomad_r3_non_v2 has no unexpected
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -19239,7 +19239,7 @@ exports[`TranscriptPageContainer with dataset gnomad_r4 has no unexpected change
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >
@@ -20694,7 +20694,7 @@ exports[`TranscriptPageContainer with dataset gnomad_r4_non_ukb has no unexpecte
                     onClick={[Function]}
                     onKeyDown={[Function]}
                   >
-                    ExAC v1.0
+                    ExAC
                     <div
                       className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                     >

--- a/browser/src/VariantCooccurrencePage/__snapshots__/VariantCooccurrencePage.spec.tsx.snap
+++ b/browser/src/VariantCooccurrencePage/__snapshots__/VariantCooccurrencePage.spec.tsx.snap
@@ -15577,7 +15577,7 @@ exports[`VariantCoocurrencePage for non-2.1 dataset exac has no unexpected chang
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            ExAC v1.0
+            ExAC
           </a>
         </li>
         <li

--- a/browser/src/VariantPage/__snapshots__/VariantPage.spec.tsx.snap
+++ b/browser/src/VariantPage/__snapshots__/VariantPage.spec.tsx.snap
@@ -56875,7 +56875,7 @@ exports[`VariantPage with the dataset exac has no unexpected changes 1`] = `
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            ExAC v1.0
+            ExAC
           </a>
         </li>
         <li
@@ -57149,7 +57149,7 @@ exports[`VariantPage with the dataset exac has no unexpected changes 1`] = `
                   onClick={[Function]}
                   onKeyDown={[Function]}
                 >
-                  ExAC v1.0
+                  ExAC
                   <div
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >
@@ -64641,7 +64641,7 @@ exports[`VariantPage with the dataset gnomad_r2_1 has no unexpected changes 1`] 
                   onClick={[Function]}
                   onKeyDown={[Function]}
                 >
-                  ExAC v1.0
+                  ExAC
                   <div
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >
@@ -74318,7 +74318,7 @@ exports[`VariantPage with the dataset gnomad_r2_1_controls has no unexpected cha
                   onClick={[Function]}
                   onKeyDown={[Function]}
                 >
-                  ExAC v1.0
+                  ExAC
                   <div
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >
@@ -83995,7 +83995,7 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_cancer has no unexpected c
                   onClick={[Function]}
                   onKeyDown={[Function]}
                 >
-                  ExAC v1.0
+                  ExAC
                   <div
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >
@@ -93672,7 +93672,7 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_neuro has no unexpected ch
                   onClick={[Function]}
                   onKeyDown={[Function]}
                 >
-                  ExAC v1.0
+                  ExAC
                   <div
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >
@@ -103349,7 +103349,7 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_topmed has no unexpected c
                   onClick={[Function]}
                   onKeyDown={[Function]}
                 >
-                  ExAC v1.0
+                  ExAC
                   <div
                     className="DatasetSelector__ItemDescription-sc-1p2fxbn-6 jjgqnf"
                   >

--- a/browser/src/__snapshots__/DatasetSelector.spec.tsx.snap
+++ b/browser/src/__snapshots__/DatasetSelector.spec.tsx.snap
@@ -178,7 +178,7 @@ exports[`DataSelector with "exac" dataset selected has no unexpected changes 1`]
       onClick={[Function]}
       onKeyDown={[Function]}
     >
-      ExAC v1.0
+      ExAC
     </a>
   </li>
   <li
@@ -435,7 +435,7 @@ exports[`DataSelector with "exac" dataset selected has no unexpected changes 1`]
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            ExAC v1.0
+            ExAC
             <div
               className="c8"
             >
@@ -770,7 +770,7 @@ exports[`DataSelector with "exac" dataset selected has no unexpected changes whe
       onClick={[Function]}
       onKeyDown={[Function]}
     >
-      ExAC v1.0
+      ExAC
     </a>
   </li>
   <li
@@ -1027,7 +1027,7 @@ exports[`DataSelector with "exac" dataset selected has no unexpected changes whe
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            ExAC v1.0
+            ExAC
             <div
               className="c8"
             >
@@ -1619,7 +1619,7 @@ exports[`DataSelector with "gnomad_cnv_r4" dataset selected has no unexpected ch
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            ExAC v1.0
+            ExAC
             <div
               className="c8"
             >
@@ -2211,7 +2211,7 @@ exports[`DataSelector with "gnomad_cnv_r4" dataset selected has no unexpected ch
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            ExAC v1.0
+            ExAC
             <div
               className="c8"
             >
@@ -2803,7 +2803,7 @@ exports[`DataSelector with "gnomad_r2_1" dataset selected has no unexpected chan
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            ExAC v1.0
+            ExAC
             <div
               className="c8"
             >
@@ -3395,7 +3395,7 @@ exports[`DataSelector with "gnomad_r2_1" dataset selected has no unexpected chan
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            ExAC v1.0
+            ExAC
             <div
               className="c8"
             >
@@ -3987,7 +3987,7 @@ exports[`DataSelector with "gnomad_r2_1_controls" dataset selected has no unexpe
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            ExAC v1.0
+            ExAC
             <div
               className="c8"
             >
@@ -4579,7 +4579,7 @@ exports[`DataSelector with "gnomad_r2_1_controls" dataset selected has no unexpe
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            ExAC v1.0
+            ExAC
             <div
               className="c8"
             >
@@ -5171,7 +5171,7 @@ exports[`DataSelector with "gnomad_r2_1_non_cancer" dataset selected has no unex
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            ExAC v1.0
+            ExAC
             <div
               className="c8"
             >
@@ -5763,7 +5763,7 @@ exports[`DataSelector with "gnomad_r2_1_non_cancer" dataset selected has no unex
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            ExAC v1.0
+            ExAC
             <div
               className="c8"
             >
@@ -6355,7 +6355,7 @@ exports[`DataSelector with "gnomad_r2_1_non_neuro" dataset selected has no unexp
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            ExAC v1.0
+            ExAC
             <div
               className="c8"
             >
@@ -6947,7 +6947,7 @@ exports[`DataSelector with "gnomad_r2_1_non_neuro" dataset selected has no unexp
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            ExAC v1.0
+            ExAC
             <div
               className="c8"
             >
@@ -7539,7 +7539,7 @@ exports[`DataSelector with "gnomad_r2_1_non_topmed" dataset selected has no unex
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            ExAC v1.0
+            ExAC
             <div
               className="c8"
             >
@@ -8131,7 +8131,7 @@ exports[`DataSelector with "gnomad_r2_1_non_topmed" dataset selected has no unex
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            ExAC v1.0
+            ExAC
             <div
               className="c8"
             >
@@ -8723,7 +8723,7 @@ exports[`DataSelector with "gnomad_r3" dataset selected has no unexpected change
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            ExAC v1.0
+            ExAC
             <div
               className="c8"
             >
@@ -9315,7 +9315,7 @@ exports[`DataSelector with "gnomad_r3" dataset selected has no unexpected change
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            ExAC v1.0
+            ExAC
             <div
               className="c8"
             >
@@ -9907,7 +9907,7 @@ exports[`DataSelector with "gnomad_r3_controls_and_biobanks" dataset selected ha
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            ExAC v1.0
+            ExAC
             <div
               className="c8"
             >
@@ -10499,7 +10499,7 @@ exports[`DataSelector with "gnomad_r3_controls_and_biobanks" dataset selected ha
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            ExAC v1.0
+            ExAC
             <div
               className="c8"
             >
@@ -11091,7 +11091,7 @@ exports[`DataSelector with "gnomad_r3_non_cancer" dataset selected has no unexpe
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            ExAC v1.0
+            ExAC
             <div
               className="c8"
             >
@@ -11683,7 +11683,7 @@ exports[`DataSelector with "gnomad_r3_non_cancer" dataset selected has no unexpe
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            ExAC v1.0
+            ExAC
             <div
               className="c8"
             >
@@ -12275,7 +12275,7 @@ exports[`DataSelector with "gnomad_r3_non_neuro" dataset selected has no unexpec
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            ExAC v1.0
+            ExAC
             <div
               className="c8"
             >
@@ -12867,7 +12867,7 @@ exports[`DataSelector with "gnomad_r3_non_neuro" dataset selected has no unexpec
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            ExAC v1.0
+            ExAC
             <div
               className="c8"
             >
@@ -13459,7 +13459,7 @@ exports[`DataSelector with "gnomad_r3_non_topmed" dataset selected has no unexpe
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            ExAC v1.0
+            ExAC
             <div
               className="c8"
             >
@@ -14051,7 +14051,7 @@ exports[`DataSelector with "gnomad_r3_non_topmed" dataset selected has no unexpe
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            ExAC v1.0
+            ExAC
             <div
               className="c8"
             >
@@ -14643,7 +14643,7 @@ exports[`DataSelector with "gnomad_r3_non_v2" dataset selected has no unexpected
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            ExAC v1.0
+            ExAC
             <div
               className="c8"
             >
@@ -15235,7 +15235,7 @@ exports[`DataSelector with "gnomad_r3_non_v2" dataset selected has no unexpected
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            ExAC v1.0
+            ExAC
             <div
               className="c8"
             >
@@ -15827,7 +15827,7 @@ exports[`DataSelector with "gnomad_r4" dataset selected has no unexpected change
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            ExAC v1.0
+            ExAC
             <div
               className="c8"
             >
@@ -16419,7 +16419,7 @@ exports[`DataSelector with "gnomad_r4" dataset selected has no unexpected change
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            ExAC v1.0
+            ExAC
             <div
               className="c8"
             >
@@ -17011,7 +17011,7 @@ exports[`DataSelector with "gnomad_r4_non_ukb" dataset selected has no unexpecte
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            ExAC v1.0
+            ExAC
             <div
               className="c8"
             >
@@ -17603,7 +17603,7 @@ exports[`DataSelector with "gnomad_r4_non_ukb" dataset selected has no unexpecte
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            ExAC v1.0
+            ExAC
             <div
               className="c8"
             >
@@ -18195,7 +18195,7 @@ exports[`DataSelector with "gnomad_sv_r2_1" dataset selected has no unexpected c
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            ExAC v1.0
+            ExAC
             <div
               className="c8"
             >
@@ -18787,7 +18787,7 @@ exports[`DataSelector with "gnomad_sv_r2_1" dataset selected has no unexpected c
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            ExAC v1.0
+            ExAC
             <div
               className="c8"
             >
@@ -19379,7 +19379,7 @@ exports[`DataSelector with "gnomad_sv_r2_1_controls" dataset selected has no une
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            ExAC v1.0
+            ExAC
             <div
               className="c8"
             >
@@ -19971,7 +19971,7 @@ exports[`DataSelector with "gnomad_sv_r2_1_controls" dataset selected has no une
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            ExAC v1.0
+            ExAC
             <div
               className="c8"
             >
@@ -20563,7 +20563,7 @@ exports[`DataSelector with "gnomad_sv_r2_1_non_neuro" dataset selected has no un
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            ExAC v1.0
+            ExAC
             <div
               className="c8"
             >
@@ -21155,7 +21155,7 @@ exports[`DataSelector with "gnomad_sv_r2_1_non_neuro" dataset selected has no un
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            ExAC v1.0
+            ExAC
             <div
               className="c8"
             >
@@ -21747,7 +21747,7 @@ exports[`DataSelector with "gnomad_sv_r4" dataset selected has no unexpected cha
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            ExAC v1.0
+            ExAC
             <div
               className="c8"
             >
@@ -22339,7 +22339,7 @@ exports[`DataSelector with "gnomad_sv_r4" dataset selected has no unexpected cha
             onClick={[Function]}
             onKeyDown={[Function]}
           >
-            ExAC v1.0
+            ExAC
             <div
               className="c8"
             >

--- a/browser/src/__snapshots__/HomePage.spec.tsx.snap
+++ b/browser/src/__snapshots__/HomePage.spec.tsx.snap
@@ -213,12 +213,12 @@ exports[`Home Page has no unexpected changes 1`] = `
         <option
           value="gnomad_sv_r4"
         >
-          gnomAD SVs v4
+          gnomAD SVs v4.1.0
         </option>
         <option
           value="gnomad_cnv_r4"
         >
-          gnomAD CNVs v4.0
+          gnomAD CNVs v4.1.0
         </option>
       </optgroup>
       <optgroup
@@ -237,7 +237,7 @@ exports[`Home Page has no unexpected changes 1`] = `
         <option
           value="exac"
         >
-          ExAC
+          ExAC v1.0
         </option>
       </optgroup>
     </select>

--- a/browser/src/__snapshots__/HomePage.spec.tsx.snap
+++ b/browser/src/__snapshots__/HomePage.spec.tsx.snap
@@ -237,7 +237,7 @@ exports[`Home Page has no unexpected changes 1`] = `
         <option
           value="exac"
         >
-          ExAC v1.0
+          ExAC
         </option>
       </optgroup>
     </select>

--- a/browser/src/__snapshots__/NavBar.spec.tsx.snap
+++ b/browser/src/__snapshots__/NavBar.spec.tsx.snap
@@ -268,12 +268,12 @@ exports[`NavBar has no unexpected changes 1`] = `
         <option
           value="gnomad_sv_r4"
         >
-          gnomAD SVs v4
+          gnomAD SVs v4.1.0
         </option>
         <option
           value="gnomad_cnv_r4"
         >
-          gnomAD CNVs v4.0
+          gnomAD CNVs v4.1.0
         </option>
       </optgroup>
       <optgroup
@@ -292,7 +292,7 @@ exports[`NavBar has no unexpected changes 1`] = `
         <option
           value="exac"
         >
-          ExAC
+          ExAC v1.0
         </option>
       </optgroup>
     </select>

--- a/browser/src/__snapshots__/NavBar.spec.tsx.snap
+++ b/browser/src/__snapshots__/NavBar.spec.tsx.snap
@@ -292,7 +292,7 @@ exports[`NavBar has no unexpected changes 1`] = `
         <option
           value="exac"
         >
-          ExAC v1.0
+          ExAC
         </option>
       </optgroup>
     </select>

--- a/browser/src/__snapshots__/Searchbox.spec.tsx.snap
+++ b/browser/src/__snapshots__/Searchbox.spec.tsx.snap
@@ -25,12 +25,12 @@ exports[`Searchbox has no unexpected changes when no dataset specified 1`] = `
       <option
         value="gnomad_sv_r4"
       >
-        gnomAD SVs v4
+        gnomAD SVs v4.1.0
       </option>
       <option
         value="gnomad_cnv_r4"
       >
-        gnomAD CNVs v4.0
+        gnomAD CNVs v4.1.0
       </option>
     </optgroup>
     <optgroup
@@ -49,7 +49,7 @@ exports[`Searchbox has no unexpected changes when no dataset specified 1`] = `
       <option
         value="exac"
       >
-        ExAC
+        ExAC v1.0
       </option>
     </optgroup>
   </select>
@@ -113,12 +113,12 @@ exports[`Searchbox with selected dataset exac has no unexpected changes 1`] = `
       <option
         value="gnomad_sv_r4"
       >
-        gnomAD SVs v4
+        gnomAD SVs v4.1.0
       </option>
       <option
         value="gnomad_cnv_r4"
       >
-        gnomAD CNVs v4.0
+        gnomAD CNVs v4.1.0
       </option>
     </optgroup>
     <optgroup
@@ -137,7 +137,7 @@ exports[`Searchbox with selected dataset exac has no unexpected changes 1`] = `
       <option
         value="exac"
       >
-        ExAC
+        ExAC v1.0
       </option>
     </optgroup>
   </select>
@@ -201,12 +201,12 @@ exports[`Searchbox with selected dataset gnomad_cnv_r4 has no unexpected changes
       <option
         value="gnomad_sv_r4"
       >
-        gnomAD SVs v4
+        gnomAD SVs v4.1.0
       </option>
       <option
         value="gnomad_cnv_r4"
       >
-        gnomAD CNVs v4.0
+        gnomAD CNVs v4.1.0
       </option>
     </optgroup>
     <optgroup
@@ -225,7 +225,7 @@ exports[`Searchbox with selected dataset gnomad_cnv_r4 has no unexpected changes
       <option
         value="exac"
       >
-        ExAC
+        ExAC v1.0
       </option>
     </optgroup>
   </select>
@@ -289,12 +289,12 @@ exports[`Searchbox with selected dataset gnomad_r2_1 has no unexpected changes 1
       <option
         value="gnomad_sv_r4"
       >
-        gnomAD SVs v4
+        gnomAD SVs v4.1.0
       </option>
       <option
         value="gnomad_cnv_r4"
       >
-        gnomAD CNVs v4.0
+        gnomAD CNVs v4.1.0
       </option>
     </optgroup>
     <optgroup
@@ -313,7 +313,7 @@ exports[`Searchbox with selected dataset gnomad_r2_1 has no unexpected changes 1
       <option
         value="exac"
       >
-        ExAC
+        ExAC v1.0
       </option>
     </optgroup>
   </select>
@@ -377,12 +377,12 @@ exports[`Searchbox with selected dataset gnomad_r2_1_controls has no unexpected 
       <option
         value="gnomad_sv_r4"
       >
-        gnomAD SVs v4
+        gnomAD SVs v4.1.0
       </option>
       <option
         value="gnomad_cnv_r4"
       >
-        gnomAD CNVs v4.0
+        gnomAD CNVs v4.1.0
       </option>
     </optgroup>
     <optgroup
@@ -401,7 +401,7 @@ exports[`Searchbox with selected dataset gnomad_r2_1_controls has no unexpected 
       <option
         value="exac"
       >
-        ExAC
+        ExAC v1.0
       </option>
     </optgroup>
   </select>
@@ -465,12 +465,12 @@ exports[`Searchbox with selected dataset gnomad_r2_1_non_cancer has no unexpecte
       <option
         value="gnomad_sv_r4"
       >
-        gnomAD SVs v4
+        gnomAD SVs v4.1.0
       </option>
       <option
         value="gnomad_cnv_r4"
       >
-        gnomAD CNVs v4.0
+        gnomAD CNVs v4.1.0
       </option>
     </optgroup>
     <optgroup
@@ -489,7 +489,7 @@ exports[`Searchbox with selected dataset gnomad_r2_1_non_cancer has no unexpecte
       <option
         value="exac"
       >
-        ExAC
+        ExAC v1.0
       </option>
     </optgroup>
   </select>
@@ -553,12 +553,12 @@ exports[`Searchbox with selected dataset gnomad_r2_1_non_neuro has no unexpected
       <option
         value="gnomad_sv_r4"
       >
-        gnomAD SVs v4
+        gnomAD SVs v4.1.0
       </option>
       <option
         value="gnomad_cnv_r4"
       >
-        gnomAD CNVs v4.0
+        gnomAD CNVs v4.1.0
       </option>
     </optgroup>
     <optgroup
@@ -577,7 +577,7 @@ exports[`Searchbox with selected dataset gnomad_r2_1_non_neuro has no unexpected
       <option
         value="exac"
       >
-        ExAC
+        ExAC v1.0
       </option>
     </optgroup>
   </select>
@@ -641,12 +641,12 @@ exports[`Searchbox with selected dataset gnomad_r2_1_non_topmed has no unexpecte
       <option
         value="gnomad_sv_r4"
       >
-        gnomAD SVs v4
+        gnomAD SVs v4.1.0
       </option>
       <option
         value="gnomad_cnv_r4"
       >
-        gnomAD CNVs v4.0
+        gnomAD CNVs v4.1.0
       </option>
     </optgroup>
     <optgroup
@@ -665,7 +665,7 @@ exports[`Searchbox with selected dataset gnomad_r2_1_non_topmed has no unexpecte
       <option
         value="exac"
       >
-        ExAC
+        ExAC v1.0
       </option>
     </optgroup>
   </select>
@@ -729,12 +729,12 @@ exports[`Searchbox with selected dataset gnomad_r3 has no unexpected changes 1`]
       <option
         value="gnomad_sv_r4"
       >
-        gnomAD SVs v4
+        gnomAD SVs v4.1.0
       </option>
       <option
         value="gnomad_cnv_r4"
       >
-        gnomAD CNVs v4.0
+        gnomAD CNVs v4.1.0
       </option>
     </optgroup>
     <optgroup
@@ -753,7 +753,7 @@ exports[`Searchbox with selected dataset gnomad_r3 has no unexpected changes 1`]
       <option
         value="exac"
       >
-        ExAC
+        ExAC v1.0
       </option>
     </optgroup>
   </select>
@@ -817,12 +817,12 @@ exports[`Searchbox with selected dataset gnomad_r3_controls_and_biobanks has no 
       <option
         value="gnomad_sv_r4"
       >
-        gnomAD SVs v4
+        gnomAD SVs v4.1.0
       </option>
       <option
         value="gnomad_cnv_r4"
       >
-        gnomAD CNVs v4.0
+        gnomAD CNVs v4.1.0
       </option>
     </optgroup>
     <optgroup
@@ -841,7 +841,7 @@ exports[`Searchbox with selected dataset gnomad_r3_controls_and_biobanks has no 
       <option
         value="exac"
       >
-        ExAC
+        ExAC v1.0
       </option>
     </optgroup>
   </select>
@@ -905,12 +905,12 @@ exports[`Searchbox with selected dataset gnomad_r3_non_cancer has no unexpected 
       <option
         value="gnomad_sv_r4"
       >
-        gnomAD SVs v4
+        gnomAD SVs v4.1.0
       </option>
       <option
         value="gnomad_cnv_r4"
       >
-        gnomAD CNVs v4.0
+        gnomAD CNVs v4.1.0
       </option>
     </optgroup>
     <optgroup
@@ -929,7 +929,7 @@ exports[`Searchbox with selected dataset gnomad_r3_non_cancer has no unexpected 
       <option
         value="exac"
       >
-        ExAC
+        ExAC v1.0
       </option>
     </optgroup>
   </select>
@@ -993,12 +993,12 @@ exports[`Searchbox with selected dataset gnomad_r3_non_neuro has no unexpected c
       <option
         value="gnomad_sv_r4"
       >
-        gnomAD SVs v4
+        gnomAD SVs v4.1.0
       </option>
       <option
         value="gnomad_cnv_r4"
       >
-        gnomAD CNVs v4.0
+        gnomAD CNVs v4.1.0
       </option>
     </optgroup>
     <optgroup
@@ -1017,7 +1017,7 @@ exports[`Searchbox with selected dataset gnomad_r3_non_neuro has no unexpected c
       <option
         value="exac"
       >
-        ExAC
+        ExAC v1.0
       </option>
     </optgroup>
   </select>
@@ -1081,12 +1081,12 @@ exports[`Searchbox with selected dataset gnomad_r3_non_topmed has no unexpected 
       <option
         value="gnomad_sv_r4"
       >
-        gnomAD SVs v4
+        gnomAD SVs v4.1.0
       </option>
       <option
         value="gnomad_cnv_r4"
       >
-        gnomAD CNVs v4.0
+        gnomAD CNVs v4.1.0
       </option>
     </optgroup>
     <optgroup
@@ -1105,7 +1105,7 @@ exports[`Searchbox with selected dataset gnomad_r3_non_topmed has no unexpected 
       <option
         value="exac"
       >
-        ExAC
+        ExAC v1.0
       </option>
     </optgroup>
   </select>
@@ -1169,12 +1169,12 @@ exports[`Searchbox with selected dataset gnomad_r3_non_v2 has no unexpected chan
       <option
         value="gnomad_sv_r4"
       >
-        gnomAD SVs v4
+        gnomAD SVs v4.1.0
       </option>
       <option
         value="gnomad_cnv_r4"
       >
-        gnomAD CNVs v4.0
+        gnomAD CNVs v4.1.0
       </option>
     </optgroup>
     <optgroup
@@ -1193,7 +1193,7 @@ exports[`Searchbox with selected dataset gnomad_r3_non_v2 has no unexpected chan
       <option
         value="exac"
       >
-        ExAC
+        ExAC v1.0
       </option>
     </optgroup>
   </select>
@@ -1257,12 +1257,12 @@ exports[`Searchbox with selected dataset gnomad_r4 has no unexpected changes 1`]
       <option
         value="gnomad_sv_r4"
       >
-        gnomAD SVs v4
+        gnomAD SVs v4.1.0
       </option>
       <option
         value="gnomad_cnv_r4"
       >
-        gnomAD CNVs v4.0
+        gnomAD CNVs v4.1.0
       </option>
     </optgroup>
     <optgroup
@@ -1281,7 +1281,7 @@ exports[`Searchbox with selected dataset gnomad_r4 has no unexpected changes 1`]
       <option
         value="exac"
       >
-        ExAC
+        ExAC v1.0
       </option>
     </optgroup>
   </select>
@@ -1345,12 +1345,12 @@ exports[`Searchbox with selected dataset gnomad_r4_non_ukb has no unexpected cha
       <option
         value="gnomad_sv_r4"
       >
-        gnomAD SVs v4
+        gnomAD SVs v4.1.0
       </option>
       <option
         value="gnomad_cnv_r4"
       >
-        gnomAD CNVs v4.0
+        gnomAD CNVs v4.1.0
       </option>
     </optgroup>
     <optgroup
@@ -1369,7 +1369,7 @@ exports[`Searchbox with selected dataset gnomad_r4_non_ukb has no unexpected cha
       <option
         value="exac"
       >
-        ExAC
+        ExAC v1.0
       </option>
     </optgroup>
   </select>
@@ -1433,12 +1433,12 @@ exports[`Searchbox with selected dataset gnomad_sv_r2_1 has no unexpected change
       <option
         value="gnomad_sv_r4"
       >
-        gnomAD SVs v4
+        gnomAD SVs v4.1.0
       </option>
       <option
         value="gnomad_cnv_r4"
       >
-        gnomAD CNVs v4.0
+        gnomAD CNVs v4.1.0
       </option>
     </optgroup>
     <optgroup
@@ -1457,7 +1457,7 @@ exports[`Searchbox with selected dataset gnomad_sv_r2_1 has no unexpected change
       <option
         value="exac"
       >
-        ExAC
+        ExAC v1.0
       </option>
     </optgroup>
   </select>
@@ -1521,12 +1521,12 @@ exports[`Searchbox with selected dataset gnomad_sv_r2_1_controls has no unexpect
       <option
         value="gnomad_sv_r4"
       >
-        gnomAD SVs v4
+        gnomAD SVs v4.1.0
       </option>
       <option
         value="gnomad_cnv_r4"
       >
-        gnomAD CNVs v4.0
+        gnomAD CNVs v4.1.0
       </option>
     </optgroup>
     <optgroup
@@ -1545,7 +1545,7 @@ exports[`Searchbox with selected dataset gnomad_sv_r2_1_controls has no unexpect
       <option
         value="exac"
       >
-        ExAC
+        ExAC v1.0
       </option>
     </optgroup>
   </select>
@@ -1609,12 +1609,12 @@ exports[`Searchbox with selected dataset gnomad_sv_r2_1_non_neuro has no unexpec
       <option
         value="gnomad_sv_r4"
       >
-        gnomAD SVs v4
+        gnomAD SVs v4.1.0
       </option>
       <option
         value="gnomad_cnv_r4"
       >
-        gnomAD CNVs v4.0
+        gnomAD CNVs v4.1.0
       </option>
     </optgroup>
     <optgroup
@@ -1633,7 +1633,7 @@ exports[`Searchbox with selected dataset gnomad_sv_r2_1_non_neuro has no unexpec
       <option
         value="exac"
       >
-        ExAC
+        ExAC v1.0
       </option>
     </optgroup>
   </select>
@@ -1697,12 +1697,12 @@ exports[`Searchbox with selected dataset gnomad_sv_r4 has no unexpected changes 
       <option
         value="gnomad_sv_r4"
       >
-        gnomAD SVs v4
+        gnomAD SVs v4.1.0
       </option>
       <option
         value="gnomad_cnv_r4"
       >
-        gnomAD CNVs v4.0
+        gnomAD CNVs v4.1.0
       </option>
     </optgroup>
     <optgroup
@@ -1721,7 +1721,7 @@ exports[`Searchbox with selected dataset gnomad_sv_r4 has no unexpected changes 
       <option
         value="exac"
       >
-        ExAC
+        ExAC v1.0
       </option>
     </optgroup>
   </select>

--- a/browser/src/__snapshots__/Searchbox.spec.tsx.snap
+++ b/browser/src/__snapshots__/Searchbox.spec.tsx.snap
@@ -49,7 +49,7 @@ exports[`Searchbox has no unexpected changes when no dataset specified 1`] = `
       <option
         value="exac"
       >
-        ExAC v1.0
+        ExAC
       </option>
     </optgroup>
   </select>
@@ -137,7 +137,7 @@ exports[`Searchbox with selected dataset exac has no unexpected changes 1`] = `
       <option
         value="exac"
       >
-        ExAC v1.0
+        ExAC
       </option>
     </optgroup>
   </select>
@@ -225,7 +225,7 @@ exports[`Searchbox with selected dataset gnomad_cnv_r4 has no unexpected changes
       <option
         value="exac"
       >
-        ExAC v1.0
+        ExAC
       </option>
     </optgroup>
   </select>
@@ -313,7 +313,7 @@ exports[`Searchbox with selected dataset gnomad_r2_1 has no unexpected changes 1
       <option
         value="exac"
       >
-        ExAC v1.0
+        ExAC
       </option>
     </optgroup>
   </select>
@@ -401,7 +401,7 @@ exports[`Searchbox with selected dataset gnomad_r2_1_controls has no unexpected 
       <option
         value="exac"
       >
-        ExAC v1.0
+        ExAC
       </option>
     </optgroup>
   </select>
@@ -489,7 +489,7 @@ exports[`Searchbox with selected dataset gnomad_r2_1_non_cancer has no unexpecte
       <option
         value="exac"
       >
-        ExAC v1.0
+        ExAC
       </option>
     </optgroup>
   </select>
@@ -577,7 +577,7 @@ exports[`Searchbox with selected dataset gnomad_r2_1_non_neuro has no unexpected
       <option
         value="exac"
       >
-        ExAC v1.0
+        ExAC
       </option>
     </optgroup>
   </select>
@@ -665,7 +665,7 @@ exports[`Searchbox with selected dataset gnomad_r2_1_non_topmed has no unexpecte
       <option
         value="exac"
       >
-        ExAC v1.0
+        ExAC
       </option>
     </optgroup>
   </select>
@@ -753,7 +753,7 @@ exports[`Searchbox with selected dataset gnomad_r3 has no unexpected changes 1`]
       <option
         value="exac"
       >
-        ExAC v1.0
+        ExAC
       </option>
     </optgroup>
   </select>
@@ -841,7 +841,7 @@ exports[`Searchbox with selected dataset gnomad_r3_controls_and_biobanks has no 
       <option
         value="exac"
       >
-        ExAC v1.0
+        ExAC
       </option>
     </optgroup>
   </select>
@@ -929,7 +929,7 @@ exports[`Searchbox with selected dataset gnomad_r3_non_cancer has no unexpected 
       <option
         value="exac"
       >
-        ExAC v1.0
+        ExAC
       </option>
     </optgroup>
   </select>
@@ -1017,7 +1017,7 @@ exports[`Searchbox with selected dataset gnomad_r3_non_neuro has no unexpected c
       <option
         value="exac"
       >
-        ExAC v1.0
+        ExAC
       </option>
     </optgroup>
   </select>
@@ -1105,7 +1105,7 @@ exports[`Searchbox with selected dataset gnomad_r3_non_topmed has no unexpected 
       <option
         value="exac"
       >
-        ExAC v1.0
+        ExAC
       </option>
     </optgroup>
   </select>
@@ -1193,7 +1193,7 @@ exports[`Searchbox with selected dataset gnomad_r3_non_v2 has no unexpected chan
       <option
         value="exac"
       >
-        ExAC v1.0
+        ExAC
       </option>
     </optgroup>
   </select>
@@ -1281,7 +1281,7 @@ exports[`Searchbox with selected dataset gnomad_r4 has no unexpected changes 1`]
       <option
         value="exac"
       >
-        ExAC v1.0
+        ExAC
       </option>
     </optgroup>
   </select>
@@ -1369,7 +1369,7 @@ exports[`Searchbox with selected dataset gnomad_r4_non_ukb has no unexpected cha
       <option
         value="exac"
       >
-        ExAC v1.0
+        ExAC
       </option>
     </optgroup>
   </select>
@@ -1457,7 +1457,7 @@ exports[`Searchbox with selected dataset gnomad_sv_r2_1 has no unexpected change
       <option
         value="exac"
       >
-        ExAC v1.0
+        ExAC
       </option>
     </optgroup>
   </select>
@@ -1545,7 +1545,7 @@ exports[`Searchbox with selected dataset gnomad_sv_r2_1_controls has no unexpect
       <option
         value="exac"
       >
-        ExAC v1.0
+        ExAC
       </option>
     </optgroup>
   </select>
@@ -1633,7 +1633,7 @@ exports[`Searchbox with selected dataset gnomad_sv_r2_1_non_neuro has no unexpec
       <option
         value="exac"
       >
-        ExAC v1.0
+        ExAC
       </option>
     </optgroup>
   </select>
@@ -1721,7 +1721,7 @@ exports[`Searchbox with selected dataset gnomad_sv_r4 has no unexpected changes 
       <option
         value="exac"
       >
-        ExAC v1.0
+        ExAC
       </option>
     </optgroup>
   </select>

--- a/dataset-metadata/metadata.ts
+++ b/dataset-metadata/metadata.ts
@@ -1,7 +1,7 @@
 export type ReferenceGenome = 'GRCh37' | 'GRCh38'
 
 export const datasetLabels = {
-  exac: 'ExAC v1.0',
+  exac: 'ExAC',
   gnomad_r2_1: 'gnomAD v2.1.1',
   gnomad_r2_1_controls: 'gnomAD v2.1.1 (controls)',
   gnomad_r2_1_non_cancer: 'gnomAD v2.1.1 (non-cancer)',


### PR DESCRIPTION
Made the `SearchBox` consistent with the `DatasetSelector`. Also in related discussion with @ch-kr we decided to use plain "ExAC" as the label for `exac`, rather than "ExAC v1.0".