### PR TITLE
Update HGDP/1KG tutorial download links

### DIFF
--- a/browser/src/DownloadsPage/ExacDownloads.tsx
+++ b/browser/src/DownloadsPage/ExacDownloads.tsx
@@ -66,7 +66,7 @@ const ExacDownloads = () => (
             path="/legacy/exac_browser/ExAC.r1.sites.vep.vcf.gz"
             size="4.56 GiB"
             md5="f2b57a6f0660a00e7550f62da2654948"
-            includeTBI
+            associatedFileType="TBI"
           />
         </ListItem>
       </FileList>

--- a/browser/src/DownloadsPage/GnomadV2Downloads.tsx
+++ b/browser/src/DownloadsPage/GnomadV2Downloads.tsx
@@ -212,7 +212,7 @@ const GnomadV2Downloads = () => {
                   path="/release/2.1.1/vcf/exomes/gnomad.exomes.r2.1.1.sites.vcf.bgz"
                   size="58.81 GiB"
                   md5="f034173bf6e57fbb5e8ce680e95134f2"
-                  includeTBI
+                  associatedFileType="TBI"
                 />
               </ListItem>
               {exomeChromosomeVcfs.map(({ chrom, size, md5 }) => (
@@ -223,7 +223,7 @@ const GnomadV2Downloads = () => {
                     path={`/release/2.1.1/vcf/exomes/gnomad.exomes.r2.1.1.sites.${chrom}.vcf.bgz`}
                     size={size}
                     md5={md5}
-                    includeTBI
+                    associatedFileType="TBI"
                   />
                 </ListItem>
               ))}
@@ -247,7 +247,7 @@ const GnomadV2Downloads = () => {
                   path="/release/2.1.1/vcf/genomes/gnomad.genomes.r2.1.1.sites.vcf.bgz"
                   size="460.93 GiB"
                   md5="e6eadf5ac7b2821b40f350da6e1279a2"
-                  includeTBI
+                  associatedFileType="TBI"
                 />
               </ListItem>
               {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
@@ -257,7 +257,7 @@ const GnomadV2Downloads = () => {
                   path="/release/2.1.1/vcf/genomes/gnomad.genomes.r2.1.1.exome_calling_intervals.sites.vcf.bgz"
                   size="9.7 GiB"
                   md5="e5bd69a0f89468149bc3afca78cd5acc"
-                  includeTBI
+                  associatedFileType="TBI"
                 />
               </ListItem>
               {genomeChromosomeVcfs.map(({ chrom, size, md5 }) => (
@@ -268,7 +268,7 @@ const GnomadV2Downloads = () => {
                     path={`/release/2.1.1/vcf/genomes/gnomad.genomes.r2.1.1.sites.${chrom}.vcf.bgz`}
                     size={size}
                     md5={md5}
-                    includeTBI
+                    associatedFileType="TBI"
                   />
                 </ListItem>
               ))}
@@ -331,7 +331,7 @@ const GnomadV2Downloads = () => {
             <DownloadLinks
               label="SV 2.1 sites VCF"
               path="/papers/2019-sv/gnomad_v2.1_sv.sites.vcf.gz"
-              includeTBI
+              associatedFileType="TBI"
             />
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
@@ -339,7 +339,7 @@ const GnomadV2Downloads = () => {
             <DownloadLinks
               label="SV 2.1 sites BED"
               path="/papers/2019-sv/gnomad_v2.1_sv.sites.bed.gz"
-              includeTBI
+              associatedFileType="TBI"
             />
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
@@ -347,7 +347,7 @@ const GnomadV2Downloads = () => {
             <DownloadLinks
               label="SV 2.1 (controls) sites VCF"
               path="/papers/2019-sv/gnomad_v2.1_sv.controls_only.sites.vcf.gz"
-              includeTBI
+              associatedFileType="TBI"
             />
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
@@ -355,7 +355,7 @@ const GnomadV2Downloads = () => {
             <DownloadLinks
               label="SV 2.1 (controls) sites BED"
               path="/papers/2019-sv/gnomad_v2.1_sv.controls_only.sites.bed.gz"
-              includeTBI
+              associatedFileType="TBI"
             />
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
@@ -363,7 +363,7 @@ const GnomadV2Downloads = () => {
             <DownloadLinks
               label="SV 2.1 (non-neuro) sites VCF"
               path="/papers/2019-sv/gnomad_v2.1_sv.nonneuro.sites.vcf.gz"
-              includeTBI
+              associatedFileType="TBI"
             />
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
@@ -371,7 +371,7 @@ const GnomadV2Downloads = () => {
             <DownloadLinks
               label="SV 2.1 (non-neuro) sites BED"
               path="/papers/2019-sv/gnomad_v2.1_sv.nonneuro.sites.bed.gz"
-              includeTBI
+              associatedFileType="TBI"
             />
           </ListItem>
         </FileList>

--- a/browser/src/DownloadsPage/GnomadV2LiftoverDownloads.tsx
+++ b/browser/src/DownloadsPage/GnomadV2LiftoverDownloads.tsx
@@ -109,7 +109,7 @@ const Gnomadv2LiftoverDownloads = () => {
                   path="/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.liftover_grch38.vcf.bgz"
                   size="85.31 GiB"
                   md5="cff8d0cfed50adc9211d1feaed2d4ca7"
-                  includeTBI
+                  associatedFileType="TBI"
                 />
               </ListItem>
               {liftoverExomeChromosomeVcfs.map(({ chrom, size, md5 }) => (
@@ -120,7 +120,7 @@ const Gnomadv2LiftoverDownloads = () => {
                     path={`/release/2.1.1/liftover_grch38/vcf/exomes/gnomad.exomes.r2.1.1.sites.${chrom}.liftover_grch38.vcf.bgz`}
                     size={size}
                     md5={md5}
-                    includeTBI
+                    associatedFileType="TBI"
                   />
                 </ListItem>
               ))}
@@ -144,7 +144,7 @@ const Gnomadv2LiftoverDownloads = () => {
                   path="/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.liftover_grch38.vcf.bgz"
                   size="743.06 GiB"
                   md5="83de3d5b52669f714e810d4fcf047c18"
-                  includeTBI
+                  associatedFileType="TBI"
                 />
               </ListItem>
               {liftoverGenomeChromosomeVcfs.map(({ chrom, size, md5 }) => (
@@ -155,7 +155,7 @@ const Gnomadv2LiftoverDownloads = () => {
                     path={`/release/2.1.1/liftover_grch38/vcf/genomes/gnomad.genomes.r2.1.1.sites.${chrom}.liftover_grch38.vcf.bgz`}
                     size={size}
                     md5={md5}
-                    includeTBI
+                    associatedFileType="TBI"
                   />
                 </ListItem>
               ))}

--- a/browser/src/DownloadsPage/GnomadV3Downloads.tsx
+++ b/browser/src/DownloadsPage/GnomadV3Downloads.tsx
@@ -195,7 +195,7 @@ const GnomadV3Downloads = () => (
         <ListItem>
           <DownloadLinks
             label="Sample metadata TSV"
-            path="/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_1kg_subset_sample_meta.tsv.bgz"
+            path="/release/3.1/secondary_analyses/hgdp_1kg_v2/metadata_and_qc/gnomad_meta_updated.tsv"
           />
         </ListItem>
         {hgdpAnd1kgChromosomeVcfs.map(({ chrom, size, md5 }) => (
@@ -435,21 +435,21 @@ const GnomadV3Downloads = () => (
         <ListItem>
           <DownloadLinks
             label="Sample metadata TSV"
-            path="/release/3.1/secondary_analyses/hgdp_1kg/metadata_and_qc/gnomad_meta_v1.tsv"
+            path="/release/3.1/secondary_analyses/hgdp_1kg_v2/metadata_and_qc/gnomad_meta_v1.tsv"
           />
         </ListItem>
         {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
         <ListItem>
           <GetUrlButtons
             label="Subset of the HGDP+1KG callset MatrixTable"
-            path="/release/3.1/secondary_analyses/hgdp_1kg/pca_preprocessing/ld_pruned.mt"
+            path="/release/3.1/secondary_analyses/hgdp_1kg_v2/pca_preprocessing/ld_pruned.mt"
           />
         </ListItem>
         {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
         <ListItem>
           <GetUrlButtons
             label="Related sample IDs Hail Table"
-            path="/release/3.1/secondary_analyses/hgdp_1kg/pca_preprocessing/related_sample_ids.ht"
+            path="/release/3.1/secondary_analyses/hgdp_1kg_v2/pca_preprocessing/related_sample_ids.ht"
           />
         </ListItem>
 
@@ -457,21 +457,21 @@ const GnomadV3Downloads = () => (
         <ListItem>
           <GetUrlButtons
             label="Principal component analysis (PCA) PC score tables GCS Bucket"
-            path="/release/3.1/secondary_analyses/hgdp_1kg/pca/pc_scores_with_outliers/"
+            path="/release/3.1/secondary_analyses/hgdp_1kg_v2/pca/pc_scores_with_outliers/"
           />
         </ListItem>
         {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
         <ListItem>
           <DownloadLinks
             label="PCA outliers table"
-            path="/release/3.1/secondary_analyses/hgdp_1kg/pca/pca_outliers.txt"
+            path="/release/3.1/secondary_analyses/hgdp_1kg_v2/pca/pca_outliers.txt"
           />
         </ListItem>
         {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
         <ListItem>
           <GetUrlButtons
             label="PCA PC score tables without outliers GCS Buckets"
-            path="/release/3.1/secondary_analyses/hgdp_1kg/pca/pc_scores_without_outliers/"
+            path="/release/3.1/secondary_analyses/hgdp_1kg_v2/pca/pc_scores_without_outliers/"
           />
         </ListItem>
 
@@ -479,42 +479,56 @@ const GnomadV3Downloads = () => (
         <ListItem>
           <GetUrlButtons
             label="Variants and unrelated samples MatrixTable"
-            path="/release/3.1/secondary_analyses/hgdp_1kg/pca_results/unrelateds_without_outliers.mt"
+            path="/release/3.1/secondary_analyses/hgdp_1kg_v2/pca_results/unrelateds_without_outliers.mt"
           />
         </ListItem>
         {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
         <ListItem>
           <GetUrlButtons
             label="Variants and related samples MatrixTable"
-            path="/release/3.1/secondary_analyses/hgdp_1kg/pca_results/relateds_without_outliers.mt"
+            path="/release/3.1/secondary_analyses/hgdp_1kg_v2/pca_results/relateds_without_outliers.mt"
           />
         </ListItem>
         {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
         <ListItem>
           <DownloadLinks
             label="Population-level statistical summary TSV"
-            path="/release/3.1/secondary_analyses/hgdp_1kg/metadata_and_qc/post_qc_summary.tsv"
+            path="/release/3.1/secondary_analyses/hgdp_1kg_v2/metadata_and_qc/post_qc_summary.tsv"
           />
         </ListItem>
         {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
         <ListItem>
           <DownloadLinks
             label="Doubleton counts CSV"
-            path="/release/3.1/secondary_analyses/hgdp_1kg/f2_fst/doubleton_count.csv"
+            path="/release/3.1/secondary_analyses/hgdp_1kg_v2/f2_fst/doubleton_count.csv"
           />
         </ListItem>
         {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
         <ListItem>
           <GetUrlButtons
-            label="Variants and unrelated sample PLINK files"
-            path="/release/3.1/secondary_analyses/hgdp_1kg/f2_fst/hgdp_tgp*"
+            label="Variants and unrelated sample PLINK files - .bed"
+            path="/release/3.1/secondary_analyses/hgdp_1kg_v2/f2_fst/hgdp_tgp.bed"
+          />
+        </ListItem>
+        {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+        <ListItem>
+          <GetUrlButtons
+            label="Variants and unrelated sample PLINK files - .bim"
+            path="/release/3.1/secondary_analyses/hgdp_1kg_v2/f2_fst/hgdp_tgp.bim"
+          />
+        </ListItem>
+        {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+        <ListItem>
+          <GetUrlButtons
+            label="Variants and unrelated sample PLINK files - .fam"
+            path="/release/3.1/secondary_analyses/hgdp_1kg_v2/f2_fst/hgdp_tgp.fam"
           />
         </ListItem>
         {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
         <ListItem>
           <DownloadLinks
             label="Population-level mean fixation index table"
-            path="/release/3.1/secondary_analyses/hgdp_1kg/f2_fst/mean_fst.txt"
+            path="/release/3.1/secondary_analyses/hgdp_1kg_v2/f2_fst/mean_fst.txt"
           />
         </ListItem>
         {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
@@ -542,7 +556,7 @@ const GnomadV3Downloads = () => (
         <ListItem>
           <GetUrlButtons
             label="HGDP+1KG and GVV intersection Matrix Table"
-            path="/release/3.1/secondary_analyses/hgdp_1kg/data_intersection/hgdp_tgp_ggv_intersect.mt"
+            path="/release/3.1/secondary_analyses/hgdp_1kg_v2/data_intersection/hgdp_tgp_ggv_intersect.mt"
           />
         </ListItem>
         {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
@@ -565,21 +579,21 @@ const GnomadV3Downloads = () => (
         <ListItem>
           <GetUrlButtons
             label="Pre-QC column fields Hail Table"
-            path="/release/3.1/secondary_analyses/hgdp_1kg/plot_datasets/pre_qc_plotting.ht"
+            path="/release/3.1/secondary_analyses/hgdp_1kg_v2/plot_datasets/pre_qc_plotting.ht"
           />
         </ListItem>
         {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
         <ListItem>
           <GetUrlButtons
             label="Pre-QC expected heterozygosity Hail Table"
-            path="/release/3.1/secondary_analyses/hgdp_1kg/plot_datasets/expected_hets_pre_qc.ht"
+            path="/release/3.1/secondary_analyses/hgdp_1kg_v2/plot_datasets/expected_hets_pre_qc.ht"
           />
         </ListItem>
         {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
         <ListItem>
           <GetUrlButtons
             label="Pre-QC actual heterozygosity Hail Table"
-            path="/release/3.1/secondary_analyses/hgdp_1kg/plot_datasets/actual_hets_pre_qc.ht"
+            path="/release/3.1/secondary_analyses/hgdp_1kg_v2/plot_datasets/actual_hets_pre_qc.ht"
           />
         </ListItem>
 
@@ -588,28 +602,52 @@ const GnomadV3Downloads = () => (
         <ListItem>
           <GetUrlButtons
             label="Post-QC column fields Hail Table"
-            path="/release/3.1/secondary_analyses/hgdp_1kg/plot_datasets/post_qc_plotting.ht"
+            path="/release/3.1/secondary_analyses/hgdp_1kg_v2/plot_datasets/post_qc_plotting.ht"
           />
         </ListItem>
         {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
         <ListItem>
           <GetUrlButtons
             label="Post-QC expected heterozygosity Hail Table"
-            path="/release/3.1/secondary_analyses/hgdp_1kg/plot_datasets/expected_hets_post_qc.ht"
+            path="/release/3.1/secondary_analyses/hgdp_1kg_v2/plot_datasets/expected_hets_post_qc.ht"
           />
         </ListItem>
         {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
         <ListItem>
           <GetUrlButtons
             label="Post-QC actual heterozygosity Hail Table"
-            path="/release/3.1/secondary_analyses/hgdp_1kg/plot_datasets/actual_hets_post_qc.ht"
+            path="/release/3.1/secondary_analyses/hgdp_1kg_v2/plot_datasets/actual_hets_post_qc.ht"
           />
         </ListItem>
         {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
         <ListItem>
           <DownloadLinks
             label="Post-QC site frequency spectrum table"
-            path="/release/3.1/secondary_analyses/hgdp_1kg/plot_datasets/sfs_post_qc.txt"
+            path="/release/3.1/secondary_analyses/hgdp_1kg_v2/plot_datasets/sfs_post_qc.txt"
+          />
+        </ListItem>
+        {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+        <ListItem>
+          <DownloadLinks
+            label="Phased haplotype ChrX PAR1"
+            path="/resources/hgdp_1kg/phased_haplotypes_v2/hgdp1kgp_chrX_par1.shapeit5_common.bcf"
+            associatedFileType="CSI"
+          />
+        </ListItem>
+        {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+        <ListItem>
+          <DownloadLinks
+            label="Phased haplotype ChrX PAR2"
+            path="/resources/hgdp_1kg/phased_haplotypes_v2/hgdp1kgp_chrX_par2.shapeit5_common.bcf"
+            associatedFileType="CSI"
+          />
+        </ListItem>
+        {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+        <ListItem>
+          <DownloadLinks
+            label="Phased haplotype ChrX Non-PAR"
+            path="/resources/hgdp_1kg/phased_haplotypes_v2/hgdp1kgp_chrX_non_par.full.shapeit5_rare.bcf"
+            associatedFileType="CSI"
           />
         </ListItem>
       </FileList>

--- a/browser/src/DownloadsPage/GnomadV3Downloads.tsx
+++ b/browser/src/DownloadsPage/GnomadV3Downloads.tsx
@@ -116,7 +116,7 @@ const GnomadV3Downloads = () => (
               path={`/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.sites.chr${chrom}.vcf.bgz`}
               size={size}
               md5={md5}
-              includeTBI
+              associatedFileType="TBI"
             />
           </ListItem>
         ))}
@@ -206,7 +206,7 @@ const GnomadV3Downloads = () => (
               path={`/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_tgp.chr${chrom}.vcf.bgz`}
               size={size}
               md5={md5}
-              includeTBI
+              associatedFileType="TBI"
             />
           </ListItem>
         ))}
@@ -238,7 +238,7 @@ const GnomadV3Downloads = () => (
             path="/release/3.1/vcf/genomes/gnomad.genomes.v3.1.sites.chrM.vcf.bgz"
             size="4.77 MiB"
             md5="d0ef2bd882ae44236897d743cb5528cf"
-            includeTBI
+            associatedFileType="TBI"
           />
         </ListItem>
         {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}

--- a/browser/src/DownloadsPage/GnomadV4Downloads.tsx
+++ b/browser/src/DownloadsPage/GnomadV4Downloads.tsx
@@ -357,7 +357,7 @@ const GnomadV4Downloads = () => {
               label="Genome SV VCF"
               path="/release/4.1/genome_sv/gnomad.v4.1.sv.sites.vcf.gz"
               size="1.62 GiB"
-              hash="3ee614951c2f0c36659842876f7ce0ba"
+              md5="3ee614951c2f0c36659842876f7ce0ba"
               includeTBI
             />
           </ListItem>
@@ -366,8 +366,8 @@ const GnomadV4Downloads = () => {
             <DownloadLinks
               label="Genome SV non neuro controls VCF"
               path="/release/4.1/genome_sv/gnomad.v4.1.sv.non_neuro_controls.sites.vcf.gz"
-              size="3.12 GiB"
-              hash="eb9eae81e32923829d256695731e899a"
+              size="3.19 GiB"
+              md5="442b43a740f7f12f1f9b054f9d09b530"
               includeTBI
             />
           </ListItem>
@@ -386,8 +386,8 @@ const GnomadV4Downloads = () => {
             <DownloadLinks
               label="Exome CNV VCF"
               path="/release/4.1/exome_cnv/gnomad.v4.1.cnv.all.vcf.gz"
-              size="8.51 MiB"
-              hash="a662f9c838eeda60c4b9918e437bee89"
+              size="8.5 MiB"
+              md5="74000fc29d0b9bc547859cfc2ba4ac84"
             />
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
@@ -395,8 +395,8 @@ const GnomadV4Downloads = () => {
             <DownloadLinks
               label="Exome CNV non neuro VCF"
               path="/release/4.1/exome_cnv/gnomad.v4.1.cnv.non_neuro.vcf.gz"
-              size="7.90 MiB"
-              hash="532c77b717f7d67d4424c76c1f4ea0f2"
+              size="7.9 MiB"
+              md5="e2976db50823d608f2cf2fb8077f0ddd"
             />
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
@@ -404,8 +404,8 @@ const GnomadV4Downloads = () => {
             <DownloadLinks
               label="Exome CNV non neuro controls VCF"
               path="/release/4.1/exome_cnv/gnomad.v4.1.cnv.non_neuro_controls.vcf.gz"
-              size="5.33 MiB"
-              hash="e75e0ee3f5b7fb6e174a3fa7637a3d6d"
+              size="5.32 MiB"
+              md5="10e6b0d9585d79d9620c40c96c257e4c"
             />
           </ListItem>
         </FileList>

--- a/browser/src/DownloadsPage/GnomadV4Downloads.tsx
+++ b/browser/src/DownloadsPage/GnomadV4Downloads.tsx
@@ -147,7 +147,7 @@ const GnomadV4Downloads = () => {
                     path={`/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr${chrom}.vcf.bgz`}
                     size={size}
                     md5={md5}
-                    includeTBI
+                    associatedFileType="TBI"
                   />
                 </ListItem>
               ))}
@@ -172,7 +172,7 @@ const GnomadV4Downloads = () => {
                     path={`/release/4.1/vcf/genomes/gnomad.genomes.v4.1.sites.chr${chrom}.vcf.bgz`}
                     size={size}
                     md5={md5}
-                    includeTBI
+                    associatedFileType="TBI"
                   />
                 </ListItem>
               ))}
@@ -199,7 +199,7 @@ const GnomadV4Downloads = () => {
                 path={`/release/4.1/vcf/joint/gnomad.joint.v4.1.sites.chr${chrom}.vcf.bgz`}
                 size={size}
                 md5={md5}
-                includeTBI
+                associatedFileType="TBI"
               />
             </ListItem>
           ))}
@@ -358,7 +358,7 @@ const GnomadV4Downloads = () => {
               path="/release/4.1/genome_sv/gnomad.v4.1.sv.sites.vcf.gz"
               size="1.62 GiB"
               md5="3ee614951c2f0c36659842876f7ce0ba"
-              includeTBI
+              associatedFileType="TBI"
             />
           </ListItem>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
@@ -368,7 +368,7 @@ const GnomadV4Downloads = () => {
               path="/release/4.1/genome_sv/gnomad.v4.1.sv.non_neuro_controls.sites.vcf.gz"
               size="3.19 GiB"
               md5="442b43a740f7f12f1f9b054f9d09b530"
-              includeTBI
+              associatedFileType="TBI"
             />
           </ListItem>
         </FileList>

--- a/browser/src/DownloadsPage/__snapshots__/DownloadsPage.spec.tsx.snap
+++ b/browser/src/DownloadsPage/__snapshots__/DownloadsPage.spec.tsx.snap
@@ -10651,7 +10651,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             <a
               aria-label="Download Sample metadata TSV from Google"
               className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_1kg_subset_sample_meta.tsv.bgz"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/secondary_analyses/hgdp_1kg_v2/metadata_and_qc/gnomad_meta_updated.tsv"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -10661,7 +10661,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             <a
               aria-label="Download Sample metadata TSV from Amazon"
               className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_1kg_subset_sample_meta.tsv.bgz"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/secondary_analyses/hgdp_1kg_v2/metadata_and_qc/gnomad_meta_updated.tsv"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -10671,7 +10671,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             <a
               aria-label="Download Sample metadata TSV from Microsoft"
               className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1.2/vcf/genomes/gnomad.genomes.v3.1.2.hgdp_1kg_subset_sample_meta.tsv.bgz"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/secondary_analyses/hgdp_1kg_v2/metadata_and_qc/gnomad_meta_updated.tsv"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -13654,7 +13654,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             <a
               aria-label="Download Sample metadata TSV from Google"
               className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/secondary_analyses/hgdp_1kg/metadata_and_qc/gnomad_meta_v1.tsv"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/secondary_analyses/hgdp_1kg_v2/metadata_and_qc/gnomad_meta_v1.tsv"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -13664,7 +13664,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             <a
               aria-label="Download Sample metadata TSV from Amazon"
               className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/secondary_analyses/hgdp_1kg/metadata_and_qc/gnomad_meta_v1.tsv"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/secondary_analyses/hgdp_1kg_v2/metadata_and_qc/gnomad_meta_v1.tsv"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -13674,7 +13674,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             <a
               aria-label="Download Sample metadata TSV from Microsoft"
               className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/secondary_analyses/hgdp_1kg/metadata_and_qc/gnomad_meta_v1.tsv"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/secondary_analyses/hgdp_1kg_v2/metadata_and_qc/gnomad_meta_v1.tsv"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -13803,7 +13803,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             <a
               aria-label="Download PCA outliers table from Google"
               className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/secondary_analyses/hgdp_1kg/pca/pca_outliers.txt"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/secondary_analyses/hgdp_1kg_v2/pca/pca_outliers.txt"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -13813,7 +13813,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             <a
               aria-label="Download PCA outliers table from Amazon"
               className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/secondary_analyses/hgdp_1kg/pca/pca_outliers.txt"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/secondary_analyses/hgdp_1kg_v2/pca/pca_outliers.txt"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -13823,7 +13823,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             <a
               aria-label="Download PCA outliers table from Microsoft"
               className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/secondary_analyses/hgdp_1kg/pca/pca_outliers.txt"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/secondary_analyses/hgdp_1kg_v2/pca/pca_outliers.txt"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -13952,7 +13952,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             <a
               aria-label="Download Population-level statistical summary TSV from Google"
               className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/secondary_analyses/hgdp_1kg/metadata_and_qc/post_qc_summary.tsv"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/secondary_analyses/hgdp_1kg_v2/metadata_and_qc/post_qc_summary.tsv"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -13962,7 +13962,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             <a
               aria-label="Download Population-level statistical summary TSV from Amazon"
               className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/secondary_analyses/hgdp_1kg/metadata_and_qc/post_qc_summary.tsv"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/secondary_analyses/hgdp_1kg_v2/metadata_and_qc/post_qc_summary.tsv"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -13972,7 +13972,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             <a
               aria-label="Download Population-level statistical summary TSV from Microsoft"
               className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/secondary_analyses/hgdp_1kg/metadata_and_qc/post_qc_summary.tsv"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/secondary_analyses/hgdp_1kg_v2/metadata_and_qc/post_qc_summary.tsv"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -13993,7 +13993,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             <a
               aria-label="Download Doubleton counts CSV from Google"
               className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/secondary_analyses/hgdp_1kg/f2_fst/doubleton_count.csv"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/secondary_analyses/hgdp_1kg_v2/f2_fst/doubleton_count.csv"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -14003,7 +14003,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             <a
               aria-label="Download Doubleton counts CSV from Amazon"
               className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/secondary_analyses/hgdp_1kg/f2_fst/doubleton_count.csv"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/secondary_analyses/hgdp_1kg_v2/f2_fst/doubleton_count.csv"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -14013,7 +14013,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             <a
               aria-label="Download Doubleton counts CSV from Microsoft"
               className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/secondary_analyses/hgdp_1kg/f2_fst/doubleton_count.csv"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/secondary_analyses/hgdp_1kg_v2/f2_fst/doubleton_count.csv"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -14025,13 +14025,13 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           className="c20"
         >
           <span>
-            Variants and unrelated sample PLINK files
+            Variants and unrelated sample PLINK files - .bed
           </span>
           <br />
           Show URL for
            
           <button
-            aria-label="Show Google URL for Variants and unrelated sample PLINK files"
+            aria-label="Show Google URL for Variants and unrelated sample PLINK files - .bed"
             className="c21"
             onClick={[Function]}
             type="button"
@@ -14040,7 +14040,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </button>
            / 
           <button
-            aria-label="Show Amazon URL for Variants and unrelated sample PLINK files"
+            aria-label="Show Amazon URL for Variants and unrelated sample PLINK files - .bed"
             className="c21"
             onClick={[Function]}
             type="button"
@@ -14049,7 +14049,79 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </button>
            / 
           <button
-            aria-label="Show Microsoft URL for Variants and unrelated sample PLINK files"
+            aria-label="Show Microsoft URL for Variants and unrelated sample PLINK files - .bed"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Microsoft
+          </button>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            Variants and unrelated sample PLINK files - .bim
+          </span>
+          <br />
+          Show URL for
+           
+          <button
+            aria-label="Show Google URL for Variants and unrelated sample PLINK files - .bim"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Google
+          </button>
+           / 
+          <button
+            aria-label="Show Amazon URL for Variants and unrelated sample PLINK files - .bim"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Amazon
+          </button>
+           / 
+          <button
+            aria-label="Show Microsoft URL for Variants and unrelated sample PLINK files - .bim"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Microsoft
+          </button>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            Variants and unrelated sample PLINK files - .fam
+          </span>
+          <br />
+          Show URL for
+           
+          <button
+            aria-label="Show Google URL for Variants and unrelated sample PLINK files - .fam"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Google
+          </button>
+           / 
+          <button
+            aria-label="Show Amazon URL for Variants and unrelated sample PLINK files - .fam"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Amazon
+          </button>
+           / 
+          <button
+            aria-label="Show Microsoft URL for Variants and unrelated sample PLINK files - .fam"
             className="c21"
             onClick={[Function]}
             type="button"
@@ -14070,7 +14142,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             <a
               aria-label="Download Population-level mean fixation index table from Google"
               className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/secondary_analyses/hgdp_1kg/f2_fst/mean_fst.txt"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/secondary_analyses/hgdp_1kg_v2/f2_fst/mean_fst.txt"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -14080,7 +14152,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             <a
               aria-label="Download Population-level mean fixation index table from Amazon"
               className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/secondary_analyses/hgdp_1kg/f2_fst/mean_fst.txt"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/secondary_analyses/hgdp_1kg_v2/f2_fst/mean_fst.txt"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -14090,7 +14162,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             <a
               aria-label="Download Population-level mean fixation index table from Microsoft"
               className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/secondary_analyses/hgdp_1kg/f2_fst/mean_fst.txt"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/secondary_analyses/hgdp_1kg_v2/f2_fst/mean_fst.txt"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -14559,7 +14631,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             <a
               aria-label="Download Post-QC site frequency spectrum table from Google"
               className="c10"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/secondary_analyses/hgdp_1kg/plot_datasets/sfs_post_qc.txt"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/secondary_analyses/hgdp_1kg_v2/plot_datasets/sfs_post_qc.txt"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -14569,7 +14641,7 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             <a
               aria-label="Download Post-QC site frequency spectrum table from Amazon"
               className="c10"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/secondary_analyses/hgdp_1kg/plot_datasets/sfs_post_qc.txt"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/secondary_analyses/hgdp_1kg_v2/plot_datasets/sfs_post_qc.txt"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -14579,7 +14651,238 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             <a
               aria-label="Download Post-QC site frequency spectrum table from Microsoft"
               className="c10"
-              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/secondary_analyses/hgdp_1kg/plot_datasets/sfs_post_qc.txt"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/secondary_analyses/hgdp_1kg_v2/plot_datasets/sfs_post_qc.txt"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            Phased haplotype ChrX PAR1
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download Phased haplotype ChrX PAR1 from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/resources/hgdp_1kg/phased_haplotypes_v2/hgdp1kgp_chrX_par1.shapeit5_common.bcf"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download Phased haplotype ChrX PAR1 from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/resources/hgdp_1kg/phased_haplotypes_v2/hgdp1kgp_chrX_par1.shapeit5_common.bcf"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download Phased haplotype ChrX PAR1 from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/resources/hgdp_1kg/phased_haplotypes_v2/hgdp1kgp_chrX_par1.shapeit5_common.bcf"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download 
+            CSI
+             from
+             
+            <a
+              aria-label="Download CSI file for Phased haplotype ChrX PAR1 from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/resources/hgdp_1kg/phased_haplotypes_v2/hgdp1kgp_chrX_par1.shapeit5_common.bcf.csi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download CSI file for Phased haplotype ChrX PAR1 from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/resources/hgdp_1kg/phased_haplotypes_v2/hgdp1kgp_chrX_par1.shapeit5_common.bcf.csi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download CSI file for Phased haplotype ChrX PAR1 from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/resources/hgdp_1kg/phased_haplotypes_v2/hgdp1kgp_chrX_par1.shapeit5_common.bcf.csi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            Phased haplotype ChrX PAR2
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download Phased haplotype ChrX PAR2 from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/resources/hgdp_1kg/phased_haplotypes_v2/hgdp1kgp_chrX_par2.shapeit5_common.bcf"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download Phased haplotype ChrX PAR2 from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/resources/hgdp_1kg/phased_haplotypes_v2/hgdp1kgp_chrX_par2.shapeit5_common.bcf"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download Phased haplotype ChrX PAR2 from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/resources/hgdp_1kg/phased_haplotypes_v2/hgdp1kgp_chrX_par2.shapeit5_common.bcf"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download 
+            CSI
+             from
+             
+            <a
+              aria-label="Download CSI file for Phased haplotype ChrX PAR2 from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/resources/hgdp_1kg/phased_haplotypes_v2/hgdp1kgp_chrX_par2.shapeit5_common.bcf.csi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download CSI file for Phased haplotype ChrX PAR2 from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/resources/hgdp_1kg/phased_haplotypes_v2/hgdp1kgp_chrX_par2.shapeit5_common.bcf.csi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download CSI file for Phased haplotype ChrX PAR2 from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/resources/hgdp_1kg/phased_haplotypes_v2/hgdp1kgp_chrX_par2.shapeit5_common.bcf.csi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            Phased haplotype ChrX Non-PAR
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download Phased haplotype ChrX Non-PAR from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/resources/hgdp_1kg/phased_haplotypes_v2/hgdp1kgp_chrX_non_par.full.shapeit5_rare.bcf"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download Phased haplotype ChrX Non-PAR from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/resources/hgdp_1kg/phased_haplotypes_v2/hgdp1kgp_chrX_non_par.full.shapeit5_rare.bcf"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download Phased haplotype ChrX Non-PAR from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/resources/hgdp_1kg/phased_haplotypes_v2/hgdp1kgp_chrX_non_par.full.shapeit5_rare.bcf"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+          <br />
+          <span>
+            Download 
+            CSI
+             from
+             
+            <a
+              aria-label="Download CSI file for Phased haplotype ChrX Non-PAR from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/resources/hgdp_1kg/phased_haplotypes_v2/hgdp1kgp_chrX_non_par.full.shapeit5_rare.bcf.csi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download CSI file for Phased haplotype ChrX Non-PAR from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/resources/hgdp_1kg/phased_haplotypes_v2/hgdp1kgp_chrX_non_par.full.shapeit5_rare.bcf.csi"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download CSI file for Phased haplotype ChrX Non-PAR from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/resources/hgdp_1kg/phased_haplotypes_v2/hgdp1kgp_chrX_non_par.full.shapeit5_rare.bcf.csi"
               rel="noopener noreferrer"
               target="_blank"
             >

--- a/browser/src/DownloadsPage/__snapshots__/DownloadsPage.spec.tsx.snap
+++ b/browser/src/DownloadsPage/__snapshots__/DownloadsPage.spec.tsx.snap
@@ -7427,6 +7427,12 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
+            1.62 GiB
+            , MD5: 
+            3ee614951c2f0c36659842876f7ce0ba
+          </span>
+          <br />
+          <span>
             Download from
              
             <a
@@ -7499,6 +7505,12 @@ exports[`Downloads Page has no unexpected changes 1`] = `
         >
           <span>
             Genome SV non neuro controls VCF
+          </span>
+          <br />
+          <span>
+            3.19 GiB
+            , MD5: 
+            442b43a740f7f12f1f9b054f9d09b530
           </span>
           <br />
           <span>
@@ -7619,6 +7631,12 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
+            8.5 MiB
+            , MD5: 
+            74000fc29d0b9bc547859cfc2ba4ac84
+          </span>
+          <br />
+          <span>
             Download from
              
             <a
@@ -7660,6 +7678,12 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
+            7.9 MiB
+            , MD5: 
+            e2976db50823d608f2cf2fb8077f0ddd
+          </span>
+          <br />
+          <span>
             Download from
              
             <a
@@ -7698,6 +7722,12 @@ exports[`Downloads Page has no unexpected changes 1`] = `
         >
           <span>
             Exome CNV non neuro controls VCF
+          </span>
+          <br />
+          <span>
+            5.32 MiB
+            , MD5: 
+            10e6b0d9585d79d9620c40c96c257e4c
           </span>
           <br />
           <span>

--- a/browser/src/DownloadsPage/__snapshots__/DownloadsPage.spec.tsx.snap
+++ b/browser/src/DownloadsPage/__snapshots__/DownloadsPage.spec.tsx.snap
@@ -823,7 +823,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr1 sites VCF from Google"
@@ -904,7 +906,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr2 sites VCF from Google"
@@ -985,7 +989,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr3 sites VCF from Google"
@@ -1066,7 +1072,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr4 sites VCF from Google"
@@ -1147,7 +1155,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr5 sites VCF from Google"
@@ -1228,7 +1238,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr6 sites VCF from Google"
@@ -1309,7 +1321,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr7 sites VCF from Google"
@@ -1390,7 +1404,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr8 sites VCF from Google"
@@ -1471,7 +1487,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr9 sites VCF from Google"
@@ -1552,7 +1570,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr10 sites VCF from Google"
@@ -1633,7 +1653,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr11 sites VCF from Google"
@@ -1714,7 +1736,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr12 sites VCF from Google"
@@ -1795,7 +1819,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr13 sites VCF from Google"
@@ -1876,7 +1902,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr14 sites VCF from Google"
@@ -1957,7 +1985,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr15 sites VCF from Google"
@@ -2038,7 +2068,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr16 sites VCF from Google"
@@ -2119,7 +2151,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr17 sites VCF from Google"
@@ -2200,7 +2234,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr18 sites VCF from Google"
@@ -2281,7 +2317,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr19 sites VCF from Google"
@@ -2362,7 +2400,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr20 sites VCF from Google"
@@ -2443,7 +2483,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr21 sites VCF from Google"
@@ -2524,7 +2566,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr22 sites VCF from Google"
@@ -2605,7 +2649,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chrX sites VCF from Google"
@@ -2686,7 +2732,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chrY sites VCF from Google"
@@ -2814,7 +2862,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr1 sites VCF from Google"
@@ -2895,7 +2945,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr2 sites VCF from Google"
@@ -2976,7 +3028,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr3 sites VCF from Google"
@@ -3057,7 +3111,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr4 sites VCF from Google"
@@ -3138,7 +3194,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr5 sites VCF from Google"
@@ -3219,7 +3277,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr6 sites VCF from Google"
@@ -3300,7 +3360,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr7 sites VCF from Google"
@@ -3381,7 +3443,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr8 sites VCF from Google"
@@ -3462,7 +3526,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr9 sites VCF from Google"
@@ -3543,7 +3609,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr10 sites VCF from Google"
@@ -3624,7 +3692,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr11 sites VCF from Google"
@@ -3705,7 +3775,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr12 sites VCF from Google"
@@ -3786,7 +3858,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr13 sites VCF from Google"
@@ -3867,7 +3941,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr14 sites VCF from Google"
@@ -3948,7 +4024,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr15 sites VCF from Google"
@@ -4029,7 +4107,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr16 sites VCF from Google"
@@ -4110,7 +4190,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr17 sites VCF from Google"
@@ -4191,7 +4273,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr18 sites VCF from Google"
@@ -4272,7 +4356,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr19 sites VCF from Google"
@@ -4353,7 +4439,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr20 sites VCF from Google"
@@ -4434,7 +4522,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr21 sites VCF from Google"
@@ -4515,7 +4605,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr22 sites VCF from Google"
@@ -4596,7 +4688,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chrX sites VCF from Google"
@@ -4677,7 +4771,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chrY sites VCF from Google"
@@ -4827,7 +4923,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr1 sites VCF from Google"
@@ -4908,7 +5006,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr2 sites VCF from Google"
@@ -4989,7 +5089,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr3 sites VCF from Google"
@@ -5070,7 +5172,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr4 sites VCF from Google"
@@ -5151,7 +5255,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr5 sites VCF from Google"
@@ -5232,7 +5338,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr6 sites VCF from Google"
@@ -5313,7 +5421,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr7 sites VCF from Google"
@@ -5394,7 +5504,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr8 sites VCF from Google"
@@ -5475,7 +5587,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr9 sites VCF from Google"
@@ -5556,7 +5670,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr10 sites VCF from Google"
@@ -5637,7 +5753,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr11 sites VCF from Google"
@@ -5718,7 +5836,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr12 sites VCF from Google"
@@ -5799,7 +5919,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr13 sites VCF from Google"
@@ -5880,7 +6002,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr14 sites VCF from Google"
@@ -5961,7 +6085,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr15 sites VCF from Google"
@@ -6042,7 +6168,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr16 sites VCF from Google"
@@ -6123,7 +6251,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr17 sites VCF from Google"
@@ -6204,7 +6334,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr18 sites VCF from Google"
@@ -6285,7 +6417,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr19 sites VCF from Google"
@@ -6366,7 +6500,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr20 sites VCF from Google"
@@ -6447,7 +6583,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr21 sites VCF from Google"
@@ -6528,7 +6666,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr22 sites VCF from Google"
@@ -6609,7 +6749,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chrX sites VCF from Google"
@@ -6690,7 +6832,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chrY sites VCF from Google"
@@ -7467,7 +7611,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for Genome SV VCF from Google"
@@ -7548,7 +7694,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for Genome SV non neuro controls VCF from Google"
@@ -8231,7 +8379,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr1 sites VCF from Google"
@@ -8312,7 +8462,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr2 sites VCF from Google"
@@ -8393,7 +8545,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr3 sites VCF from Google"
@@ -8474,7 +8628,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr4 sites VCF from Google"
@@ -8555,7 +8711,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr5 sites VCF from Google"
@@ -8636,7 +8794,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr6 sites VCF from Google"
@@ -8717,7 +8877,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr7 sites VCF from Google"
@@ -8798,7 +8960,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr8 sites VCF from Google"
@@ -8879,7 +9043,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr9 sites VCF from Google"
@@ -8960,7 +9126,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr10 sites VCF from Google"
@@ -9041,7 +9209,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr11 sites VCF from Google"
@@ -9122,7 +9292,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr12 sites VCF from Google"
@@ -9203,7 +9375,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr13 sites VCF from Google"
@@ -9284,7 +9458,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr14 sites VCF from Google"
@@ -9365,7 +9541,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr15 sites VCF from Google"
@@ -9446,7 +9624,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr16 sites VCF from Google"
@@ -9527,7 +9707,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr17 sites VCF from Google"
@@ -9608,7 +9790,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr18 sites VCF from Google"
@@ -9689,7 +9873,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr19 sites VCF from Google"
@@ -9770,7 +9956,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr20 sites VCF from Google"
@@ -9851,7 +10039,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr21 sites VCF from Google"
@@ -9932,7 +10122,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr22 sites VCF from Google"
@@ -10013,7 +10205,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chrX sites VCF from Google"
@@ -10094,7 +10288,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chrY sites VCF from Google"
@@ -10531,7 +10727,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr1 VCF from Google"
@@ -10612,7 +10810,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr2 VCF from Google"
@@ -10693,7 +10893,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr3 VCF from Google"
@@ -10774,7 +10976,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr4 VCF from Google"
@@ -10855,7 +11059,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr5 VCF from Google"
@@ -10936,7 +11142,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr6 VCF from Google"
@@ -11017,7 +11225,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr7 VCF from Google"
@@ -11098,7 +11308,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr8 VCF from Google"
@@ -11179,7 +11391,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr9 VCF from Google"
@@ -11260,7 +11474,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr10 VCF from Google"
@@ -11341,7 +11557,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr11 VCF from Google"
@@ -11422,7 +11640,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr12 VCF from Google"
@@ -11503,7 +11723,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr13 VCF from Google"
@@ -11584,7 +11806,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr14 VCF from Google"
@@ -11665,7 +11889,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr15 VCF from Google"
@@ -11746,7 +11972,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr16 VCF from Google"
@@ -11827,7 +12055,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr17 VCF from Google"
@@ -11908,7 +12138,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr18 VCF from Google"
@@ -11989,7 +12221,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr19 VCF from Google"
@@ -12070,7 +12304,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr20 VCF from Google"
@@ -12151,7 +12387,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr21 VCF from Google"
@@ -12232,7 +12470,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chr22 VCF from Google"
@@ -12313,7 +12553,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chrX VCF from Google"
@@ -12394,7 +12636,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chrY VCF from Google"
@@ -12555,7 +12799,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for chrM sites VCF from Google"
@@ -14524,7 +14770,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for All chromosomes VCF from Google"
@@ -14605,7 +14853,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr1 sites VCF from Google"
@@ -14686,7 +14936,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr2 sites VCF from Google"
@@ -14767,7 +15019,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr3 sites VCF from Google"
@@ -14848,7 +15102,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr4 sites VCF from Google"
@@ -14929,7 +15185,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr5 sites VCF from Google"
@@ -15010,7 +15268,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr6 sites VCF from Google"
@@ -15091,7 +15351,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr7 sites VCF from Google"
@@ -15172,7 +15434,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr8 sites VCF from Google"
@@ -15253,7 +15517,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr9 sites VCF from Google"
@@ -15334,7 +15600,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr10 sites VCF from Google"
@@ -15415,7 +15683,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr11 sites VCF from Google"
@@ -15496,7 +15766,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr12 sites VCF from Google"
@@ -15577,7 +15849,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr13 sites VCF from Google"
@@ -15658,7 +15932,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr14 sites VCF from Google"
@@ -15739,7 +16015,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr15 sites VCF from Google"
@@ -15820,7 +16098,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr16 sites VCF from Google"
@@ -15901,7 +16181,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr17 sites VCF from Google"
@@ -15982,7 +16264,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr18 sites VCF from Google"
@@ -16063,7 +16347,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr19 sites VCF from Google"
@@ -16144,7 +16430,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr20 sites VCF from Google"
@@ -16225,7 +16513,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr21 sites VCF from Google"
@@ -16306,7 +16596,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr22 sites VCF from Google"
@@ -16387,7 +16679,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chrX sites VCF from Google"
@@ -16468,7 +16762,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chrY sites VCF from Google"
@@ -16596,7 +16892,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for All chromosomes VCF from Google"
@@ -16677,7 +16975,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr1 sites VCF from Google"
@@ -16758,7 +17058,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr2 sites VCF from Google"
@@ -16839,7 +17141,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr3 sites VCF from Google"
@@ -16920,7 +17224,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr4 sites VCF from Google"
@@ -17001,7 +17307,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr5 sites VCF from Google"
@@ -17082,7 +17390,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr6 sites VCF from Google"
@@ -17163,7 +17473,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr7 sites VCF from Google"
@@ -17244,7 +17556,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr8 sites VCF from Google"
@@ -17325,7 +17639,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr9 sites VCF from Google"
@@ -17406,7 +17722,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr10 sites VCF from Google"
@@ -17487,7 +17805,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr11 sites VCF from Google"
@@ -17568,7 +17888,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr12 sites VCF from Google"
@@ -17649,7 +17971,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr13 sites VCF from Google"
@@ -17730,7 +18054,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr14 sites VCF from Google"
@@ -17811,7 +18137,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr15 sites VCF from Google"
@@ -17892,7 +18220,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr16 sites VCF from Google"
@@ -17973,7 +18303,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr17 sites VCF from Google"
@@ -18054,7 +18386,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr18 sites VCF from Google"
@@ -18135,7 +18469,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr19 sites VCF from Google"
@@ -18216,7 +18552,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr20 sites VCF from Google"
@@ -18297,7 +18635,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr21 sites VCF from Google"
@@ -18378,7 +18718,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr22 sites VCF from Google"
@@ -18459,7 +18801,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chrX sites VCF from Google"
@@ -18746,7 +19090,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for All chromosomes sites VCF from Google"
@@ -18827,7 +19173,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr1 sites VCF from Google"
@@ -18908,7 +19256,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr2 sites VCF from Google"
@@ -18989,7 +19339,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr3 sites VCF from Google"
@@ -19070,7 +19422,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr4 sites VCF from Google"
@@ -19151,7 +19505,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr5 sites VCF from Google"
@@ -19232,7 +19588,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr6 sites VCF from Google"
@@ -19313,7 +19671,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr7 sites VCF from Google"
@@ -19394,7 +19754,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr8 sites VCF from Google"
@@ -19475,7 +19837,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr9 sites VCF from Google"
@@ -19556,7 +19920,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr10 sites VCF from Google"
@@ -19637,7 +20003,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr11 sites VCF from Google"
@@ -19718,7 +20086,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr12 sites VCF from Google"
@@ -19799,7 +20169,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr13 sites VCF from Google"
@@ -19880,7 +20252,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr14 sites VCF from Google"
@@ -19961,7 +20335,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr15 sites VCF from Google"
@@ -20042,7 +20418,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr16 sites VCF from Google"
@@ -20123,7 +20501,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr17 sites VCF from Google"
@@ -20204,7 +20584,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr18 sites VCF from Google"
@@ -20285,7 +20667,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr19 sites VCF from Google"
@@ -20366,7 +20750,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr20 sites VCF from Google"
@@ -20447,7 +20833,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr21 sites VCF from Google"
@@ -20528,7 +20916,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr22 sites VCF from Google"
@@ -20609,7 +20999,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chrX sites VCF from Google"
@@ -20690,7 +21082,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chrY sites VCF from Google"
@@ -20818,7 +21212,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for All chromosomes sites VCF from Google"
@@ -20899,7 +21295,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for Exome calling intervals VCF from Google"
@@ -20980,7 +21378,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr1 sites VCF from Google"
@@ -21061,7 +21461,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr2 sites VCF from Google"
@@ -21142,7 +21544,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr3 sites VCF from Google"
@@ -21223,7 +21627,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr4 sites VCF from Google"
@@ -21304,7 +21710,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr5 sites VCF from Google"
@@ -21385,7 +21793,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr6 sites VCF from Google"
@@ -21466,7 +21876,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr7 sites VCF from Google"
@@ -21547,7 +21959,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr8 sites VCF from Google"
@@ -21628,7 +22042,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr9 sites VCF from Google"
@@ -21709,7 +22125,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr10 sites VCF from Google"
@@ -21790,7 +22208,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr11 sites VCF from Google"
@@ -21871,7 +22291,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr12 sites VCF from Google"
@@ -21952,7 +22374,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr13 sites VCF from Google"
@@ -22033,7 +22457,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr14 sites VCF from Google"
@@ -22114,7 +22540,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr15 sites VCF from Google"
@@ -22195,7 +22623,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr16 sites VCF from Google"
@@ -22276,7 +22706,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr17 sites VCF from Google"
@@ -22357,7 +22789,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr18 sites VCF from Google"
@@ -22438,7 +22872,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr19 sites VCF from Google"
@@ -22519,7 +22955,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr20 sites VCF from Google"
@@ -22600,7 +23038,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr21 sites VCF from Google"
@@ -22681,7 +23121,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chr22 sites VCF from Google"
@@ -22762,7 +23204,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
               </span>
               <br />
               <span>
-                Download TBI from
+                Download 
+                TBI
+                 from
                  
                 <a
                   aria-label="Download TBI file for chrX sites VCF from Google"
@@ -23082,7 +23526,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for SV 2.1 sites VCF from Google"
@@ -23157,7 +23603,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for SV 2.1 sites BED from Google"
@@ -23232,7 +23680,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for SV 2.1 (controls) sites VCF from Google"
@@ -23307,7 +23757,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for SV 2.1 (controls) sites BED from Google"
@@ -23382,7 +23834,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for SV 2.1 (non-neuro) sites VCF from Google"
@@ -23457,7 +23911,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for SV 2.1 (non-neuro) sites BED from Google"
@@ -26466,7 +26922,9 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           </span>
           <br />
           <span>
-            Download TBI from
+            Download 
+            TBI
+             from
              
             <a
               aria-label="Download TBI file for All chromosomes VCF from Google"

--- a/browser/src/DownloadsPage/downloadsPageStyles.tsx
+++ b/browser/src/DownloadsPage/downloadsPageStyles.tsx
@@ -256,7 +256,7 @@ GetUrlButtons.defaultProps = {
   includeAzure: true,
 }
 
-type OwnDownloadLinksProps = {
+type DownloadLinksProps = {
   label: string
   path: string
   size?: string
@@ -266,24 +266,21 @@ type OwnDownloadLinksProps = {
   includeGCP?: boolean
   includeAWS?: boolean
   includeAzure?: boolean
-  includeTBI?: boolean
+  associatedFileType?: string
+  logClicks?: boolean
 }
 
-// @ts-expect-error TS(2456) FIXME: Type alias 'DownloadLinksProps' circula... Remove this comment to see the full error message
-type DownloadLinksProps = OwnDownloadLinksProps & typeof DownloadLinks.defaultProps
-
-// @ts-expect-error TS(7022) FIXME: 'DownloadLinks' implicitly has type 'an... Remove this comment to see the full error message
 export const DownloadLinks = ({
   label,
   path,
   size,
   md5,
   crc32c,
-  gcsBucket,
-  includeGCP,
-  includeAWS,
-  includeAzure,
-  includeTBI,
+  gcsBucket = 'gcp-public-data--gnomad',
+  includeGCP = true,
+  includeAWS = true,
+  includeAzure = true,
+  associatedFileType,
 }: DownloadLinksProps) => {
   return (
     <>
@@ -340,18 +337,18 @@ export const DownloadLinks = ({
           ),
         ])}
       </span>
-      {includeTBI && (
+      {associatedFileType && (
         <>
           <br />
           <span>
-            Download TBI from{' '}
+            Download {associatedFileType.toUpperCase()} from{' '}
             {renderDownloadOptions([
               includeGCP && (
                 // @ts-expect-error TS(2786) FIXME: 'ExternalLink' cannot be used as a JSX component.
                 <ExternalLink
                   key="gcp"
-                  aria-label={`Download TBI file for ${label} from Google`}
-                  href={`https://storage.googleapis.com/${gcsBucket}${path}.tbi`}
+                  aria-label={`Download ${associatedFileType.toUpperCase()} file for ${label} from Google`}
+                  href={`https://storage.googleapis.com/${gcsBucket}${path}.${associatedFileType.toLowerCase()}`}
                 >
                   Google
                 </ExternalLink>
@@ -360,8 +357,8 @@ export const DownloadLinks = ({
                 // @ts-expect-error TS(2786) FIXME: 'ExternalLink' cannot be used as a JSX component.
                 <ExternalLink
                   key="aws"
-                  aria-label={`Download TBI file for ${label} from Amazon`}
-                  href={`https://gnomad-public-us-east-1.s3.amazonaws.com${path}.tbi`}
+                  aria-label={`Download ${associatedFileType.toUpperCase()} file for ${label} from Amazon`}
+                  href={`https://gnomad-public-us-east-1.s3.amazonaws.com${path}.${associatedFileType.toLowerCase()}`}
                 >
                   Amazon
                 </ExternalLink>
@@ -370,8 +367,8 @@ export const DownloadLinks = ({
                 // @ts-expect-error TS(2786) FIXME: 'ExternalLink' cannot be used as a JSX component.
                 <ExternalLink
                   key="azure"
-                  aria-label={`Download TBI file for ${label} from Microsoft`}
-                  href={`https://datasetgnomad.blob.core.windows.net/dataset${path}.tbi`}
+                  aria-label={`Download ${associatedFileType.toUpperCase()} file for ${label} from Microsoft`}
+                  href={`https://datasetgnomad.blob.core.windows.net/dataset${path}.${associatedFileType.toLowerCase()}`}
                 >
                   Microsoft
                 </ExternalLink>
@@ -382,14 +379,4 @@ export const DownloadLinks = ({
       )}
     </>
   )
-}
-
-DownloadLinks.defaultProps = {
-  size: undefined,
-  md5: undefined,
-  gcsBucket: 'gcp-public-data--gnomad',
-  includeGCP: true,
-  includeAWS: true,
-  includeAzure: true,
-  includeTBI: false,
 }


### PR DESCRIPTION
Resolves #1527 

- Minorly refactors a component in downloads page styles to more generally be able to link an associated arbitrary file type (`path.tbi` or `path.csi` for example)
- Updates the HGDP/1KG tutorial paths