### PR TITLE
Fix typo in SV table

### DIFF
--- a/browser/src/StructuralVariantList/structuralVariantTableColumns.tsx
+++ b/browser/src/StructuralVariantList/structuralVariantTableColumns.tsx
@@ -137,7 +137,7 @@ const structuralVariantTableColumns = [
         position = `${variant.pos}`
       } else if (variant.type === 'BND' || variant.type === 'CTX') {
         // Only show pos because end == pos + 1 for BNDs and CTXs
-        position = `${variant.chrom}:${variant.pos}} | ${variant.chrom2}:${variant.pos2}`
+        position = `${variant.chrom}:${variant.pos} | ${variant.chrom2}:${variant.pos2}`
       } else {
         position = `${variant.pos} - ${variant.end}`
       }


### PR DESCRIPTION
Fixes a single character typo where an erroneous `}` was being rendered.

As part of working on GeniE I was referencing added SVs against their frequencies in gnomAD and noticed this apparent typo. Quick one liner (even one character-er!) to fix this

![Screenshot 2024-05-28 at 20 15 55](https://github.com/broadinstitute/gnomad-browser/assets/59549713/33ccacb5-b15d-435b-8e84-d5f3cb2d378d)
