### PR TITLE
Switch to multi-dir dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,28 +12,11 @@ updates:
     reviewers:
       - 'broadinstitute/gnomad-browser'
   - package-ecosystem: 'pip'
-    directory: '/deploy/dockerfiles/blog'
-    schedule:
-      interval: 'weekly'
-    open-pull-requests-limit: 0
-    reviewers:
-      - 'broadinstitute/gnomad-browser'
-  - package-ecosystem: 'pip'
-    directory: '/'
-    schedule:
-      interval: 'weekly'
-    open-pull-requests-limit: 0
-    reviewers:
-      - 'broadinstitute/gnomad-browser'
-  - package-ecosystem: 'pip'
-    directory: '/deploy/deployctl'
-    schedule:
-      interval: 'weekly'
-    open-pull-requests-limit: 0
-    reviewers:
-      - 'broadinstitute/gnomad-browser'
-  - package-ecosystem: 'pip'
-    directory: '/data-pipeline'
+    directories:
+      - '/'
+      - '/deploy/dockerfiles/blog'
+      - '/deploy/deployctl'
+      - '/data-pipeline'
     schedule:
       interval: 'weekly'
     open-pull-requests-limit: 0


### PR DESCRIPTION
Apparently github rolled out the ability to have multiple folders for a given package manager, back at the end of April: https://github.blog/changelog/2024-04-29-dependabot-multi-directory-configuration-public-beta-now-available/