### PR TITLE
feat(data-pipelines): allow pinning of hail in requirements

### DIFF
--- a/.github/workflows/deploy-scripts-ci.yml
+++ b/.github/workflows/deploy-scripts-ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.9
       - name: Use pip cache
         uses: actions/cache@v2
         with:

--- a/data-pipeline/requirements.txt
+++ b/data-pipeline/requirements.txt
@@ -1,5 +1,5 @@
 elasticsearch~=7.17
-hail
+hail==0.2.127
 tqdm
 loguru
 attrs

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,2 @@
 black==22.3.0  # This should be kept in sync with the version in .pre-commit-config.yaml
-pylint==2.6.0
+pylint==2.7.1


### PR DESCRIPTION
Allows pinning of hail in `data-pipeline/requirements.txt`, and pins it.

`deployctl`'s `start_cluster` command now checks if the locally installed version of hail is the same as the version pinned in `requirements.txt`, and raises and error if not. 

Since `deployctl` calls `hailctl` in its `start_cluster` command, this approach allows pinning of hail by manually checking the versions match.