### PR TITLE
increase Ingress backend timeout from 30 -> 60

### DIFF
--- a/deploy/manifests/ingress/gnomad.backendconfig.yaml
+++ b/deploy/manifests/ingress/gnomad.backendconfig.yaml
@@ -3,5 +3,6 @@ kind: BackendConfig
 metadata:
   name: gnomad-backend-config
 spec:
+  timeoutSec: 60
   securityPolicy:
     name: 'deny-problematic-requests'


### PR DESCRIPTION
From debugging this morning -- changing this is an effort to try an ensure that we can load the TTN JSON cache and get it into the HTTP cache... hoping a few more seconds is enough of a bandaid there.