### PR TITLE
Update banner with user survey

### DIFF
--- a/browser/src/App.tsx
+++ b/browser/src/App.tsx
@@ -73,11 +73,8 @@ const Banner = styled.div`
 
 const BANNER_CONTENT = (
   <>
-    gnomAD v4.1.0 is now available. Read our {/* @ts-expect-error */}
-    <ExternalLink href="https://gnomad.broadinstitute.org/news/2024-04-gnomad-v4-1">
-      blog post
-    </ExternalLink>{' '}
-    for more details
+    Help us continue to improve gnomAD by taking 5 minutes to fill out our {/* @ts-expect-error */}
+    <ExternalLink href="http://broad.io/2024_survey">user survey</ExternalLink>.
   </>
 )
 const App = () => {


### PR DESCRIPTION
Resolves #1550 

Updates the gnomAD banner to point to the user survey.

![Screenshot 2024-05-30 at 15 39 51](https://github.com/broadinstitute/gnomad-browser/assets/59549713/8a43907f-e53b-4039-911c-ef8232f1f28b)
