### PR TITLE
Add hemizygous count to structural variant tables

### DIFF
--- a/browser/src/GenePage/StructuralVariantsInGene.tsx
+++ b/browser/src/GenePage/StructuralVariantsInGene.tsx
@@ -29,6 +29,7 @@ const StructuralVariantsInGene = ({ datasetId, gene, zoomRegion, ...rest }: Prop
       gene(gene_id: $geneId, reference_genome: $referenceGenome) {
         structural_variants(dataset: $datasetId) {
           ac
+          ac_hemi
           ac_hom
           an
           af

--- a/browser/src/RegionPage/StructuralVariantsInRegion.tsx
+++ b/browser/src/RegionPage/StructuralVariantsInRegion.tsx
@@ -30,6 +30,7 @@ const StructuralVariantsInRegion = ({ datasetId, region, zoomRegion, ...rest }: 
       region(chrom: $chrom, start: $start, stop: $stop, reference_genome: $referenceGenome) {
         structural_variants(dataset: $datasetId) {
           ac
+          ac_hemi
           ac_hom
           an
           af

--- a/browser/src/StructuralVariantList/StructuralVariants.tsx
+++ b/browser/src/StructuralVariantList/StructuralVariants.tsx
@@ -56,6 +56,7 @@ const DEFAULT_COLUMNS = [
   'an',
   'af',
   'homozygote_count',
+  'hemizygote_count',
 ]
 
 const sortVariants = (variants: any, { sortKey, sortOrder }: any) => {

--- a/browser/src/StructuralVariantList/structuralVariantTableColumns.tsx
+++ b/browser/src/StructuralVariantList/structuralVariantTableColumns.tsx
@@ -103,6 +103,16 @@ const structuralVariantTableColumns = [
   },
 
   {
+    key: 'hemizygote_count',
+    heading: 'Number of Hemizygotes',
+    contextNotes: 'Only shown when viewing X or Y chromosomes',
+    minWidth: 100,
+    compareFunction: makeNumericCompareFunction('ac_hemi'),
+    render: (variant: any) => renderAlleleCountCell(variant, 'ac_hemi'),
+    shouldShowInContext: (context: any) => context.chrom === 'X' || context.chrom === 'Y',
+  },
+
+  {
     key: 'length',
     heading: 'Size',
     minWidth: 100,


### PR DESCRIPTION
Per https://github.com/broadinstitute/gnomad-browser/issues/1462, the hemizygous AC was available in short variant but not structural variant tables. This adds that field to SV tables.

Note that I'm breaking my own first rule here and not adding test coverage: these components turn out to be coupled together with some other logic in a way that makes writing a coherent test for them a real pain. I don't love doing this but this is a very basic change that fixes something the end-user already needs, and it's not really clear to me yet how to best refactor this to make testing it less of a circus.