### PR TITLE
Fix homepage CNV link text and point to PCSK9 instead

### DIFF
--- a/browser/src/HomePage.tsx
+++ b/browser/src/HomePage.tsx
@@ -156,7 +156,7 @@ export default () => (
             search: queryString.stringify({ dataset: 'gnomad_cnv_r4' }),
           }}
         >
-          19-11078371-11144910
+          2-49918501-51225575
         </Link>
       </ListItem>
       {/* @ts-expect-error TS(2746) FIXME: This JSX tag's 'children' prop expects a single ch... Remove this comment to see the full error message */}

--- a/browser/src/HomePage.tsx
+++ b/browser/src/HomePage.tsx
@@ -152,11 +152,11 @@ export default () => (
         <Link
           preserveSelectedDataset={false}
           to={{
-            pathname: '/region/2-49918501-51225575',
+            pathname: '/region/1-55039447-55064852',
             search: queryString.stringify({ dataset: 'gnomad_cnv_r4' }),
           }}
         >
-          2-49918501-51225575
+          1-55039447-55064852
         </Link>
       </ListItem>
       {/* @ts-expect-error TS(2746) FIXME: This JSX tag's 'children' prop expects a single ch... Remove this comment to see the full error message */}

--- a/browser/src/__snapshots__/HomePage.spec.tsx.snap
+++ b/browser/src/__snapshots__/HomePage.spec.tsx.snap
@@ -443,10 +443,10 @@ exports[`Home Page has no unexpected changes 1`] = `
        
       <a
         className="-Link c8"
-        href="/region/2-49918501-51225575?dataset=gnomad_cnv_r4"
+        href="/region/1-55039447-55064852?dataset=gnomad_cnv_r4"
         onClick={[Function]}
       >
-        2-49918501-51225575
+        1-55039447-55064852
       </a>
     </li>
     <li

--- a/browser/src/__snapshots__/HomePage.spec.tsx.snap
+++ b/browser/src/__snapshots__/HomePage.spec.tsx.snap
@@ -446,7 +446,7 @@ exports[`Home Page has no unexpected changes 1`] = `
         href="/region/2-49918501-51225575?dataset=gnomad_cnv_r4"
         onClick={[Function]}
       >
-        19-11078371-11144910
+        2-49918501-51225575
       </a>
     </li>
     <li


### PR DESCRIPTION
Waiting on confirmation of what we actually want to link to, but should be good to go after that.

fixes #1584 