### PR TITLE
fix: get_caids.py

### DIFF
--- a/data-pipeline/caids/get_caids.py
+++ b/data-pipeline/caids/get_caids.py
@@ -139,13 +139,13 @@ async def get_caids(sharded_vcf_url: str, output_url: str, *, parallelism: int =
 
             # Get list of VCF partitions.
             all_part_urls = [
-                await f.url() async for f in await fs.listfiles(sharded_vcf_url) if f.name().startswith("part-")
+                await f.url() async for f in await fs.listfiles(sharded_vcf_url) if f.basename().startswith("part-")
             ]
 
             # Get list of parts in output.
             try:
                 completed_part_urls = [
-                    await f.url() async for f in await fs.listfiles(output_url) if f.name().startswith("part-")
+                    await f.url() async for f in await fs.listfiles(output_url) if f.basename().startswith("part-")
                 ]
             except FileNotFoundError:
                 completed_part_urls = []


### PR DESCRIPTION
Relates to https://github.com/broadinstitute/gnomad-browser/issues/1620 

Updates method name to match that from the `aiogoogle` [GoogleStorageFileListEntry class from the Hail library](https://github.com/hail-is/hail/blob/6a24c2b6206756694a0e5d72e2c1fb0ab6e4ba14/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py#L483).

Previously gave an error (see issue for details). Now `get_caids.py` is able to start running (see screenshot below).

![image](https://github.com/user-attachments/assets/528b2f2e-221f-4a2a-bcd2-afdda7520680)
