### PR TITLE
Fix compose browser startup

### DIFF
--- a/deploy/dockerfiles/browser/browser.dockerfile
+++ b/deploy/dockerfiles/browser/browser.dockerfile
@@ -1,4 +1,5 @@
 FROM --platform=linux/amd64 node:18.17-alpine as build
+RUN apk add bash
 RUN npm install -g pnpm@^8.14.3
 
 RUN mkdir -p /home/node/app && chown -R node:node /home/node/app

--- a/deploy/dockerfiles/browser/browser.dockerfile.dockerignore
+++ b/deploy/dockerfiles/browser/browser.dockerfile.dockerignore
@@ -11,6 +11,7 @@
 !browser/help
 !browser/package.json
 !browser/src
+!browser/start.sh
 !browser/webpack.config.js
 !dataset-metadata
 !deploy/dockerfiles/browser/browser.nginx.conf

--- a/development/browser.docker-compose.yaml
+++ b/development/browser.docker-compose.yaml
@@ -7,7 +7,7 @@ services:
     command:
       - sh
       - -c
-      - pnpm ts-node ./browser/build/buildHelp.ts && cd browser && pnpm webpack serve --host '0.0.0.0'
+      - pnpm start:browser
     environment:
       - NODE_ENV=development
       - GNOMAD_API_URL

--- a/development/browser.docker-compose.yaml
+++ b/development/browser.docker-compose.yaml
@@ -7,7 +7,7 @@ services:
     command:
       - sh
       - -c
-      - pnpm run ts-node ./browser/build/buildHelp.ts && pnpm workspace '@gnomad/browser' run webpack serve --host '0.0.0.0'
+      - pnpm ts-node ./browser/build/buildHelp.ts && cd browser && pnpm webpack serve --host '0.0.0.0'
     environment:
       - NODE_ENV=development
       - GNOMAD_API_URL

--- a/development/env.sh
+++ b/development/env.sh
@@ -44,8 +44,13 @@ fi
 if [ $with_browser ]; then
   compose_config="$compose_config --file=development/browser.docker-compose.yaml"
 
-  export GNOMAD_API_URL="https://gnomad.broadinstitute.org/api"
-  export READS_API_URL="https://gnomad.broadinstitute.org/reads"
+  if [ -z ${GNOMAD_API_URL:-} ]; then
+    export GNOMAD_API_URL="https://gnomad.broadinstitute.org/api"
+  fi
+
+  if [ -z ${READS_API_URL:-} ]; then
+    export READS_API_URL="https://gnomad.broadinstitute.org/reads"
+  fi
 
   if [ $with_api ]; then
     export GNOMAD_API_URL="http://api:8000/api"


### PR DESCRIPTION
Looks like some things got lost in translation in the switch to pnpm, which left our compose config in a broken state. Since this is a very easy way to start up a local development browser, I think it's worth maintaining even if it's not getting much usage from local devs.

This adds `bash` to (only) the build stage of the browser image so that we can use the same app start.sh script that we have defined for usage elsewhere.

This set of changes gets me a local browser listening on :8008, and pointed at the public gnomad API, after running:

```bash
./development/env.sh browser build
./development/env.sh browser up
```