### PR TITLE
Add v4.1 SV BED files to downloads page

### DIFF
--- a/browser/src/DownloadsPage/GnomadV4Downloads.tsx
+++ b/browser/src/DownloadsPage/GnomadV4Downloads.tsx
@@ -371,6 +371,24 @@ const GnomadV4Downloads = () => {
               associatedFileType="TBI"
             />
           </ListItem>
+          {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+          <ListItem>
+            <DownloadLinks
+              label="Genome SV BED"
+              path="/release/4.1/genome_sv/gnomad.v4.1.sv.sites.bed.gz"
+              size="1.26 GiB"
+              md5="a898e3e37aacfdb1e4d6218d5479683a"
+            />
+          </ListItem>
+          {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+          <ListItem>
+            <DownloadLinks
+              label="Genome SV non neuro controls BED"
+              path="/release/4.1/genome_sv/gnomad.v4.1.sv.non_neuro_controls.sites.bed.gz"
+              size="1.95 GiB"
+              md5="42cc0071d81dd8ae0492a53a462e8c33"
+            />
+          </ListItem>
         </FileList>
       </DownloadsSection>
 

--- a/browser/src/DownloadsPage/__snapshots__/DownloadsPage.spec.tsx.snap
+++ b/browser/src/DownloadsPage/__snapshots__/DownloadsPage.spec.tsx.snap
@@ -7729,6 +7729,100 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             </a>
           </span>
         </li>
+        <li
+          className="c20"
+        >
+          <span>
+            Genome SV BED
+          </span>
+          <br />
+          <span>
+            1.26 GiB
+            , MD5: 
+            a898e3e37aacfdb1e4d6218d5479683a
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download Genome SV BED from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/genome_sv/gnomad.v4.1.sv.sites.bed.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download Genome SV BED from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/genome_sv/gnomad.v4.1.sv.sites.bed.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download Genome SV BED from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/genome_sv/gnomad.v4.1.sv.sites.bed.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+        <li
+          className="c20"
+        >
+          <span>
+            Genome SV non neuro controls BED
+          </span>
+          <br />
+          <span>
+            1.95 GiB
+            , MD5: 
+            42cc0071d81dd8ae0492a53a462e8c33
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download Genome SV non neuro controls BED from Google"
+              className="c10"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/genome_sv/gnomad.v4.1.sv.non_neuro_controls.sites.bed.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download Genome SV non neuro controls BED from Amazon"
+              className="c10"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/genome_sv/gnomad.v4.1.sv.non_neuro_controls.sites.bed.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download Genome SV non neuro controls BED from Microsoft"
+              className="c10"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/genome_sv/gnomad.v4.1.sv.non_neuro_controls.sites.bed.gz"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
       </ul>
     </section>
     <section


### PR DESCRIPTION
Resolves #1588 

Adds links to synced v4.1 SV BED files

Since I'll be out (most likely) by the the time this gets approved (assuming there's nothing to be changed, which there could be), could whoever approves this merge it into `main`?