### PR TITLE
Fix CSV export of non-UKB v4 variants

### DIFF
--- a/browser/src/GenePage/VariantsInGene.tsx
+++ b/browser/src/GenePage/VariantsInGene.tsx
@@ -240,6 +240,12 @@ query ${operationName}($geneId: String!, $datasetId: DatasetId!, $referenceGenom
           ac_hemi
           ac_hom
         }
+        fafmax {
+          faf95_max
+          faf95_max_gen_anc
+          faf99_max
+          faf99_max_gen_anc
+        }
       }
       genome {
         ac

--- a/browser/src/RegionPage/VariantsInRegion.tsx
+++ b/browser/src/RegionPage/VariantsInRegion.tsx
@@ -149,6 +149,12 @@ query ${operationName}($chrom: String!, $start: Int!, $stop: Int!, $datasetId: D
           ac_hemi
           ac_hom
         }
+        fafmax {
+          faf95_max
+          faf95_max_gen_anc
+          faf99_max
+          faf99_max_gen_anc
+        }
       }
       genome {
         ac

--- a/browser/src/TranscriptPage/VariantsInTranscript.tsx
+++ b/browser/src/TranscriptPage/VariantsInTranscript.tsx
@@ -181,6 +181,12 @@ query ${operationName}($transcriptId: String!, $datasetId: DatasetId!, $referenc
           ac_hemi
           ac_hom
         }
+        fafmax {
+          faf95_max
+          faf95_max_gen_anc
+          faf99_max
+          faf99_max_gen_anc
+        }
       }
       genome {
         ac

--- a/browser/src/VariantList/ExportVariantsButton.spec.tsx
+++ b/browser/src/VariantList/ExportVariantsButton.spec.tsx
@@ -1,7 +1,25 @@
 import { test, expect } from '@jest/globals'
 
 import { forAllDatasets } from '../../../tests/__helpers__/datasets'
-import { createPopulationColumns, createVersionSpecificColumns } from './ExportVariantsButton'
+import {
+  createPopulationColumns,
+  createVersionSpecificColumns,
+  Column,
+  getJointFAFFreq,
+  getJointFilters,
+  getJointFAFGroup,
+  getExomeFAFFreq,
+  getExomeFAFGroup,
+  getGenomeFAFFreq,
+  getGenomeFAFGroup,
+  getCadd,
+  getRevel,
+  getSpliceAI,
+  getPangolin,
+  getPhylop,
+  getSift,
+  getPolyphen,
+} from './ExportVariantsButton'
 import {
   GNOMAD_POPULATION_NAMES,
   PopulationId,
@@ -81,37 +99,37 @@ const EXOME_GROUPMAX_FREQ_LABEL = 'Exome GroupMax FAF frequency'
 const GENOME_GROUPMAX_GROUP_LABEL = 'Genome GroupMax FAF group'
 const GENOME_GROUPMAX_FREQ_LABEL = 'Genome GroupMax FAF frequency'
 
-const expectedVersionSpecificColumns: Record<DatasetId, string[]> = {
+const expectedVersionSpecificColumns: Record<DatasetId, Column[]> = {
   exac: [],
   gnomad_r2_1: [
-    EXOME_GROUPMAX_GROUP_LABEL,
-    EXOME_GROUPMAX_FREQ_LABEL,
-    GENOME_GROUPMAX_GROUP_LABEL,
-    GENOME_GROUPMAX_FREQ_LABEL,
+    { label: EXOME_GROUPMAX_GROUP_LABEL, getValue: getExomeFAFGroup },
+    { label: EXOME_GROUPMAX_FREQ_LABEL, getValue: getExomeFAFFreq },
+    { label: GENOME_GROUPMAX_GROUP_LABEL, getValue: getGenomeFAFGroup },
+    { label: GENOME_GROUPMAX_FREQ_LABEL, getValue: getGenomeFAFFreq },
   ],
   gnomad_r2_1_controls: [
-    EXOME_GROUPMAX_GROUP_LABEL,
-    EXOME_GROUPMAX_FREQ_LABEL,
-    GENOME_GROUPMAX_GROUP_LABEL,
-    GENOME_GROUPMAX_FREQ_LABEL,
+    { label: EXOME_GROUPMAX_GROUP_LABEL, getValue: getExomeFAFGroup },
+    { label: EXOME_GROUPMAX_FREQ_LABEL, getValue: getExomeFAFFreq },
+    { label: GENOME_GROUPMAX_GROUP_LABEL, getValue: getGenomeFAFGroup },
+    { label: GENOME_GROUPMAX_FREQ_LABEL, getValue: getGenomeFAFFreq },
   ],
   gnomad_r2_1_non_cancer: [
-    EXOME_GROUPMAX_GROUP_LABEL,
-    EXOME_GROUPMAX_FREQ_LABEL,
-    GENOME_GROUPMAX_GROUP_LABEL,
-    GENOME_GROUPMAX_FREQ_LABEL,
+    { label: EXOME_GROUPMAX_GROUP_LABEL, getValue: getExomeFAFGroup },
+    { label: EXOME_GROUPMAX_FREQ_LABEL, getValue: getExomeFAFFreq },
+    { label: GENOME_GROUPMAX_GROUP_LABEL, getValue: getGenomeFAFGroup },
+    { label: GENOME_GROUPMAX_FREQ_LABEL, getValue: getGenomeFAFFreq },
   ],
   gnomad_r2_1_non_neuro: [
-    EXOME_GROUPMAX_GROUP_LABEL,
-    EXOME_GROUPMAX_FREQ_LABEL,
-    GENOME_GROUPMAX_GROUP_LABEL,
-    GENOME_GROUPMAX_FREQ_LABEL,
+    { label: EXOME_GROUPMAX_GROUP_LABEL, getValue: getExomeFAFGroup },
+    { label: EXOME_GROUPMAX_FREQ_LABEL, getValue: getExomeFAFFreq },
+    { label: GENOME_GROUPMAX_GROUP_LABEL, getValue: getGenomeFAFGroup },
+    { label: GENOME_GROUPMAX_FREQ_LABEL, getValue: getGenomeFAFFreq },
   ],
   gnomad_r2_1_non_topmed: [
-    EXOME_GROUPMAX_GROUP_LABEL,
-    EXOME_GROUPMAX_FREQ_LABEL,
-    GENOME_GROUPMAX_GROUP_LABEL,
-    GENOME_GROUPMAX_FREQ_LABEL,
+    { label: EXOME_GROUPMAX_GROUP_LABEL, getValue: getExomeFAFGroup },
+    { label: EXOME_GROUPMAX_FREQ_LABEL, getValue: getExomeFAFFreq },
+    { label: GENOME_GROUPMAX_GROUP_LABEL, getValue: getGenomeFAFGroup },
+    { label: GENOME_GROUPMAX_FREQ_LABEL, getValue: getGenomeFAFFreq },
   ],
   gnomad_r3: [],
   gnomad_r3_controls_and_biobanks: [],
@@ -123,60 +141,60 @@ const expectedVersionSpecificColumns: Record<DatasetId, string[]> = {
   gnomad_sv_r2_1_controls: [],
   gnomad_sv_r2_1_non_neuro: [],
   gnomad_sv_r4: [
-    JOINT_FILTERS_LABEL,
-    JOINT_GROUPMAX_GROUP_LABEL,
-    JOINT_GROUPMAX_FREQ_LABEL,
-    CADD_LABEL,
-    REVEL_MAX_LABEL,
-    SPLICEAI_DS_MAX_LABEL,
-    PANGOLIN_LARGEST_DS_LABEL,
-    PHYLOP_LABEL,
-    SIFT_MAX_LABEL,
-    POLYPHEN_MAX_LABEL,
+    { label: JOINT_FILTERS_LABEL, getValue: getJointFilters },
+    { label: JOINT_GROUPMAX_GROUP_LABEL, getValue: getJointFAFGroup },
+    { label: JOINT_GROUPMAX_FREQ_LABEL, getValue: getJointFAFFreq },
+    { label: CADD_LABEL, getValue: getCadd },
+    { label: REVEL_MAX_LABEL, getValue: getRevel },
+    { label: SPLICEAI_DS_MAX_LABEL, getValue: getSpliceAI },
+    { label: PANGOLIN_LARGEST_DS_LABEL, getValue: getPangolin },
+    { label: PHYLOP_LABEL, getValue: getPhylop },
+    { label: SIFT_MAX_LABEL, getValue: getSift },
+    { label: POLYPHEN_MAX_LABEL, getValue: getPolyphen },
   ],
   gnomad_cnv_r4: [
-    JOINT_FILTERS_LABEL,
-    JOINT_GROUPMAX_GROUP_LABEL,
-    JOINT_GROUPMAX_FREQ_LABEL,
-    CADD_LABEL,
-    REVEL_MAX_LABEL,
-    SPLICEAI_DS_MAX_LABEL,
-    PANGOLIN_LARGEST_DS_LABEL,
-    PHYLOP_LABEL,
-    SIFT_MAX_LABEL,
-    POLYPHEN_MAX_LABEL,
+    { label: JOINT_FILTERS_LABEL, getValue: getJointFilters },
+    { label: JOINT_GROUPMAX_GROUP_LABEL, getValue: getJointFAFGroup },
+    { label: JOINT_GROUPMAX_FREQ_LABEL, getValue: getJointFAFFreq },
+    { label: CADD_LABEL, getValue: getCadd },
+    { label: REVEL_MAX_LABEL, getValue: getRevel },
+    { label: SPLICEAI_DS_MAX_LABEL, getValue: getSpliceAI },
+    { label: PANGOLIN_LARGEST_DS_LABEL, getValue: getPangolin },
+    { label: PHYLOP_LABEL, getValue: getPhylop },
+    { label: SIFT_MAX_LABEL, getValue: getSift },
+    { label: POLYPHEN_MAX_LABEL, getValue: getPolyphen },
   ],
   gnomad_r4: [
-    JOINT_FILTERS_LABEL,
-    JOINT_GROUPMAX_GROUP_LABEL,
-    JOINT_GROUPMAX_FREQ_LABEL,
-    CADD_LABEL,
-    REVEL_MAX_LABEL,
-    SPLICEAI_DS_MAX_LABEL,
-    PANGOLIN_LARGEST_DS_LABEL,
-    PHYLOP_LABEL,
-    SIFT_MAX_LABEL,
-    POLYPHEN_MAX_LABEL,
+    { label: JOINT_FILTERS_LABEL, getValue: getJointFilters },
+    { label: JOINT_GROUPMAX_GROUP_LABEL, getValue: getJointFAFGroup },
+    { label: JOINT_GROUPMAX_FREQ_LABEL, getValue: getJointFAFFreq },
+    { label: CADD_LABEL, getValue: getCadd },
+    { label: REVEL_MAX_LABEL, getValue: getRevel },
+    { label: SPLICEAI_DS_MAX_LABEL, getValue: getSpliceAI },
+    { label: PANGOLIN_LARGEST_DS_LABEL, getValue: getPangolin },
+    { label: PHYLOP_LABEL, getValue: getPhylop },
+    { label: SIFT_MAX_LABEL, getValue: getSift },
+    { label: POLYPHEN_MAX_LABEL, getValue: getPolyphen },
   ],
   gnomad_r4_non_ukb: [
-    JOINT_FILTERS_LABEL,
-    JOINT_GROUPMAX_GROUP_LABEL,
-    JOINT_GROUPMAX_FREQ_LABEL,
-    CADD_LABEL,
-    REVEL_MAX_LABEL,
-    SPLICEAI_DS_MAX_LABEL,
-    PANGOLIN_LARGEST_DS_LABEL,
-    PHYLOP_LABEL,
-    SIFT_MAX_LABEL,
-    POLYPHEN_MAX_LABEL,
+    { label: JOINT_FILTERS_LABEL, getValue: getJointFilters },
+    { label: JOINT_GROUPMAX_GROUP_LABEL, getValue: getJointFAFGroup },
+    { label: JOINT_GROUPMAX_FREQ_LABEL, getValue: getJointFAFFreq },
+    { label: CADD_LABEL, getValue: getCadd },
+    { label: REVEL_MAX_LABEL, getValue: getRevel },
+    { label: SPLICEAI_DS_MAX_LABEL, getValue: getSpliceAI },
+    { label: PANGOLIN_LARGEST_DS_LABEL, getValue: getPangolin },
+    { label: PHYLOP_LABEL, getValue: getPhylop },
+    { label: SIFT_MAX_LABEL, getValue: getSift },
+    { label: POLYPHEN_MAX_LABEL, getValue: getPolyphen },
   ],
 }
 
 forAllDatasets('createVersionSpecificColumns for %s dataset', (datasetId) => {
-  const columnLabels = expectedVersionSpecificColumns[datasetId]
-  test(`returns the columns ${columnLabels.join(', ')}`, () => {
-    expect(createVersionSpecificColumns(datasetId).map((column) => column.label)).toEqual(
-      columnLabels
-    )
+  const expectedColumns = expectedVersionSpecificColumns[datasetId]
+  const expectedLabels = expectedColumns.map((column) => column.label)
+  test(`returns the columns ${expectedLabels.join(', ')}`, () => {
+    const actual = createVersionSpecificColumns(datasetId)
+    expect(actual).toEqual(expectedColumns)
   })
 })

--- a/browser/src/VariantList/ExportVariantsButton.spec.tsx
+++ b/browser/src/VariantList/ExportVariantsButton.spec.tsx
@@ -8,8 +8,11 @@ import {
   getJointFAFFreq,
   getJointFilters,
   getJointFAFGroup,
-  getExomeFAFFreq,
-  getExomeFAFGroup,
+  getExomeFilters,
+  getV4ExomeFAFFreq,
+  getV4ExomeFAFGroup,
+  getV2ExomeFAFFreq,
+  getV2ExomeFAFGroup,
   getGenomeFAFFreq,
   getGenomeFAFGroup,
   getCadd,
@@ -94,6 +97,7 @@ const PANGOLIN_LARGEST_DS_LABEL = 'pangolin_largest_ds'
 const PHYLOP_LABEL = 'phylop'
 const SIFT_MAX_LABEL = 'sift_max'
 const POLYPHEN_MAX_LABEL = 'polyphen_max'
+const EXOME_FILTERS_LABEL = 'Filters - exome'
 const EXOME_GROUPMAX_GROUP_LABEL = 'Exome GroupMax FAF group'
 const EXOME_GROUPMAX_FREQ_LABEL = 'Exome GroupMax FAF frequency'
 const GENOME_GROUPMAX_GROUP_LABEL = 'Genome GroupMax FAF group'
@@ -102,32 +106,32 @@ const GENOME_GROUPMAX_FREQ_LABEL = 'Genome GroupMax FAF frequency'
 const expectedVersionSpecificColumns: Record<DatasetId, Column[]> = {
   exac: [],
   gnomad_r2_1: [
-    { label: EXOME_GROUPMAX_GROUP_LABEL, getValue: getExomeFAFGroup },
-    { label: EXOME_GROUPMAX_FREQ_LABEL, getValue: getExomeFAFFreq },
+    { label: EXOME_GROUPMAX_GROUP_LABEL, getValue: getV2ExomeFAFGroup },
+    { label: EXOME_GROUPMAX_FREQ_LABEL, getValue: getV2ExomeFAFFreq },
     { label: GENOME_GROUPMAX_GROUP_LABEL, getValue: getGenomeFAFGroup },
     { label: GENOME_GROUPMAX_FREQ_LABEL, getValue: getGenomeFAFFreq },
   ],
   gnomad_r2_1_controls: [
-    { label: EXOME_GROUPMAX_GROUP_LABEL, getValue: getExomeFAFGroup },
-    { label: EXOME_GROUPMAX_FREQ_LABEL, getValue: getExomeFAFFreq },
+    { label: EXOME_GROUPMAX_GROUP_LABEL, getValue: getV2ExomeFAFGroup },
+    { label: EXOME_GROUPMAX_FREQ_LABEL, getValue: getV2ExomeFAFFreq },
     { label: GENOME_GROUPMAX_GROUP_LABEL, getValue: getGenomeFAFGroup },
     { label: GENOME_GROUPMAX_FREQ_LABEL, getValue: getGenomeFAFFreq },
   ],
   gnomad_r2_1_non_cancer: [
-    { label: EXOME_GROUPMAX_GROUP_LABEL, getValue: getExomeFAFGroup },
-    { label: EXOME_GROUPMAX_FREQ_LABEL, getValue: getExomeFAFFreq },
+    { label: EXOME_GROUPMAX_GROUP_LABEL, getValue: getV2ExomeFAFGroup },
+    { label: EXOME_GROUPMAX_FREQ_LABEL, getValue: getV2ExomeFAFFreq },
     { label: GENOME_GROUPMAX_GROUP_LABEL, getValue: getGenomeFAFGroup },
     { label: GENOME_GROUPMAX_FREQ_LABEL, getValue: getGenomeFAFFreq },
   ],
   gnomad_r2_1_non_neuro: [
-    { label: EXOME_GROUPMAX_GROUP_LABEL, getValue: getExomeFAFGroup },
-    { label: EXOME_GROUPMAX_FREQ_LABEL, getValue: getExomeFAFFreq },
+    { label: EXOME_GROUPMAX_GROUP_LABEL, getValue: getV2ExomeFAFGroup },
+    { label: EXOME_GROUPMAX_FREQ_LABEL, getValue: getV2ExomeFAFFreq },
     { label: GENOME_GROUPMAX_GROUP_LABEL, getValue: getGenomeFAFGroup },
     { label: GENOME_GROUPMAX_FREQ_LABEL, getValue: getGenomeFAFFreq },
   ],
   gnomad_r2_1_non_topmed: [
-    { label: EXOME_GROUPMAX_GROUP_LABEL, getValue: getExomeFAFGroup },
-    { label: EXOME_GROUPMAX_FREQ_LABEL, getValue: getExomeFAFFreq },
+    { label: EXOME_GROUPMAX_GROUP_LABEL, getValue: getV2ExomeFAFGroup },
+    { label: EXOME_GROUPMAX_FREQ_LABEL, getValue: getV2ExomeFAFFreq },
     { label: GENOME_GROUPMAX_GROUP_LABEL, getValue: getGenomeFAFGroup },
     { label: GENOME_GROUPMAX_FREQ_LABEL, getValue: getGenomeFAFFreq },
   ],
@@ -177,9 +181,9 @@ const expectedVersionSpecificColumns: Record<DatasetId, Column[]> = {
     { label: POLYPHEN_MAX_LABEL, getValue: getPolyphen },
   ],
   gnomad_r4_non_ukb: [
-    { label: JOINT_FILTERS_LABEL, getValue: getJointFilters },
-    { label: JOINT_GROUPMAX_GROUP_LABEL, getValue: getJointFAFGroup },
-    { label: JOINT_GROUPMAX_FREQ_LABEL, getValue: getJointFAFFreq },
+    { label: EXOME_FILTERS_LABEL, getValue: getExomeFilters },
+    { label: EXOME_GROUPMAX_GROUP_LABEL, getValue: getV4ExomeFAFGroup },
+    { label: EXOME_GROUPMAX_FREQ_LABEL, getValue: getV4ExomeFAFFreq },
     { label: CADD_LABEL, getValue: getCadd },
     { label: REVEL_MAX_LABEL, getValue: getRevel },
     { label: SPLICEAI_DS_MAX_LABEL, getValue: getSpliceAI },

--- a/browser/src/VariantList/ExportVariantsButton.spec.tsx
+++ b/browser/src/VariantList/ExportVariantsButton.spec.tsx
@@ -1,7 +1,7 @@
 import { test, expect } from '@jest/globals'
 
 import { forAllDatasets } from '../../../tests/__helpers__/datasets'
-import { createPopulationColumns } from './ExportVariantsButton'
+import { createPopulationColumns, createVersionSpecificColumns } from './ExportVariantsButton'
 import {
   GNOMAD_POPULATION_NAMES,
   PopulationId,
@@ -55,13 +55,128 @@ const createExpectedPopulationColumns = (populations: PopulationId[]) => {
   return populationColumns
 }
 
-forAllDatasets('DatasetSelector with "%s" selected', (datasetId) => {
+forAllDatasets('ExportVariantsButton with "%s" selected', (datasetId) => {
   test('returns the expected genetic ancestry group columns', () => {
     const expectedPopulations = getDatasetPopulations(datasetId)
     const result = createPopulationColumns(datasetId)
 
     expect(getAllPopulationColumns(result)).toStrictEqual(
       createExpectedPopulationColumns(expectedPopulations)
+    )
+  })
+})
+
+const JOINT_FILTERS_LABEL = 'Filters - joint'
+const JOINT_GROUPMAX_GROUP_LABEL = 'GroupMax FAF group'
+const JOINT_GROUPMAX_FREQ_LABEL = 'GroupMax FAF frequency'
+const CADD_LABEL = 'cadd'
+const REVEL_MAX_LABEL = 'revel_max'
+const SPLICEAI_DS_MAX_LABEL = 'spliceai_ds_max'
+const PANGOLIN_LARGEST_DS_LABEL = 'pangolin_largest_ds'
+const PHYLOP_LABEL = 'phylop'
+const SIFT_MAX_LABEL = 'sift_max'
+const POLYPHEN_MAX_LABEL = 'polyphen_max'
+const EXOME_GROUPMAX_GROUP_LABEL = 'Exome GroupMax FAF group'
+const EXOME_GROUPMAX_FREQ_LABEL = 'Exome GroupMax FAF frequency'
+const GENOME_GROUPMAX_GROUP_LABEL = 'Genome GroupMax FAF group'
+const GENOME_GROUPMAX_FREQ_LABEL = 'Genome GroupMax FAF frequency'
+
+const expectedVersionSpecificColumns: Record<DatasetId, string[]> = {
+  exac: [],
+  gnomad_r2_1: [
+    EXOME_GROUPMAX_GROUP_LABEL,
+    EXOME_GROUPMAX_FREQ_LABEL,
+    GENOME_GROUPMAX_GROUP_LABEL,
+    GENOME_GROUPMAX_FREQ_LABEL,
+  ],
+  gnomad_r2_1_controls: [
+    EXOME_GROUPMAX_GROUP_LABEL,
+    EXOME_GROUPMAX_FREQ_LABEL,
+    GENOME_GROUPMAX_GROUP_LABEL,
+    GENOME_GROUPMAX_FREQ_LABEL,
+  ],
+  gnomad_r2_1_non_cancer: [
+    EXOME_GROUPMAX_GROUP_LABEL,
+    EXOME_GROUPMAX_FREQ_LABEL,
+    GENOME_GROUPMAX_GROUP_LABEL,
+    GENOME_GROUPMAX_FREQ_LABEL,
+  ],
+  gnomad_r2_1_non_neuro: [
+    EXOME_GROUPMAX_GROUP_LABEL,
+    EXOME_GROUPMAX_FREQ_LABEL,
+    GENOME_GROUPMAX_GROUP_LABEL,
+    GENOME_GROUPMAX_FREQ_LABEL,
+  ],
+  gnomad_r2_1_non_topmed: [
+    EXOME_GROUPMAX_GROUP_LABEL,
+    EXOME_GROUPMAX_FREQ_LABEL,
+    GENOME_GROUPMAX_GROUP_LABEL,
+    GENOME_GROUPMAX_FREQ_LABEL,
+  ],
+  gnomad_r3: [],
+  gnomad_r3_controls_and_biobanks: [],
+  gnomad_r3_non_cancer: [],
+  gnomad_r3_non_neuro: [],
+  gnomad_r3_non_topmed: [],
+  gnomad_r3_non_v2: [],
+  gnomad_sv_r2_1: [],
+  gnomad_sv_r2_1_controls: [],
+  gnomad_sv_r2_1_non_neuro: [],
+  gnomad_sv_r4: [
+    JOINT_FILTERS_LABEL,
+    JOINT_GROUPMAX_GROUP_LABEL,
+    JOINT_GROUPMAX_FREQ_LABEL,
+    CADD_LABEL,
+    REVEL_MAX_LABEL,
+    SPLICEAI_DS_MAX_LABEL,
+    PANGOLIN_LARGEST_DS_LABEL,
+    PHYLOP_LABEL,
+    SIFT_MAX_LABEL,
+    POLYPHEN_MAX_LABEL,
+  ],
+  gnomad_cnv_r4: [
+    JOINT_FILTERS_LABEL,
+    JOINT_GROUPMAX_GROUP_LABEL,
+    JOINT_GROUPMAX_FREQ_LABEL,
+    CADD_LABEL,
+    REVEL_MAX_LABEL,
+    SPLICEAI_DS_MAX_LABEL,
+    PANGOLIN_LARGEST_DS_LABEL,
+    PHYLOP_LABEL,
+    SIFT_MAX_LABEL,
+    POLYPHEN_MAX_LABEL,
+  ],
+  gnomad_r4: [
+    JOINT_FILTERS_LABEL,
+    JOINT_GROUPMAX_GROUP_LABEL,
+    JOINT_GROUPMAX_FREQ_LABEL,
+    CADD_LABEL,
+    REVEL_MAX_LABEL,
+    SPLICEAI_DS_MAX_LABEL,
+    PANGOLIN_LARGEST_DS_LABEL,
+    PHYLOP_LABEL,
+    SIFT_MAX_LABEL,
+    POLYPHEN_MAX_LABEL,
+  ],
+  gnomad_r4_non_ukb: [
+    JOINT_FILTERS_LABEL,
+    JOINT_GROUPMAX_GROUP_LABEL,
+    JOINT_GROUPMAX_FREQ_LABEL,
+    CADD_LABEL,
+    REVEL_MAX_LABEL,
+    SPLICEAI_DS_MAX_LABEL,
+    PANGOLIN_LARGEST_DS_LABEL,
+    PHYLOP_LABEL,
+    SIFT_MAX_LABEL,
+    POLYPHEN_MAX_LABEL,
+  ],
+}
+
+forAllDatasets('createVersionSpecificColumns for %s dataset', (datasetId) => {
+  const columnLabels = expectedVersionSpecificColumns[datasetId]
+  test(`returns the columns ${columnLabels.join(', ')}`, () => {
+    expect(createVersionSpecificColumns(datasetId).map((column) => column.label)).toEqual(
+      columnLabels
     )
   })
 })

--- a/dataset-metadata/metadata.ts
+++ b/dataset-metadata/metadata.ts
@@ -72,6 +72,7 @@ export type DatasetMetadata = {
   shortVariantDatasetId: DatasetId
   structuralVariantDatasetId: DatasetId
   copyNumberVariantDatasetId: DatasetId
+  hasJointFrequencyData: boolean
 }
 
 const metadata: Record<DatasetId, DatasetMetadata> = {
@@ -122,6 +123,7 @@ const metadata: Record<DatasetId, DatasetMetadata> = {
     isV4CNVs: false,
     copyNumberVariantDatasetId: 'gnomad_cnv_r4',
     hasCopyNumberVariantCoverage: false,
+    hasJointFrequencyData: false,
   },
   gnomad_r2_1: {
     isSubset: false,
@@ -170,6 +172,7 @@ const metadata: Record<DatasetId, DatasetMetadata> = {
     isV4CNVs: false,
     copyNumberVariantDatasetId: 'gnomad_cnv_r4',
     hasCopyNumberVariantCoverage: false,
+    hasJointFrequencyData: false,
   },
   gnomad_r2_1_controls: {
     isSubset: true,
@@ -218,6 +221,7 @@ const metadata: Record<DatasetId, DatasetMetadata> = {
     isV4CNVs: false,
     copyNumberVariantDatasetId: 'gnomad_cnv_r4',
     hasCopyNumberVariantCoverage: false,
+    hasJointFrequencyData: false,
   },
   gnomad_r2_1_non_cancer: {
     isSubset: true,
@@ -266,6 +270,7 @@ const metadata: Record<DatasetId, DatasetMetadata> = {
     isV4CNVs: false,
     copyNumberVariantDatasetId: 'gnomad_cnv_r4',
     hasCopyNumberVariantCoverage: false,
+    hasJointFrequencyData: false,
   },
   gnomad_r2_1_non_neuro: {
     isSubset: true,
@@ -314,6 +319,7 @@ const metadata: Record<DatasetId, DatasetMetadata> = {
     isV4CNVs: false,
     copyNumberVariantDatasetId: 'gnomad_cnv_r4',
     hasCopyNumberVariantCoverage: false,
+    hasJointFrequencyData: false,
   },
   gnomad_r2_1_non_topmed: {
     isSubset: true,
@@ -362,6 +368,7 @@ const metadata: Record<DatasetId, DatasetMetadata> = {
     isV4CNVs: false,
     copyNumberVariantDatasetId: 'gnomad_cnv_r4',
     hasCopyNumberVariantCoverage: false,
+    hasJointFrequencyData: false,
   },
   gnomad_r3: {
     isSubset: false,
@@ -410,6 +417,7 @@ const metadata: Record<DatasetId, DatasetMetadata> = {
     isV4CNVs: false,
     copyNumberVariantDatasetId: 'gnomad_cnv_r4',
     hasCopyNumberVariantCoverage: false,
+    hasJointFrequencyData: false,
   },
   gnomad_r3_controls_and_biobanks: {
     isSubset: true,
@@ -458,6 +466,7 @@ const metadata: Record<DatasetId, DatasetMetadata> = {
     isV4CNVs: false,
     copyNumberVariantDatasetId: 'gnomad_cnv_r4',
     hasCopyNumberVariantCoverage: false,
+    hasJointFrequencyData: false,
   },
   gnomad_r3_non_cancer: {
     isSubset: true,
@@ -506,6 +515,7 @@ const metadata: Record<DatasetId, DatasetMetadata> = {
     isV4CNVs: false,
     copyNumberVariantDatasetId: 'gnomad_cnv_r4',
     hasCopyNumberVariantCoverage: false,
+    hasJointFrequencyData: false,
   },
   gnomad_r3_non_neuro: {
     isSubset: true,
@@ -554,6 +564,7 @@ const metadata: Record<DatasetId, DatasetMetadata> = {
     isV4CNVs: false,
     copyNumberVariantDatasetId: 'gnomad_cnv_r4',
     hasCopyNumberVariantCoverage: false,
+    hasJointFrequencyData: false,
   },
   gnomad_r3_non_topmed: {
     isSubset: true,
@@ -602,6 +613,7 @@ const metadata: Record<DatasetId, DatasetMetadata> = {
     isV4CNVs: false,
     copyNumberVariantDatasetId: 'gnomad_cnv_r4',
     hasCopyNumberVariantCoverage: false,
+    hasJointFrequencyData: false,
   },
   gnomad_r3_non_v2: {
     isSubset: true,
@@ -650,6 +662,7 @@ const metadata: Record<DatasetId, DatasetMetadata> = {
     isV4CNVs: false,
     copyNumberVariantDatasetId: 'gnomad_cnv_r4',
     hasCopyNumberVariantCoverage: false,
+    hasJointFrequencyData: false,
   },
   gnomad_sv_r2_1: {
     isSubset: false,
@@ -698,6 +711,7 @@ const metadata: Record<DatasetId, DatasetMetadata> = {
     isV4CNVs: false,
     copyNumberVariantDatasetId: 'gnomad_cnv_r4',
     hasCopyNumberVariantCoverage: false,
+    hasJointFrequencyData: false,
   },
   gnomad_sv_r2_1_controls: {
     isSubset: true,
@@ -746,6 +760,7 @@ const metadata: Record<DatasetId, DatasetMetadata> = {
     isV4CNVs: false,
     copyNumberVariantDatasetId: 'gnomad_cnv_r4',
     hasCopyNumberVariantCoverage: false,
+    hasJointFrequencyData: false,
   },
   gnomad_sv_r2_1_non_neuro: {
     isSubset: true,
@@ -794,6 +809,7 @@ const metadata: Record<DatasetId, DatasetMetadata> = {
     isV4CNVs: false,
     copyNumberVariantDatasetId: 'gnomad_cnv_r4',
     hasCopyNumberVariantCoverage: false,
+    hasJointFrequencyData: false,
   },
   gnomad_sv_r4: {
     isSubset: false,
@@ -842,6 +858,7 @@ const metadata: Record<DatasetId, DatasetMetadata> = {
     isV4CNVs: false,
     copyNumberVariantDatasetId: 'gnomad_cnv_r4',
     hasCopyNumberVariantCoverage: false,
+    hasJointFrequencyData: true,
   },
   gnomad_cnv_r4: {
     isSubset: false,
@@ -890,6 +907,7 @@ const metadata: Record<DatasetId, DatasetMetadata> = {
     isV4CNVs: true,
     copyNumberVariantDatasetId: 'gnomad_cnv_r4',
     hasCopyNumberVariantCoverage: true,
+    hasJointFrequencyData: true,
   },
   gnomad_r4: {
     isSubset: false,
@@ -938,6 +956,7 @@ const metadata: Record<DatasetId, DatasetMetadata> = {
     isV4CNVs: false,
     copyNumberVariantDatasetId: 'gnomad_cnv_r4',
     hasCopyNumberVariantCoverage: false,
+    hasJointFrequencyData: true,
   },
   gnomad_r4_non_ukb: {
     isSubset: true,
@@ -986,6 +1005,7 @@ const metadata: Record<DatasetId, DatasetMetadata> = {
     copyNumberVariantDatasetId: 'gnomad_cnv_r4',
     hasCopyNumberVariantCoverage: false,
     hasRelatedVariants: true,
+    hasJointFrequencyData: false,
   },
 }
 
@@ -1116,3 +1136,6 @@ export const hasCopyNumberVariantCoverage = (datasetId: DatasetId) =>
 
 export const baseDatasetForReferenceGenome = (genome: ReferenceGenome): DatasetId =>
   genome === 'GRCh37' ? 'gnomad_r2_1' : 'gnomad_r4'
+
+export const hasJointFrequencyData = (datasetId: DatasetId): boolean =>
+  getMetadata(datasetId, 'hasJointFrequencyData')

--- a/graphql-api/src/graphql/types/variant.graphql
+++ b/graphql-api/src/graphql/types/variant.graphql
@@ -99,6 +99,13 @@ type LoFCuration {
   project: String!
 }
 
+type Fafmax {
+  faf95_max: Float
+  faf95_max_gen_anc: String
+  faf99_max: Float
+  faf99_max_gen_anc: String
+}
+
 type VariantSequencingTypeData {
   ac: Int
   an: Int
@@ -107,6 +114,7 @@ type VariantSequencingTypeData {
   filters: [String!]
   populations: [VariantPopulation]
   faf95: VariantFilteringAlleleFrequency
+  fafmax: Fafmax
 
   # Deprecated - calculate from AC and AN
   # Preserved for compatibility with existing browser queries
@@ -117,13 +125,6 @@ type VariantSequencingTypeData {
   ac_hemi: Int
 }
 
-type JointFafmax {
-  faf95_max: Float
-  faf95_max_gen_anc: String
-  faf99_max: Float
-  faf99_max_gen_anc: String
-}
-
 type VariantJointSequencingTypeData {
   ac: Int
   an: Int
@@ -131,7 +132,7 @@ type VariantJointSequencingTypeData {
   hemizygote_count: Int
   filters: [String!]
   populations: [VariantPopulation]
-  fafmax: JointFafmax
+  fafmax: Fafmax
 }
 
 type NonCodingConstraintRegion {

--- a/graphql-api/src/queries/variant-datasets/gnomad-v4-variant-queries.ts
+++ b/graphql-api/src/queries/variant-datasets/gnomad-v4-variant-queries.ts
@@ -309,6 +309,7 @@ const shapeVariantSummary = (subset: Subset, context: any) => {
               (pop: any) => !(pop.id.includes('_') || pop.id === 'XX' || pop.id === 'XY')
             ),
             filters: exomeFilters,
+            fafmax: variant.exome.fafmax[subset],
           }
         : null,
       genome: hasGenomeVariant
@@ -349,6 +350,7 @@ const getMultiVariantSourceFields = (
     `value.genome.freq.${genomeSubset}`,
     `value.joint.freq.${jointSubset}`,
     'value.exome.filters',
+    'value.exome.fafmax',
     'value.genome.filters',
     'value.joint.filters',
     'value.alleles',


### PR DESCRIPTION
The root of the problem was that the browser was trying to export some joint-frequency columns, which the non-UKB subset doesn't have. This fix uses the corresponding columns from the exome instead.