### PR TITLE
Revert large gene cache path

### DIFF
--- a/deploy/deployctl/subcommands/browser_deployments.py
+++ b/deploy/deployctl/subcommands/browser_deployments.py
@@ -55,7 +55,7 @@ patches:
               - name: app
                 env:
                   - name: JSON_CACHE_PATH
-                    value: 'gs://{cluster_name}-gene-cache/2024-04-24'
+                    value: 'gs://{cluster_name}-gene-cache/2023-12-01'
 """
 
 


### PR DESCRIPTION
In production this cache is not letting TTN be hit, I'd like to revert to have a working cache for TTN while we investigate.