### PR TITLE
chore(browser): update gene cache path in yml

### DIFF
--- a/deploy/deployctl/subcommands/browser_deployments.py
+++ b/deploy/deployctl/subcommands/browser_deployments.py
@@ -55,7 +55,7 @@ patches:
               - name: app
                 env:
                   - name: JSON_CACHE_PATH
-                    value: 'gs://{cluster_name}-gene-cache/2023-12-01'
+                    value: 'gs://{cluster_name}-gene-cache/2024-04-24'
 """
 
 


### PR DESCRIPTION
Re-updates the gene cache.

Currently in main (but not in prod) it is reverted to the december cache, that patch was never deployed as reverting did not fix the issue.

Since there has been a different band aid applied, this PR re-points the deployment yml to the v4.1 gene cache from April