### PR TITLE
Use joint frequency data consistently

### DIFF
--- a/browser/src/VariantList/mergeExomeAndGenomeData.spec.ts
+++ b/browser/src/VariantList/mergeExomeAndGenomeData.spec.ts
@@ -14,15 +14,24 @@ type AncestryGroupShorthand = {
   value: number
 }
 
-const createAncestryGroupObjects = (shorthands: AncestryGroupShorthand[]) => {
+const createAncestryGroupObjects = (
+  shorthands: AncestryGroupShorthand[],
+  includeJointFields: boolean
+) => {
   const geneticAncestryGroupObjects: Population[] = shorthands.map((shorthand) => {
-    return populationFactory.build({
+    const populationFields: any = {
       id: shorthand.id,
       ac: shorthand.value,
       an: shorthand.value * 10,
       ac_hemi: shorthand.value + 1,
       ac_hom: shorthand.value + 2,
-    })
+    }
+
+    if (includeJointFields) {
+      populationFields.hemizygote_count = shorthand.value + 1
+      populationFields.homozygote_count = shorthand.value + 2
+    }
+    return populationFactory.build(populationFields)
   })
 
   return geneticAncestryGroupObjects
@@ -30,11 +39,14 @@ const createAncestryGroupObjects = (shorthands: AncestryGroupShorthand[]) => {
 
 describe('mergeExomeAndGenomePopulationData', () => {
   it('returns expected values when exomes and genomes have the same populations', () => {
-    const geneticAncestryGroupObjects = createAncestryGroupObjects([
-      { id: 'afr', value: 1 },
-      { id: 'remaining', value: 2 },
-      { id: 'eur', value: 4 },
-    ])
+    const geneticAncestryGroupObjects = createAncestryGroupObjects(
+      [
+        { id: 'afr', value: 1 },
+        { id: 'remaining', value: 2 },
+        { id: 'eur', value: 4 },
+      ],
+      false
+    )
 
     const testVariant = variantFactory.build({
       variant_id: 'test_variant',
@@ -54,18 +66,24 @@ describe('mergeExomeAndGenomePopulationData', () => {
   })
 
   it('returns expected values when exomes have less populations than genomes', () => {
-    const exomeGeneticAncestryGroupObjects = createAncestryGroupObjects([
-      { id: 'afr', value: 1 },
-      { id: 'remaining', value: 2 },
-      { id: 'eur', value: 4 },
-    ])
+    const exomeGeneticAncestryGroupObjects = createAncestryGroupObjects(
+      [
+        { id: 'afr', value: 1 },
+        { id: 'remaining', value: 2 },
+        { id: 'eur', value: 4 },
+      ],
+      false
+    )
 
-    const genomeGeneticAncestryGroupObjects = createAncestryGroupObjects([
-      { id: 'afr', value: 8 },
-      { id: 'remaining', value: 16 },
-      { id: 'eur', value: 32 },
-      { id: 'mid', value: 64 },
-    ])
+    const genomeGeneticAncestryGroupObjects = createAncestryGroupObjects(
+      [
+        { id: 'afr', value: 8 },
+        { id: 'remaining', value: 16 },
+        { id: 'eur', value: 32 },
+        { id: 'mid', value: 64 },
+      ],
+      false
+    )
 
     const testVariant = variantFactory.build({
       variant_id: 'test_variant',
@@ -86,18 +104,24 @@ describe('mergeExomeAndGenomePopulationData', () => {
   })
 
   it('returns expected values exomes have more populations than genomes', () => {
-    const exomeGeneticAncestryGroupObjects = createAncestryGroupObjects([
-      { id: 'afr', value: 1 },
-      { id: 'remaining', value: 2 },
-      { id: 'eur', value: 4 },
-      { id: 'mid', value: 8 },
-    ])
+    const exomeGeneticAncestryGroupObjects = createAncestryGroupObjects(
+      [
+        { id: 'afr', value: 1 },
+        { id: 'remaining', value: 2 },
+        { id: 'eur', value: 4 },
+        { id: 'mid', value: 8 },
+      ],
+      false
+    )
 
-    const genomeGeneticAncestryGroupObjects = createAncestryGroupObjects([
-      { id: 'afr', value: 16 },
-      { id: 'remaining', value: 32 },
-      { id: 'eur', value: 64 },
-    ])
+    const genomeGeneticAncestryGroupObjects = createAncestryGroupObjects(
+      [
+        { id: 'afr', value: 16 },
+        { id: 'remaining', value: 32 },
+        { id: 'eur', value: 64 },
+      ],
+      false
+    )
 
     const testVariant = variantFactory.build({
       variant_id: 'test_variant',
@@ -118,17 +142,23 @@ describe('mergeExomeAndGenomePopulationData', () => {
   })
 
   it('returns expected values when exome and genome populations are in a different order', () => {
-    const exomeGeneticAncestryGroupObjects = createAncestryGroupObjects([
-      { id: 'eur', value: 1 },
-      { id: 'afr', value: 2 },
-      { id: 'remaining', value: 4 },
-    ])
+    const exomeGeneticAncestryGroupObjects = createAncestryGroupObjects(
+      [
+        { id: 'eur', value: 1 },
+        { id: 'afr', value: 2 },
+        { id: 'remaining', value: 4 },
+      ],
+      false
+    )
 
-    const genomeGeneticAncestryGroupObjects = createAncestryGroupObjects([
-      { id: 'afr', value: 8 },
-      { id: 'remaining', value: 16 },
-      { id: 'eur', value: 32 },
-    ])
+    const genomeGeneticAncestryGroupObjects = createAncestryGroupObjects(
+      [
+        { id: 'afr', value: 8 },
+        { id: 'remaining', value: 16 },
+        { id: 'eur', value: 32 },
+      ],
+      false
+    )
 
     const testVariant = variantFactory.build({
       variant_id: 'test_variant',
@@ -150,11 +180,14 @@ describe('mergeExomeAndGenomePopulationData', () => {
 
 describe('mergeExomeAndGenomeData', () => {
   it('returns expected values with just exome data', () => {
-    const exomeGeneticAncestryGroupObjects = createAncestryGroupObjects([
-      { id: 'afr', value: 1 },
-      { id: 'remaining', value: 2 },
-      { id: 'eur', value: 4 },
-    ])
+    const exomeGeneticAncestryGroupObjects = createAncestryGroupObjects(
+      [
+        { id: 'afr', value: 1 },
+        { id: 'remaining', value: 2 },
+        { id: 'eur', value: 4 },
+      ],
+      false
+    )
     const testExomeOnlyVariant = variantFactory.build({
       variant_id: 'test_variant',
       exome: {
@@ -163,7 +196,10 @@ describe('mergeExomeAndGenomeData', () => {
         ac_hom: 3,
         an: 4,
         af: 5,
-        faf95: undefined,
+        faf95: {
+          popmax: null,
+          popmax_population: null,
+        },
         filters: ['RF'],
         populations: exomeGeneticAncestryGroupObjects,
       },
@@ -178,9 +214,8 @@ describe('mergeExomeAndGenomeData', () => {
         ac_hemi: 2,
         ac_hom: 3,
         an: 4,
-        af: 5,
-        allele_freq: 5,
-        faf95: undefined,
+        af: 0.25,
+        allele_freq: 0.25,
         filters: ['RF'],
         populations: exomeGeneticAncestryGroupObjects,
       },
@@ -189,21 +224,27 @@ describe('mergeExomeAndGenomeData', () => {
     expect(result).toStrictEqual(expected)
   })
   it('returns expected values with just genome data', () => {
-    const genomeGeneticAncestryGroupObjects = createAncestryGroupObjects([
-      { id: 'afr', value: 8 },
-      { id: 'remaining', value: 16 },
-      { id: 'eur', value: 32 },
-      { id: 'mid', value: 64 },
-    ])
+    const genomeGeneticAncestryGroupObjects = createAncestryGroupObjects(
+      [
+        { id: 'afr', value: 8 },
+        { id: 'remaining', value: 16 },
+        { id: 'eur', value: 32 },
+        { id: 'mid', value: 64 },
+      ],
+      false
+    )
     const testGenomeOnlyVariant = variantFactory.build({
       variant_id: 'test_variant',
       genome: {
         ac: 2,
         ac_hemi: 3,
         ac_hom: 4,
+        faf95: {
+          popmax: null,
+          popmax_population: null,
+        },
         an: 5,
         af: 6,
-        faf95: undefined,
         filters: ['AC0'],
         populations: genomeGeneticAncestryGroupObjects,
       },
@@ -218,9 +259,8 @@ describe('mergeExomeAndGenomeData', () => {
         ac_hemi: 3,
         ac_hom: 4,
         an: 5,
-        af: 6,
-        allele_freq: 6,
-        faf95: undefined,
+        af: 0.4,
+        allele_freq: 0.4,
         filters: ['AC0'],
         populations: genomeGeneticAncestryGroupObjects,
       },
@@ -230,18 +270,24 @@ describe('mergeExomeAndGenomeData', () => {
   })
 
   it('returns expected values with exome and genome data', () => {
-    const exomeGeneticAncestryGroupObjects = createAncestryGroupObjects([
-      { id: 'afr', value: 1 },
-      { id: 'remaining', value: 2 },
-      { id: 'eur', value: 4 },
-    ])
+    const exomeGeneticAncestryGroupObjects = createAncestryGroupObjects(
+      [
+        { id: 'afr', value: 1 },
+        { id: 'remaining', value: 2 },
+        { id: 'eur', value: 4 },
+      ],
+      false
+    )
 
-    const genomeGeneticAncestryGroupObjects = createAncestryGroupObjects([
-      { id: 'afr', value: 8 },
-      { id: 'remaining', value: 16 },
-      { id: 'eur', value: 32 },
-      { id: 'mid', value: 64 },
-    ])
+    const genomeGeneticAncestryGroupObjects = createAncestryGroupObjects(
+      [
+        { id: 'afr', value: 8 },
+        { id: 'remaining', value: 16 },
+        { id: 'eur', value: 32 },
+        { id: 'mid', value: 64 },
+      ],
+      false
+    )
 
     const testExomeAndGenomeVariant = variantFactory.build({
       variant_id: 'test_variant',
@@ -249,8 +295,11 @@ describe('mergeExomeAndGenomeData', () => {
         ac: 1,
         ac_hemi: 2,
         ac_hom: 3,
+        faf95: {
+          popmax: null,
+          popmax_population: null,
+        },
         an: 4,
-        faf95: undefined,
         filters: ['RF'],
         populations: exomeGeneticAncestryGroupObjects,
       },
@@ -258,8 +307,11 @@ describe('mergeExomeAndGenomeData', () => {
         ac: 2,
         ac_hemi: 3,
         ac_hom: 4,
+        faf95: {
+          popmax: null,
+          popmax_population: null,
+        },
         an: 6,
-        faf95: undefined,
         filters: ['AC0'],
         populations: genomeGeneticAncestryGroupObjects,
       },
@@ -289,26 +341,34 @@ describe('mergeExomeAndGenomeData', () => {
     expect(result).toStrictEqual(expected)
   })
   it('returns expected values with exome and joint data', () => {
-    const exomeGeneticAncestryGroupObjects = createAncestryGroupObjects([
-      { id: 'afr', value: 1 },
-      { id: 'remaining', value: 2 },
-      { id: 'eur', value: 4 },
-    ])
-    const jointGeneticAncestryGroupObjects = createAncestryGroupObjects([
-      { id: 'afr', value: 8 },
-      { id: 'remaining', value: 16 },
-      { id: 'eur', value: 32 },
-      { id: 'mid', value: 64 },
-    ])
+    const exomeGeneticAncestryGroupObjects = createAncestryGroupObjects(
+      [
+        { id: 'afr', value: 1 },
+        { id: 'remaining', value: 2 },
+        { id: 'eur', value: 4 },
+      ],
+      false
+    )
+
+    const jointGeneticAncestryGroupObjects = [
+      { ac: 8, hemizygote_count: 9, homozygote_count: 10, an: 80, id: 'afr' },
+      { ac: 16, hemizygote_count: 17, homozygote_count: 18, an: 160, id: 'remaining' },
+      { ac: 32, hemizygote_count: 33, homozygote_count: 34, an: 320, id: 'eur' },
+      { ac: 64, hemizygote_count: 65, homozygote_count: 66, an: 640, id: 'mid' },
+    ]
+
     const testExomeAndJointVariant = variantFactory.build({
       variant_id: 'test_variant',
       exome: {
         ac: 1,
         ac_hemi: 2,
         ac_hom: 3,
+        faf95: {
+          popmax: null,
+          popmax_population: null,
+        },
         an: 4,
         af: 5,
-        faf95: undefined,
         filters: ['RF'],
         populations: exomeGeneticAncestryGroupObjects,
       },
@@ -316,52 +376,73 @@ describe('mergeExomeAndGenomeData', () => {
         ac: 10,
         hemizygote_count: 20,
         homozygote_count: 30,
+        faf95: {
+          popmax: null,
+          popmax_population: null,
+        },
         an: 40,
-        faf95: undefined,
-        filters: ['RF'],
-        populations: jointGeneticAncestryGroupObjects,
+        filters: ['discrepant_frequencies'],
+        populations: jointGeneticAncestryGroupObjects as Population[],
       },
     })
 
     const result = mergeExomeAndGenomeData([testExomeAndJointVariant])
 
+    const expectedJointGeneticAncestryGroupObjects = createAncestryGroupObjects(
+      [
+        { id: 'afr', value: 8 },
+        { id: 'remaining', value: 16 },
+        { id: 'eur', value: 32 },
+        { id: 'mid', value: 64 },
+      ],
+      true
+    )
+
     const expected = [
       {
         ...testExomeAndJointVariant,
         ac: 10,
-        hemizygote_count: 20,
-        homozygote_count: 30,
+        ac_hemi: 20,
+        ac_hom: 30,
         an: 40,
+        af: 0.25,
         allele_freq: 0.25,
-        faf95: undefined,
-        filters: ['RF'],
-        populations: jointGeneticAncestryGroupObjects,
+        filters: ['RF', 'discrepant_frequencies'],
+        populations: expectedJointGeneticAncestryGroupObjects,
       },
     ]
 
     expect(result).toStrictEqual(expected)
   })
   it('returns expected values with genome and joint data', () => {
-    const genomeGeneticAncestryGroupObjects = createAncestryGroupObjects([
-      { id: 'afr', value: 8 },
-      { id: 'remaining', value: 16 },
-      { id: 'eur', value: 32 },
-      { id: 'mid', value: 64 },
-    ])
-    const jointGeneticAncestryGroupObjects = createAncestryGroupObjects([
-      { id: 'afr', value: 1 },
-      { id: 'remaining', value: 2 },
-      { id: 'eur', value: 4 },
-    ])
+    const genomeGeneticAncestryGroupObjects = createAncestryGroupObjects(
+      [
+        { id: 'afr', value: 8 },
+        { id: 'remaining', value: 16 },
+        { id: 'eur', value: 32 },
+        { id: 'mid', value: 64 },
+      ],
+      false
+    )
+
+    const jointGeneticAncestryGroupObjects = [
+      { ac: 1, hemizygote_count: 2, homozygote_count: 3, an: 10, id: 'afr' },
+      { ac: 2, hemizygote_count: 3, homozygote_count: 4, an: 20, id: 'remaining' },
+      { ac: 4, hemizygote_count: 5, homozygote_count: 6, an: 40, id: 'eur' },
+    ]
+
     const testGenomeAndJointVariant = variantFactory.build({
       variant_id: 'test_variant',
       genome: {
         ac: 1,
         ac_hemi: 2,
         ac_hom: 3,
+        faf95: {
+          popmax: null,
+          popmax_population: null,
+        },
         an: 4,
         af: 5,
-        faf95: undefined,
         filters: ['RF'],
         populations: genomeGeneticAncestryGroupObjects,
       },
@@ -369,50 +450,70 @@ describe('mergeExomeAndGenomeData', () => {
         ac: 10,
         hemizygote_count: 20,
         homozygote_count: 30,
+        faf95: {
+          popmax: null,
+          popmax_population: null,
+        },
         an: 40,
-        faf95: undefined,
-        filters: ['RF'],
-        populations: jointGeneticAncestryGroupObjects,
+        filters: ['discrepant_frequencies'],
+        populations: jointGeneticAncestryGroupObjects as Population[],
       },
     })
 
     const result = mergeExomeAndGenomeData([testGenomeAndJointVariant])
 
+    const expectedJointGeneticAncestryGroupObjects = createAncestryGroupObjects(
+      [
+        { id: 'afr', value: 1 },
+        { id: 'remaining', value: 2 },
+        { id: 'eur', value: 4 },
+      ],
+      true
+    )
+
     const expected = [
       {
         ...testGenomeAndJointVariant,
         ac: 10,
-        hemizygote_count: 20,
-        homozygote_count: 30,
+        ac_hemi: 20,
+        ac_hom: 30,
         an: 40,
+        af: 0.25,
         allele_freq: 0.25,
-        faf95: undefined,
-        filters: ['RF'],
-        populations: jointGeneticAncestryGroupObjects,
+        filters: ['RF', 'discrepant_frequencies'],
+        populations: expectedJointGeneticAncestryGroupObjects,
       },
     ]
 
     expect(result).toStrictEqual(expected)
   })
   it('returns expected values with exome, genome, and joint data', () => {
-    const exomeGeneticAncestryGroupObjects = createAncestryGroupObjects([
-      { id: 'afr', value: 1 },
-      { id: 'remaining', value: 2 },
-      { id: 'eur', value: 4 },
-    ])
-    const genomeGeneticAncestryGroupObjects = createAncestryGroupObjects([
-      { id: 'afr', value: 8 },
-      { id: 'remaining', value: 16 },
-      { id: 'eur', value: 32 },
-      { id: 'mid', value: 64 },
-    ])
-    const jointGeneticAncestryGroupObjects = createAncestryGroupObjects([
-      { id: 'afr', value: 10 },
-      { id: 'remaining', value: 20 },
-      { id: 'eur', value: 40 },
-      { id: 'mid', value: 80 },
-      { id: 'sas', value: 160 },
-    ])
+    const exomeGeneticAncestryGroupObjects = createAncestryGroupObjects(
+      [
+        { id: 'afr', value: 1 },
+        { id: 'remaining', value: 2 },
+        { id: 'eur', value: 4 },
+      ],
+      false
+    )
+    const genomeGeneticAncestryGroupObjects = createAncestryGroupObjects(
+      [
+        { id: 'afr', value: 8 },
+        { id: 'remaining', value: 16 },
+        { id: 'eur', value: 32 },
+        { id: 'mid', value: 64 },
+      ],
+      false
+    )
+
+    const jointGeneticAncestryGroupObjects = [
+      { ac: 10, hemizygote_count: 11, homozygote_count: 12, an: 100, id: 'afr' },
+      { ac: 20, hemizygote_count: 21, homozygote_count: 22, an: 200, id: 'remaining' },
+      { ac: 40, hemizygote_count: 41, homozygote_count: 42, an: 400, id: 'eur' },
+      { ac: 80, hemizygote_count: 81, homozygote_count: 82, an: 800, id: 'mid' },
+      { ac: 160, hemizygote_count: 161, homozygote_count: 162, an: 1600, id: 'sas' },
+    ]
+
     const testExomeGenomeAndJointVariant = variantFactory.build({
       variant_id: 'test_variant',
       exome: {
@@ -421,7 +522,10 @@ describe('mergeExomeAndGenomeData', () => {
         ac_hom: 3,
         an: 4,
         af: 5,
-        faf95: undefined,
+        faf95: {
+          popmax: null,
+          popmax_population: null,
+        },
         filters: ['RF'],
         populations: exomeGeneticAncestryGroupObjects,
       },
@@ -431,7 +535,10 @@ describe('mergeExomeAndGenomeData', () => {
         ac_hom: 5,
         an: 6,
         af: 5,
-        faf95: undefined,
+        faf95: {
+          popmax: null,
+          popmax_population: null,
+        },
         filters: ['AC0'],
         populations: genomeGeneticAncestryGroupObjects,
       },
@@ -440,14 +547,27 @@ describe('mergeExomeAndGenomeData', () => {
         hemizygote_count: 20,
         homozygote_count: 30,
         an: 40,
-        faf95: undefined,
+        faf95: {
+          popmax: null,
+          popmax_population: null,
+        },
         filters: ['discrepant_frequencies'],
-        populations: jointGeneticAncestryGroupObjects,
+        populations: jointGeneticAncestryGroupObjects as Population[],
       },
     })
 
     const result = mergeExomeAndGenomeData([testExomeGenomeAndJointVariant])
 
+    const expectedJointGeneticAncestryGroupObjects = createAncestryGroupObjects(
+      [
+        { id: 'afr', value: 10 },
+        { id: 'remaining', value: 20 },
+        { id: 'eur', value: 40 },
+        { id: 'mid', value: 80 },
+        { id: 'sas', value: 160 },
+      ],
+      true
+    )
     const expected = [
       {
         ...testExomeGenomeAndJointVariant,
@@ -458,12 +578,7 @@ describe('mergeExomeAndGenomeData', () => {
         af: 0.25,
         allele_freq: 0.25,
         filters: ['RF', 'AC0', 'discrepant_frequencies'],
-        populations: [
-          { ac: 9, ac_hemi: 11, ac_hom: 13, an: 90, id: 'afr' },
-          { ac: 18, ac_hemi: 20, ac_hom: 22, an: 180, id: 'remaining' },
-          { ac: 36, ac_hemi: 38, ac_hom: 40, an: 360, id: 'eur' },
-          { ac: 64, ac_hemi: 65, ac_hom: 66, an: 640, id: 'mid' },
-        ],
+        populations: expectedJointGeneticAncestryGroupObjects,
       },
     ]
 

--- a/browser/src/VariantList/mergeExomeAndGenomeData.spec.ts
+++ b/browser/src/VariantList/mergeExomeAndGenomeData.spec.ts
@@ -3,7 +3,10 @@ import { describe, it, expect } from '@jest/globals'
 import { populationFactory, variantFactory } from '../__factories__/Variant'
 import { Population } from '../VariantPage/VariantPage'
 
-import { mergeExomeAndGenomePopulationData } from './mergeExomeAndGenomeData'
+import {
+  mergeExomeAndGenomePopulationData,
+  mergeExomeAndGenomeData,
+} from './mergeExomeAndGenomeData'
 import { PopulationId } from '@gnomad/dataset-metadata/gnomadPopulations'
 
 type AncestryGroupShorthand = {
@@ -139,6 +142,329 @@ describe('mergeExomeAndGenomePopulationData', () => {
       { ac: 33, ac_hemi: 35, ac_hom: 37, an: 330, id: 'eur' },
       { ac: 10, ac_hemi: 12, ac_hom: 14, an: 100, id: 'afr' },
       { ac: 20, ac_hemi: 22, ac_hom: 24, an: 200, id: 'remaining' },
+    ]
+
+    expect(result).toStrictEqual(expected)
+  })
+})
+
+describe('mergeExomeAndGenomeData', () => {
+  it('returns expected values with just exome data', () => {
+    const exomeGeneticAncestryGroupObjects = createAncestryGroupObjects([
+      { id: 'afr', value: 1 },
+      { id: 'remaining', value: 2 },
+      { id: 'eur', value: 4 },
+    ])
+    const testExomeOnlyVariant = variantFactory.build({
+      variant_id: 'test_variant',
+      exome: {
+        ac: 1,
+        ac_hemi: 2,
+        ac_hom: 3,
+        an: 4,
+        af: 5,
+        faf95: undefined,
+        filters: ['RF'],
+        populations: exomeGeneticAncestryGroupObjects,
+      },
+    })
+
+    const result = mergeExomeAndGenomeData([testExomeOnlyVariant])
+
+    const expected = [
+      {
+        ...testExomeOnlyVariant,
+        ac: 1,
+        ac_hemi: 2,
+        ac_hom: 3,
+        an: 4,
+        af: 5,
+        allele_freq: 5,
+        faf95: undefined,
+        filters: ['RF'],
+        populations: exomeGeneticAncestryGroupObjects,
+      },
+    ]
+
+    expect(result).toStrictEqual(expected)
+  })
+  it('returns expected values with just genome data', () => {
+    const genomeGeneticAncestryGroupObjects = createAncestryGroupObjects([
+      { id: 'afr', value: 8 },
+      { id: 'remaining', value: 16 },
+      { id: 'eur', value: 32 },
+      { id: 'mid', value: 64 },
+    ])
+    const testGenomeOnlyVariant = variantFactory.build({
+      variant_id: 'test_variant',
+      genome: {
+        ac: 2,
+        ac_hemi: 3,
+        ac_hom: 4,
+        an: 5,
+        af: 6,
+        faf95: undefined,
+        filters: ['AC0'],
+        populations: genomeGeneticAncestryGroupObjects,
+      },
+    })
+
+    const result = mergeExomeAndGenomeData([testGenomeOnlyVariant])
+
+    const expected = [
+      {
+        ...testGenomeOnlyVariant,
+        ac: 2,
+        ac_hemi: 3,
+        ac_hom: 4,
+        an: 5,
+        af: 6,
+        allele_freq: 6,
+        faf95: undefined,
+        filters: ['AC0'],
+        populations: genomeGeneticAncestryGroupObjects,
+      },
+    ]
+
+    expect(result).toStrictEqual(expected)
+  })
+
+  it('returns expected values with exome and genome data', () => {
+    const exomeGeneticAncestryGroupObjects = createAncestryGroupObjects([
+      { id: 'afr', value: 1 },
+      { id: 'remaining', value: 2 },
+      { id: 'eur', value: 4 },
+    ])
+
+    const genomeGeneticAncestryGroupObjects = createAncestryGroupObjects([
+      { id: 'afr', value: 8 },
+      { id: 'remaining', value: 16 },
+      { id: 'eur', value: 32 },
+      { id: 'mid', value: 64 },
+    ])
+
+    const testExomeAndGenomeVariant = variantFactory.build({
+      variant_id: 'test_variant',
+      exome: {
+        ac: 1,
+        ac_hemi: 2,
+        ac_hom: 3,
+        an: 4,
+        faf95: undefined,
+        filters: ['RF'],
+        populations: exomeGeneticAncestryGroupObjects,
+      },
+      genome: {
+        ac: 2,
+        ac_hemi: 3,
+        ac_hom: 4,
+        an: 6,
+        faf95: undefined,
+        filters: ['AC0'],
+        populations: genomeGeneticAncestryGroupObjects,
+      },
+    })
+
+    const result = mergeExomeAndGenomeData([testExomeAndGenomeVariant])
+
+    const expected = [
+      {
+        ...testExomeAndGenomeVariant,
+        ac: 3,
+        ac_hemi: 5,
+        ac_hom: 7,
+        an: 10,
+        af: 0.3,
+        allele_freq: 0.3,
+        filters: ['RF', 'AC0'],
+        populations: [
+          { ac: 9, ac_hemi: 11, ac_hom: 13, an: 90, id: 'afr' },
+          { ac: 18, ac_hemi: 20, ac_hom: 22, an: 180, id: 'remaining' },
+          { ac: 36, ac_hemi: 38, ac_hom: 40, an: 360, id: 'eur' },
+          { ac: 64, ac_hemi: 65, ac_hom: 66, an: 640, id: 'mid' },
+        ],
+      },
+    ]
+
+    expect(result).toStrictEqual(expected)
+  })
+  it('returns expected values with exome and joint data', () => {
+    const exomeGeneticAncestryGroupObjects = createAncestryGroupObjects([
+      { id: 'afr', value: 1 },
+      { id: 'remaining', value: 2 },
+      { id: 'eur', value: 4 },
+    ])
+    const jointGeneticAncestryGroupObjects = createAncestryGroupObjects([
+      { id: 'afr', value: 8 },
+      { id: 'remaining', value: 16 },
+      { id: 'eur', value: 32 },
+      { id: 'mid', value: 64 },
+    ])
+    const testExomeAndJointVariant = variantFactory.build({
+      variant_id: 'test_variant',
+      exome: {
+        ac: 1,
+        ac_hemi: 2,
+        ac_hom: 3,
+        an: 4,
+        af: 5,
+        faf95: undefined,
+        filters: ['RF'],
+        populations: exomeGeneticAncestryGroupObjects,
+      },
+      joint: {
+        ac: 10,
+        hemizygote_count: 20,
+        homozygote_count: 30,
+        an: 40,
+        faf95: undefined,
+        filters: ['RF'],
+        populations: jointGeneticAncestryGroupObjects,
+      },
+    })
+
+    const result = mergeExomeAndGenomeData([testExomeAndJointVariant])
+
+    const expected = [
+      {
+        ...testExomeAndJointVariant,
+        ac: 10,
+        hemizygote_count: 20,
+        homozygote_count: 30,
+        an: 40,
+        allele_freq: 0.25,
+        faf95: undefined,
+        filters: ['RF'],
+        populations: jointGeneticAncestryGroupObjects,
+      },
+    ]
+
+    expect(result).toStrictEqual(expected)
+  })
+  it('returns expected values with genome and joint data', () => {
+    const genomeGeneticAncestryGroupObjects = createAncestryGroupObjects([
+      { id: 'afr', value: 8 },
+      { id: 'remaining', value: 16 },
+      { id: 'eur', value: 32 },
+      { id: 'mid', value: 64 },
+    ])
+    const jointGeneticAncestryGroupObjects = createAncestryGroupObjects([
+      { id: 'afr', value: 1 },
+      { id: 'remaining', value: 2 },
+      { id: 'eur', value: 4 },
+    ])
+    const testGenomeAndJointVariant = variantFactory.build({
+      variant_id: 'test_variant',
+      genome: {
+        ac: 1,
+        ac_hemi: 2,
+        ac_hom: 3,
+        an: 4,
+        af: 5,
+        faf95: undefined,
+        filters: ['RF'],
+        populations: genomeGeneticAncestryGroupObjects,
+      },
+      joint: {
+        ac: 10,
+        hemizygote_count: 20,
+        homozygote_count: 30,
+        an: 40,
+        faf95: undefined,
+        filters: ['RF'],
+        populations: jointGeneticAncestryGroupObjects,
+      },
+    })
+
+    const result = mergeExomeAndGenomeData([testGenomeAndJointVariant])
+
+    const expected = [
+      {
+        ...testGenomeAndJointVariant,
+        ac: 10,
+        hemizygote_count: 20,
+        homozygote_count: 30,
+        an: 40,
+        allele_freq: 0.25,
+        faf95: undefined,
+        filters: ['RF'],
+        populations: jointGeneticAncestryGroupObjects,
+      },
+    ]
+
+    expect(result).toStrictEqual(expected)
+  })
+  it('returns expected values with exome, genome, and joint data', () => {
+    const exomeGeneticAncestryGroupObjects = createAncestryGroupObjects([
+      { id: 'afr', value: 1 },
+      { id: 'remaining', value: 2 },
+      { id: 'eur', value: 4 },
+    ])
+    const genomeGeneticAncestryGroupObjects = createAncestryGroupObjects([
+      { id: 'afr', value: 8 },
+      { id: 'remaining', value: 16 },
+      { id: 'eur', value: 32 },
+      { id: 'mid', value: 64 },
+    ])
+    const jointGeneticAncestryGroupObjects = createAncestryGroupObjects([
+      { id: 'afr', value: 10 },
+      { id: 'remaining', value: 20 },
+      { id: 'eur', value: 40 },
+      { id: 'mid', value: 80 },
+      { id: 'sas', value: 160 },
+    ])
+    const testExomeGenomeAndJointVariant = variantFactory.build({
+      variant_id: 'test_variant',
+      exome: {
+        ac: 1,
+        ac_hemi: 2,
+        ac_hom: 3,
+        an: 4,
+        af: 5,
+        faf95: undefined,
+        filters: ['RF'],
+        populations: exomeGeneticAncestryGroupObjects,
+      },
+      genome: {
+        ac: 2,
+        ac_hemi: 4,
+        ac_hom: 5,
+        an: 6,
+        af: 5,
+        faf95: undefined,
+        filters: ['AC0'],
+        populations: genomeGeneticAncestryGroupObjects,
+      },
+      joint: {
+        ac: 10,
+        hemizygote_count: 20,
+        homozygote_count: 30,
+        an: 40,
+        faf95: undefined,
+        filters: ['discrepant_frequencies'],
+        populations: jointGeneticAncestryGroupObjects,
+      },
+    })
+
+    const result = mergeExomeAndGenomeData([testExomeGenomeAndJointVariant])
+
+    const expected = [
+      {
+        ...testExomeGenomeAndJointVariant,
+        ac: 10,
+        ac_hemi: 20,
+        ac_hom: 30,
+        an: 40,
+        af: 0.25,
+        allele_freq: 0.25,
+        filters: ['RF', 'AC0', 'discrepant_frequencies'],
+        populations: [
+          { ac: 9, ac_hemi: 11, ac_hom: 13, an: 90, id: 'afr' },
+          { ac: 18, ac_hemi: 20, ac_hom: 22, an: 180, id: 'remaining' },
+          { ac: 36, ac_hemi: 38, ac_hom: 40, an: 360, id: 'eur' },
+          { ac: 64, ac_hemi: 65, ac_hom: 66, an: 640, id: 'mid' },
+        ],
+      },
     ]
 
     expect(result).toStrictEqual(expected)

--- a/browser/src/VariantList/mergeExomeAndGenomeData.ts
+++ b/browser/src/VariantList/mergeExomeAndGenomeData.ts
@@ -43,21 +43,37 @@ export const mergeExomeAndGenomePopulationData = (
   return Object.values(populations)
 }
 
-const mergeExomeAndGenomeData = (variants: any) =>
+export const mergeExomeAndGenomeData = (variants: any) =>
   variants.map((variant: any) => {
-    const { exome, genome } = variant
+    const { exome, genome, joint } = variant
     if (!exome) {
+      if (!joint) {
+        return {
+          ...variant,
+          ...variant.genome,
+          allele_freq: variant.genome.af, // hack for variant track which expects allele_freq field
+        }
+      }
       return {
         ...variant,
-        ...variant.genome,
-        allele_freq: variant.genome.af, // hack for variant track which expects allele_freq field
+        ...variant.joint,
+        filters: variant.genome.filters,
+        allele_freq: variant.joint.ac / variant.joint.an,
       }
     }
     if (!genome) {
+      if (!joint) {
+        return {
+          ...variant,
+          ...variant.exome,
+          allele_freq: variant.exome.af, // hack for variant track which expects allele_freq field
+        }
+      }
       return {
         ...variant,
-        ...variant.exome,
-        allele_freq: variant.exome.af, // hack for variant track which expects allele_freq field
+        ...variant.joint,
+        filters: variant.exome.filters,
+        allele_freq: variant.joint.ac / variant.joint.an, // hack for variant track which expects allele_freq field
       }
     }
 

--- a/browser/src/VariantPage/GnomadPopulationsTable.tsx
+++ b/browser/src/VariantPage/GnomadPopulationsTable.tsx
@@ -74,6 +74,7 @@ type OwnGnomadPopulationsTableProps = {
   datasetId: DatasetId
   exomePopulations: Population[]
   genomePopulations: Population[]
+  jointPopulations: Population[] | null
   showHemizygotes?: boolean
   showHomozygotes?: boolean
 }
@@ -102,14 +103,21 @@ export class GnomadPopulationsTable extends Component<
   }
 
   render() {
-    const { datasetId, exomePopulations, genomePopulations, showHemizygotes, showHomozygotes } =
-      this.props
+    const {
+      datasetId,
+      exomePopulations,
+      genomePopulations,
+      jointPopulations,
+      showHemizygotes,
+      showHomozygotes,
+    } = this.props
     const { includeExomes, includeGenomes } = this.state
 
     const mergedPopulations = mergeExomeGenomeAndJointPopulationData({
       exomePopulations: includeExomes ? exomePopulations : [],
       genomePopulations: includeGenomes ? genomePopulations : [],
-    })
+      jointPopulations,
+    }).filter((mergedAncestry) => (mergedAncestry.id as string) !== '')
 
     const mergedPopulationsWithNames = addPopulationNames(mergedPopulations)
     const mergedNestedPopulationsWithNames = nestPopulations(mergedPopulationsWithNames)

--- a/browser/src/VariantPage/VariantPage.tsx
+++ b/browser/src/VariantPage/VariantPage.tsx
@@ -146,10 +146,10 @@ export type Population = {
   id: PopulationId
   ac: number
   an: number
-  ac_hemi?: number | null
-  ac_hom?: number
+  ac_hemi: number | null
+  ac_hom: number
   hemizygote_count?: number | null
-  homozygote_count?: number | null
+  homozygote_count?: number
 }
 
 export type LocalAncestryPopulation = {

--- a/browser/src/VariantPage/VariantPage.tsx
+++ b/browser/src/VariantPage/VariantPage.tsx
@@ -202,6 +202,7 @@ export type SequencingType = BaseSequencingType & {
   local_ancestry_populations: LocalAncestryPopulation[]
   ac_hom: number
   ac_hemi: number
+  af?: number
 }
 
 export type JointSequencingType = BaseSequencingType & {

--- a/browser/src/VariantPage/VariantPage.tsx
+++ b/browser/src/VariantPage/VariantPage.tsx
@@ -146,8 +146,10 @@ export type Population = {
   id: PopulationId
   ac: number
   an: number
-  ac_hemi: number | null
-  ac_hom: number
+  ac_hemi?: number | null
+  ac_hom?: number
+  hemizygote_count?: number | null
+  homozygote_count?: number | null
 }
 
 export type LocalAncestryPopulation = {
@@ -182,8 +184,8 @@ export type VariantQualityMetrics = {
 }
 
 export type Faf95 = {
-  popmax: number
-  popmax_population: string
+  popmax: number | null
+  popmax_population: string | null
 }
 
 type BaseSequencingType = {

--- a/browser/src/VariantPage/VariantPopulationFrequencies.tsx
+++ b/browser/src/VariantPage/VariantPopulationFrequencies.tsx
@@ -53,6 +53,7 @@ const VariantPopulationFrequencies = ({ datasetId, variant }: Props) => {
                   datasetId={datasetId}
                   exomePopulations={exomePopulations}
                   genomePopulations={genomePopulations}
+                  jointPopulations={variant.joint ? variant.joint.populations : null}
                   showHemizygotes={variant.chrom === 'X' || variant.chrom === 'Y'}
                 />
               </TableWrapper>
@@ -143,6 +144,7 @@ const VariantPopulationFrequencies = ({ datasetId, variant }: Props) => {
         datasetId={datasetId}
         exomePopulations={variant.exome ? variant.exome.populations : []}
         genomePopulations={variant.genome ? variant.genome.populations : []}
+        jointPopulations={variant.joint ? variant.joint.populations : null}
         showHemizygotes={variant.chrom === 'X' || variant.chrom === 'Y'}
       />
     </TableWrapper>

--- a/graphql-api/src/queries/variant-datasets/gnomad-v4-variant-queries.ts
+++ b/graphql-api/src/queries/variant-datasets/gnomad-v4-variant-queries.ts
@@ -203,6 +203,7 @@ const fetchVariantById = async (esClient: any, variantIdOrRsid: any, subset: Sub
       ...variant.joint,
       ...variant.joint.freq[subset],
       filters: jointFilters,
+      populations: subsetJointFreq.ancestry_groups,
       faf95: {
         popmax_population: variant.joint.fafmax.faf95_max_gen_anc,
         popmax: variant.joint.fafmax.faf95_max,


### PR DESCRIPTION
Resolves #1540 

Modifies the `combineExomeAndGenomeData` function to use joint data if theres only exome or genome data, and theres joint data

---

Screenshots:
- ![Screenshot 2024-05-08 at 15 02 15](https://github.com/broadinstitute/gnomad-browser/assets/59549713/7723e775-1043-4720-8143-359960cec0ca)



- ![Screenshot 2024-05-08 at 15 03 12](https://github.com/broadinstitute/gnomad-browser/assets/59549713/6c79cd06-2c79-42a8-b784-a354c74eb1f5)
- ![Screenshot 2024-05-08 at 15 03 45](https://github.com/broadinstitute/gnomad-browser/assets/59549713/99b212be-61fd-4fe2-8b2c-1150d72d38df)

