### PR TITLE
chore(graphql-api): revert es aliases to generic names

### DIFF
--- a/graphql-api/src/queries/copy-number-variant-queries.ts
+++ b/graphql-api/src/queries/copy-number-variant-queries.ts
@@ -1,6 +1,6 @@
 import { fetchAllSearchResults } from './helpers/elasticsearch-helpers'
 
-const GNOMAD_COPY_NUMBER_VARIANTS_V4_INDEX = 'v4p1_gnomad_v4_cnvs'
+const GNOMAD_COPY_NUMBER_VARIANTS_V4_INDEX = 'gnomad_v4_cnvs'
 
 type CnvDatasetId = 'gnomad_cnv_r4'
 type DatasetDependentQueryParams = {

--- a/graphql-api/src/queries/gene-queries.ts
+++ b/graphql-api/src/queries/gene-queries.ts
@@ -4,7 +4,7 @@ import { fetchAllSearchResults } from './helpers/elasticsearch-helpers'
 
 const GENE_INDICES = {
   GRCh37: 'genes_grch37',
-  GRCh38: 'v4p1_genes_grch38',
+  GRCh38: 'genes_grch38',
 }
 
 const _fetchGeneById = async (esClient: any, geneId: any, referenceGenome: any) => {

--- a/graphql-api/src/queries/structural-variant-queries.spec.ts
+++ b/graphql-api/src/queries/structural-variant-queries.spec.ts
@@ -54,9 +54,7 @@ const makeMockClient = (response: any) => {
 }
 
 const expectedIndex = (datasetId: SvDatasetId) =>
-  datasetId === 'gnomad_sv_r4'
-    ? 'v4p1_gnomad_structural_variants_v3'
-    : 'gnomad_structural_variants_v2'
+  datasetId === 'gnomad_sv_r4' ? 'gnomad_structural_variants_v3' : 'gnomad_structural_variants_v2'
 
 describe('fetchStructuralVariantById', () => {
   const variantId = 'dummy-variant'

--- a/graphql-api/src/queries/structural-variant-queries.ts
+++ b/graphql-api/src/queries/structural-variant-queries.ts
@@ -3,7 +3,7 @@ import { isEmpty } from 'lodash'
 import { fetchAllSearchResults } from './helpers/elasticsearch-helpers'
 
 const GNOMAD_STRUCTURAL_VARIANTS_V2_INDEX = 'gnomad_structural_variants_v2'
-const GNOMAD_STRUCTURAL_VARIANTS_V3_INDEX = 'v4p1_gnomad_structural_variants_v3'
+const GNOMAD_STRUCTURAL_VARIANTS_V3_INDEX = 'gnomad_structural_variants_v3'
 
 type SvDatasetId =
   | 'gnomad_sv_r2_1'

--- a/graphql-api/src/queries/variant-datasets/gnomad-v4-variant-queries.ts
+++ b/graphql-api/src/queries/variant-datasets/gnomad-v4-variant-queries.ts
@@ -12,7 +12,7 @@ import { getFlagsForContext } from './shared/flags'
 import { getConsequenceForContext } from './shared/transcriptConsequence'
 import largeGenes from '../helpers/large-genes'
 
-const GNOMAD_V4_VARIANT_INDEX = 'v4p1_gnomad_v4_variants'
+const GNOMAD_V4_VARIANT_INDEX = 'gnomad_v4_variants'
 
 type Subset = 'all' | 'non_ukb'
 


### PR DESCRIPTION
Importantly, this must be accompanied by the aliases changed in this PR (`genes_grch38`, `gnomad_v4_variants`, `gnomad_structural_variants_v3`, `gnomad_v4_cnvs`) to already have been re-pointed at the correct indices.

Just did a double check, and the current indices associated with these aliases are:

```
genes_grch38:             genes_grch38-2024-04-03--12-30
v4p1_genes_grch38:        genes_grch38-2024-04-03--12-30 

gnomad_v4_variants:       gnomad_v4_variants-2024-04-17--20-50   
v4p1_gnomad_v4_variants:  gnomad_v4_variants-2024-04-17--20-50   

gnomad_structural_variants_v3:      phil_demo_gnomad_structural_variants_v3-2024-04-08--18-30 
v4p1_gnomad_structural_variants_v3: phil_demo_gnomad_structural_variants_v3-2024-04-08--18-30 

gnomad_v4_cnvs:           gnomad_v4_cnvs-2024-04-24--20-12
v4p1_gnomad_v4_cnvs:      gnomad_v4_cnvs-2024-04-24--20-12 
```

So we should be good to merge and deploy this all smoothly.

After this PR is merged and deployed, we can safely drop the 4 aliases ~~indices~~ no longer referenced (the 4 above preprended with `v4p1_...`, e.g. `v4p1_genes_grch38`)

There's also some cleaning up of indices and aliases we should probably do, lots of various old indices and aliases floating around