### PR TITLE
Remove several genes from large genes list

### DIFF
--- a/graphql-api/src/queries/helpers/large-genes.ts
+++ b/graphql-api/src/queries/helpers/large-genes.ts
@@ -1,5 +1,3 @@
 export default [
   'ENSG00000155657', // TTN
-  'ENSG00000183091', // NEB
-  'ENSG00000154358', // OBSCN
 ]


### PR DESCRIPTION
These genes are actually small enough that they will load without the cache, albeit somewhat slowly, and having them not on this list allows users to browse transcripts of them