### PR TITLE
Add azure link to browser tables

### DIFF
--- a/browser/about/contributors/contributing-projects.md
+++ b/browser/about/contributors/contributing-projects.md
@@ -81,7 +81,7 @@
   - SCHEMA - Spain
 - Schizophrenia Trios from Taiwan
 - Sequencing Initiative Suomi (SiSu)
-- SHARE
+- SHARE: Translational Studies in Inflammatory Bowel Disease
 - SIGMA-T2D
 - SubPopulations and InteRmediate Outcome Measures In COPD Study (SPIROMICS)
 - SUPER Study – “A Finnish study of hereditary mechanisms of psychosis disorders”

--- a/browser/src/DownloadsPage/GnomadV2Downloads.tsx
+++ b/browser/src/DownloadsPage/GnomadV2Downloads.tsx
@@ -304,7 +304,6 @@ const GnomadV2Downloads = () => {
             <GetUrlButtons
               label="Browser GRCh37 gene models Hail Table"
               path="/resources/grch37/genes/gnomad.genes.GRCh37.GENCODEv19.ht"
-              includeAzure={false}
             />
           </ListItem>
         </FileList>

--- a/browser/src/DownloadsPage/GnomadV4Downloads.tsx
+++ b/browser/src/DownloadsPage/GnomadV4Downloads.tsx
@@ -283,7 +283,6 @@ const GnomadV4Downloads = () => {
             <GetUrlButtons
               label="Browser variants Hail Table"
               path="/release/4.1/ht/browser/gnomad.browser.v4.1.sites.ht"
-              includeAzure={false}
             />
           </ListItem>
         </FileList>
@@ -295,7 +294,6 @@ const GnomadV4Downloads = () => {
             <GetUrlButtons
               label="Browser GRCh38 gene models Hail Table"
               path="/resources/grch38/genes/gnomad.genes.GRCh38.GENCODEv39.ht"
-              includeAzure={false}
             />
           </ListItem>
         </FileList>

--- a/browser/src/DownloadsPage/__snapshots__/DownloadsPage.spec.tsx.snap
+++ b/browser/src/DownloadsPage/__snapshots__/DownloadsPage.spec.tsx.snap
@@ -7389,6 +7389,15 @@ exports[`Downloads Page has no unexpected changes 1`] = `
           >
             Amazon
           </button>
+           / 
+          <button
+            aria-label="Show Microsoft URL for Browser variants Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Microsoft
+          </button>
         </li>
       </ul>
       <h3>
@@ -7422,6 +7431,15 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             type="button"
           >
             Amazon
+          </button>
+           / 
+          <button
+            aria-label="Show Microsoft URL for Browser GRCh38 gene models Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Microsoft
           </button>
         </li>
       </ul>
@@ -24620,6 +24638,15 @@ exports[`Downloads Page has no unexpected changes 1`] = `
             type="button"
           >
             Amazon
+          </button>
+           / 
+          <button
+            aria-label="Show Microsoft URL for Browser GRCh37 gene models Hail Table"
+            className="c21"
+            onClick={[Function]}
+            type="button"
+          >
+            Microsoft
           </button>
         </li>
       </ul>

--- a/browser/src/__snapshots__/AboutPage.spec.tsx.snap
+++ b/browser/src/__snapshots__/AboutPage.spec.tsx.snap
@@ -653,7 +653,7 @@ See our blog post [here](https://gnomad.broadinstitute.org/news/2022-12-gnomad-s
   - SCHEMA - Spain
 - Schizophrenia Trios from Taiwan
 - Sequencing Initiative Suomi (SiSu)
-- SHARE
+- SHARE: Translational Studies in Inflammatory Bowel Disease
 - SIGMA-T2D
 - SubPopulations and InteRmediate Outcome Measures In COPD Study (SPIROMICS)
 - SUPER Study – “A Finnish study of hereditary mechanisms of psychosis disorders”


### PR DESCRIPTION
A minor content PR
- Adds the Azure link to the browser hail tables on the the downloads now that the files have synced
- Updates the SHARE description on the about page (requested by Heidi through Sam)