### PR TITLE
Hide readviz by default

### DIFF
--- a/browser/help/topics/hidden-reads-visualizations.md
+++ b/browser/help/topics/hidden-reads-visualizations.md
@@ -1,0 +1,8 @@
+---
+id: hidden-reads-visualization
+title: 'Reads visualization hidden by default'
+---
+
+Visualizations of reads data is hidden by default. This helps to save cost on egress fees.
+
+Users can opt into loading the reads data for a variant once by clicking the "Load read data" button, and can opt to have the read data always load on variant pages by checking the "Always load read data" box.

--- a/browser/src/ReadData/ReadData.spec.tsx
+++ b/browser/src/ReadData/ReadData.spec.tsx
@@ -38,6 +38,9 @@ const {
 } = mockQueries()
 
 beforeEach(() => {
+  localStorage.clear()
+  localStorage.setItem('alwaysLoadReadsDataOnVariantPage', 'true')
+
   Query.mockImplementation(
     jest.fn(({ query, children, operationName, variables }) =>
       simulateApiResponse('Query', query, children, operationName, variables)

--- a/browser/src/ReadData/ReadData.tsx
+++ b/browser/src/ReadData/ReadData.tsx
@@ -154,7 +154,26 @@ type OwnReadDataProps = {
   showHemizygotes?: boolean
 }
 
-type ReadDataState = any
+type SequencingType = 'exome' | 'genome'
+
+type TrackCategory = 'het' | 'hom' | 'hemi'
+
+type ReadDataTracks = {
+  het: number
+  hom: number
+  hemi: number
+}
+
+type ReadDataState = {
+  tracksAvailable: {
+    exome: ReadDataTracks
+    genome: ReadDataTracks
+  }
+  tracksLoaded: {
+    exome: ReadDataTracks
+    genome: ReadDataTracks
+  }
+}
 
 type ReadDataProps = OwnReadDataProps & typeof ReadData.defaultProps
 
@@ -236,7 +255,7 @@ class ReadData extends Component<ReadDataProps, ReadDataState> {
     return false
   }
 
-  canLoadMoreTracks(exomeOrGenome: any, category: any) {
+  canLoadMoreTracks(exomeOrGenome: SequencingType, category: TrackCategory) {
     const { showHemizygotes } = this.props
     const { tracksAvailable, tracksLoaded } = this.state
 
@@ -254,9 +273,8 @@ class ReadData extends Component<ReadDataProps, ReadDataState> {
     return tracksLoadedForCategory < tracksAvailableForCategory
   }
 
-  loadNextTrack(exomeOrGenome: any, category: any) {
+  loadNextTrack(exomeOrGenome: SequencingType, category: TrackCategory) {
     const { exomeReads, genomeReads } = this.props
-    // @ts-expect-error TS(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
     const reads = {
       exome: exomeReads,
       genome: genomeReads,
@@ -307,8 +325,8 @@ class ReadData extends Component<ReadDataProps, ReadDataState> {
   }
 
   loadInitialTracks() {
-    ;['exome', 'genome'].forEach((exomeOrGenome) => {
-      ;['het', 'hom', 'hemi'].forEach((category) => {
+    ;(['exome', 'genome'] as SequencingType[]).forEach((exomeOrGenome) => {
+      ;(['het', 'hom', 'hemi'] as TrackCategory[]).forEach((category) => {
         if (this.canLoadMoreTracks(exomeOrGenome, category)) {
           this.loadNextTrack(exomeOrGenome, category)
         }
@@ -319,8 +337,8 @@ class ReadData extends Component<ReadDataProps, ReadDataState> {
   loadAllTracks() {
     const { tracksAvailable, tracksLoaded } = this.state
 
-    ;['exome', 'genome'].forEach((exomeOrGenome) => {
-      ;['het', 'hom', 'hemi'].forEach((category) => {
+    ;(['exome', 'genome'] as SequencingType[]).forEach((exomeOrGenome) => {
+      ;(['het', 'hom', 'hemi'] as TrackCategory[]).forEach((category) => {
         const tracksAvailableForCategory = tracksAvailable[exomeOrGenome][category]
         const tracksLoadedForCategory = tracksLoaded[exomeOrGenome][category]
 

--- a/browser/src/ReadData/__snapshots__/ReadData.spec.tsx.snap
+++ b/browser/src/ReadData/__snapshots__/ReadData.spec.tsx.snap
@@ -1,7 +1,136 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ReadData with "exac" dataset selected has no unexpected changes with exome and genome data both missing 1`] = `
+[
+  .c2 {
+  box-sizing: border-box;
+  height: calc(2em + 2px);
+  padding: 0.375em 0.75em;
+  border-color: #6c757d;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0.5em;
+  background-color: #f8f9fa;
+  cursor: pointer;
+  font-size: 1em;
+  line-height: 1.25;
+  outline: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c2:active,
+.c2:hover {
+  background-color: #cbd3da;
+}
+
+.c2:disabled {
+  background-color: rgba(248,249,250,0.5);
+  cursor: not-allowed;
+}
+
+.c2:focus {
+  box-shadow: 0 0 0 0.2em rgba(108,117,125,0.5);
+}
+
+.c2 svg {
+  position: relative;
+  top: 0.11em;
+  width: 0.9em;
+  height: 0.9em;
+}
+
+.c3 {
+  margin-right: 0.5em;
+}
+
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  outline: none;
+  padding: 0 3px;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.c1 img {
+  position: relative;
+  top: 0.13em;
+  width: 14px;
+  height: 14px;
+  border-radius: 7px;
+}
+
+.c1:focus img {
+  box-shadow: 0 0 0 0.2em rgba(70,130,180,0.5);
+}
+
 .c0 {
+  margin-bottom: 3rem;
+}
+
+<div
+    className="c0"
+  >
+    <button
+      className="c1"
+      onClick={[Function]}
+      type="button"
+    >
+      <img
+        alt=""
+        aria-hidden="true"
+        src="test-file-stub"
+      />
+      <span
+        style={
+          {
+            "border": "0",
+            "clip": "rect(0 0 0 0)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+      >
+        More information
+      </span>
+    </button>
+     
+    <button
+      className="c2"
+      disabled={false}
+      id="load-once"
+      onClick={[Function]}
+      type="button"
+    >
+      Load read data
+    </button>
+    <div>
+      <br />
+      <input
+        checked={true}
+        className="c3"
+        id="always-load"
+        onChange={[Function]}
+        type="checkbox"
+      />
+      Always load read data
+    </div>
+  </div>,
+  .c0 {
   position: relative;
   top: -0.1em;
   display: inline-block;
@@ -16,22 +145,152 @@ exports[`ReadData with "exac" dataset selected has no unexpected changes with ex
 }
 
 <div>
-  <p>
-    No read data available for this variant.
-  </p>
-  <p>
-    <span
-      className="c0"
-    >
-      Note
-    </span>
-     Read data for non-coding regions is not available in gnomAD v2.1.1 and ExAC.
-  </p>
-</div>
+    <p>
+      No read data available for this variant.
+    </p>
+    <p>
+      <span
+        className="c0"
+      >
+        Note
+      </span>
+       Read data for non-coding regions is not available in gnomAD v2.1.1 and ExAC.
+    </p>
+  </div>,
+]
 `;
 
 exports[`ReadData with "exac" dataset selected has no unexpected changes with exome data present 1`] = `
-.c2 {
+[
+  .c2 {
+  box-sizing: border-box;
+  height: calc(2em + 2px);
+  padding: 0.375em 0.75em;
+  border-color: #6c757d;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0.5em;
+  background-color: #f8f9fa;
+  cursor: pointer;
+  font-size: 1em;
+  line-height: 1.25;
+  outline: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c2:active,
+.c2:hover {
+  background-color: #cbd3da;
+}
+
+.c2:disabled {
+  background-color: rgba(248,249,250,0.5);
+  cursor: not-allowed;
+}
+
+.c2:focus {
+  box-shadow: 0 0 0 0.2em rgba(108,117,125,0.5);
+}
+
+.c2 svg {
+  position: relative;
+  top: 0.11em;
+  width: 0.9em;
+  height: 0.9em;
+}
+
+.c3 {
+  margin-right: 0.5em;
+}
+
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  outline: none;
+  padding: 0 3px;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.c1 img {
+  position: relative;
+  top: 0.13em;
+  width: 14px;
+  height: 14px;
+  border-radius: 7px;
+}
+
+.c1:focus img {
+  box-shadow: 0 0 0 0.2em rgba(70,130,180,0.5);
+}
+
+.c0 {
+  margin-bottom: 3rem;
+}
+
+<div
+    className="c0"
+  >
+    <button
+      className="c1"
+      onClick={[Function]}
+      type="button"
+    >
+      <img
+        alt=""
+        aria-hidden="true"
+        src="test-file-stub"
+      />
+      <span
+        style={
+          {
+            "border": "0",
+            "clip": "rect(0 0 0 0)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+      >
+        More information
+      </span>
+    </button>
+     
+    <button
+      className="c2"
+      disabled={false}
+      id="load-once"
+      onClick={[Function]}
+      type="button"
+    >
+      Load read data
+    </button>
+    <div>
+      <br />
+      <input
+        checked={true}
+        className="c3"
+        id="always-load"
+        onChange={[Function]}
+        type="checkbox"
+      />
+      Always load read data
+    </div>
+  </div>,
+  .c2 {
   box-sizing: border-box;
   height: calc(2em + 2px);
   padding: 0.375em 0.75em;
@@ -135,75 +394,76 @@ exports[`ReadData with "exac" dataset selected has no unexpected changes with ex
 }
 
 <div>
-  <p>
-    This interactive
-     
-    <a
-      className="c0"
-      href="https://github.com/igvteam/igv.js"
-      rel="noopener noreferrer"
-      target="_blank"
+    <p>
+      This interactive
+       
+      <a
+        className="c0"
+        href="https://github.com/igvteam/igv.js"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        IGV.js
+      </a>
+       visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
+    </p>
+    <p>
+      These are reassembled reads produced by
+       
+      <a
+        className="c0"
+        href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        GATK HaplotypeCaller --bamOutput
+      </a>
+      , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
+    </p>
+    <div
+      className="c1"
     >
-      IGV.js
-    </a>
-     visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
-  </p>
-  <p>
-    These are reassembled reads produced by
-     
-    <a
-      className="c0"
-      href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
-      rel="noopener noreferrer"
-      target="_blank"
+      <strong>
+        Exomes:
+      </strong>
+      <button
+        className="c2"
+        disabled={true}
+        onClick={[Function]}
+        type="button"
+      >
+        Load +1 
+        het
+      </button>
+      <button
+        className="c2"
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+      >
+        Load +1 
+        hom
+      </button>
+    </div>
+    <div
+      className="c1"
     >
-      GATK HaplotypeCaller --bamOutput
-    </a>
-    , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
-  </p>
-  <div
-    className="c1"
-  >
-    <strong>
-      Exomes:
-    </strong>
-    <button
-      className="c2"
-      disabled={true}
-      onClick={[Function]}
-      type="button"
-    >
-      Load +1 
-      het
-    </button>
-    <button
-      className="c2"
-      disabled={false}
-      onClick={[Function]}
-      type="button"
-    >
-      Load +1 
-      hom
-    </button>
-  </div>
-  <div
-    className="c1"
-  >
-    <button
-      className="c2"
-      disabled={false}
-      onClick={[Function]}
-      style={
-        {
-          "marginLeft": "80px",
+      <button
+        className="c2"
+        disabled={false}
+        onClick={[Function]}
+        style={
+          {
+            "marginLeft": "80px",
+          }
         }
-      }
-      type="button"
-    >
-      Load all
-    </button>
-  </div>
-</div>
+        type="button"
+      >
+        Load all
+      </button>
+    </div>
+  </div>,
+]
 `;
 
 exports[`ReadData with "exac" dataset selected queries against the correct dataset 1`] = `
@@ -228,15 +488,274 @@ exports[`ReadData with "exac" dataset selected queries against the correct datas
 `;
 
 exports[`ReadData with "gnomad_cnv_r4" dataset selected has no unexpected changes with exome and genome data both missing 1`] = `
-<div>
-  <p>
-    No read data available for this variant.
-  </p>
-</div>
+[
+  .c2 {
+  box-sizing: border-box;
+  height: calc(2em + 2px);
+  padding: 0.375em 0.75em;
+  border-color: #6c757d;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0.5em;
+  background-color: #f8f9fa;
+  cursor: pointer;
+  font-size: 1em;
+  line-height: 1.25;
+  outline: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c2:active,
+.c2:hover {
+  background-color: #cbd3da;
+}
+
+.c2:disabled {
+  background-color: rgba(248,249,250,0.5);
+  cursor: not-allowed;
+}
+
+.c2:focus {
+  box-shadow: 0 0 0 0.2em rgba(108,117,125,0.5);
+}
+
+.c2 svg {
+  position: relative;
+  top: 0.11em;
+  width: 0.9em;
+  height: 0.9em;
+}
+
+.c3 {
+  margin-right: 0.5em;
+}
+
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  outline: none;
+  padding: 0 3px;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.c1 img {
+  position: relative;
+  top: 0.13em;
+  width: 14px;
+  height: 14px;
+  border-radius: 7px;
+}
+
+.c1:focus img {
+  box-shadow: 0 0 0 0.2em rgba(70,130,180,0.5);
+}
+
+.c0 {
+  margin-bottom: 3rem;
+}
+
+<div
+    className="c0"
+  >
+    <button
+      className="c1"
+      onClick={[Function]}
+      type="button"
+    >
+      <img
+        alt=""
+        aria-hidden="true"
+        src="test-file-stub"
+      />
+      <span
+        style={
+          {
+            "border": "0",
+            "clip": "rect(0 0 0 0)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+      >
+        More information
+      </span>
+    </button>
+     
+    <button
+      className="c2"
+      disabled={false}
+      id="load-once"
+      onClick={[Function]}
+      type="button"
+    >
+      Load read data
+    </button>
+    <div>
+      <br />
+      <input
+        checked={true}
+        className="c3"
+        id="always-load"
+        onChange={[Function]}
+        type="checkbox"
+      />
+      Always load read data
+    </div>
+  </div>,
+  <div>
+    <p>
+      No read data available for this variant.
+    </p>
+  </div>,
+]
 `;
 
 exports[`ReadData with "gnomad_cnv_r4" dataset selected has no unexpected changes with exome data present 1`] = `
-.c2 {
+[
+  .c2 {
+  box-sizing: border-box;
+  height: calc(2em + 2px);
+  padding: 0.375em 0.75em;
+  border-color: #6c757d;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0.5em;
+  background-color: #f8f9fa;
+  cursor: pointer;
+  font-size: 1em;
+  line-height: 1.25;
+  outline: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c2:active,
+.c2:hover {
+  background-color: #cbd3da;
+}
+
+.c2:disabled {
+  background-color: rgba(248,249,250,0.5);
+  cursor: not-allowed;
+}
+
+.c2:focus {
+  box-shadow: 0 0 0 0.2em rgba(108,117,125,0.5);
+}
+
+.c2 svg {
+  position: relative;
+  top: 0.11em;
+  width: 0.9em;
+  height: 0.9em;
+}
+
+.c3 {
+  margin-right: 0.5em;
+}
+
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  outline: none;
+  padding: 0 3px;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.c1 img {
+  position: relative;
+  top: 0.13em;
+  width: 14px;
+  height: 14px;
+  border-radius: 7px;
+}
+
+.c1:focus img {
+  box-shadow: 0 0 0 0.2em rgba(70,130,180,0.5);
+}
+
+.c0 {
+  margin-bottom: 3rem;
+}
+
+<div
+    className="c0"
+  >
+    <button
+      className="c1"
+      onClick={[Function]}
+      type="button"
+    >
+      <img
+        alt=""
+        aria-hidden="true"
+        src="test-file-stub"
+      />
+      <span
+        style={
+          {
+            "border": "0",
+            "clip": "rect(0 0 0 0)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+      >
+        More information
+      </span>
+    </button>
+     
+    <button
+      className="c2"
+      disabled={false}
+      id="load-once"
+      onClick={[Function]}
+      type="button"
+    >
+      Load read data
+    </button>
+    <div>
+      <br />
+      <input
+        checked={true}
+        className="c3"
+        id="always-load"
+        onChange={[Function]}
+        type="checkbox"
+      />
+      Always load read data
+    </div>
+  </div>,
+  .c2 {
   box-sizing: border-box;
   height: calc(2em + 2px);
   padding: 0.375em 0.75em;
@@ -340,75 +859,76 @@ exports[`ReadData with "gnomad_cnv_r4" dataset selected has no unexpected change
 }
 
 <div>
-  <p>
-    This interactive
-     
-    <a
-      className="c0"
-      href="https://github.com/igvteam/igv.js"
-      rel="noopener noreferrer"
-      target="_blank"
+    <p>
+      This interactive
+       
+      <a
+        className="c0"
+        href="https://github.com/igvteam/igv.js"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        IGV.js
+      </a>
+       visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
+    </p>
+    <p>
+      These are reassembled reads produced by
+       
+      <a
+        className="c0"
+        href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        GATK HaplotypeCaller --bamOutput
+      </a>
+      , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
+    </p>
+    <div
+      className="c1"
     >
-      IGV.js
-    </a>
-     visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
-  </p>
-  <p>
-    These are reassembled reads produced by
-     
-    <a
-      className="c0"
-      href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
-      rel="noopener noreferrer"
-      target="_blank"
+      <strong>
+        Exomes:
+      </strong>
+      <button
+        className="c2"
+        disabled={true}
+        onClick={[Function]}
+        type="button"
+      >
+        Load +1 
+        het
+      </button>
+      <button
+        className="c2"
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+      >
+        Load +1 
+        hom
+      </button>
+    </div>
+    <div
+      className="c1"
     >
-      GATK HaplotypeCaller --bamOutput
-    </a>
-    , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
-  </p>
-  <div
-    className="c1"
-  >
-    <strong>
-      Exomes:
-    </strong>
-    <button
-      className="c2"
-      disabled={true}
-      onClick={[Function]}
-      type="button"
-    >
-      Load +1 
-      het
-    </button>
-    <button
-      className="c2"
-      disabled={false}
-      onClick={[Function]}
-      type="button"
-    >
-      Load +1 
-      hom
-    </button>
-  </div>
-  <div
-    className="c1"
-  >
-    <button
-      className="c2"
-      disabled={false}
-      onClick={[Function]}
-      style={
-        {
-          "marginLeft": "80px",
+      <button
+        className="c2"
+        disabled={false}
+        onClick={[Function]}
+        style={
+          {
+            "marginLeft": "80px",
+          }
         }
-      }
-      type="button"
-    >
-      Load all
-    </button>
-  </div>
-</div>
+        type="button"
+      >
+        Load all
+      </button>
+    </div>
+  </div>,
+]
 `;
 
 exports[`ReadData with "gnomad_cnv_r4" dataset selected queries against the correct dataset 1`] = `
@@ -433,7 +953,136 @@ exports[`ReadData with "gnomad_cnv_r4" dataset selected queries against the corr
 `;
 
 exports[`ReadData with "gnomad_r2_1" dataset selected has no unexpected changes with exome and genome data both missing 1`] = `
+[
+  .c2 {
+  box-sizing: border-box;
+  height: calc(2em + 2px);
+  padding: 0.375em 0.75em;
+  border-color: #6c757d;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0.5em;
+  background-color: #f8f9fa;
+  cursor: pointer;
+  font-size: 1em;
+  line-height: 1.25;
+  outline: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c2:active,
+.c2:hover {
+  background-color: #cbd3da;
+}
+
+.c2:disabled {
+  background-color: rgba(248,249,250,0.5);
+  cursor: not-allowed;
+}
+
+.c2:focus {
+  box-shadow: 0 0 0 0.2em rgba(108,117,125,0.5);
+}
+
+.c2 svg {
+  position: relative;
+  top: 0.11em;
+  width: 0.9em;
+  height: 0.9em;
+}
+
+.c3 {
+  margin-right: 0.5em;
+}
+
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  outline: none;
+  padding: 0 3px;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.c1 img {
+  position: relative;
+  top: 0.13em;
+  width: 14px;
+  height: 14px;
+  border-radius: 7px;
+}
+
+.c1:focus img {
+  box-shadow: 0 0 0 0.2em rgba(70,130,180,0.5);
+}
+
 .c0 {
+  margin-bottom: 3rem;
+}
+
+<div
+    className="c0"
+  >
+    <button
+      className="c1"
+      onClick={[Function]}
+      type="button"
+    >
+      <img
+        alt=""
+        aria-hidden="true"
+        src="test-file-stub"
+      />
+      <span
+        style={
+          {
+            "border": "0",
+            "clip": "rect(0 0 0 0)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+      >
+        More information
+      </span>
+    </button>
+     
+    <button
+      className="c2"
+      disabled={false}
+      id="load-once"
+      onClick={[Function]}
+      type="button"
+    >
+      Load read data
+    </button>
+    <div>
+      <br />
+      <input
+        checked={true}
+        className="c3"
+        id="always-load"
+        onChange={[Function]}
+        type="checkbox"
+      />
+      Always load read data
+    </div>
+  </div>,
+  .c0 {
   position: relative;
   top: -0.1em;
   display: inline-block;
@@ -448,22 +1097,152 @@ exports[`ReadData with "gnomad_r2_1" dataset selected has no unexpected changes 
 }
 
 <div>
-  <p>
-    No read data available for this variant.
-  </p>
-  <p>
-    <span
-      className="c0"
-    >
-      Note
-    </span>
-     Read data for non-coding regions is not available in gnomAD v2.1.1 and ExAC.
-  </p>
-</div>
+    <p>
+      No read data available for this variant.
+    </p>
+    <p>
+      <span
+        className="c0"
+      >
+        Note
+      </span>
+       Read data for non-coding regions is not available in gnomAD v2.1.1 and ExAC.
+    </p>
+  </div>,
+]
 `;
 
 exports[`ReadData with "gnomad_r2_1" dataset selected has no unexpected changes with exome data present 1`] = `
+[
+  .c2 {
+  box-sizing: border-box;
+  height: calc(2em + 2px);
+  padding: 0.375em 0.75em;
+  border-color: #6c757d;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0.5em;
+  background-color: #f8f9fa;
+  cursor: pointer;
+  font-size: 1em;
+  line-height: 1.25;
+  outline: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c2:active,
+.c2:hover {
+  background-color: #cbd3da;
+}
+
+.c2:disabled {
+  background-color: rgba(248,249,250,0.5);
+  cursor: not-allowed;
+}
+
+.c2:focus {
+  box-shadow: 0 0 0 0.2em rgba(108,117,125,0.5);
+}
+
+.c2 svg {
+  position: relative;
+  top: 0.11em;
+  width: 0.9em;
+  height: 0.9em;
+}
+
 .c3 {
+  margin-right: 0.5em;
+}
+
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  outline: none;
+  padding: 0 3px;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.c1 img {
+  position: relative;
+  top: 0.13em;
+  width: 14px;
+  height: 14px;
+  border-radius: 7px;
+}
+
+.c1:focus img {
+  box-shadow: 0 0 0 0.2em rgba(70,130,180,0.5);
+}
+
+.c0 {
+  margin-bottom: 3rem;
+}
+
+<div
+    className="c0"
+  >
+    <button
+      className="c1"
+      onClick={[Function]}
+      type="button"
+    >
+      <img
+        alt=""
+        aria-hidden="true"
+        src="test-file-stub"
+      />
+      <span
+        style={
+          {
+            "border": "0",
+            "clip": "rect(0 0 0 0)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+      >
+        More information
+      </span>
+    </button>
+     
+    <button
+      className="c2"
+      disabled={false}
+      id="load-once"
+      onClick={[Function]}
+      type="button"
+    >
+      Load read data
+    </button>
+    <div>
+      <br />
+      <input
+        checked={true}
+        className="c3"
+        id="always-load"
+        onChange={[Function]}
+        type="checkbox"
+      />
+      Always load read data
+    </div>
+  </div>,
+  .c3 {
   box-sizing: border-box;
   height: calc(2em + 2px);
   padding: 0.375em 0.75em;
@@ -581,83 +1360,84 @@ exports[`ReadData with "gnomad_r2_1" dataset selected has no unexpected changes 
 }
 
 <div>
-  <p>
-    This interactive
-     
-    <a
-      className="c0"
-      href="https://github.com/igvteam/igv.js"
-      rel="noopener noreferrer"
-      target="_blank"
+    <p>
+      This interactive
+       
+      <a
+        className="c0"
+        href="https://github.com/igvteam/igv.js"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        IGV.js
+      </a>
+       visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
+    </p>
+    <p>
+      These are reassembled reads produced by
+       
+      <a
+        className="c0"
+        href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        GATK HaplotypeCaller --bamOutput
+      </a>
+      , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
+    </p>
+    <p>
+      <span
+        className="c1"
+      >
+        Note
+      </span>
+       Reads shown here may include low quality genotypes that were excluded from allele counts.
+    </p>
+    <div
+      className="c2"
     >
-      IGV.js
-    </a>
-     visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
-  </p>
-  <p>
-    These are reassembled reads produced by
-     
-    <a
-      className="c0"
-      href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
-      rel="noopener noreferrer"
-      target="_blank"
+      <strong>
+        Exomes:
+      </strong>
+      <button
+        className="c3"
+        disabled={true}
+        onClick={[Function]}
+        type="button"
+      >
+        Load +1 
+        het
+      </button>
+      <button
+        className="c3"
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+      >
+        Load +1 
+        hom
+      </button>
+    </div>
+    <div
+      className="c2"
     >
-      GATK HaplotypeCaller --bamOutput
-    </a>
-    , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
-  </p>
-  <p>
-    <span
-      className="c1"
-    >
-      Note
-    </span>
-     Reads shown here may include low quality genotypes that were excluded from allele counts.
-  </p>
-  <div
-    className="c2"
-  >
-    <strong>
-      Exomes:
-    </strong>
-    <button
-      className="c3"
-      disabled={true}
-      onClick={[Function]}
-      type="button"
-    >
-      Load +1 
-      het
-    </button>
-    <button
-      className="c3"
-      disabled={false}
-      onClick={[Function]}
-      type="button"
-    >
-      Load +1 
-      hom
-    </button>
-  </div>
-  <div
-    className="c2"
-  >
-    <button
-      className="c3"
-      disabled={false}
-      onClick={[Function]}
-      style={
-        {
-          "marginLeft": "80px",
+      <button
+        className="c3"
+        disabled={false}
+        onClick={[Function]}
+        style={
+          {
+            "marginLeft": "80px",
+          }
         }
-      }
-      type="button"
-    >
-      Load all
-    </button>
-  </div>
-</div>
+        type="button"
+      >
+        Load all
+      </button>
+    </div>
+  </div>,
+]
 `;
 
 exports[`ReadData with "gnomad_r2_1" dataset selected queries against the correct dataset 1`] = `
@@ -682,7 +1462,136 @@ exports[`ReadData with "gnomad_r2_1" dataset selected queries against the correc
 `;
 
 exports[`ReadData with "gnomad_r2_1_controls" dataset selected has no unexpected changes with exome and genome data both missing 1`] = `
+[
+  .c2 {
+  box-sizing: border-box;
+  height: calc(2em + 2px);
+  padding: 0.375em 0.75em;
+  border-color: #6c757d;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0.5em;
+  background-color: #f8f9fa;
+  cursor: pointer;
+  font-size: 1em;
+  line-height: 1.25;
+  outline: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c2:active,
+.c2:hover {
+  background-color: #cbd3da;
+}
+
+.c2:disabled {
+  background-color: rgba(248,249,250,0.5);
+  cursor: not-allowed;
+}
+
+.c2:focus {
+  box-shadow: 0 0 0 0.2em rgba(108,117,125,0.5);
+}
+
+.c2 svg {
+  position: relative;
+  top: 0.11em;
+  width: 0.9em;
+  height: 0.9em;
+}
+
+.c3 {
+  margin-right: 0.5em;
+}
+
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  outline: none;
+  padding: 0 3px;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.c1 img {
+  position: relative;
+  top: 0.13em;
+  width: 14px;
+  height: 14px;
+  border-radius: 7px;
+}
+
+.c1:focus img {
+  box-shadow: 0 0 0 0.2em rgba(70,130,180,0.5);
+}
+
 .c0 {
+  margin-bottom: 3rem;
+}
+
+<div
+    className="c0"
+  >
+    <button
+      className="c1"
+      onClick={[Function]}
+      type="button"
+    >
+      <img
+        alt=""
+        aria-hidden="true"
+        src="test-file-stub"
+      />
+      <span
+        style={
+          {
+            "border": "0",
+            "clip": "rect(0 0 0 0)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+      >
+        More information
+      </span>
+    </button>
+     
+    <button
+      className="c2"
+      disabled={false}
+      id="load-once"
+      onClick={[Function]}
+      type="button"
+    >
+      Load read data
+    </button>
+    <div>
+      <br />
+      <input
+        checked={true}
+        className="c3"
+        id="always-load"
+        onChange={[Function]}
+        type="checkbox"
+      />
+      Always load read data
+    </div>
+  </div>,
+  .c0 {
   position: relative;
   top: -0.1em;
   display: inline-block;
@@ -697,22 +1606,152 @@ exports[`ReadData with "gnomad_r2_1_controls" dataset selected has no unexpected
 }
 
 <div>
-  <p>
-    No read data available for this variant.
-  </p>
-  <p>
-    <span
-      className="c0"
-    >
-      Note
-    </span>
-     Read data for non-coding regions is not available in gnomAD v2.1.1 and ExAC.
-  </p>
-</div>
+    <p>
+      No read data available for this variant.
+    </p>
+    <p>
+      <span
+        className="c0"
+      >
+        Note
+      </span>
+       Read data for non-coding regions is not available in gnomAD v2.1.1 and ExAC.
+    </p>
+  </div>,
+]
 `;
 
 exports[`ReadData with "gnomad_r2_1_controls" dataset selected has no unexpected changes with exome data present 1`] = `
+[
+  .c2 {
+  box-sizing: border-box;
+  height: calc(2em + 2px);
+  padding: 0.375em 0.75em;
+  border-color: #6c757d;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0.5em;
+  background-color: #f8f9fa;
+  cursor: pointer;
+  font-size: 1em;
+  line-height: 1.25;
+  outline: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c2:active,
+.c2:hover {
+  background-color: #cbd3da;
+}
+
+.c2:disabled {
+  background-color: rgba(248,249,250,0.5);
+  cursor: not-allowed;
+}
+
+.c2:focus {
+  box-shadow: 0 0 0 0.2em rgba(108,117,125,0.5);
+}
+
+.c2 svg {
+  position: relative;
+  top: 0.11em;
+  width: 0.9em;
+  height: 0.9em;
+}
+
 .c3 {
+  margin-right: 0.5em;
+}
+
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  outline: none;
+  padding: 0 3px;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.c1 img {
+  position: relative;
+  top: 0.13em;
+  width: 14px;
+  height: 14px;
+  border-radius: 7px;
+}
+
+.c1:focus img {
+  box-shadow: 0 0 0 0.2em rgba(70,130,180,0.5);
+}
+
+.c0 {
+  margin-bottom: 3rem;
+}
+
+<div
+    className="c0"
+  >
+    <button
+      className="c1"
+      onClick={[Function]}
+      type="button"
+    >
+      <img
+        alt=""
+        aria-hidden="true"
+        src="test-file-stub"
+      />
+      <span
+        style={
+          {
+            "border": "0",
+            "clip": "rect(0 0 0 0)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+      >
+        More information
+      </span>
+    </button>
+     
+    <button
+      className="c2"
+      disabled={false}
+      id="load-once"
+      onClick={[Function]}
+      type="button"
+    >
+      Load read data
+    </button>
+    <div>
+      <br />
+      <input
+        checked={true}
+        className="c3"
+        id="always-load"
+        onChange={[Function]}
+        type="checkbox"
+      />
+      Always load read data
+    </div>
+  </div>,
+  .c3 {
   box-sizing: border-box;
   height: calc(2em + 2px);
   padding: 0.375em 0.75em;
@@ -830,91 +1869,92 @@ exports[`ReadData with "gnomad_r2_1_controls" dataset selected has no unexpected
 }
 
 <div>
-  <p>
-    This interactive
-     
-    <a
-      className="c0"
-      href="https://github.com/igvteam/igv.js"
-      rel="noopener noreferrer"
-      target="_blank"
+    <p>
+      This interactive
+       
+      <a
+        className="c0"
+        href="https://github.com/igvteam/igv.js"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        IGV.js
+      </a>
+       visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
+    </p>
+    <p>
+      These are reassembled reads produced by
+       
+      <a
+        className="c0"
+        href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        GATK HaplotypeCaller --bamOutput
+      </a>
+      , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
+    </p>
+    <p>
+      <span
+        className="c1"
+      >
+        Note
+      </span>
+       Reads shown here may include low quality genotypes that were excluded from allele counts.
+    </p>
+    <p>
+      <span
+        className="c1"
+      >
+        Note
+      </span>
+       Samples shown below are not guaranteed to be part of the selected subset.
+    </p>
+    <div
+      className="c2"
     >
-      IGV.js
-    </a>
-     visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
-  </p>
-  <p>
-    These are reassembled reads produced by
-     
-    <a
-      className="c0"
-      href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
-      rel="noopener noreferrer"
-      target="_blank"
+      <strong>
+        Exomes:
+      </strong>
+      <button
+        className="c3"
+        disabled={true}
+        onClick={[Function]}
+        type="button"
+      >
+        Load +1 
+        het
+      </button>
+      <button
+        className="c3"
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+      >
+        Load +1 
+        hom
+      </button>
+    </div>
+    <div
+      className="c2"
     >
-      GATK HaplotypeCaller --bamOutput
-    </a>
-    , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
-  </p>
-  <p>
-    <span
-      className="c1"
-    >
-      Note
-    </span>
-     Reads shown here may include low quality genotypes that were excluded from allele counts.
-  </p>
-  <p>
-    <span
-      className="c1"
-    >
-      Note
-    </span>
-     Samples shown below are not guaranteed to be part of the selected subset.
-  </p>
-  <div
-    className="c2"
-  >
-    <strong>
-      Exomes:
-    </strong>
-    <button
-      className="c3"
-      disabled={true}
-      onClick={[Function]}
-      type="button"
-    >
-      Load +1 
-      het
-    </button>
-    <button
-      className="c3"
-      disabled={false}
-      onClick={[Function]}
-      type="button"
-    >
-      Load +1 
-      hom
-    </button>
-  </div>
-  <div
-    className="c2"
-  >
-    <button
-      className="c3"
-      disabled={false}
-      onClick={[Function]}
-      style={
-        {
-          "marginLeft": "80px",
+      <button
+        className="c3"
+        disabled={false}
+        onClick={[Function]}
+        style={
+          {
+            "marginLeft": "80px",
+          }
         }
-      }
-      type="button"
-    >
-      Load all
-    </button>
-  </div>
-</div>
+        type="button"
+      >
+        Load all
+      </button>
+    </div>
+  </div>,
+]
 `;
 
 exports[`ReadData with "gnomad_r2_1_controls" dataset selected queries against the correct dataset 1`] = `
@@ -939,7 +1979,136 @@ exports[`ReadData with "gnomad_r2_1_controls" dataset selected queries against t
 `;
 
 exports[`ReadData with "gnomad_r2_1_non_cancer" dataset selected has no unexpected changes with exome and genome data both missing 1`] = `
+[
+  .c2 {
+  box-sizing: border-box;
+  height: calc(2em + 2px);
+  padding: 0.375em 0.75em;
+  border-color: #6c757d;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0.5em;
+  background-color: #f8f9fa;
+  cursor: pointer;
+  font-size: 1em;
+  line-height: 1.25;
+  outline: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c2:active,
+.c2:hover {
+  background-color: #cbd3da;
+}
+
+.c2:disabled {
+  background-color: rgba(248,249,250,0.5);
+  cursor: not-allowed;
+}
+
+.c2:focus {
+  box-shadow: 0 0 0 0.2em rgba(108,117,125,0.5);
+}
+
+.c2 svg {
+  position: relative;
+  top: 0.11em;
+  width: 0.9em;
+  height: 0.9em;
+}
+
+.c3 {
+  margin-right: 0.5em;
+}
+
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  outline: none;
+  padding: 0 3px;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.c1 img {
+  position: relative;
+  top: 0.13em;
+  width: 14px;
+  height: 14px;
+  border-radius: 7px;
+}
+
+.c1:focus img {
+  box-shadow: 0 0 0 0.2em rgba(70,130,180,0.5);
+}
+
 .c0 {
+  margin-bottom: 3rem;
+}
+
+<div
+    className="c0"
+  >
+    <button
+      className="c1"
+      onClick={[Function]}
+      type="button"
+    >
+      <img
+        alt=""
+        aria-hidden="true"
+        src="test-file-stub"
+      />
+      <span
+        style={
+          {
+            "border": "0",
+            "clip": "rect(0 0 0 0)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+      >
+        More information
+      </span>
+    </button>
+     
+    <button
+      className="c2"
+      disabled={false}
+      id="load-once"
+      onClick={[Function]}
+      type="button"
+    >
+      Load read data
+    </button>
+    <div>
+      <br />
+      <input
+        checked={true}
+        className="c3"
+        id="always-load"
+        onChange={[Function]}
+        type="checkbox"
+      />
+      Always load read data
+    </div>
+  </div>,
+  .c0 {
   position: relative;
   top: -0.1em;
   display: inline-block;
@@ -954,22 +2123,152 @@ exports[`ReadData with "gnomad_r2_1_non_cancer" dataset selected has no unexpect
 }
 
 <div>
-  <p>
-    No read data available for this variant.
-  </p>
-  <p>
-    <span
-      className="c0"
-    >
-      Note
-    </span>
-     Read data for non-coding regions is not available in gnomAD v2.1.1 and ExAC.
-  </p>
-</div>
+    <p>
+      No read data available for this variant.
+    </p>
+    <p>
+      <span
+        className="c0"
+      >
+        Note
+      </span>
+       Read data for non-coding regions is not available in gnomAD v2.1.1 and ExAC.
+    </p>
+  </div>,
+]
 `;
 
 exports[`ReadData with "gnomad_r2_1_non_cancer" dataset selected has no unexpected changes with exome data present 1`] = `
+[
+  .c2 {
+  box-sizing: border-box;
+  height: calc(2em + 2px);
+  padding: 0.375em 0.75em;
+  border-color: #6c757d;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0.5em;
+  background-color: #f8f9fa;
+  cursor: pointer;
+  font-size: 1em;
+  line-height: 1.25;
+  outline: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c2:active,
+.c2:hover {
+  background-color: #cbd3da;
+}
+
+.c2:disabled {
+  background-color: rgba(248,249,250,0.5);
+  cursor: not-allowed;
+}
+
+.c2:focus {
+  box-shadow: 0 0 0 0.2em rgba(108,117,125,0.5);
+}
+
+.c2 svg {
+  position: relative;
+  top: 0.11em;
+  width: 0.9em;
+  height: 0.9em;
+}
+
 .c3 {
+  margin-right: 0.5em;
+}
+
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  outline: none;
+  padding: 0 3px;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.c1 img {
+  position: relative;
+  top: 0.13em;
+  width: 14px;
+  height: 14px;
+  border-radius: 7px;
+}
+
+.c1:focus img {
+  box-shadow: 0 0 0 0.2em rgba(70,130,180,0.5);
+}
+
+.c0 {
+  margin-bottom: 3rem;
+}
+
+<div
+    className="c0"
+  >
+    <button
+      className="c1"
+      onClick={[Function]}
+      type="button"
+    >
+      <img
+        alt=""
+        aria-hidden="true"
+        src="test-file-stub"
+      />
+      <span
+        style={
+          {
+            "border": "0",
+            "clip": "rect(0 0 0 0)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+      >
+        More information
+      </span>
+    </button>
+     
+    <button
+      className="c2"
+      disabled={false}
+      id="load-once"
+      onClick={[Function]}
+      type="button"
+    >
+      Load read data
+    </button>
+    <div>
+      <br />
+      <input
+        checked={true}
+        className="c3"
+        id="always-load"
+        onChange={[Function]}
+        type="checkbox"
+      />
+      Always load read data
+    </div>
+  </div>,
+  .c3 {
   box-sizing: border-box;
   height: calc(2em + 2px);
   padding: 0.375em 0.75em;
@@ -1087,91 +2386,92 @@ exports[`ReadData with "gnomad_r2_1_non_cancer" dataset selected has no unexpect
 }
 
 <div>
-  <p>
-    This interactive
-     
-    <a
-      className="c0"
-      href="https://github.com/igvteam/igv.js"
-      rel="noopener noreferrer"
-      target="_blank"
+    <p>
+      This interactive
+       
+      <a
+        className="c0"
+        href="https://github.com/igvteam/igv.js"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        IGV.js
+      </a>
+       visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
+    </p>
+    <p>
+      These are reassembled reads produced by
+       
+      <a
+        className="c0"
+        href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        GATK HaplotypeCaller --bamOutput
+      </a>
+      , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
+    </p>
+    <p>
+      <span
+        className="c1"
+      >
+        Note
+      </span>
+       Reads shown here may include low quality genotypes that were excluded from allele counts.
+    </p>
+    <p>
+      <span
+        className="c1"
+      >
+        Note
+      </span>
+       Samples shown below are not guaranteed to be part of the selected subset.
+    </p>
+    <div
+      className="c2"
     >
-      IGV.js
-    </a>
-     visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
-  </p>
-  <p>
-    These are reassembled reads produced by
-     
-    <a
-      className="c0"
-      href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
-      rel="noopener noreferrer"
-      target="_blank"
+      <strong>
+        Exomes:
+      </strong>
+      <button
+        className="c3"
+        disabled={true}
+        onClick={[Function]}
+        type="button"
+      >
+        Load +1 
+        het
+      </button>
+      <button
+        className="c3"
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+      >
+        Load +1 
+        hom
+      </button>
+    </div>
+    <div
+      className="c2"
     >
-      GATK HaplotypeCaller --bamOutput
-    </a>
-    , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
-  </p>
-  <p>
-    <span
-      className="c1"
-    >
-      Note
-    </span>
-     Reads shown here may include low quality genotypes that were excluded from allele counts.
-  </p>
-  <p>
-    <span
-      className="c1"
-    >
-      Note
-    </span>
-     Samples shown below are not guaranteed to be part of the selected subset.
-  </p>
-  <div
-    className="c2"
-  >
-    <strong>
-      Exomes:
-    </strong>
-    <button
-      className="c3"
-      disabled={true}
-      onClick={[Function]}
-      type="button"
-    >
-      Load +1 
-      het
-    </button>
-    <button
-      className="c3"
-      disabled={false}
-      onClick={[Function]}
-      type="button"
-    >
-      Load +1 
-      hom
-    </button>
-  </div>
-  <div
-    className="c2"
-  >
-    <button
-      className="c3"
-      disabled={false}
-      onClick={[Function]}
-      style={
-        {
-          "marginLeft": "80px",
+      <button
+        className="c3"
+        disabled={false}
+        onClick={[Function]}
+        style={
+          {
+            "marginLeft": "80px",
+          }
         }
-      }
-      type="button"
-    >
-      Load all
-    </button>
-  </div>
-</div>
+        type="button"
+      >
+        Load all
+      </button>
+    </div>
+  </div>,
+]
 `;
 
 exports[`ReadData with "gnomad_r2_1_non_cancer" dataset selected queries against the correct dataset 1`] = `
@@ -1196,7 +2496,136 @@ exports[`ReadData with "gnomad_r2_1_non_cancer" dataset selected queries against
 `;
 
 exports[`ReadData with "gnomad_r2_1_non_neuro" dataset selected has no unexpected changes with exome and genome data both missing 1`] = `
+[
+  .c2 {
+  box-sizing: border-box;
+  height: calc(2em + 2px);
+  padding: 0.375em 0.75em;
+  border-color: #6c757d;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0.5em;
+  background-color: #f8f9fa;
+  cursor: pointer;
+  font-size: 1em;
+  line-height: 1.25;
+  outline: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c2:active,
+.c2:hover {
+  background-color: #cbd3da;
+}
+
+.c2:disabled {
+  background-color: rgba(248,249,250,0.5);
+  cursor: not-allowed;
+}
+
+.c2:focus {
+  box-shadow: 0 0 0 0.2em rgba(108,117,125,0.5);
+}
+
+.c2 svg {
+  position: relative;
+  top: 0.11em;
+  width: 0.9em;
+  height: 0.9em;
+}
+
+.c3 {
+  margin-right: 0.5em;
+}
+
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  outline: none;
+  padding: 0 3px;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.c1 img {
+  position: relative;
+  top: 0.13em;
+  width: 14px;
+  height: 14px;
+  border-radius: 7px;
+}
+
+.c1:focus img {
+  box-shadow: 0 0 0 0.2em rgba(70,130,180,0.5);
+}
+
 .c0 {
+  margin-bottom: 3rem;
+}
+
+<div
+    className="c0"
+  >
+    <button
+      className="c1"
+      onClick={[Function]}
+      type="button"
+    >
+      <img
+        alt=""
+        aria-hidden="true"
+        src="test-file-stub"
+      />
+      <span
+        style={
+          {
+            "border": "0",
+            "clip": "rect(0 0 0 0)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+      >
+        More information
+      </span>
+    </button>
+     
+    <button
+      className="c2"
+      disabled={false}
+      id="load-once"
+      onClick={[Function]}
+      type="button"
+    >
+      Load read data
+    </button>
+    <div>
+      <br />
+      <input
+        checked={true}
+        className="c3"
+        id="always-load"
+        onChange={[Function]}
+        type="checkbox"
+      />
+      Always load read data
+    </div>
+  </div>,
+  .c0 {
   position: relative;
   top: -0.1em;
   display: inline-block;
@@ -1211,22 +2640,152 @@ exports[`ReadData with "gnomad_r2_1_non_neuro" dataset selected has no unexpecte
 }
 
 <div>
-  <p>
-    No read data available for this variant.
-  </p>
-  <p>
-    <span
-      className="c0"
-    >
-      Note
-    </span>
-     Read data for non-coding regions is not available in gnomAD v2.1.1 and ExAC.
-  </p>
-</div>
+    <p>
+      No read data available for this variant.
+    </p>
+    <p>
+      <span
+        className="c0"
+      >
+        Note
+      </span>
+       Read data for non-coding regions is not available in gnomAD v2.1.1 and ExAC.
+    </p>
+  </div>,
+]
 `;
 
 exports[`ReadData with "gnomad_r2_1_non_neuro" dataset selected has no unexpected changes with exome data present 1`] = `
+[
+  .c2 {
+  box-sizing: border-box;
+  height: calc(2em + 2px);
+  padding: 0.375em 0.75em;
+  border-color: #6c757d;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0.5em;
+  background-color: #f8f9fa;
+  cursor: pointer;
+  font-size: 1em;
+  line-height: 1.25;
+  outline: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c2:active,
+.c2:hover {
+  background-color: #cbd3da;
+}
+
+.c2:disabled {
+  background-color: rgba(248,249,250,0.5);
+  cursor: not-allowed;
+}
+
+.c2:focus {
+  box-shadow: 0 0 0 0.2em rgba(108,117,125,0.5);
+}
+
+.c2 svg {
+  position: relative;
+  top: 0.11em;
+  width: 0.9em;
+  height: 0.9em;
+}
+
 .c3 {
+  margin-right: 0.5em;
+}
+
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  outline: none;
+  padding: 0 3px;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.c1 img {
+  position: relative;
+  top: 0.13em;
+  width: 14px;
+  height: 14px;
+  border-radius: 7px;
+}
+
+.c1:focus img {
+  box-shadow: 0 0 0 0.2em rgba(70,130,180,0.5);
+}
+
+.c0 {
+  margin-bottom: 3rem;
+}
+
+<div
+    className="c0"
+  >
+    <button
+      className="c1"
+      onClick={[Function]}
+      type="button"
+    >
+      <img
+        alt=""
+        aria-hidden="true"
+        src="test-file-stub"
+      />
+      <span
+        style={
+          {
+            "border": "0",
+            "clip": "rect(0 0 0 0)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+      >
+        More information
+      </span>
+    </button>
+     
+    <button
+      className="c2"
+      disabled={false}
+      id="load-once"
+      onClick={[Function]}
+      type="button"
+    >
+      Load read data
+    </button>
+    <div>
+      <br />
+      <input
+        checked={true}
+        className="c3"
+        id="always-load"
+        onChange={[Function]}
+        type="checkbox"
+      />
+      Always load read data
+    </div>
+  </div>,
+  .c3 {
   box-sizing: border-box;
   height: calc(2em + 2px);
   padding: 0.375em 0.75em;
@@ -1344,91 +2903,92 @@ exports[`ReadData with "gnomad_r2_1_non_neuro" dataset selected has no unexpecte
 }
 
 <div>
-  <p>
-    This interactive
-     
-    <a
-      className="c0"
-      href="https://github.com/igvteam/igv.js"
-      rel="noopener noreferrer"
-      target="_blank"
+    <p>
+      This interactive
+       
+      <a
+        className="c0"
+        href="https://github.com/igvteam/igv.js"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        IGV.js
+      </a>
+       visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
+    </p>
+    <p>
+      These are reassembled reads produced by
+       
+      <a
+        className="c0"
+        href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        GATK HaplotypeCaller --bamOutput
+      </a>
+      , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
+    </p>
+    <p>
+      <span
+        className="c1"
+      >
+        Note
+      </span>
+       Reads shown here may include low quality genotypes that were excluded from allele counts.
+    </p>
+    <p>
+      <span
+        className="c1"
+      >
+        Note
+      </span>
+       Samples shown below are not guaranteed to be part of the selected subset.
+    </p>
+    <div
+      className="c2"
     >
-      IGV.js
-    </a>
-     visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
-  </p>
-  <p>
-    These are reassembled reads produced by
-     
-    <a
-      className="c0"
-      href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
-      rel="noopener noreferrer"
-      target="_blank"
+      <strong>
+        Exomes:
+      </strong>
+      <button
+        className="c3"
+        disabled={true}
+        onClick={[Function]}
+        type="button"
+      >
+        Load +1 
+        het
+      </button>
+      <button
+        className="c3"
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+      >
+        Load +1 
+        hom
+      </button>
+    </div>
+    <div
+      className="c2"
     >
-      GATK HaplotypeCaller --bamOutput
-    </a>
-    , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
-  </p>
-  <p>
-    <span
-      className="c1"
-    >
-      Note
-    </span>
-     Reads shown here may include low quality genotypes that were excluded from allele counts.
-  </p>
-  <p>
-    <span
-      className="c1"
-    >
-      Note
-    </span>
-     Samples shown below are not guaranteed to be part of the selected subset.
-  </p>
-  <div
-    className="c2"
-  >
-    <strong>
-      Exomes:
-    </strong>
-    <button
-      className="c3"
-      disabled={true}
-      onClick={[Function]}
-      type="button"
-    >
-      Load +1 
-      het
-    </button>
-    <button
-      className="c3"
-      disabled={false}
-      onClick={[Function]}
-      type="button"
-    >
-      Load +1 
-      hom
-    </button>
-  </div>
-  <div
-    className="c2"
-  >
-    <button
-      className="c3"
-      disabled={false}
-      onClick={[Function]}
-      style={
-        {
-          "marginLeft": "80px",
+      <button
+        className="c3"
+        disabled={false}
+        onClick={[Function]}
+        style={
+          {
+            "marginLeft": "80px",
+          }
         }
-      }
-      type="button"
-    >
-      Load all
-    </button>
-  </div>
-</div>
+        type="button"
+      >
+        Load all
+      </button>
+    </div>
+  </div>,
+]
 `;
 
 exports[`ReadData with "gnomad_r2_1_non_neuro" dataset selected queries against the correct dataset 1`] = `
@@ -1453,7 +3013,136 @@ exports[`ReadData with "gnomad_r2_1_non_neuro" dataset selected queries against 
 `;
 
 exports[`ReadData with "gnomad_r2_1_non_topmed" dataset selected has no unexpected changes with exome and genome data both missing 1`] = `
+[
+  .c2 {
+  box-sizing: border-box;
+  height: calc(2em + 2px);
+  padding: 0.375em 0.75em;
+  border-color: #6c757d;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0.5em;
+  background-color: #f8f9fa;
+  cursor: pointer;
+  font-size: 1em;
+  line-height: 1.25;
+  outline: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c2:active,
+.c2:hover {
+  background-color: #cbd3da;
+}
+
+.c2:disabled {
+  background-color: rgba(248,249,250,0.5);
+  cursor: not-allowed;
+}
+
+.c2:focus {
+  box-shadow: 0 0 0 0.2em rgba(108,117,125,0.5);
+}
+
+.c2 svg {
+  position: relative;
+  top: 0.11em;
+  width: 0.9em;
+  height: 0.9em;
+}
+
+.c3 {
+  margin-right: 0.5em;
+}
+
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  outline: none;
+  padding: 0 3px;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.c1 img {
+  position: relative;
+  top: 0.13em;
+  width: 14px;
+  height: 14px;
+  border-radius: 7px;
+}
+
+.c1:focus img {
+  box-shadow: 0 0 0 0.2em rgba(70,130,180,0.5);
+}
+
 .c0 {
+  margin-bottom: 3rem;
+}
+
+<div
+    className="c0"
+  >
+    <button
+      className="c1"
+      onClick={[Function]}
+      type="button"
+    >
+      <img
+        alt=""
+        aria-hidden="true"
+        src="test-file-stub"
+      />
+      <span
+        style={
+          {
+            "border": "0",
+            "clip": "rect(0 0 0 0)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+      >
+        More information
+      </span>
+    </button>
+     
+    <button
+      className="c2"
+      disabled={false}
+      id="load-once"
+      onClick={[Function]}
+      type="button"
+    >
+      Load read data
+    </button>
+    <div>
+      <br />
+      <input
+        checked={true}
+        className="c3"
+        id="always-load"
+        onChange={[Function]}
+        type="checkbox"
+      />
+      Always load read data
+    </div>
+  </div>,
+  .c0 {
   position: relative;
   top: -0.1em;
   display: inline-block;
@@ -1468,22 +3157,152 @@ exports[`ReadData with "gnomad_r2_1_non_topmed" dataset selected has no unexpect
 }
 
 <div>
-  <p>
-    No read data available for this variant.
-  </p>
-  <p>
-    <span
-      className="c0"
-    >
-      Note
-    </span>
-     Read data for non-coding regions is not available in gnomAD v2.1.1 and ExAC.
-  </p>
-</div>
+    <p>
+      No read data available for this variant.
+    </p>
+    <p>
+      <span
+        className="c0"
+      >
+        Note
+      </span>
+       Read data for non-coding regions is not available in gnomAD v2.1.1 and ExAC.
+    </p>
+  </div>,
+]
 `;
 
 exports[`ReadData with "gnomad_r2_1_non_topmed" dataset selected has no unexpected changes with exome data present 1`] = `
+[
+  .c2 {
+  box-sizing: border-box;
+  height: calc(2em + 2px);
+  padding: 0.375em 0.75em;
+  border-color: #6c757d;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0.5em;
+  background-color: #f8f9fa;
+  cursor: pointer;
+  font-size: 1em;
+  line-height: 1.25;
+  outline: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c2:active,
+.c2:hover {
+  background-color: #cbd3da;
+}
+
+.c2:disabled {
+  background-color: rgba(248,249,250,0.5);
+  cursor: not-allowed;
+}
+
+.c2:focus {
+  box-shadow: 0 0 0 0.2em rgba(108,117,125,0.5);
+}
+
+.c2 svg {
+  position: relative;
+  top: 0.11em;
+  width: 0.9em;
+  height: 0.9em;
+}
+
 .c3 {
+  margin-right: 0.5em;
+}
+
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  outline: none;
+  padding: 0 3px;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.c1 img {
+  position: relative;
+  top: 0.13em;
+  width: 14px;
+  height: 14px;
+  border-radius: 7px;
+}
+
+.c1:focus img {
+  box-shadow: 0 0 0 0.2em rgba(70,130,180,0.5);
+}
+
+.c0 {
+  margin-bottom: 3rem;
+}
+
+<div
+    className="c0"
+  >
+    <button
+      className="c1"
+      onClick={[Function]}
+      type="button"
+    >
+      <img
+        alt=""
+        aria-hidden="true"
+        src="test-file-stub"
+      />
+      <span
+        style={
+          {
+            "border": "0",
+            "clip": "rect(0 0 0 0)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+      >
+        More information
+      </span>
+    </button>
+     
+    <button
+      className="c2"
+      disabled={false}
+      id="load-once"
+      onClick={[Function]}
+      type="button"
+    >
+      Load read data
+    </button>
+    <div>
+      <br />
+      <input
+        checked={true}
+        className="c3"
+        id="always-load"
+        onChange={[Function]}
+        type="checkbox"
+      />
+      Always load read data
+    </div>
+  </div>,
+  .c3 {
   box-sizing: border-box;
   height: calc(2em + 2px);
   padding: 0.375em 0.75em;
@@ -1601,91 +3420,92 @@ exports[`ReadData with "gnomad_r2_1_non_topmed" dataset selected has no unexpect
 }
 
 <div>
-  <p>
-    This interactive
-     
-    <a
-      className="c0"
-      href="https://github.com/igvteam/igv.js"
-      rel="noopener noreferrer"
-      target="_blank"
+    <p>
+      This interactive
+       
+      <a
+        className="c0"
+        href="https://github.com/igvteam/igv.js"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        IGV.js
+      </a>
+       visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
+    </p>
+    <p>
+      These are reassembled reads produced by
+       
+      <a
+        className="c0"
+        href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        GATK HaplotypeCaller --bamOutput
+      </a>
+      , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
+    </p>
+    <p>
+      <span
+        className="c1"
+      >
+        Note
+      </span>
+       Reads shown here may include low quality genotypes that were excluded from allele counts.
+    </p>
+    <p>
+      <span
+        className="c1"
+      >
+        Note
+      </span>
+       Samples shown below are not guaranteed to be part of the selected subset.
+    </p>
+    <div
+      className="c2"
     >
-      IGV.js
-    </a>
-     visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
-  </p>
-  <p>
-    These are reassembled reads produced by
-     
-    <a
-      className="c0"
-      href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
-      rel="noopener noreferrer"
-      target="_blank"
+      <strong>
+        Exomes:
+      </strong>
+      <button
+        className="c3"
+        disabled={true}
+        onClick={[Function]}
+        type="button"
+      >
+        Load +1 
+        het
+      </button>
+      <button
+        className="c3"
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+      >
+        Load +1 
+        hom
+      </button>
+    </div>
+    <div
+      className="c2"
     >
-      GATK HaplotypeCaller --bamOutput
-    </a>
-    , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
-  </p>
-  <p>
-    <span
-      className="c1"
-    >
-      Note
-    </span>
-     Reads shown here may include low quality genotypes that were excluded from allele counts.
-  </p>
-  <p>
-    <span
-      className="c1"
-    >
-      Note
-    </span>
-     Samples shown below are not guaranteed to be part of the selected subset.
-  </p>
-  <div
-    className="c2"
-  >
-    <strong>
-      Exomes:
-    </strong>
-    <button
-      className="c3"
-      disabled={true}
-      onClick={[Function]}
-      type="button"
-    >
-      Load +1 
-      het
-    </button>
-    <button
-      className="c3"
-      disabled={false}
-      onClick={[Function]}
-      type="button"
-    >
-      Load +1 
-      hom
-    </button>
-  </div>
-  <div
-    className="c2"
-  >
-    <button
-      className="c3"
-      disabled={false}
-      onClick={[Function]}
-      style={
-        {
-          "marginLeft": "80px",
+      <button
+        className="c3"
+        disabled={false}
+        onClick={[Function]}
+        style={
+          {
+            "marginLeft": "80px",
+          }
         }
-      }
-      type="button"
-    >
-      Load all
-    </button>
-  </div>
-</div>
+        type="button"
+      >
+        Load all
+      </button>
+    </div>
+  </div>,
+]
 `;
 
 exports[`ReadData with "gnomad_r2_1_non_topmed" dataset selected queries against the correct dataset 1`] = `
@@ -1710,15 +3530,274 @@ exports[`ReadData with "gnomad_r2_1_non_topmed" dataset selected queries against
 `;
 
 exports[`ReadData with "gnomad_r3" dataset selected has no unexpected changes with exome and genome data both missing 1`] = `
-<div>
-  <p>
-    No read data available for this variant.
-  </p>
-</div>
+[
+  .c2 {
+  box-sizing: border-box;
+  height: calc(2em + 2px);
+  padding: 0.375em 0.75em;
+  border-color: #6c757d;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0.5em;
+  background-color: #f8f9fa;
+  cursor: pointer;
+  font-size: 1em;
+  line-height: 1.25;
+  outline: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c2:active,
+.c2:hover {
+  background-color: #cbd3da;
+}
+
+.c2:disabled {
+  background-color: rgba(248,249,250,0.5);
+  cursor: not-allowed;
+}
+
+.c2:focus {
+  box-shadow: 0 0 0 0.2em rgba(108,117,125,0.5);
+}
+
+.c2 svg {
+  position: relative;
+  top: 0.11em;
+  width: 0.9em;
+  height: 0.9em;
+}
+
+.c3 {
+  margin-right: 0.5em;
+}
+
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  outline: none;
+  padding: 0 3px;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.c1 img {
+  position: relative;
+  top: 0.13em;
+  width: 14px;
+  height: 14px;
+  border-radius: 7px;
+}
+
+.c1:focus img {
+  box-shadow: 0 0 0 0.2em rgba(70,130,180,0.5);
+}
+
+.c0 {
+  margin-bottom: 3rem;
+}
+
+<div
+    className="c0"
+  >
+    <button
+      className="c1"
+      onClick={[Function]}
+      type="button"
+    >
+      <img
+        alt=""
+        aria-hidden="true"
+        src="test-file-stub"
+      />
+      <span
+        style={
+          {
+            "border": "0",
+            "clip": "rect(0 0 0 0)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+      >
+        More information
+      </span>
+    </button>
+     
+    <button
+      className="c2"
+      disabled={false}
+      id="load-once"
+      onClick={[Function]}
+      type="button"
+    >
+      Load read data
+    </button>
+    <div>
+      <br />
+      <input
+        checked={true}
+        className="c3"
+        id="always-load"
+        onChange={[Function]}
+        type="checkbox"
+      />
+      Always load read data
+    </div>
+  </div>,
+  <div>
+    <p>
+      No read data available for this variant.
+    </p>
+  </div>,
+]
 `;
 
 exports[`ReadData with "gnomad_r3" dataset selected has no unexpected changes with exome data present 1`] = `
-.c2 {
+[
+  .c2 {
+  box-sizing: border-box;
+  height: calc(2em + 2px);
+  padding: 0.375em 0.75em;
+  border-color: #6c757d;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0.5em;
+  background-color: #f8f9fa;
+  cursor: pointer;
+  font-size: 1em;
+  line-height: 1.25;
+  outline: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c2:active,
+.c2:hover {
+  background-color: #cbd3da;
+}
+
+.c2:disabled {
+  background-color: rgba(248,249,250,0.5);
+  cursor: not-allowed;
+}
+
+.c2:focus {
+  box-shadow: 0 0 0 0.2em rgba(108,117,125,0.5);
+}
+
+.c2 svg {
+  position: relative;
+  top: 0.11em;
+  width: 0.9em;
+  height: 0.9em;
+}
+
+.c3 {
+  margin-right: 0.5em;
+}
+
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  outline: none;
+  padding: 0 3px;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.c1 img {
+  position: relative;
+  top: 0.13em;
+  width: 14px;
+  height: 14px;
+  border-radius: 7px;
+}
+
+.c1:focus img {
+  box-shadow: 0 0 0 0.2em rgba(70,130,180,0.5);
+}
+
+.c0 {
+  margin-bottom: 3rem;
+}
+
+<div
+    className="c0"
+  >
+    <button
+      className="c1"
+      onClick={[Function]}
+      type="button"
+    >
+      <img
+        alt=""
+        aria-hidden="true"
+        src="test-file-stub"
+      />
+      <span
+        style={
+          {
+            "border": "0",
+            "clip": "rect(0 0 0 0)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+      >
+        More information
+      </span>
+    </button>
+     
+    <button
+      className="c2"
+      disabled={false}
+      id="load-once"
+      onClick={[Function]}
+      type="button"
+    >
+      Load read data
+    </button>
+    <div>
+      <br />
+      <input
+        checked={true}
+        className="c3"
+        id="always-load"
+        onChange={[Function]}
+        type="checkbox"
+      />
+      Always load read data
+    </div>
+  </div>,
+  .c2 {
   box-sizing: border-box;
   height: calc(2em + 2px);
   padding: 0.375em 0.75em;
@@ -1822,75 +3901,76 @@ exports[`ReadData with "gnomad_r3" dataset selected has no unexpected changes wi
 }
 
 <div>
-  <p>
-    This interactive
-     
-    <a
-      className="c0"
-      href="https://github.com/igvteam/igv.js"
-      rel="noopener noreferrer"
-      target="_blank"
+    <p>
+      This interactive
+       
+      <a
+        className="c0"
+        href="https://github.com/igvteam/igv.js"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        IGV.js
+      </a>
+       visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
+    </p>
+    <p>
+      These are reassembled reads produced by
+       
+      <a
+        className="c0"
+        href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        GATK HaplotypeCaller --bamOutput
+      </a>
+      , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
+    </p>
+    <div
+      className="c1"
     >
-      IGV.js
-    </a>
-     visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
-  </p>
-  <p>
-    These are reassembled reads produced by
-     
-    <a
-      className="c0"
-      href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
-      rel="noopener noreferrer"
-      target="_blank"
+      <strong>
+        Exomes:
+      </strong>
+      <button
+        className="c2"
+        disabled={true}
+        onClick={[Function]}
+        type="button"
+      >
+        Load +1 
+        het
+      </button>
+      <button
+        className="c2"
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+      >
+        Load +1 
+        hom
+      </button>
+    </div>
+    <div
+      className="c1"
     >
-      GATK HaplotypeCaller --bamOutput
-    </a>
-    , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
-  </p>
-  <div
-    className="c1"
-  >
-    <strong>
-      Exomes:
-    </strong>
-    <button
-      className="c2"
-      disabled={true}
-      onClick={[Function]}
-      type="button"
-    >
-      Load +1 
-      het
-    </button>
-    <button
-      className="c2"
-      disabled={false}
-      onClick={[Function]}
-      type="button"
-    >
-      Load +1 
-      hom
-    </button>
-  </div>
-  <div
-    className="c1"
-  >
-    <button
-      className="c2"
-      disabled={false}
-      onClick={[Function]}
-      style={
-        {
-          "marginLeft": "80px",
+      <button
+        className="c2"
+        disabled={false}
+        onClick={[Function]}
+        style={
+          {
+            "marginLeft": "80px",
+          }
         }
-      }
-      type="button"
-    >
-      Load all
-    </button>
-  </div>
-</div>
+        type="button"
+      >
+        Load all
+      </button>
+    </div>
+  </div>,
+]
 `;
 
 exports[`ReadData with "gnomad_r3" dataset selected queries against the correct dataset 1`] = `
@@ -1915,15 +3995,274 @@ exports[`ReadData with "gnomad_r3" dataset selected queries against the correct 
 `;
 
 exports[`ReadData with "gnomad_r3_controls_and_biobanks" dataset selected has no unexpected changes with exome and genome data both missing 1`] = `
-<div>
-  <p>
-    No read data available for this variant.
-  </p>
-</div>
+[
+  .c2 {
+  box-sizing: border-box;
+  height: calc(2em + 2px);
+  padding: 0.375em 0.75em;
+  border-color: #6c757d;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0.5em;
+  background-color: #f8f9fa;
+  cursor: pointer;
+  font-size: 1em;
+  line-height: 1.25;
+  outline: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c2:active,
+.c2:hover {
+  background-color: #cbd3da;
+}
+
+.c2:disabled {
+  background-color: rgba(248,249,250,0.5);
+  cursor: not-allowed;
+}
+
+.c2:focus {
+  box-shadow: 0 0 0 0.2em rgba(108,117,125,0.5);
+}
+
+.c2 svg {
+  position: relative;
+  top: 0.11em;
+  width: 0.9em;
+  height: 0.9em;
+}
+
+.c3 {
+  margin-right: 0.5em;
+}
+
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  outline: none;
+  padding: 0 3px;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.c1 img {
+  position: relative;
+  top: 0.13em;
+  width: 14px;
+  height: 14px;
+  border-radius: 7px;
+}
+
+.c1:focus img {
+  box-shadow: 0 0 0 0.2em rgba(70,130,180,0.5);
+}
+
+.c0 {
+  margin-bottom: 3rem;
+}
+
+<div
+    className="c0"
+  >
+    <button
+      className="c1"
+      onClick={[Function]}
+      type="button"
+    >
+      <img
+        alt=""
+        aria-hidden="true"
+        src="test-file-stub"
+      />
+      <span
+        style={
+          {
+            "border": "0",
+            "clip": "rect(0 0 0 0)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+      >
+        More information
+      </span>
+    </button>
+     
+    <button
+      className="c2"
+      disabled={false}
+      id="load-once"
+      onClick={[Function]}
+      type="button"
+    >
+      Load read data
+    </button>
+    <div>
+      <br />
+      <input
+        checked={true}
+        className="c3"
+        id="always-load"
+        onChange={[Function]}
+        type="checkbox"
+      />
+      Always load read data
+    </div>
+  </div>,
+  <div>
+    <p>
+      No read data available for this variant.
+    </p>
+  </div>,
+]
 `;
 
 exports[`ReadData with "gnomad_r3_controls_and_biobanks" dataset selected has no unexpected changes with exome data present 1`] = `
+[
+  .c2 {
+  box-sizing: border-box;
+  height: calc(2em + 2px);
+  padding: 0.375em 0.75em;
+  border-color: #6c757d;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0.5em;
+  background-color: #f8f9fa;
+  cursor: pointer;
+  font-size: 1em;
+  line-height: 1.25;
+  outline: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c2:active,
+.c2:hover {
+  background-color: #cbd3da;
+}
+
+.c2:disabled {
+  background-color: rgba(248,249,250,0.5);
+  cursor: not-allowed;
+}
+
+.c2:focus {
+  box-shadow: 0 0 0 0.2em rgba(108,117,125,0.5);
+}
+
+.c2 svg {
+  position: relative;
+  top: 0.11em;
+  width: 0.9em;
+  height: 0.9em;
+}
+
 .c3 {
+  margin-right: 0.5em;
+}
+
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  outline: none;
+  padding: 0 3px;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.c1 img {
+  position: relative;
+  top: 0.13em;
+  width: 14px;
+  height: 14px;
+  border-radius: 7px;
+}
+
+.c1:focus img {
+  box-shadow: 0 0 0 0.2em rgba(70,130,180,0.5);
+}
+
+.c0 {
+  margin-bottom: 3rem;
+}
+
+<div
+    className="c0"
+  >
+    <button
+      className="c1"
+      onClick={[Function]}
+      type="button"
+    >
+      <img
+        alt=""
+        aria-hidden="true"
+        src="test-file-stub"
+      />
+      <span
+        style={
+          {
+            "border": "0",
+            "clip": "rect(0 0 0 0)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+      >
+        More information
+      </span>
+    </button>
+     
+    <button
+      className="c2"
+      disabled={false}
+      id="load-once"
+      onClick={[Function]}
+      type="button"
+    >
+      Load read data
+    </button>
+    <div>
+      <br />
+      <input
+        checked={true}
+        className="c3"
+        id="always-load"
+        onChange={[Function]}
+        type="checkbox"
+      />
+      Always load read data
+    </div>
+  </div>,
+  .c3 {
   box-sizing: border-box;
   height: calc(2em + 2px);
   padding: 0.375em 0.75em;
@@ -2041,83 +4380,84 @@ exports[`ReadData with "gnomad_r3_controls_and_biobanks" dataset selected has no
 }
 
 <div>
-  <p>
-    This interactive
-     
-    <a
-      className="c0"
-      href="https://github.com/igvteam/igv.js"
-      rel="noopener noreferrer"
-      target="_blank"
+    <p>
+      This interactive
+       
+      <a
+        className="c0"
+        href="https://github.com/igvteam/igv.js"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        IGV.js
+      </a>
+       visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
+    </p>
+    <p>
+      These are reassembled reads produced by
+       
+      <a
+        className="c0"
+        href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        GATK HaplotypeCaller --bamOutput
+      </a>
+      , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
+    </p>
+    <p>
+      <span
+        className="c1"
+      >
+        Note
+      </span>
+       Samples shown below are not guaranteed to be part of the selected subset.
+    </p>
+    <div
+      className="c2"
     >
-      IGV.js
-    </a>
-     visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
-  </p>
-  <p>
-    These are reassembled reads produced by
-     
-    <a
-      className="c0"
-      href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
-      rel="noopener noreferrer"
-      target="_blank"
+      <strong>
+        Exomes:
+      </strong>
+      <button
+        className="c3"
+        disabled={true}
+        onClick={[Function]}
+        type="button"
+      >
+        Load +1 
+        het
+      </button>
+      <button
+        className="c3"
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+      >
+        Load +1 
+        hom
+      </button>
+    </div>
+    <div
+      className="c2"
     >
-      GATK HaplotypeCaller --bamOutput
-    </a>
-    , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
-  </p>
-  <p>
-    <span
-      className="c1"
-    >
-      Note
-    </span>
-     Samples shown below are not guaranteed to be part of the selected subset.
-  </p>
-  <div
-    className="c2"
-  >
-    <strong>
-      Exomes:
-    </strong>
-    <button
-      className="c3"
-      disabled={true}
-      onClick={[Function]}
-      type="button"
-    >
-      Load +1 
-      het
-    </button>
-    <button
-      className="c3"
-      disabled={false}
-      onClick={[Function]}
-      type="button"
-    >
-      Load +1 
-      hom
-    </button>
-  </div>
-  <div
-    className="c2"
-  >
-    <button
-      className="c3"
-      disabled={false}
-      onClick={[Function]}
-      style={
-        {
-          "marginLeft": "80px",
+      <button
+        className="c3"
+        disabled={false}
+        onClick={[Function]}
+        style={
+          {
+            "marginLeft": "80px",
+          }
         }
-      }
-      type="button"
-    >
-      Load all
-    </button>
-  </div>
-</div>
+        type="button"
+      >
+        Load all
+      </button>
+    </div>
+  </div>,
+]
 `;
 
 exports[`ReadData with "gnomad_r3_controls_and_biobanks" dataset selected queries against the correct dataset 1`] = `
@@ -2142,15 +4482,274 @@ exports[`ReadData with "gnomad_r3_controls_and_biobanks" dataset selected querie
 `;
 
 exports[`ReadData with "gnomad_r3_non_cancer" dataset selected has no unexpected changes with exome and genome data both missing 1`] = `
-<div>
-  <p>
-    No read data available for this variant.
-  </p>
-</div>
+[
+  .c2 {
+  box-sizing: border-box;
+  height: calc(2em + 2px);
+  padding: 0.375em 0.75em;
+  border-color: #6c757d;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0.5em;
+  background-color: #f8f9fa;
+  cursor: pointer;
+  font-size: 1em;
+  line-height: 1.25;
+  outline: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c2:active,
+.c2:hover {
+  background-color: #cbd3da;
+}
+
+.c2:disabled {
+  background-color: rgba(248,249,250,0.5);
+  cursor: not-allowed;
+}
+
+.c2:focus {
+  box-shadow: 0 0 0 0.2em rgba(108,117,125,0.5);
+}
+
+.c2 svg {
+  position: relative;
+  top: 0.11em;
+  width: 0.9em;
+  height: 0.9em;
+}
+
+.c3 {
+  margin-right: 0.5em;
+}
+
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  outline: none;
+  padding: 0 3px;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.c1 img {
+  position: relative;
+  top: 0.13em;
+  width: 14px;
+  height: 14px;
+  border-radius: 7px;
+}
+
+.c1:focus img {
+  box-shadow: 0 0 0 0.2em rgba(70,130,180,0.5);
+}
+
+.c0 {
+  margin-bottom: 3rem;
+}
+
+<div
+    className="c0"
+  >
+    <button
+      className="c1"
+      onClick={[Function]}
+      type="button"
+    >
+      <img
+        alt=""
+        aria-hidden="true"
+        src="test-file-stub"
+      />
+      <span
+        style={
+          {
+            "border": "0",
+            "clip": "rect(0 0 0 0)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+      >
+        More information
+      </span>
+    </button>
+     
+    <button
+      className="c2"
+      disabled={false}
+      id="load-once"
+      onClick={[Function]}
+      type="button"
+    >
+      Load read data
+    </button>
+    <div>
+      <br />
+      <input
+        checked={true}
+        className="c3"
+        id="always-load"
+        onChange={[Function]}
+        type="checkbox"
+      />
+      Always load read data
+    </div>
+  </div>,
+  <div>
+    <p>
+      No read data available for this variant.
+    </p>
+  </div>,
+]
 `;
 
 exports[`ReadData with "gnomad_r3_non_cancer" dataset selected has no unexpected changes with exome data present 1`] = `
+[
+  .c2 {
+  box-sizing: border-box;
+  height: calc(2em + 2px);
+  padding: 0.375em 0.75em;
+  border-color: #6c757d;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0.5em;
+  background-color: #f8f9fa;
+  cursor: pointer;
+  font-size: 1em;
+  line-height: 1.25;
+  outline: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c2:active,
+.c2:hover {
+  background-color: #cbd3da;
+}
+
+.c2:disabled {
+  background-color: rgba(248,249,250,0.5);
+  cursor: not-allowed;
+}
+
+.c2:focus {
+  box-shadow: 0 0 0 0.2em rgba(108,117,125,0.5);
+}
+
+.c2 svg {
+  position: relative;
+  top: 0.11em;
+  width: 0.9em;
+  height: 0.9em;
+}
+
 .c3 {
+  margin-right: 0.5em;
+}
+
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  outline: none;
+  padding: 0 3px;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.c1 img {
+  position: relative;
+  top: 0.13em;
+  width: 14px;
+  height: 14px;
+  border-radius: 7px;
+}
+
+.c1:focus img {
+  box-shadow: 0 0 0 0.2em rgba(70,130,180,0.5);
+}
+
+.c0 {
+  margin-bottom: 3rem;
+}
+
+<div
+    className="c0"
+  >
+    <button
+      className="c1"
+      onClick={[Function]}
+      type="button"
+    >
+      <img
+        alt=""
+        aria-hidden="true"
+        src="test-file-stub"
+      />
+      <span
+        style={
+          {
+            "border": "0",
+            "clip": "rect(0 0 0 0)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+      >
+        More information
+      </span>
+    </button>
+     
+    <button
+      className="c2"
+      disabled={false}
+      id="load-once"
+      onClick={[Function]}
+      type="button"
+    >
+      Load read data
+    </button>
+    <div>
+      <br />
+      <input
+        checked={true}
+        className="c3"
+        id="always-load"
+        onChange={[Function]}
+        type="checkbox"
+      />
+      Always load read data
+    </div>
+  </div>,
+  .c3 {
   box-sizing: border-box;
   height: calc(2em + 2px);
   padding: 0.375em 0.75em;
@@ -2268,83 +4867,84 @@ exports[`ReadData with "gnomad_r3_non_cancer" dataset selected has no unexpected
 }
 
 <div>
-  <p>
-    This interactive
-     
-    <a
-      className="c0"
-      href="https://github.com/igvteam/igv.js"
-      rel="noopener noreferrer"
-      target="_blank"
+    <p>
+      This interactive
+       
+      <a
+        className="c0"
+        href="https://github.com/igvteam/igv.js"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        IGV.js
+      </a>
+       visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
+    </p>
+    <p>
+      These are reassembled reads produced by
+       
+      <a
+        className="c0"
+        href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        GATK HaplotypeCaller --bamOutput
+      </a>
+      , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
+    </p>
+    <p>
+      <span
+        className="c1"
+      >
+        Note
+      </span>
+       Samples shown below are not guaranteed to be part of the selected subset.
+    </p>
+    <div
+      className="c2"
     >
-      IGV.js
-    </a>
-     visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
-  </p>
-  <p>
-    These are reassembled reads produced by
-     
-    <a
-      className="c0"
-      href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
-      rel="noopener noreferrer"
-      target="_blank"
+      <strong>
+        Exomes:
+      </strong>
+      <button
+        className="c3"
+        disabled={true}
+        onClick={[Function]}
+        type="button"
+      >
+        Load +1 
+        het
+      </button>
+      <button
+        className="c3"
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+      >
+        Load +1 
+        hom
+      </button>
+    </div>
+    <div
+      className="c2"
     >
-      GATK HaplotypeCaller --bamOutput
-    </a>
-    , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
-  </p>
-  <p>
-    <span
-      className="c1"
-    >
-      Note
-    </span>
-     Samples shown below are not guaranteed to be part of the selected subset.
-  </p>
-  <div
-    className="c2"
-  >
-    <strong>
-      Exomes:
-    </strong>
-    <button
-      className="c3"
-      disabled={true}
-      onClick={[Function]}
-      type="button"
-    >
-      Load +1 
-      het
-    </button>
-    <button
-      className="c3"
-      disabled={false}
-      onClick={[Function]}
-      type="button"
-    >
-      Load +1 
-      hom
-    </button>
-  </div>
-  <div
-    className="c2"
-  >
-    <button
-      className="c3"
-      disabled={false}
-      onClick={[Function]}
-      style={
-        {
-          "marginLeft": "80px",
+      <button
+        className="c3"
+        disabled={false}
+        onClick={[Function]}
+        style={
+          {
+            "marginLeft": "80px",
+          }
         }
-      }
-      type="button"
-    >
-      Load all
-    </button>
-  </div>
-</div>
+        type="button"
+      >
+        Load all
+      </button>
+    </div>
+  </div>,
+]
 `;
 
 exports[`ReadData with "gnomad_r3_non_cancer" dataset selected queries against the correct dataset 1`] = `
@@ -2369,15 +4969,274 @@ exports[`ReadData with "gnomad_r3_non_cancer" dataset selected queries against t
 `;
 
 exports[`ReadData with "gnomad_r3_non_neuro" dataset selected has no unexpected changes with exome and genome data both missing 1`] = `
-<div>
-  <p>
-    No read data available for this variant.
-  </p>
-</div>
+[
+  .c2 {
+  box-sizing: border-box;
+  height: calc(2em + 2px);
+  padding: 0.375em 0.75em;
+  border-color: #6c757d;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0.5em;
+  background-color: #f8f9fa;
+  cursor: pointer;
+  font-size: 1em;
+  line-height: 1.25;
+  outline: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c2:active,
+.c2:hover {
+  background-color: #cbd3da;
+}
+
+.c2:disabled {
+  background-color: rgba(248,249,250,0.5);
+  cursor: not-allowed;
+}
+
+.c2:focus {
+  box-shadow: 0 0 0 0.2em rgba(108,117,125,0.5);
+}
+
+.c2 svg {
+  position: relative;
+  top: 0.11em;
+  width: 0.9em;
+  height: 0.9em;
+}
+
+.c3 {
+  margin-right: 0.5em;
+}
+
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  outline: none;
+  padding: 0 3px;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.c1 img {
+  position: relative;
+  top: 0.13em;
+  width: 14px;
+  height: 14px;
+  border-radius: 7px;
+}
+
+.c1:focus img {
+  box-shadow: 0 0 0 0.2em rgba(70,130,180,0.5);
+}
+
+.c0 {
+  margin-bottom: 3rem;
+}
+
+<div
+    className="c0"
+  >
+    <button
+      className="c1"
+      onClick={[Function]}
+      type="button"
+    >
+      <img
+        alt=""
+        aria-hidden="true"
+        src="test-file-stub"
+      />
+      <span
+        style={
+          {
+            "border": "0",
+            "clip": "rect(0 0 0 0)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+      >
+        More information
+      </span>
+    </button>
+     
+    <button
+      className="c2"
+      disabled={false}
+      id="load-once"
+      onClick={[Function]}
+      type="button"
+    >
+      Load read data
+    </button>
+    <div>
+      <br />
+      <input
+        checked={true}
+        className="c3"
+        id="always-load"
+        onChange={[Function]}
+        type="checkbox"
+      />
+      Always load read data
+    </div>
+  </div>,
+  <div>
+    <p>
+      No read data available for this variant.
+    </p>
+  </div>,
+]
 `;
 
 exports[`ReadData with "gnomad_r3_non_neuro" dataset selected has no unexpected changes with exome data present 1`] = `
+[
+  .c2 {
+  box-sizing: border-box;
+  height: calc(2em + 2px);
+  padding: 0.375em 0.75em;
+  border-color: #6c757d;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0.5em;
+  background-color: #f8f9fa;
+  cursor: pointer;
+  font-size: 1em;
+  line-height: 1.25;
+  outline: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c2:active,
+.c2:hover {
+  background-color: #cbd3da;
+}
+
+.c2:disabled {
+  background-color: rgba(248,249,250,0.5);
+  cursor: not-allowed;
+}
+
+.c2:focus {
+  box-shadow: 0 0 0 0.2em rgba(108,117,125,0.5);
+}
+
+.c2 svg {
+  position: relative;
+  top: 0.11em;
+  width: 0.9em;
+  height: 0.9em;
+}
+
 .c3 {
+  margin-right: 0.5em;
+}
+
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  outline: none;
+  padding: 0 3px;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.c1 img {
+  position: relative;
+  top: 0.13em;
+  width: 14px;
+  height: 14px;
+  border-radius: 7px;
+}
+
+.c1:focus img {
+  box-shadow: 0 0 0 0.2em rgba(70,130,180,0.5);
+}
+
+.c0 {
+  margin-bottom: 3rem;
+}
+
+<div
+    className="c0"
+  >
+    <button
+      className="c1"
+      onClick={[Function]}
+      type="button"
+    >
+      <img
+        alt=""
+        aria-hidden="true"
+        src="test-file-stub"
+      />
+      <span
+        style={
+          {
+            "border": "0",
+            "clip": "rect(0 0 0 0)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+      >
+        More information
+      </span>
+    </button>
+     
+    <button
+      className="c2"
+      disabled={false}
+      id="load-once"
+      onClick={[Function]}
+      type="button"
+    >
+      Load read data
+    </button>
+    <div>
+      <br />
+      <input
+        checked={true}
+        className="c3"
+        id="always-load"
+        onChange={[Function]}
+        type="checkbox"
+      />
+      Always load read data
+    </div>
+  </div>,
+  .c3 {
   box-sizing: border-box;
   height: calc(2em + 2px);
   padding: 0.375em 0.75em;
@@ -2495,83 +5354,84 @@ exports[`ReadData with "gnomad_r3_non_neuro" dataset selected has no unexpected 
 }
 
 <div>
-  <p>
-    This interactive
-     
-    <a
-      className="c0"
-      href="https://github.com/igvteam/igv.js"
-      rel="noopener noreferrer"
-      target="_blank"
+    <p>
+      This interactive
+       
+      <a
+        className="c0"
+        href="https://github.com/igvteam/igv.js"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        IGV.js
+      </a>
+       visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
+    </p>
+    <p>
+      These are reassembled reads produced by
+       
+      <a
+        className="c0"
+        href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        GATK HaplotypeCaller --bamOutput
+      </a>
+      , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
+    </p>
+    <p>
+      <span
+        className="c1"
+      >
+        Note
+      </span>
+       Samples shown below are not guaranteed to be part of the selected subset.
+    </p>
+    <div
+      className="c2"
     >
-      IGV.js
-    </a>
-     visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
-  </p>
-  <p>
-    These are reassembled reads produced by
-     
-    <a
-      className="c0"
-      href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
-      rel="noopener noreferrer"
-      target="_blank"
+      <strong>
+        Exomes:
+      </strong>
+      <button
+        className="c3"
+        disabled={true}
+        onClick={[Function]}
+        type="button"
+      >
+        Load +1 
+        het
+      </button>
+      <button
+        className="c3"
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+      >
+        Load +1 
+        hom
+      </button>
+    </div>
+    <div
+      className="c2"
     >
-      GATK HaplotypeCaller --bamOutput
-    </a>
-    , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
-  </p>
-  <p>
-    <span
-      className="c1"
-    >
-      Note
-    </span>
-     Samples shown below are not guaranteed to be part of the selected subset.
-  </p>
-  <div
-    className="c2"
-  >
-    <strong>
-      Exomes:
-    </strong>
-    <button
-      className="c3"
-      disabled={true}
-      onClick={[Function]}
-      type="button"
-    >
-      Load +1 
-      het
-    </button>
-    <button
-      className="c3"
-      disabled={false}
-      onClick={[Function]}
-      type="button"
-    >
-      Load +1 
-      hom
-    </button>
-  </div>
-  <div
-    className="c2"
-  >
-    <button
-      className="c3"
-      disabled={false}
-      onClick={[Function]}
-      style={
-        {
-          "marginLeft": "80px",
+      <button
+        className="c3"
+        disabled={false}
+        onClick={[Function]}
+        style={
+          {
+            "marginLeft": "80px",
+          }
         }
-      }
-      type="button"
-    >
-      Load all
-    </button>
-  </div>
-</div>
+        type="button"
+      >
+        Load all
+      </button>
+    </div>
+  </div>,
+]
 `;
 
 exports[`ReadData with "gnomad_r3_non_neuro" dataset selected queries against the correct dataset 1`] = `
@@ -2596,15 +5456,274 @@ exports[`ReadData with "gnomad_r3_non_neuro" dataset selected queries against th
 `;
 
 exports[`ReadData with "gnomad_r3_non_topmed" dataset selected has no unexpected changes with exome and genome data both missing 1`] = `
-<div>
-  <p>
-    No read data available for this variant.
-  </p>
-</div>
+[
+  .c2 {
+  box-sizing: border-box;
+  height: calc(2em + 2px);
+  padding: 0.375em 0.75em;
+  border-color: #6c757d;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0.5em;
+  background-color: #f8f9fa;
+  cursor: pointer;
+  font-size: 1em;
+  line-height: 1.25;
+  outline: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c2:active,
+.c2:hover {
+  background-color: #cbd3da;
+}
+
+.c2:disabled {
+  background-color: rgba(248,249,250,0.5);
+  cursor: not-allowed;
+}
+
+.c2:focus {
+  box-shadow: 0 0 0 0.2em rgba(108,117,125,0.5);
+}
+
+.c2 svg {
+  position: relative;
+  top: 0.11em;
+  width: 0.9em;
+  height: 0.9em;
+}
+
+.c3 {
+  margin-right: 0.5em;
+}
+
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  outline: none;
+  padding: 0 3px;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.c1 img {
+  position: relative;
+  top: 0.13em;
+  width: 14px;
+  height: 14px;
+  border-radius: 7px;
+}
+
+.c1:focus img {
+  box-shadow: 0 0 0 0.2em rgba(70,130,180,0.5);
+}
+
+.c0 {
+  margin-bottom: 3rem;
+}
+
+<div
+    className="c0"
+  >
+    <button
+      className="c1"
+      onClick={[Function]}
+      type="button"
+    >
+      <img
+        alt=""
+        aria-hidden="true"
+        src="test-file-stub"
+      />
+      <span
+        style={
+          {
+            "border": "0",
+            "clip": "rect(0 0 0 0)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+      >
+        More information
+      </span>
+    </button>
+     
+    <button
+      className="c2"
+      disabled={false}
+      id="load-once"
+      onClick={[Function]}
+      type="button"
+    >
+      Load read data
+    </button>
+    <div>
+      <br />
+      <input
+        checked={true}
+        className="c3"
+        id="always-load"
+        onChange={[Function]}
+        type="checkbox"
+      />
+      Always load read data
+    </div>
+  </div>,
+  <div>
+    <p>
+      No read data available for this variant.
+    </p>
+  </div>,
+]
 `;
 
 exports[`ReadData with "gnomad_r3_non_topmed" dataset selected has no unexpected changes with exome data present 1`] = `
+[
+  .c2 {
+  box-sizing: border-box;
+  height: calc(2em + 2px);
+  padding: 0.375em 0.75em;
+  border-color: #6c757d;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0.5em;
+  background-color: #f8f9fa;
+  cursor: pointer;
+  font-size: 1em;
+  line-height: 1.25;
+  outline: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c2:active,
+.c2:hover {
+  background-color: #cbd3da;
+}
+
+.c2:disabled {
+  background-color: rgba(248,249,250,0.5);
+  cursor: not-allowed;
+}
+
+.c2:focus {
+  box-shadow: 0 0 0 0.2em rgba(108,117,125,0.5);
+}
+
+.c2 svg {
+  position: relative;
+  top: 0.11em;
+  width: 0.9em;
+  height: 0.9em;
+}
+
 .c3 {
+  margin-right: 0.5em;
+}
+
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  outline: none;
+  padding: 0 3px;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.c1 img {
+  position: relative;
+  top: 0.13em;
+  width: 14px;
+  height: 14px;
+  border-radius: 7px;
+}
+
+.c1:focus img {
+  box-shadow: 0 0 0 0.2em rgba(70,130,180,0.5);
+}
+
+.c0 {
+  margin-bottom: 3rem;
+}
+
+<div
+    className="c0"
+  >
+    <button
+      className="c1"
+      onClick={[Function]}
+      type="button"
+    >
+      <img
+        alt=""
+        aria-hidden="true"
+        src="test-file-stub"
+      />
+      <span
+        style={
+          {
+            "border": "0",
+            "clip": "rect(0 0 0 0)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+      >
+        More information
+      </span>
+    </button>
+     
+    <button
+      className="c2"
+      disabled={false}
+      id="load-once"
+      onClick={[Function]}
+      type="button"
+    >
+      Load read data
+    </button>
+    <div>
+      <br />
+      <input
+        checked={true}
+        className="c3"
+        id="always-load"
+        onChange={[Function]}
+        type="checkbox"
+      />
+      Always load read data
+    </div>
+  </div>,
+  .c3 {
   box-sizing: border-box;
   height: calc(2em + 2px);
   padding: 0.375em 0.75em;
@@ -2722,83 +5841,84 @@ exports[`ReadData with "gnomad_r3_non_topmed" dataset selected has no unexpected
 }
 
 <div>
-  <p>
-    This interactive
-     
-    <a
-      className="c0"
-      href="https://github.com/igvteam/igv.js"
-      rel="noopener noreferrer"
-      target="_blank"
+    <p>
+      This interactive
+       
+      <a
+        className="c0"
+        href="https://github.com/igvteam/igv.js"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        IGV.js
+      </a>
+       visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
+    </p>
+    <p>
+      These are reassembled reads produced by
+       
+      <a
+        className="c0"
+        href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        GATK HaplotypeCaller --bamOutput
+      </a>
+      , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
+    </p>
+    <p>
+      <span
+        className="c1"
+      >
+        Note
+      </span>
+       Samples shown below are not guaranteed to be part of the selected subset.
+    </p>
+    <div
+      className="c2"
     >
-      IGV.js
-    </a>
-     visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
-  </p>
-  <p>
-    These are reassembled reads produced by
-     
-    <a
-      className="c0"
-      href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
-      rel="noopener noreferrer"
-      target="_blank"
+      <strong>
+        Exomes:
+      </strong>
+      <button
+        className="c3"
+        disabled={true}
+        onClick={[Function]}
+        type="button"
+      >
+        Load +1 
+        het
+      </button>
+      <button
+        className="c3"
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+      >
+        Load +1 
+        hom
+      </button>
+    </div>
+    <div
+      className="c2"
     >
-      GATK HaplotypeCaller --bamOutput
-    </a>
-    , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
-  </p>
-  <p>
-    <span
-      className="c1"
-    >
-      Note
-    </span>
-     Samples shown below are not guaranteed to be part of the selected subset.
-  </p>
-  <div
-    className="c2"
-  >
-    <strong>
-      Exomes:
-    </strong>
-    <button
-      className="c3"
-      disabled={true}
-      onClick={[Function]}
-      type="button"
-    >
-      Load +1 
-      het
-    </button>
-    <button
-      className="c3"
-      disabled={false}
-      onClick={[Function]}
-      type="button"
-    >
-      Load +1 
-      hom
-    </button>
-  </div>
-  <div
-    className="c2"
-  >
-    <button
-      className="c3"
-      disabled={false}
-      onClick={[Function]}
-      style={
-        {
-          "marginLeft": "80px",
+      <button
+        className="c3"
+        disabled={false}
+        onClick={[Function]}
+        style={
+          {
+            "marginLeft": "80px",
+          }
         }
-      }
-      type="button"
-    >
-      Load all
-    </button>
-  </div>
-</div>
+        type="button"
+      >
+        Load all
+      </button>
+    </div>
+  </div>,
+]
 `;
 
 exports[`ReadData with "gnomad_r3_non_topmed" dataset selected queries against the correct dataset 1`] = `
@@ -2823,15 +5943,274 @@ exports[`ReadData with "gnomad_r3_non_topmed" dataset selected queries against t
 `;
 
 exports[`ReadData with "gnomad_r3_non_v2" dataset selected has no unexpected changes with exome and genome data both missing 1`] = `
-<div>
-  <p>
-    No read data available for this variant.
-  </p>
-</div>
+[
+  .c2 {
+  box-sizing: border-box;
+  height: calc(2em + 2px);
+  padding: 0.375em 0.75em;
+  border-color: #6c757d;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0.5em;
+  background-color: #f8f9fa;
+  cursor: pointer;
+  font-size: 1em;
+  line-height: 1.25;
+  outline: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c2:active,
+.c2:hover {
+  background-color: #cbd3da;
+}
+
+.c2:disabled {
+  background-color: rgba(248,249,250,0.5);
+  cursor: not-allowed;
+}
+
+.c2:focus {
+  box-shadow: 0 0 0 0.2em rgba(108,117,125,0.5);
+}
+
+.c2 svg {
+  position: relative;
+  top: 0.11em;
+  width: 0.9em;
+  height: 0.9em;
+}
+
+.c3 {
+  margin-right: 0.5em;
+}
+
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  outline: none;
+  padding: 0 3px;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.c1 img {
+  position: relative;
+  top: 0.13em;
+  width: 14px;
+  height: 14px;
+  border-radius: 7px;
+}
+
+.c1:focus img {
+  box-shadow: 0 0 0 0.2em rgba(70,130,180,0.5);
+}
+
+.c0 {
+  margin-bottom: 3rem;
+}
+
+<div
+    className="c0"
+  >
+    <button
+      className="c1"
+      onClick={[Function]}
+      type="button"
+    >
+      <img
+        alt=""
+        aria-hidden="true"
+        src="test-file-stub"
+      />
+      <span
+        style={
+          {
+            "border": "0",
+            "clip": "rect(0 0 0 0)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+      >
+        More information
+      </span>
+    </button>
+     
+    <button
+      className="c2"
+      disabled={false}
+      id="load-once"
+      onClick={[Function]}
+      type="button"
+    >
+      Load read data
+    </button>
+    <div>
+      <br />
+      <input
+        checked={true}
+        className="c3"
+        id="always-load"
+        onChange={[Function]}
+        type="checkbox"
+      />
+      Always load read data
+    </div>
+  </div>,
+  <div>
+    <p>
+      No read data available for this variant.
+    </p>
+  </div>,
+]
 `;
 
 exports[`ReadData with "gnomad_r3_non_v2" dataset selected has no unexpected changes with exome data present 1`] = `
+[
+  .c2 {
+  box-sizing: border-box;
+  height: calc(2em + 2px);
+  padding: 0.375em 0.75em;
+  border-color: #6c757d;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0.5em;
+  background-color: #f8f9fa;
+  cursor: pointer;
+  font-size: 1em;
+  line-height: 1.25;
+  outline: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c2:active,
+.c2:hover {
+  background-color: #cbd3da;
+}
+
+.c2:disabled {
+  background-color: rgba(248,249,250,0.5);
+  cursor: not-allowed;
+}
+
+.c2:focus {
+  box-shadow: 0 0 0 0.2em rgba(108,117,125,0.5);
+}
+
+.c2 svg {
+  position: relative;
+  top: 0.11em;
+  width: 0.9em;
+  height: 0.9em;
+}
+
 .c3 {
+  margin-right: 0.5em;
+}
+
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  outline: none;
+  padding: 0 3px;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.c1 img {
+  position: relative;
+  top: 0.13em;
+  width: 14px;
+  height: 14px;
+  border-radius: 7px;
+}
+
+.c1:focus img {
+  box-shadow: 0 0 0 0.2em rgba(70,130,180,0.5);
+}
+
+.c0 {
+  margin-bottom: 3rem;
+}
+
+<div
+    className="c0"
+  >
+    <button
+      className="c1"
+      onClick={[Function]}
+      type="button"
+    >
+      <img
+        alt=""
+        aria-hidden="true"
+        src="test-file-stub"
+      />
+      <span
+        style={
+          {
+            "border": "0",
+            "clip": "rect(0 0 0 0)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+      >
+        More information
+      </span>
+    </button>
+     
+    <button
+      className="c2"
+      disabled={false}
+      id="load-once"
+      onClick={[Function]}
+      type="button"
+    >
+      Load read data
+    </button>
+    <div>
+      <br />
+      <input
+        checked={true}
+        className="c3"
+        id="always-load"
+        onChange={[Function]}
+        type="checkbox"
+      />
+      Always load read data
+    </div>
+  </div>,
+  .c3 {
   box-sizing: border-box;
   height: calc(2em + 2px);
   padding: 0.375em 0.75em;
@@ -2949,83 +6328,84 @@ exports[`ReadData with "gnomad_r3_non_v2" dataset selected has no unexpected cha
 }
 
 <div>
-  <p>
-    This interactive
-     
-    <a
-      className="c0"
-      href="https://github.com/igvteam/igv.js"
-      rel="noopener noreferrer"
-      target="_blank"
+    <p>
+      This interactive
+       
+      <a
+        className="c0"
+        href="https://github.com/igvteam/igv.js"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        IGV.js
+      </a>
+       visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
+    </p>
+    <p>
+      These are reassembled reads produced by
+       
+      <a
+        className="c0"
+        href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        GATK HaplotypeCaller --bamOutput
+      </a>
+      , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
+    </p>
+    <p>
+      <span
+        className="c1"
+      >
+        Note
+      </span>
+       Samples shown below are not guaranteed to be part of the selected subset.
+    </p>
+    <div
+      className="c2"
     >
-      IGV.js
-    </a>
-     visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
-  </p>
-  <p>
-    These are reassembled reads produced by
-     
-    <a
-      className="c0"
-      href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
-      rel="noopener noreferrer"
-      target="_blank"
+      <strong>
+        Exomes:
+      </strong>
+      <button
+        className="c3"
+        disabled={true}
+        onClick={[Function]}
+        type="button"
+      >
+        Load +1 
+        het
+      </button>
+      <button
+        className="c3"
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+      >
+        Load +1 
+        hom
+      </button>
+    </div>
+    <div
+      className="c2"
     >
-      GATK HaplotypeCaller --bamOutput
-    </a>
-    , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
-  </p>
-  <p>
-    <span
-      className="c1"
-    >
-      Note
-    </span>
-     Samples shown below are not guaranteed to be part of the selected subset.
-  </p>
-  <div
-    className="c2"
-  >
-    <strong>
-      Exomes:
-    </strong>
-    <button
-      className="c3"
-      disabled={true}
-      onClick={[Function]}
-      type="button"
-    >
-      Load +1 
-      het
-    </button>
-    <button
-      className="c3"
-      disabled={false}
-      onClick={[Function]}
-      type="button"
-    >
-      Load +1 
-      hom
-    </button>
-  </div>
-  <div
-    className="c2"
-  >
-    <button
-      className="c3"
-      disabled={false}
-      onClick={[Function]}
-      style={
-        {
-          "marginLeft": "80px",
+      <button
+        className="c3"
+        disabled={false}
+        onClick={[Function]}
+        style={
+          {
+            "marginLeft": "80px",
+          }
         }
-      }
-      type="button"
-    >
-      Load all
-    </button>
-  </div>
-</div>
+        type="button"
+      >
+        Load all
+      </button>
+    </div>
+  </div>,
+]
 `;
 
 exports[`ReadData with "gnomad_r3_non_v2" dataset selected queries against the correct dataset 1`] = `
@@ -3050,15 +6430,274 @@ exports[`ReadData with "gnomad_r3_non_v2" dataset selected queries against the c
 `;
 
 exports[`ReadData with "gnomad_r4" dataset selected has no unexpected changes with exome and genome data both missing 1`] = `
-<div>
-  <p>
-    No read data available for this variant.
-  </p>
-</div>
+[
+  .c2 {
+  box-sizing: border-box;
+  height: calc(2em + 2px);
+  padding: 0.375em 0.75em;
+  border-color: #6c757d;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0.5em;
+  background-color: #f8f9fa;
+  cursor: pointer;
+  font-size: 1em;
+  line-height: 1.25;
+  outline: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c2:active,
+.c2:hover {
+  background-color: #cbd3da;
+}
+
+.c2:disabled {
+  background-color: rgba(248,249,250,0.5);
+  cursor: not-allowed;
+}
+
+.c2:focus {
+  box-shadow: 0 0 0 0.2em rgba(108,117,125,0.5);
+}
+
+.c2 svg {
+  position: relative;
+  top: 0.11em;
+  width: 0.9em;
+  height: 0.9em;
+}
+
+.c3 {
+  margin-right: 0.5em;
+}
+
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  outline: none;
+  padding: 0 3px;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.c1 img {
+  position: relative;
+  top: 0.13em;
+  width: 14px;
+  height: 14px;
+  border-radius: 7px;
+}
+
+.c1:focus img {
+  box-shadow: 0 0 0 0.2em rgba(70,130,180,0.5);
+}
+
+.c0 {
+  margin-bottom: 3rem;
+}
+
+<div
+    className="c0"
+  >
+    <button
+      className="c1"
+      onClick={[Function]}
+      type="button"
+    >
+      <img
+        alt=""
+        aria-hidden="true"
+        src="test-file-stub"
+      />
+      <span
+        style={
+          {
+            "border": "0",
+            "clip": "rect(0 0 0 0)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+      >
+        More information
+      </span>
+    </button>
+     
+    <button
+      className="c2"
+      disabled={false}
+      id="load-once"
+      onClick={[Function]}
+      type="button"
+    >
+      Load read data
+    </button>
+    <div>
+      <br />
+      <input
+        checked={true}
+        className="c3"
+        id="always-load"
+        onChange={[Function]}
+        type="checkbox"
+      />
+      Always load read data
+    </div>
+  </div>,
+  <div>
+    <p>
+      No read data available for this variant.
+    </p>
+  </div>,
+]
 `;
 
 exports[`ReadData with "gnomad_r4" dataset selected has no unexpected changes with exome data present 1`] = `
-.c2 {
+[
+  .c2 {
+  box-sizing: border-box;
+  height: calc(2em + 2px);
+  padding: 0.375em 0.75em;
+  border-color: #6c757d;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0.5em;
+  background-color: #f8f9fa;
+  cursor: pointer;
+  font-size: 1em;
+  line-height: 1.25;
+  outline: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c2:active,
+.c2:hover {
+  background-color: #cbd3da;
+}
+
+.c2:disabled {
+  background-color: rgba(248,249,250,0.5);
+  cursor: not-allowed;
+}
+
+.c2:focus {
+  box-shadow: 0 0 0 0.2em rgba(108,117,125,0.5);
+}
+
+.c2 svg {
+  position: relative;
+  top: 0.11em;
+  width: 0.9em;
+  height: 0.9em;
+}
+
+.c3 {
+  margin-right: 0.5em;
+}
+
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  outline: none;
+  padding: 0 3px;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.c1 img {
+  position: relative;
+  top: 0.13em;
+  width: 14px;
+  height: 14px;
+  border-radius: 7px;
+}
+
+.c1:focus img {
+  box-shadow: 0 0 0 0.2em rgba(70,130,180,0.5);
+}
+
+.c0 {
+  margin-bottom: 3rem;
+}
+
+<div
+    className="c0"
+  >
+    <button
+      className="c1"
+      onClick={[Function]}
+      type="button"
+    >
+      <img
+        alt=""
+        aria-hidden="true"
+        src="test-file-stub"
+      />
+      <span
+        style={
+          {
+            "border": "0",
+            "clip": "rect(0 0 0 0)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+      >
+        More information
+      </span>
+    </button>
+     
+    <button
+      className="c2"
+      disabled={false}
+      id="load-once"
+      onClick={[Function]}
+      type="button"
+    >
+      Load read data
+    </button>
+    <div>
+      <br />
+      <input
+        checked={true}
+        className="c3"
+        id="always-load"
+        onChange={[Function]}
+        type="checkbox"
+      />
+      Always load read data
+    </div>
+  </div>,
+  .c2 {
   box-sizing: border-box;
   height: calc(2em + 2px);
   padding: 0.375em 0.75em;
@@ -3162,75 +6801,76 @@ exports[`ReadData with "gnomad_r4" dataset selected has no unexpected changes wi
 }
 
 <div>
-  <p>
-    This interactive
-     
-    <a
-      className="c0"
-      href="https://github.com/igvteam/igv.js"
-      rel="noopener noreferrer"
-      target="_blank"
+    <p>
+      This interactive
+       
+      <a
+        className="c0"
+        href="https://github.com/igvteam/igv.js"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        IGV.js
+      </a>
+       visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
+    </p>
+    <p>
+      These are reassembled reads produced by
+       
+      <a
+        className="c0"
+        href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        GATK HaplotypeCaller --bamOutput
+      </a>
+      , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
+    </p>
+    <div
+      className="c1"
     >
-      IGV.js
-    </a>
-     visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
-  </p>
-  <p>
-    These are reassembled reads produced by
-     
-    <a
-      className="c0"
-      href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
-      rel="noopener noreferrer"
-      target="_blank"
+      <strong>
+        Exomes:
+      </strong>
+      <button
+        className="c2"
+        disabled={true}
+        onClick={[Function]}
+        type="button"
+      >
+        Load +1 
+        het
+      </button>
+      <button
+        className="c2"
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+      >
+        Load +1 
+        hom
+      </button>
+    </div>
+    <div
+      className="c1"
     >
-      GATK HaplotypeCaller --bamOutput
-    </a>
-    , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
-  </p>
-  <div
-    className="c1"
-  >
-    <strong>
-      Exomes:
-    </strong>
-    <button
-      className="c2"
-      disabled={true}
-      onClick={[Function]}
-      type="button"
-    >
-      Load +1 
-      het
-    </button>
-    <button
-      className="c2"
-      disabled={false}
-      onClick={[Function]}
-      type="button"
-    >
-      Load +1 
-      hom
-    </button>
-  </div>
-  <div
-    className="c1"
-  >
-    <button
-      className="c2"
-      disabled={false}
-      onClick={[Function]}
-      style={
-        {
-          "marginLeft": "80px",
+      <button
+        className="c2"
+        disabled={false}
+        onClick={[Function]}
+        style={
+          {
+            "marginLeft": "80px",
+          }
         }
-      }
-      type="button"
-    >
-      Load all
-    </button>
-  </div>
-</div>
+        type="button"
+      >
+        Load all
+      </button>
+    </div>
+  </div>,
+]
 `;
 
 exports[`ReadData with "gnomad_r4" dataset selected queries against the correct dataset 1`] = `
@@ -3255,15 +6895,274 @@ exports[`ReadData with "gnomad_r4" dataset selected queries against the correct 
 `;
 
 exports[`ReadData with "gnomad_r4_non_ukb" dataset selected has no unexpected changes with exome and genome data both missing 1`] = `
-<div>
-  <p>
-    No read data available for this variant.
-  </p>
-</div>
+[
+  .c2 {
+  box-sizing: border-box;
+  height: calc(2em + 2px);
+  padding: 0.375em 0.75em;
+  border-color: #6c757d;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0.5em;
+  background-color: #f8f9fa;
+  cursor: pointer;
+  font-size: 1em;
+  line-height: 1.25;
+  outline: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c2:active,
+.c2:hover {
+  background-color: #cbd3da;
+}
+
+.c2:disabled {
+  background-color: rgba(248,249,250,0.5);
+  cursor: not-allowed;
+}
+
+.c2:focus {
+  box-shadow: 0 0 0 0.2em rgba(108,117,125,0.5);
+}
+
+.c2 svg {
+  position: relative;
+  top: 0.11em;
+  width: 0.9em;
+  height: 0.9em;
+}
+
+.c3 {
+  margin-right: 0.5em;
+}
+
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  outline: none;
+  padding: 0 3px;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.c1 img {
+  position: relative;
+  top: 0.13em;
+  width: 14px;
+  height: 14px;
+  border-radius: 7px;
+}
+
+.c1:focus img {
+  box-shadow: 0 0 0 0.2em rgba(70,130,180,0.5);
+}
+
+.c0 {
+  margin-bottom: 3rem;
+}
+
+<div
+    className="c0"
+  >
+    <button
+      className="c1"
+      onClick={[Function]}
+      type="button"
+    >
+      <img
+        alt=""
+        aria-hidden="true"
+        src="test-file-stub"
+      />
+      <span
+        style={
+          {
+            "border": "0",
+            "clip": "rect(0 0 0 0)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+      >
+        More information
+      </span>
+    </button>
+     
+    <button
+      className="c2"
+      disabled={false}
+      id="load-once"
+      onClick={[Function]}
+      type="button"
+    >
+      Load read data
+    </button>
+    <div>
+      <br />
+      <input
+        checked={true}
+        className="c3"
+        id="always-load"
+        onChange={[Function]}
+        type="checkbox"
+      />
+      Always load read data
+    </div>
+  </div>,
+  <div>
+    <p>
+      No read data available for this variant.
+    </p>
+  </div>,
+]
 `;
 
 exports[`ReadData with "gnomad_r4_non_ukb" dataset selected has no unexpected changes with exome data present 1`] = `
+[
+  .c2 {
+  box-sizing: border-box;
+  height: calc(2em + 2px);
+  padding: 0.375em 0.75em;
+  border-color: #6c757d;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0.5em;
+  background-color: #f8f9fa;
+  cursor: pointer;
+  font-size: 1em;
+  line-height: 1.25;
+  outline: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c2:active,
+.c2:hover {
+  background-color: #cbd3da;
+}
+
+.c2:disabled {
+  background-color: rgba(248,249,250,0.5);
+  cursor: not-allowed;
+}
+
+.c2:focus {
+  box-shadow: 0 0 0 0.2em rgba(108,117,125,0.5);
+}
+
+.c2 svg {
+  position: relative;
+  top: 0.11em;
+  width: 0.9em;
+  height: 0.9em;
+}
+
 .c3 {
+  margin-right: 0.5em;
+}
+
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  outline: none;
+  padding: 0 3px;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.c1 img {
+  position: relative;
+  top: 0.13em;
+  width: 14px;
+  height: 14px;
+  border-radius: 7px;
+}
+
+.c1:focus img {
+  box-shadow: 0 0 0 0.2em rgba(70,130,180,0.5);
+}
+
+.c0 {
+  margin-bottom: 3rem;
+}
+
+<div
+    className="c0"
+  >
+    <button
+      className="c1"
+      onClick={[Function]}
+      type="button"
+    >
+      <img
+        alt=""
+        aria-hidden="true"
+        src="test-file-stub"
+      />
+      <span
+        style={
+          {
+            "border": "0",
+            "clip": "rect(0 0 0 0)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+      >
+        More information
+      </span>
+    </button>
+     
+    <button
+      className="c2"
+      disabled={false}
+      id="load-once"
+      onClick={[Function]}
+      type="button"
+    >
+      Load read data
+    </button>
+    <div>
+      <br />
+      <input
+        checked={true}
+        className="c3"
+        id="always-load"
+        onChange={[Function]}
+        type="checkbox"
+      />
+      Always load read data
+    </div>
+  </div>,
+  .c3 {
   box-sizing: border-box;
   height: calc(2em + 2px);
   padding: 0.375em 0.75em;
@@ -3381,83 +7280,84 @@ exports[`ReadData with "gnomad_r4_non_ukb" dataset selected has no unexpected ch
 }
 
 <div>
-  <p>
-    This interactive
-     
-    <a
-      className="c0"
-      href="https://github.com/igvteam/igv.js"
-      rel="noopener noreferrer"
-      target="_blank"
+    <p>
+      This interactive
+       
+      <a
+        className="c0"
+        href="https://github.com/igvteam/igv.js"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        IGV.js
+      </a>
+       visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
+    </p>
+    <p>
+      These are reassembled reads produced by
+       
+      <a
+        className="c0"
+        href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        GATK HaplotypeCaller --bamOutput
+      </a>
+      , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
+    </p>
+    <p>
+      <span
+        className="c1"
+      >
+        Note
+      </span>
+       Samples shown below are not guaranteed to be part of the selected subset.
+    </p>
+    <div
+      className="c2"
     >
-      IGV.js
-    </a>
-     visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
-  </p>
-  <p>
-    These are reassembled reads produced by
-     
-    <a
-      className="c0"
-      href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
-      rel="noopener noreferrer"
-      target="_blank"
+      <strong>
+        Exomes:
+      </strong>
+      <button
+        className="c3"
+        disabled={true}
+        onClick={[Function]}
+        type="button"
+      >
+        Load +1 
+        het
+      </button>
+      <button
+        className="c3"
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+      >
+        Load +1 
+        hom
+      </button>
+    </div>
+    <div
+      className="c2"
     >
-      GATK HaplotypeCaller --bamOutput
-    </a>
-    , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
-  </p>
-  <p>
-    <span
-      className="c1"
-    >
-      Note
-    </span>
-     Samples shown below are not guaranteed to be part of the selected subset.
-  </p>
-  <div
-    className="c2"
-  >
-    <strong>
-      Exomes:
-    </strong>
-    <button
-      className="c3"
-      disabled={true}
-      onClick={[Function]}
-      type="button"
-    >
-      Load +1 
-      het
-    </button>
-    <button
-      className="c3"
-      disabled={false}
-      onClick={[Function]}
-      type="button"
-    >
-      Load +1 
-      hom
-    </button>
-  </div>
-  <div
-    className="c2"
-  >
-    <button
-      className="c3"
-      disabled={false}
-      onClick={[Function]}
-      style={
-        {
-          "marginLeft": "80px",
+      <button
+        className="c3"
+        disabled={false}
+        onClick={[Function]}
+        style={
+          {
+            "marginLeft": "80px",
+          }
         }
-      }
-      type="button"
-    >
-      Load all
-    </button>
-  </div>
-</div>
+        type="button"
+      >
+        Load all
+      </button>
+    </div>
+  </div>,
+]
 `;
 
 exports[`ReadData with "gnomad_r4_non_ukb" dataset selected queries against the correct dataset 1`] = `
@@ -3482,15 +7382,274 @@ exports[`ReadData with "gnomad_r4_non_ukb" dataset selected queries against the 
 `;
 
 exports[`ReadData with "gnomad_sv_r2_1" dataset selected has no unexpected changes with exome and genome data both missing 1`] = `
-<div>
-  <p>
-    No read data available for this variant.
-  </p>
-</div>
+[
+  .c2 {
+  box-sizing: border-box;
+  height: calc(2em + 2px);
+  padding: 0.375em 0.75em;
+  border-color: #6c757d;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0.5em;
+  background-color: #f8f9fa;
+  cursor: pointer;
+  font-size: 1em;
+  line-height: 1.25;
+  outline: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c2:active,
+.c2:hover {
+  background-color: #cbd3da;
+}
+
+.c2:disabled {
+  background-color: rgba(248,249,250,0.5);
+  cursor: not-allowed;
+}
+
+.c2:focus {
+  box-shadow: 0 0 0 0.2em rgba(108,117,125,0.5);
+}
+
+.c2 svg {
+  position: relative;
+  top: 0.11em;
+  width: 0.9em;
+  height: 0.9em;
+}
+
+.c3 {
+  margin-right: 0.5em;
+}
+
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  outline: none;
+  padding: 0 3px;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.c1 img {
+  position: relative;
+  top: 0.13em;
+  width: 14px;
+  height: 14px;
+  border-radius: 7px;
+}
+
+.c1:focus img {
+  box-shadow: 0 0 0 0.2em rgba(70,130,180,0.5);
+}
+
+.c0 {
+  margin-bottom: 3rem;
+}
+
+<div
+    className="c0"
+  >
+    <button
+      className="c1"
+      onClick={[Function]}
+      type="button"
+    >
+      <img
+        alt=""
+        aria-hidden="true"
+        src="test-file-stub"
+      />
+      <span
+        style={
+          {
+            "border": "0",
+            "clip": "rect(0 0 0 0)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+      >
+        More information
+      </span>
+    </button>
+     
+    <button
+      className="c2"
+      disabled={false}
+      id="load-once"
+      onClick={[Function]}
+      type="button"
+    >
+      Load read data
+    </button>
+    <div>
+      <br />
+      <input
+        checked={true}
+        className="c3"
+        id="always-load"
+        onChange={[Function]}
+        type="checkbox"
+      />
+      Always load read data
+    </div>
+  </div>,
+  <div>
+    <p>
+      No read data available for this variant.
+    </p>
+  </div>,
+]
 `;
 
 exports[`ReadData with "gnomad_sv_r2_1" dataset selected has no unexpected changes with exome data present 1`] = `
-.c2 {
+[
+  .c2 {
+  box-sizing: border-box;
+  height: calc(2em + 2px);
+  padding: 0.375em 0.75em;
+  border-color: #6c757d;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0.5em;
+  background-color: #f8f9fa;
+  cursor: pointer;
+  font-size: 1em;
+  line-height: 1.25;
+  outline: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c2:active,
+.c2:hover {
+  background-color: #cbd3da;
+}
+
+.c2:disabled {
+  background-color: rgba(248,249,250,0.5);
+  cursor: not-allowed;
+}
+
+.c2:focus {
+  box-shadow: 0 0 0 0.2em rgba(108,117,125,0.5);
+}
+
+.c2 svg {
+  position: relative;
+  top: 0.11em;
+  width: 0.9em;
+  height: 0.9em;
+}
+
+.c3 {
+  margin-right: 0.5em;
+}
+
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  outline: none;
+  padding: 0 3px;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.c1 img {
+  position: relative;
+  top: 0.13em;
+  width: 14px;
+  height: 14px;
+  border-radius: 7px;
+}
+
+.c1:focus img {
+  box-shadow: 0 0 0 0.2em rgba(70,130,180,0.5);
+}
+
+.c0 {
+  margin-bottom: 3rem;
+}
+
+<div
+    className="c0"
+  >
+    <button
+      className="c1"
+      onClick={[Function]}
+      type="button"
+    >
+      <img
+        alt=""
+        aria-hidden="true"
+        src="test-file-stub"
+      />
+      <span
+        style={
+          {
+            "border": "0",
+            "clip": "rect(0 0 0 0)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+      >
+        More information
+      </span>
+    </button>
+     
+    <button
+      className="c2"
+      disabled={false}
+      id="load-once"
+      onClick={[Function]}
+      type="button"
+    >
+      Load read data
+    </button>
+    <div>
+      <br />
+      <input
+        checked={true}
+        className="c3"
+        id="always-load"
+        onChange={[Function]}
+        type="checkbox"
+      />
+      Always load read data
+    </div>
+  </div>,
+  .c2 {
   box-sizing: border-box;
   height: calc(2em + 2px);
   padding: 0.375em 0.75em;
@@ -3594,75 +7753,76 @@ exports[`ReadData with "gnomad_sv_r2_1" dataset selected has no unexpected chang
 }
 
 <div>
-  <p>
-    This interactive
-     
-    <a
-      className="c0"
-      href="https://github.com/igvteam/igv.js"
-      rel="noopener noreferrer"
-      target="_blank"
+    <p>
+      This interactive
+       
+      <a
+        className="c0"
+        href="https://github.com/igvteam/igv.js"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        IGV.js
+      </a>
+       visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
+    </p>
+    <p>
+      These are reassembled reads produced by
+       
+      <a
+        className="c0"
+        href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        GATK HaplotypeCaller --bamOutput
+      </a>
+      , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
+    </p>
+    <div
+      className="c1"
     >
-      IGV.js
-    </a>
-     visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
-  </p>
-  <p>
-    These are reassembled reads produced by
-     
-    <a
-      className="c0"
-      href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
-      rel="noopener noreferrer"
-      target="_blank"
+      <strong>
+        Exomes:
+      </strong>
+      <button
+        className="c2"
+        disabled={true}
+        onClick={[Function]}
+        type="button"
+      >
+        Load +1 
+        het
+      </button>
+      <button
+        className="c2"
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+      >
+        Load +1 
+        hom
+      </button>
+    </div>
+    <div
+      className="c1"
     >
-      GATK HaplotypeCaller --bamOutput
-    </a>
-    , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
-  </p>
-  <div
-    className="c1"
-  >
-    <strong>
-      Exomes:
-    </strong>
-    <button
-      className="c2"
-      disabled={true}
-      onClick={[Function]}
-      type="button"
-    >
-      Load +1 
-      het
-    </button>
-    <button
-      className="c2"
-      disabled={false}
-      onClick={[Function]}
-      type="button"
-    >
-      Load +1 
-      hom
-    </button>
-  </div>
-  <div
-    className="c1"
-  >
-    <button
-      className="c2"
-      disabled={false}
-      onClick={[Function]}
-      style={
-        {
-          "marginLeft": "80px",
+      <button
+        className="c2"
+        disabled={false}
+        onClick={[Function]}
+        style={
+          {
+            "marginLeft": "80px",
+          }
         }
-      }
-      type="button"
-    >
-      Load all
-    </button>
-  </div>
-</div>
+        type="button"
+      >
+        Load all
+      </button>
+    </div>
+  </div>,
+]
 `;
 
 exports[`ReadData with "gnomad_sv_r2_1" dataset selected queries against the correct dataset 1`] = `
@@ -3687,15 +7847,274 @@ exports[`ReadData with "gnomad_sv_r2_1" dataset selected queries against the cor
 `;
 
 exports[`ReadData with "gnomad_sv_r2_1_controls" dataset selected has no unexpected changes with exome and genome data both missing 1`] = `
-<div>
-  <p>
-    No read data available for this variant.
-  </p>
-</div>
+[
+  .c2 {
+  box-sizing: border-box;
+  height: calc(2em + 2px);
+  padding: 0.375em 0.75em;
+  border-color: #6c757d;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0.5em;
+  background-color: #f8f9fa;
+  cursor: pointer;
+  font-size: 1em;
+  line-height: 1.25;
+  outline: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c2:active,
+.c2:hover {
+  background-color: #cbd3da;
+}
+
+.c2:disabled {
+  background-color: rgba(248,249,250,0.5);
+  cursor: not-allowed;
+}
+
+.c2:focus {
+  box-shadow: 0 0 0 0.2em rgba(108,117,125,0.5);
+}
+
+.c2 svg {
+  position: relative;
+  top: 0.11em;
+  width: 0.9em;
+  height: 0.9em;
+}
+
+.c3 {
+  margin-right: 0.5em;
+}
+
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  outline: none;
+  padding: 0 3px;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.c1 img {
+  position: relative;
+  top: 0.13em;
+  width: 14px;
+  height: 14px;
+  border-radius: 7px;
+}
+
+.c1:focus img {
+  box-shadow: 0 0 0 0.2em rgba(70,130,180,0.5);
+}
+
+.c0 {
+  margin-bottom: 3rem;
+}
+
+<div
+    className="c0"
+  >
+    <button
+      className="c1"
+      onClick={[Function]}
+      type="button"
+    >
+      <img
+        alt=""
+        aria-hidden="true"
+        src="test-file-stub"
+      />
+      <span
+        style={
+          {
+            "border": "0",
+            "clip": "rect(0 0 0 0)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+      >
+        More information
+      </span>
+    </button>
+     
+    <button
+      className="c2"
+      disabled={false}
+      id="load-once"
+      onClick={[Function]}
+      type="button"
+    >
+      Load read data
+    </button>
+    <div>
+      <br />
+      <input
+        checked={true}
+        className="c3"
+        id="always-load"
+        onChange={[Function]}
+        type="checkbox"
+      />
+      Always load read data
+    </div>
+  </div>,
+  <div>
+    <p>
+      No read data available for this variant.
+    </p>
+  </div>,
+]
 `;
 
 exports[`ReadData with "gnomad_sv_r2_1_controls" dataset selected has no unexpected changes with exome data present 1`] = `
+[
+  .c2 {
+  box-sizing: border-box;
+  height: calc(2em + 2px);
+  padding: 0.375em 0.75em;
+  border-color: #6c757d;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0.5em;
+  background-color: #f8f9fa;
+  cursor: pointer;
+  font-size: 1em;
+  line-height: 1.25;
+  outline: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c2:active,
+.c2:hover {
+  background-color: #cbd3da;
+}
+
+.c2:disabled {
+  background-color: rgba(248,249,250,0.5);
+  cursor: not-allowed;
+}
+
+.c2:focus {
+  box-shadow: 0 0 0 0.2em rgba(108,117,125,0.5);
+}
+
+.c2 svg {
+  position: relative;
+  top: 0.11em;
+  width: 0.9em;
+  height: 0.9em;
+}
+
 .c3 {
+  margin-right: 0.5em;
+}
+
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  outline: none;
+  padding: 0 3px;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.c1 img {
+  position: relative;
+  top: 0.13em;
+  width: 14px;
+  height: 14px;
+  border-radius: 7px;
+}
+
+.c1:focus img {
+  box-shadow: 0 0 0 0.2em rgba(70,130,180,0.5);
+}
+
+.c0 {
+  margin-bottom: 3rem;
+}
+
+<div
+    className="c0"
+  >
+    <button
+      className="c1"
+      onClick={[Function]}
+      type="button"
+    >
+      <img
+        alt=""
+        aria-hidden="true"
+        src="test-file-stub"
+      />
+      <span
+        style={
+          {
+            "border": "0",
+            "clip": "rect(0 0 0 0)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+      >
+        More information
+      </span>
+    </button>
+     
+    <button
+      className="c2"
+      disabled={false}
+      id="load-once"
+      onClick={[Function]}
+      type="button"
+    >
+      Load read data
+    </button>
+    <div>
+      <br />
+      <input
+        checked={true}
+        className="c3"
+        id="always-load"
+        onChange={[Function]}
+        type="checkbox"
+      />
+      Always load read data
+    </div>
+  </div>,
+  .c3 {
   box-sizing: border-box;
   height: calc(2em + 2px);
   padding: 0.375em 0.75em;
@@ -3813,83 +8232,84 @@ exports[`ReadData with "gnomad_sv_r2_1_controls" dataset selected has no unexpec
 }
 
 <div>
-  <p>
-    This interactive
-     
-    <a
-      className="c0"
-      href="https://github.com/igvteam/igv.js"
-      rel="noopener noreferrer"
-      target="_blank"
+    <p>
+      This interactive
+       
+      <a
+        className="c0"
+        href="https://github.com/igvteam/igv.js"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        IGV.js
+      </a>
+       visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
+    </p>
+    <p>
+      These are reassembled reads produced by
+       
+      <a
+        className="c0"
+        href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        GATK HaplotypeCaller --bamOutput
+      </a>
+      , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
+    </p>
+    <p>
+      <span
+        className="c1"
+      >
+        Note
+      </span>
+       Samples shown below are not guaranteed to be part of the selected subset.
+    </p>
+    <div
+      className="c2"
     >
-      IGV.js
-    </a>
-     visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
-  </p>
-  <p>
-    These are reassembled reads produced by
-     
-    <a
-      className="c0"
-      href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
-      rel="noopener noreferrer"
-      target="_blank"
+      <strong>
+        Exomes:
+      </strong>
+      <button
+        className="c3"
+        disabled={true}
+        onClick={[Function]}
+        type="button"
+      >
+        Load +1 
+        het
+      </button>
+      <button
+        className="c3"
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+      >
+        Load +1 
+        hom
+      </button>
+    </div>
+    <div
+      className="c2"
     >
-      GATK HaplotypeCaller --bamOutput
-    </a>
-    , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
-  </p>
-  <p>
-    <span
-      className="c1"
-    >
-      Note
-    </span>
-     Samples shown below are not guaranteed to be part of the selected subset.
-  </p>
-  <div
-    className="c2"
-  >
-    <strong>
-      Exomes:
-    </strong>
-    <button
-      className="c3"
-      disabled={true}
-      onClick={[Function]}
-      type="button"
-    >
-      Load +1 
-      het
-    </button>
-    <button
-      className="c3"
-      disabled={false}
-      onClick={[Function]}
-      type="button"
-    >
-      Load +1 
-      hom
-    </button>
-  </div>
-  <div
-    className="c2"
-  >
-    <button
-      className="c3"
-      disabled={false}
-      onClick={[Function]}
-      style={
-        {
-          "marginLeft": "80px",
+      <button
+        className="c3"
+        disabled={false}
+        onClick={[Function]}
+        style={
+          {
+            "marginLeft": "80px",
+          }
         }
-      }
-      type="button"
-    >
-      Load all
-    </button>
-  </div>
-</div>
+        type="button"
+      >
+        Load all
+      </button>
+    </div>
+  </div>,
+]
 `;
 
 exports[`ReadData with "gnomad_sv_r2_1_controls" dataset selected queries against the correct dataset 1`] = `
@@ -3914,15 +8334,274 @@ exports[`ReadData with "gnomad_sv_r2_1_controls" dataset selected queries agains
 `;
 
 exports[`ReadData with "gnomad_sv_r2_1_non_neuro" dataset selected has no unexpected changes with exome and genome data both missing 1`] = `
-<div>
-  <p>
-    No read data available for this variant.
-  </p>
-</div>
+[
+  .c2 {
+  box-sizing: border-box;
+  height: calc(2em + 2px);
+  padding: 0.375em 0.75em;
+  border-color: #6c757d;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0.5em;
+  background-color: #f8f9fa;
+  cursor: pointer;
+  font-size: 1em;
+  line-height: 1.25;
+  outline: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c2:active,
+.c2:hover {
+  background-color: #cbd3da;
+}
+
+.c2:disabled {
+  background-color: rgba(248,249,250,0.5);
+  cursor: not-allowed;
+}
+
+.c2:focus {
+  box-shadow: 0 0 0 0.2em rgba(108,117,125,0.5);
+}
+
+.c2 svg {
+  position: relative;
+  top: 0.11em;
+  width: 0.9em;
+  height: 0.9em;
+}
+
+.c3 {
+  margin-right: 0.5em;
+}
+
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  outline: none;
+  padding: 0 3px;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.c1 img {
+  position: relative;
+  top: 0.13em;
+  width: 14px;
+  height: 14px;
+  border-radius: 7px;
+}
+
+.c1:focus img {
+  box-shadow: 0 0 0 0.2em rgba(70,130,180,0.5);
+}
+
+.c0 {
+  margin-bottom: 3rem;
+}
+
+<div
+    className="c0"
+  >
+    <button
+      className="c1"
+      onClick={[Function]}
+      type="button"
+    >
+      <img
+        alt=""
+        aria-hidden="true"
+        src="test-file-stub"
+      />
+      <span
+        style={
+          {
+            "border": "0",
+            "clip": "rect(0 0 0 0)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+      >
+        More information
+      </span>
+    </button>
+     
+    <button
+      className="c2"
+      disabled={false}
+      id="load-once"
+      onClick={[Function]}
+      type="button"
+    >
+      Load read data
+    </button>
+    <div>
+      <br />
+      <input
+        checked={true}
+        className="c3"
+        id="always-load"
+        onChange={[Function]}
+        type="checkbox"
+      />
+      Always load read data
+    </div>
+  </div>,
+  <div>
+    <p>
+      No read data available for this variant.
+    </p>
+  </div>,
+]
 `;
 
 exports[`ReadData with "gnomad_sv_r2_1_non_neuro" dataset selected has no unexpected changes with exome data present 1`] = `
+[
+  .c2 {
+  box-sizing: border-box;
+  height: calc(2em + 2px);
+  padding: 0.375em 0.75em;
+  border-color: #6c757d;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0.5em;
+  background-color: #f8f9fa;
+  cursor: pointer;
+  font-size: 1em;
+  line-height: 1.25;
+  outline: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c2:active,
+.c2:hover {
+  background-color: #cbd3da;
+}
+
+.c2:disabled {
+  background-color: rgba(248,249,250,0.5);
+  cursor: not-allowed;
+}
+
+.c2:focus {
+  box-shadow: 0 0 0 0.2em rgba(108,117,125,0.5);
+}
+
+.c2 svg {
+  position: relative;
+  top: 0.11em;
+  width: 0.9em;
+  height: 0.9em;
+}
+
 .c3 {
+  margin-right: 0.5em;
+}
+
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  outline: none;
+  padding: 0 3px;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.c1 img {
+  position: relative;
+  top: 0.13em;
+  width: 14px;
+  height: 14px;
+  border-radius: 7px;
+}
+
+.c1:focus img {
+  box-shadow: 0 0 0 0.2em rgba(70,130,180,0.5);
+}
+
+.c0 {
+  margin-bottom: 3rem;
+}
+
+<div
+    className="c0"
+  >
+    <button
+      className="c1"
+      onClick={[Function]}
+      type="button"
+    >
+      <img
+        alt=""
+        aria-hidden="true"
+        src="test-file-stub"
+      />
+      <span
+        style={
+          {
+            "border": "0",
+            "clip": "rect(0 0 0 0)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+      >
+        More information
+      </span>
+    </button>
+     
+    <button
+      className="c2"
+      disabled={false}
+      id="load-once"
+      onClick={[Function]}
+      type="button"
+    >
+      Load read data
+    </button>
+    <div>
+      <br />
+      <input
+        checked={true}
+        className="c3"
+        id="always-load"
+        onChange={[Function]}
+        type="checkbox"
+      />
+      Always load read data
+    </div>
+  </div>,
+  .c3 {
   box-sizing: border-box;
   height: calc(2em + 2px);
   padding: 0.375em 0.75em;
@@ -4040,83 +8719,84 @@ exports[`ReadData with "gnomad_sv_r2_1_non_neuro" dataset selected has no unexpe
 }
 
 <div>
-  <p>
-    This interactive
-     
-    <a
-      className="c0"
-      href="https://github.com/igvteam/igv.js"
-      rel="noopener noreferrer"
-      target="_blank"
+    <p>
+      This interactive
+       
+      <a
+        className="c0"
+        href="https://github.com/igvteam/igv.js"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        IGV.js
+      </a>
+       visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
+    </p>
+    <p>
+      These are reassembled reads produced by
+       
+      <a
+        className="c0"
+        href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        GATK HaplotypeCaller --bamOutput
+      </a>
+      , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
+    </p>
+    <p>
+      <span
+        className="c1"
+      >
+        Note
+      </span>
+       Samples shown below are not guaranteed to be part of the selected subset.
+    </p>
+    <div
+      className="c2"
     >
-      IGV.js
-    </a>
-     visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
-  </p>
-  <p>
-    These are reassembled reads produced by
-     
-    <a
-      className="c0"
-      href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
-      rel="noopener noreferrer"
-      target="_blank"
+      <strong>
+        Exomes:
+      </strong>
+      <button
+        className="c3"
+        disabled={true}
+        onClick={[Function]}
+        type="button"
+      >
+        Load +1 
+        het
+      </button>
+      <button
+        className="c3"
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+      >
+        Load +1 
+        hom
+      </button>
+    </div>
+    <div
+      className="c2"
     >
-      GATK HaplotypeCaller --bamOutput
-    </a>
-    , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
-  </p>
-  <p>
-    <span
-      className="c1"
-    >
-      Note
-    </span>
-     Samples shown below are not guaranteed to be part of the selected subset.
-  </p>
-  <div
-    className="c2"
-  >
-    <strong>
-      Exomes:
-    </strong>
-    <button
-      className="c3"
-      disabled={true}
-      onClick={[Function]}
-      type="button"
-    >
-      Load +1 
-      het
-    </button>
-    <button
-      className="c3"
-      disabled={false}
-      onClick={[Function]}
-      type="button"
-    >
-      Load +1 
-      hom
-    </button>
-  </div>
-  <div
-    className="c2"
-  >
-    <button
-      className="c3"
-      disabled={false}
-      onClick={[Function]}
-      style={
-        {
-          "marginLeft": "80px",
+      <button
+        className="c3"
+        disabled={false}
+        onClick={[Function]}
+        style={
+          {
+            "marginLeft": "80px",
+          }
         }
-      }
-      type="button"
-    >
-      Load all
-    </button>
-  </div>
-</div>
+        type="button"
+      >
+        Load all
+      </button>
+    </div>
+  </div>,
+]
 `;
 
 exports[`ReadData with "gnomad_sv_r2_1_non_neuro" dataset selected queries against the correct dataset 1`] = `
@@ -4141,15 +8821,274 @@ exports[`ReadData with "gnomad_sv_r2_1_non_neuro" dataset selected queries again
 `;
 
 exports[`ReadData with "gnomad_sv_r4" dataset selected has no unexpected changes with exome and genome data both missing 1`] = `
-<div>
-  <p>
-    No read data available for this variant.
-  </p>
-</div>
+[
+  .c2 {
+  box-sizing: border-box;
+  height: calc(2em + 2px);
+  padding: 0.375em 0.75em;
+  border-color: #6c757d;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0.5em;
+  background-color: #f8f9fa;
+  cursor: pointer;
+  font-size: 1em;
+  line-height: 1.25;
+  outline: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c2:active,
+.c2:hover {
+  background-color: #cbd3da;
+}
+
+.c2:disabled {
+  background-color: rgba(248,249,250,0.5);
+  cursor: not-allowed;
+}
+
+.c2:focus {
+  box-shadow: 0 0 0 0.2em rgba(108,117,125,0.5);
+}
+
+.c2 svg {
+  position: relative;
+  top: 0.11em;
+  width: 0.9em;
+  height: 0.9em;
+}
+
+.c3 {
+  margin-right: 0.5em;
+}
+
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  outline: none;
+  padding: 0 3px;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.c1 img {
+  position: relative;
+  top: 0.13em;
+  width: 14px;
+  height: 14px;
+  border-radius: 7px;
+}
+
+.c1:focus img {
+  box-shadow: 0 0 0 0.2em rgba(70,130,180,0.5);
+}
+
+.c0 {
+  margin-bottom: 3rem;
+}
+
+<div
+    className="c0"
+  >
+    <button
+      className="c1"
+      onClick={[Function]}
+      type="button"
+    >
+      <img
+        alt=""
+        aria-hidden="true"
+        src="test-file-stub"
+      />
+      <span
+        style={
+          {
+            "border": "0",
+            "clip": "rect(0 0 0 0)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+      >
+        More information
+      </span>
+    </button>
+     
+    <button
+      className="c2"
+      disabled={false}
+      id="load-once"
+      onClick={[Function]}
+      type="button"
+    >
+      Load read data
+    </button>
+    <div>
+      <br />
+      <input
+        checked={true}
+        className="c3"
+        id="always-load"
+        onChange={[Function]}
+        type="checkbox"
+      />
+      Always load read data
+    </div>
+  </div>,
+  <div>
+    <p>
+      No read data available for this variant.
+    </p>
+  </div>,
+]
 `;
 
 exports[`ReadData with "gnomad_sv_r4" dataset selected has no unexpected changes with exome data present 1`] = `
-.c2 {
+[
+  .c2 {
+  box-sizing: border-box;
+  height: calc(2em + 2px);
+  padding: 0.375em 0.75em;
+  border-color: #6c757d;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0.5em;
+  background-color: #f8f9fa;
+  cursor: pointer;
+  font-size: 1em;
+  line-height: 1.25;
+  outline: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c2:active,
+.c2:hover {
+  background-color: #cbd3da;
+}
+
+.c2:disabled {
+  background-color: rgba(248,249,250,0.5);
+  cursor: not-allowed;
+}
+
+.c2:focus {
+  box-shadow: 0 0 0 0.2em rgba(108,117,125,0.5);
+}
+
+.c2 svg {
+  position: relative;
+  top: 0.11em;
+  width: 0.9em;
+  height: 0.9em;
+}
+
+.c3 {
+  margin-right: 0.5em;
+}
+
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  outline: none;
+  padding: 0 3px;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.c1 img {
+  position: relative;
+  top: 0.13em;
+  width: 14px;
+  height: 14px;
+  border-radius: 7px;
+}
+
+.c1:focus img {
+  box-shadow: 0 0 0 0.2em rgba(70,130,180,0.5);
+}
+
+.c0 {
+  margin-bottom: 3rem;
+}
+
+<div
+    className="c0"
+  >
+    <button
+      className="c1"
+      onClick={[Function]}
+      type="button"
+    >
+      <img
+        alt=""
+        aria-hidden="true"
+        src="test-file-stub"
+      />
+      <span
+        style={
+          {
+            "border": "0",
+            "clip": "rect(0 0 0 0)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+      >
+        More information
+      </span>
+    </button>
+     
+    <button
+      className="c2"
+      disabled={false}
+      id="load-once"
+      onClick={[Function]}
+      type="button"
+    >
+      Load read data
+    </button>
+    <div>
+      <br />
+      <input
+        checked={true}
+        className="c3"
+        id="always-load"
+        onChange={[Function]}
+        type="checkbox"
+      />
+      Always load read data
+    </div>
+  </div>,
+  .c2 {
   box-sizing: border-box;
   height: calc(2em + 2px);
   padding: 0.375em 0.75em;
@@ -4253,75 +9192,76 @@ exports[`ReadData with "gnomad_sv_r4" dataset selected has no unexpected changes
 }
 
 <div>
-  <p>
-    This interactive
-     
-    <a
-      className="c0"
-      href="https://github.com/igvteam/igv.js"
-      rel="noopener noreferrer"
-      target="_blank"
+    <p>
+      This interactive
+       
+      <a
+        className="c0"
+        href="https://github.com/igvteam/igv.js"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        IGV.js
+      </a>
+       visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
+    </p>
+    <p>
+      These are reassembled reads produced by
+       
+      <a
+        className="c0"
+        href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        GATK HaplotypeCaller --bamOutput
+      </a>
+      , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
+    </p>
+    <div
+      className="c1"
     >
-      IGV.js
-    </a>
-     visualization shows reads that went into calling this variant. Reads may not be available for every sample carrying this variant.
-  </p>
-  <p>
-    These are reassembled reads produced by
-     
-    <a
-      className="c0"
-      href="https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php#--bamOutput"
-      rel="noopener noreferrer"
-      target="_blank"
+      <strong>
+        Exomes:
+      </strong>
+      <button
+        className="c2"
+        disabled={true}
+        onClick={[Function]}
+        type="button"
+      >
+        Load +1 
+        het
+      </button>
+      <button
+        className="c2"
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+      >
+        Load +1 
+        hom
+      </button>
+    </div>
+    <div
+      className="c1"
     >
-      GATK HaplotypeCaller --bamOutput
-    </a>
-    , so they accurately represent what HaplotypeCaller was seeing when it called this variant.
-  </p>
-  <div
-    className="c1"
-  >
-    <strong>
-      Exomes:
-    </strong>
-    <button
-      className="c2"
-      disabled={true}
-      onClick={[Function]}
-      type="button"
-    >
-      Load +1 
-      het
-    </button>
-    <button
-      className="c2"
-      disabled={false}
-      onClick={[Function]}
-      type="button"
-    >
-      Load +1 
-      hom
-    </button>
-  </div>
-  <div
-    className="c1"
-  >
-    <button
-      className="c2"
-      disabled={false}
-      onClick={[Function]}
-      style={
-        {
-          "marginLeft": "80px",
+      <button
+        className="c2"
+        disabled={false}
+        onClick={[Function]}
+        style={
+          {
+            "marginLeft": "80px",
+          }
         }
-      }
-      type="button"
-    >
-      Load all
-    </button>
-  </div>
-</div>
+        type="button"
+      >
+        Load all
+      </button>
+    </div>
+  </div>,
+]
 `;
 
 exports[`ReadData with "gnomad_sv_r4" dataset selected queries against the correct dataset 1`] = `

--- a/browser/src/VariantPage/__snapshots__/VariantPage.spec.tsx.snap
+++ b/browser/src/VariantPage/__snapshots__/VariantPage.spec.tsx.snap
@@ -9859,11 +9859,62 @@ exports[`VariantPage with the dataset "gnomad_r3" has no unexpected changes 1`] 
       <h2>
         Read Data
       </h2>
-      <div>
-        <p>
-          No read data available for this variant.
-        </p>
+      <div
+        className="ReadData__LoadReadsControls-sc-p2sb8k-0 cOzoPQ"
+      >
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+          >
+            More information
+          </span>
+        </button>
+         
+        <button
+          className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+          disabled={false}
+          id="load-once"
+          onClick={[Function]}
+          type="button"
+        >
+          Load read data
+        </button>
+        <div>
+          <br />
+          <input
+            checked={false}
+            className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
+            id="always-load"
+            onChange={[Function]}
+            type="checkbox"
+          />
+          Always load read data
+        </div>
       </div>
+      <div
+        className="ReadData__NoReadsSpacer-sc-p2sb8k-1 dYfzIa"
+      />
     </section>
   </div>
 </div>
@@ -19731,11 +19782,62 @@ exports[`VariantPage with the dataset "gnomad_r3_controls_and_biobanks" has no u
       <h2>
         Read Data
       </h2>
-      <div>
-        <p>
-          No read data available for this variant.
-        </p>
+      <div
+        className="ReadData__LoadReadsControls-sc-p2sb8k-0 cOzoPQ"
+      >
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+          >
+            More information
+          </span>
+        </button>
+         
+        <button
+          className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+          disabled={false}
+          id="load-once"
+          onClick={[Function]}
+          type="button"
+        >
+          Load read data
+        </button>
+        <div>
+          <br />
+          <input
+            checked={false}
+            className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
+            id="always-load"
+            onChange={[Function]}
+            type="checkbox"
+          />
+          Always load read data
+        </div>
       </div>
+      <div
+        className="ReadData__NoReadsSpacer-sc-p2sb8k-1 dYfzIa"
+      />
     </section>
   </div>
 </div>
@@ -29603,11 +29705,62 @@ exports[`VariantPage with the dataset "gnomad_r3_non_cancer" has no unexpected c
       <h2>
         Read Data
       </h2>
-      <div>
-        <p>
-          No read data available for this variant.
-        </p>
+      <div
+        className="ReadData__LoadReadsControls-sc-p2sb8k-0 cOzoPQ"
+      >
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+          >
+            More information
+          </span>
+        </button>
+         
+        <button
+          className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+          disabled={false}
+          id="load-once"
+          onClick={[Function]}
+          type="button"
+        >
+          Load read data
+        </button>
+        <div>
+          <br />
+          <input
+            checked={false}
+            className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
+            id="always-load"
+            onChange={[Function]}
+            type="checkbox"
+          />
+          Always load read data
+        </div>
       </div>
+      <div
+        className="ReadData__NoReadsSpacer-sc-p2sb8k-1 dYfzIa"
+      />
     </section>
   </div>
 </div>
@@ -39475,11 +39628,62 @@ exports[`VariantPage with the dataset "gnomad_r3_non_neuro" has no unexpected ch
       <h2>
         Read Data
       </h2>
-      <div>
-        <p>
-          No read data available for this variant.
-        </p>
+      <div
+        className="ReadData__LoadReadsControls-sc-p2sb8k-0 cOzoPQ"
+      >
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+          >
+            More information
+          </span>
+        </button>
+         
+        <button
+          className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+          disabled={false}
+          id="load-once"
+          onClick={[Function]}
+          type="button"
+        >
+          Load read data
+        </button>
+        <div>
+          <br />
+          <input
+            checked={false}
+            className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
+            id="always-load"
+            onChange={[Function]}
+            type="checkbox"
+          />
+          Always load read data
+        </div>
       </div>
+      <div
+        className="ReadData__NoReadsSpacer-sc-p2sb8k-1 dYfzIa"
+      />
     </section>
   </div>
 </div>
@@ -49347,11 +49551,62 @@ exports[`VariantPage with the dataset "gnomad_r3_non_topmed" has no unexpected c
       <h2>
         Read Data
       </h2>
-      <div>
-        <p>
-          No read data available for this variant.
-        </p>
+      <div
+        className="ReadData__LoadReadsControls-sc-p2sb8k-0 cOzoPQ"
+      >
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+          >
+            More information
+          </span>
+        </button>
+         
+        <button
+          className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+          disabled={false}
+          id="load-once"
+          onClick={[Function]}
+          type="button"
+        >
+          Load read data
+        </button>
+        <div>
+          <br />
+          <input
+            checked={false}
+            className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
+            id="always-load"
+            onChange={[Function]}
+            type="checkbox"
+          />
+          Always load read data
+        </div>
       </div>
+      <div
+        className="ReadData__NoReadsSpacer-sc-p2sb8k-1 dYfzIa"
+      />
     </section>
   </div>
 </div>
@@ -59219,11 +59474,62 @@ exports[`VariantPage with the dataset "gnomad_r3_non_v2" has no unexpected chang
       <h2>
         Read Data
       </h2>
-      <div>
-        <p>
-          No read data available for this variant.
-        </p>
+      <div
+        className="ReadData__LoadReadsControls-sc-p2sb8k-0 cOzoPQ"
+      >
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+          >
+            More information
+          </span>
+        </button>
+         
+        <button
+          className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+          disabled={false}
+          id="load-once"
+          onClick={[Function]}
+          type="button"
+        >
+          Load read data
+        </button>
+        <div>
+          <br />
+          <input
+            checked={false}
+            className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
+            id="always-load"
+            onChange={[Function]}
+            type="checkbox"
+          />
+          Always load read data
+        </div>
       </div>
+      <div
+        className="ReadData__NoReadsSpacer-sc-p2sb8k-1 dYfzIa"
+      />
     </section>
   </div>
 </div>
@@ -66990,19 +67296,62 @@ exports[`VariantPage with the dataset exac has no unexpected changes 1`] = `
       <h2>
         Read Data
       </h2>
-      <div>
-        <p>
-          No read data available for this variant.
-        </p>
-        <p>
+      <div
+        className="ReadData__LoadReadsControls-sc-p2sb8k-0 cOzoPQ"
+      >
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
           <span
-            className="Badge__BadgeWrapper-sc-j4izdp-1 jEnuJq"
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
           >
-            Note
+            More information
           </span>
-           Read data for non-coding regions is not available in gnomAD v2.1.1 and ExAC.
-        </p>
+        </button>
+         
+        <button
+          className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+          disabled={false}
+          id="load-once"
+          onClick={[Function]}
+          type="button"
+        >
+          Load read data
+        </button>
+        <div>
+          <br />
+          <input
+            checked={false}
+            className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
+            id="always-load"
+            onChange={[Function]}
+            type="checkbox"
+          />
+          Always load read data
+        </div>
       </div>
+      <div
+        className="ReadData__NoReadsSpacer-sc-p2sb8k-1 dYfzIa"
+      />
     </section>
   </div>
 </div>
@@ -76995,19 +77344,62 @@ exports[`VariantPage with the dataset gnomad_r2_1 has no unexpected changes 1`] 
       <h2>
         Read Data
       </h2>
-      <div>
-        <p>
-          No read data available for this variant.
-        </p>
-        <p>
+      <div
+        className="ReadData__LoadReadsControls-sc-p2sb8k-0 cOzoPQ"
+      >
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
           <span
-            className="Badge__BadgeWrapper-sc-j4izdp-1 jEnuJq"
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
           >
-            Note
+            More information
           </span>
-           Read data for non-coding regions is not available in gnomAD v2.1.1 and ExAC.
-        </p>
+        </button>
+         
+        <button
+          className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+          disabled={false}
+          id="load-once"
+          onClick={[Function]}
+          type="button"
+        >
+          Load read data
+        </button>
+        <div>
+          <br />
+          <input
+            checked={false}
+            className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
+            id="always-load"
+            onChange={[Function]}
+            type="checkbox"
+          />
+          Always load read data
+        </div>
       </div>
+      <div
+        className="ReadData__NoReadsSpacer-sc-p2sb8k-1 dYfzIa"
+      />
     </section>
   </div>
 </div>
@@ -87000,19 +87392,62 @@ exports[`VariantPage with the dataset gnomad_r2_1_controls has no unexpected cha
       <h2>
         Read Data
       </h2>
-      <div>
-        <p>
-          No read data available for this variant.
-        </p>
-        <p>
+      <div
+        className="ReadData__LoadReadsControls-sc-p2sb8k-0 cOzoPQ"
+      >
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
           <span
-            className="Badge__BadgeWrapper-sc-j4izdp-1 jEnuJq"
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
           >
-            Note
+            More information
           </span>
-           Read data for non-coding regions is not available in gnomAD v2.1.1 and ExAC.
-        </p>
+        </button>
+         
+        <button
+          className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+          disabled={false}
+          id="load-once"
+          onClick={[Function]}
+          type="button"
+        >
+          Load read data
+        </button>
+        <div>
+          <br />
+          <input
+            checked={false}
+            className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
+            id="always-load"
+            onChange={[Function]}
+            type="checkbox"
+          />
+          Always load read data
+        </div>
       </div>
+      <div
+        className="ReadData__NoReadsSpacer-sc-p2sb8k-1 dYfzIa"
+      />
     </section>
   </div>
 </div>
@@ -97005,19 +97440,62 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_cancer has no unexpected c
       <h2>
         Read Data
       </h2>
-      <div>
-        <p>
-          No read data available for this variant.
-        </p>
-        <p>
+      <div
+        className="ReadData__LoadReadsControls-sc-p2sb8k-0 cOzoPQ"
+      >
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
           <span
-            className="Badge__BadgeWrapper-sc-j4izdp-1 jEnuJq"
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
           >
-            Note
+            More information
           </span>
-           Read data for non-coding regions is not available in gnomAD v2.1.1 and ExAC.
-        </p>
+        </button>
+         
+        <button
+          className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+          disabled={false}
+          id="load-once"
+          onClick={[Function]}
+          type="button"
+        >
+          Load read data
+        </button>
+        <div>
+          <br />
+          <input
+            checked={false}
+            className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
+            id="always-load"
+            onChange={[Function]}
+            type="checkbox"
+          />
+          Always load read data
+        </div>
       </div>
+      <div
+        className="ReadData__NoReadsSpacer-sc-p2sb8k-1 dYfzIa"
+      />
     </section>
   </div>
 </div>
@@ -107010,19 +107488,62 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_neuro has no unexpected ch
       <h2>
         Read Data
       </h2>
-      <div>
-        <p>
-          No read data available for this variant.
-        </p>
-        <p>
+      <div
+        className="ReadData__LoadReadsControls-sc-p2sb8k-0 cOzoPQ"
+      >
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
           <span
-            className="Badge__BadgeWrapper-sc-j4izdp-1 jEnuJq"
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
           >
-            Note
+            More information
           </span>
-           Read data for non-coding regions is not available in gnomAD v2.1.1 and ExAC.
-        </p>
+        </button>
+         
+        <button
+          className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+          disabled={false}
+          id="load-once"
+          onClick={[Function]}
+          type="button"
+        >
+          Load read data
+        </button>
+        <div>
+          <br />
+          <input
+            checked={false}
+            className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
+            id="always-load"
+            onChange={[Function]}
+            type="checkbox"
+          />
+          Always load read data
+        </div>
       </div>
+      <div
+        className="ReadData__NoReadsSpacer-sc-p2sb8k-1 dYfzIa"
+      />
     </section>
   </div>
 </div>
@@ -117015,19 +117536,62 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_topmed has no unexpected c
       <h2>
         Read Data
       </h2>
-      <div>
-        <p>
-          No read data available for this variant.
-        </p>
-        <p>
+      <div
+        className="ReadData__LoadReadsControls-sc-p2sb8k-0 cOzoPQ"
+      >
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 gxsoyZ"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
           <span
-            className="Badge__BadgeWrapper-sc-j4izdp-1 jEnuJq"
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
           >
-            Note
+            More information
           </span>
-           Read data for non-coding regions is not available in gnomAD v2.1.1 and ExAC.
-        </p>
+        </button>
+         
+        <button
+          className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 indcWT"
+          disabled={false}
+          id="load-once"
+          onClick={[Function]}
+          type="button"
+        >
+          Load read data
+        </button>
+        <div>
+          <br />
+          <input
+            checked={false}
+            className="ChartStyles__CheckboxInput-sc-atxio9-4 jqlQQw"
+            id="always-load"
+            onChange={[Function]}
+            type="checkbox"
+          />
+          Always load read data
+        </div>
       </div>
+      <div
+        className="ReadData__NoReadsSpacer-sc-p2sb8k-1 dYfzIa"
+      />
     </section>
   </div>
 </div>


### PR DESCRIPTION
Resolves #633 

Hides readviz by default on Variant pages to try and save on egress fees.

Gives two options,
- a button to load the data just this time
- a checkbox to always load readviz data, this uses `localStorage` to save the value of this on load and when toggling this

Also adds tracking to these two buttons to try and see how often people use these

