### PR TITLE
Add python dependabot configs for our various roots, set freq to weekly for all

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,48 @@
-#  - Disables non-security update PRs
-#  - Schedules security update PRs daily
+#  - Disables non-security update PRs (by setting pull requests limit to 0)
+#  - Schedules security update PRs weekly
 #  - Auto assigns PRs to the gnomad-browser team
 
 version: 2
 updates:
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
-      interval: "daily"
-    # Disable version updates for npm dependencies
+      interval: 'weekly'
     open-pull-requests-limit: 0
     reviewers:
-      - "broadinstitute/gnomad-browser"
+      - 'broadinstitute/gnomad-browser'
+  - package-ecosystem: 'pip'
+    directory: '/deploy/dockerfiles/blog'
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 0
+    reviewers:
+      - 'broadinstitute/gnomad-browser'
+  - package-ecosystem: 'pip'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 0
+    reviewers:
+      - 'broadinstitute/gnomad-browser'
+  - package-ecosystem: 'pip'
+    directory: '/deploy/deployctl'
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 0
+    reviewers:
+      - 'broadinstitute/gnomad-browser'
+  - package-ecosystem: 'pip'
+    directory: '/data-pipeline'
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 0
+    reviewers:
+      - 'broadinstitute/gnomad-browser'
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 0
+    reviewers:
+      - 'broadinstitute/gnomad-browser'


### PR DESCRIPTION
This sets dependabot frequencies to weekly, since daily seemed excessive. It also adds pip/pip-compile/github-actions package configs for our various requirements files, so that they get managed independently (or, at least, the hope is that dependabot will do that with this config)