### PR TITLE
Fix ClinVar track crash

### DIFF
--- a/browser/src/ClinvarVariantsTrack/ClinvarAllVariantsPlot.tsx
+++ b/browser/src/ClinvarVariantsTrack/ClinvarAllVariantsPlot.tsx
@@ -210,7 +210,9 @@ const VariantLine = ({
   }
 
   if (category === 'frameshift') {
-    const transcript = transcripts.find((t) => t.transcript_id === variant.transcript_id)
+    const transcript: Transcript | undefined = transcripts.find(
+      (t) => t.transcript_id === variant.transcript_id
+    )
     const [endpoint1, endpoint2] = getGlobalFrameshiftCoordinates(variant, transcript)
     const frameshiftMinPos = Math.min(endpoint1, endpoint2)
     const frameshiftMaxPos = Math.max(endpoint1, endpoint2)

--- a/browser/src/ClinvarVariantsTrack/ClinvarAllVariantsPlot.tsx
+++ b/browser/src/ClinvarVariantsTrack/ClinvarAllVariantsPlot.tsx
@@ -216,15 +216,19 @@ const VariantLine = ({
     const frameshiftMaxPos = Math.max(endpoint1, endpoint2)
     const terminationPos =
       transcript && transcript.strand === '+' ? frameshiftMaxPos : frameshiftMinPos
-    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
-    const frameshiftExonRegions = transcript.exons
-      .sort((e1, e2) => e1.start - e2.start)
-      .filter((e) => e.start <= frameshiftMaxPos && e.stop >= frameshiftMinPos)
-      .map((e) => ({
-        start: Math.max(e.start, frameshiftMinPos),
-        stop: Math.min(e.stop, frameshiftMaxPos),
-        feature_type: e.feature_type,
-      }))
+
+    // if a frameshift variant-consequence pair from ClinVar exists for a transcript
+    //   that the browser doesn't recognize, use an empty array for exon information
+    const frameshiftExonRegions = transcript
+      ? transcript.exons
+          .sort((e1, e2) => e1.start - e2.start)
+          .filter((e) => e.start <= frameshiftMaxPos && e.stop >= frameshiftMinPos)
+          .map((e) => ({
+            start: Math.max(e.start, frameshiftMinPos),
+            stop: Math.min(e.stop, frameshiftMaxPos),
+            feature_type: e.feature_type,
+          }))
+      : []
 
     return (
       <TooltipAnchor


### PR DESCRIPTION
Resolves: #1525 

Frameshift variants are displayed with a line that is either solid or dotted, depending on if the region being shifted through is an exon that is part of the transcript or not.

In rare cases, there can be a frameshift variant from ClinVar on a transcript that the browser doesn't display, here we manually set the exon array to an empty array to prevent a crash when trying to render the line.

Alternatively, we could edit the logic to always return one type of line or another for the entire length of the frameshift, but without knowledge of which exons are part of the transcript, we can very possibly make a mistake and be inconsistent with how we display things. However, by not displaying any line, we are already being inconsistent with how we display frameshift variants. We should discuss on which is the lesser of the two evils.

One thing to try and better understand is why we don't display some transcripts that ClinVar has entries for.