### PR TITLE
Split variant flags

### DIFF
--- a/browser/src/GenePage/VariantsInGene.tsx
+++ b/browser/src/GenePage/VariantsInGene.tsx
@@ -246,6 +246,7 @@ query ${operationName}($geneId: String!, $datasetId: DatasetId!, $referenceGenom
           faf99_max
           faf99_max_gen_anc
         }
+	flags
       }
       genome {
         ac
@@ -265,6 +266,7 @@ query ${operationName}($geneId: String!, $datasetId: DatasetId!, $referenceGenom
           ac_hemi
           ac_hom
         }
+	flags
       }
       joint {
         ac

--- a/browser/src/RegionPage/VariantsInRegion.tsx
+++ b/browser/src/RegionPage/VariantsInRegion.tsx
@@ -155,6 +155,7 @@ query ${operationName}($chrom: String!, $start: Int!, $stop: Int!, $datasetId: D
           faf99_max
           faf99_max_gen_anc
         }
+	flags
       }
       genome {
         ac
@@ -174,6 +175,7 @@ query ${operationName}($chrom: String!, $start: Int!, $stop: Int!, $datasetId: D
           ac_hemi
           ac_hom
         }
+	flags
       }
       joint {
         ac

--- a/browser/src/VariantList/VariantFlag.tsx
+++ b/browser/src/VariantList/VariantFlag.tsx
@@ -8,6 +8,17 @@ type Flag = {
   formatTooltip: (input: any) => string
 }
 
+const formatMonoallelicFlag = (variant: any) => {
+  if (variant.exome && variant.exome.flags && variant.exome.flags.includes('monoallelic')) {
+    if (variant.genome && variant.genome.flags && variant.genome.flags.includes('monoallelic')) {
+      return 'All samples are homozygous alternate for the variant in both the exome and genome data'
+    }
+    return 'All samples are homozygous alternate for the variant in the exome data'
+  }
+
+  return 'All samples are homozygous alternate for the variant in the genome data'
+}
+
 export const FLAGS_CONFIG: Record<string, Flag> = {
   lcr: {
     label: 'LCR',
@@ -46,7 +57,7 @@ export const FLAGS_CONFIG: Record<string, Flag> = {
   monoallelic: {
     label: 'Monoallelic',
     level: 'info',
-    formatTooltip: () => 'All samples are homozygous alternate for the variant',
+    formatTooltip: formatMonoallelicFlag,
   },
   // Mitochondrial variants
   common_low_heteroplasmy: {

--- a/browser/src/VariantList/variantTableColumns.tsx
+++ b/browser/src/VariantList/variantTableColumns.tsx
@@ -46,6 +46,15 @@ const getConsequenceDescription = (contextType: any) => {
       return ' for consequence in this transcript'
   }
 }
+
+const consolidatedFlags = (row: any) => {
+  const variantFlags = row.flags || []
+  const exomeFlags = row.exome?.flags || []
+  const genomeFlags = row.genome?.flags || []
+  const allFlags = Array.from(new Set([...variantFlags, ...exomeFlags, ...genomeFlags]))
+  return allFlags.sort()
+}
+
 export type VariantTableColumn = {
   key: string
   heading: string
@@ -163,11 +172,16 @@ const variantTableColumns: VariantTableColumn[] = [
     description: 'Flags that may affect annotation and/or confidence',
     grow: 0,
     minWidth: 140,
-    compareFunction: makeNumericCompareFunction((variant: any) => variant.flags.length || null),
-    render: (row: any, key: any) =>
-      row[key]
-        .filter((flag: any) => flag !== 'segdup' && flag !== 'par')
-        .map((flag: any) => <VariantFlag key={flag} type={flag} variant={row} />),
+    compareFunction: makeNumericCompareFunction(
+      (variant: any) => consolidatedFlags(variant).length || null
+    ),
+    render: (row: any) => (
+      <>
+        {consolidatedFlags(row).map((flag: any) => (
+          <VariantFlag key={flag} type={flag} variant={row} />
+        ))}
+      </>
+    ),
   },
 
   {
@@ -208,7 +222,7 @@ const variantTableColumns: VariantTableColumn[] = [
     minWidth: 160,
     compareFunction: makeStringCompareFunction('hgvs'),
     getSearchTerms: (variant: any) => [variant.hgvs],
-    render: (variant: any, key: any, { highlightWords }: any) => (
+    render: (variant: any, _: any, { highlightWords }: any) => (
       <Cell>
         <Highlighter autoEscape searchWords={highlightWords} textToHighlight={variant.hgvs || ''} />
       </Cell>
@@ -225,7 +239,7 @@ const variantTableColumns: VariantTableColumn[] = [
     minWidth: 160,
     compareFunction: makeStringCompareFunction('hgvsc'),
     getSearchTerms: (variant: any) => [variant.hgvsc],
-    render: (variant: any, key: any, { highlightWords }: any) => (
+    render: (variant: any, _: any, { highlightWords }: any) => (
       <Cell>
         <Highlighter
           autoEscape
@@ -246,7 +260,7 @@ const variantTableColumns: VariantTableColumn[] = [
     minWidth: 160,
     compareFunction: makeStringCompareFunction('hgvsp'),
     getSearchTerms: (variant: any) => [variant.hgvsp],
-    render: (variant: any, key: any, { highlightWords }: any) => (
+    render: (variant: any, _: any, { highlightWords }: any) => (
       <Cell>
         <Highlighter
           autoEscape
@@ -315,7 +329,7 @@ const variantTableColumns: VariantTableColumn[] = [
       rsids1[0].localeCompare(rsids2[0])
     ),
     getSearchTerms: (variant: any) => variant.rsids || [],
-    render: (variant: any, key: any, { highlightWords }: any) => (
+    render: (variant: any, _: any, { highlightWords }: any) => (
       <Cell>
         <Highlighter
           autoEscape
@@ -366,7 +380,7 @@ const variantTableColumns: VariantTableColumn[] = [
     grow: 1,
     compareFunction: makeNumericCompareFunction('pos'),
     getSearchTerms: (variant: any) => [variant.variant_id].concat(variant.rsids || []),
-    render: (row: any, key: any, { highlightWords }: any) => (
+    render: (row: any, _: any, { highlightWords }: any) => (
       <Cell>
         <Link target="_blank" to={`/variant/${row.variant_id}`}>
           <Highlighter autoEscape searchWords={highlightWords} textToHighlight={row.variant_id} />
@@ -409,7 +423,7 @@ export const getColumnsForContext = (context: any) => {
       : context.canonical_transcript_id
 
     // @ts-expect-error TS(2339) Property 'hgvs' does not exist on type '{}'.
-    columns.hgvs.render = (variant: any, key: any, { highlightWords }: any) => (
+    columns.hgvs.render = (variant: any, _: any, { highlightWords }: any) => (
       <Cell>
         <Highlighter autoEscape searchWords={highlightWords} textToHighlight={variant.hgvs || ''} />
         {primaryTranscriptId && variant.transcript_id !== primaryTranscriptId && ' †'}

--- a/browser/src/VariantPage/VariantPage.tsx
+++ b/browser/src/VariantPage/VariantPage.tsx
@@ -586,6 +586,7 @@ query ${operationName}($variantId: String!, $datasetId: DatasetId!, $referenceGe
           value
         }
       }
+      flags
     }
     genome {
       ac
@@ -665,6 +666,7 @@ query ${operationName}($variantId: String!, $datasetId: DatasetId!, $referenceGe
           value
         }
       }
+      flags
     }
     joint {
       ac

--- a/browser/src/VariantPage/VariantPage.tsx
+++ b/browser/src/VariantPage/VariantPage.tsx
@@ -205,6 +205,7 @@ export type SequencingType = BaseSequencingType & {
   ac_hom: number
   ac_hemi: number
   af?: number
+  flags: string[] | null
 }
 
 export type JointSequencingType = BaseSequencingType & {

--- a/browser/src/__factories__/Variant.ts
+++ b/browser/src/__factories__/Variant.ts
@@ -190,9 +190,11 @@ export const variantTableVariantFactory = Factory.define<VariantTableVariant>(
     const {
       exome = {
         filters: [],
+        flags: [],
       },
       genome = {
         filters: [],
+        flags: [],
       },
     } = associations
 
@@ -228,6 +230,7 @@ export const sequencingFactory = Factory.define<SequencingType>(({ params, assoc
     homozygote_count = 0,
     hemizygote_count = 0,
     filters = [],
+    flags = [],
     populations = [],
     local_ancestry_populations = [],
     ac_hemi = 1,
@@ -256,6 +259,7 @@ export const sequencingFactory = Factory.define<SequencingType>(({ params, assoc
     homozygote_count,
     hemizygote_count,
     filters,
+    flags,
     populations,
     local_ancestry_populations,
     age_distribution,

--- a/graphql-api/src/graphql/types/variant.graphql
+++ b/graphql-api/src/graphql/types/variant.graphql
@@ -115,6 +115,7 @@ type VariantSequencingTypeData {
   populations: [VariantPopulation]
   faf95: VariantFilteringAlleleFrequency
   fafmax: Fafmax
+  flags: [String!]
 
   # Deprecated - calculate from AC and AN
   # Preserved for compatibility with existing browser queries
@@ -222,6 +223,7 @@ type VariantDetailsSequencingTypeData {
   faf95: VariantFilteringAlleleFrequency
   faf99: VariantFilteringAlleleFrequency
   filters: [String!]
+  flags: [String!]
   populations: [VariantPopulation]
   local_ancestry_populations: [VariantLocalAncestryPopulation]!
   age_distribution: VariantAgeDistribution

--- a/graphql-api/src/queries/mitochondrial-variant-datasets/gnomad-v3-mitochondrial-variant-queries.ts
+++ b/graphql-api/src/queries/mitochondrial-variant-datasets/gnomad-v3-mitochondrial-variant-queries.ts
@@ -2,7 +2,7 @@ import { omit } from 'lodash'
 import { isRsId } from '@gnomad/identifiers'
 import { fetchAllSearchResults } from '../helpers/elasticsearch-helpers'
 import { mergeOverlappingRegions } from '../helpers/region-helpers'
-import { getFlagsForContext } from '../variant-datasets/shared/flags'
+import { getLofteeFlagsForContext } from '../variant-datasets/shared/flags'
 import { getConsequenceForContext } from '../variant-datasets/shared/transcriptConsequence'
 
 const GNOMAD_V3_MITOCHONDRIAL_VARIANT_INDEX = 'gnomad_v3_mitochondrial_variants'
@@ -33,7 +33,7 @@ const fetchMitochondrialVariantById = async (esClient: any, variantIdOrRsid: any
   const variant = response.body.hits.hits[0]._source.value
 
   // Remove nc_transcript flag due to issues with LOFTEE on mitochondrial variants
-  const flags = getFlagsForContext({ type: 'region' })(variant).filter(
+  const flags = getLofteeFlagsForContext({ type: 'region' })(variant).filter(
     (f: any) => f !== 'nc_transcript'
   )
 
@@ -73,7 +73,7 @@ const FIELDS_TO_FETCH = [
 
 const shapeMitochondrialVariantSummary = (context: any) => {
   const getConsequence = getConsequenceForContext(context)
-  const getFlags = getFlagsForContext(context)
+  const getFlags = getLofteeFlagsForContext(context)
 
   return (variant: any) => {
     const transcriptConsequence = getConsequence(variant) || {}

--- a/graphql-api/src/queries/mitochondrial-variant-datasets/gnomad-v3-mitochondrial-variant-queries.ts
+++ b/graphql-api/src/queries/mitochondrial-variant-datasets/gnomad-v3-mitochondrial-variant-queries.ts
@@ -2,7 +2,7 @@ import { omit } from 'lodash'
 import { isRsId } from '@gnomad/identifiers'
 import { fetchAllSearchResults } from '../helpers/elasticsearch-helpers'
 import { mergeOverlappingRegions } from '../helpers/region-helpers'
-import { getLofteeFlagsForContext } from '../variant-datasets/shared/flags'
+import { getFlagsForContext } from '../variant-datasets/shared/flags'
 import { getConsequenceForContext } from '../variant-datasets/shared/transcriptConsequence'
 
 const GNOMAD_V3_MITOCHONDRIAL_VARIANT_INDEX = 'gnomad_v3_mitochondrial_variants'
@@ -33,9 +33,8 @@ const fetchMitochondrialVariantById = async (esClient: any, variantIdOrRsid: any
   const variant = response.body.hits.hits[0]._source.value
 
   // Remove nc_transcript flag due to issues with LOFTEE on mitochondrial variants
-  const flags = getLofteeFlagsForContext({ type: 'region' })(variant).filter(
-    (f: any) => f !== 'nc_transcript'
-  )
+  const { variantFlags } = getFlagsForContext({ type: 'region' }, variant)
+  const flags = variantFlags.filter((f: any) => f !== 'nc_transcript')
 
   return {
     ...variant,
@@ -73,12 +72,12 @@ const FIELDS_TO_FETCH = [
 
 const shapeMitochondrialVariantSummary = (context: any) => {
   const getConsequence = getConsequenceForContext(context)
-  const getFlags = getLofteeFlagsForContext(context)
 
   return (variant: any) => {
     const transcriptConsequence = getConsequence(variant) || {}
     // Remove nc_transcript flag due to issues with LOFTEE on mitochondrial variants
-    const flags = getFlags(variant).filter((f: any) => f !== 'nc_transcript')
+    const { variantFlags } = getFlagsForContext(context, variant)
+    const flags = variantFlags.filter((f: any) => f !== 'nc_transcript')
 
     return {
       ...omit(variant, 'transcript_consequences', 'locus', 'alleles'), // Omit full transcript consequences list to avoid caching it

--- a/graphql-api/src/queries/variant-datasets/exac-variant-queries.ts
+++ b/graphql-api/src/queries/variant-datasets/exac-variant-queries.ts
@@ -10,7 +10,7 @@ import {
   fetchLofCurationResultsByRegion,
 } from '../lof-curation-result-queries'
 
-import { getFlagsForContext } from './shared/flags'
+import { getLofteeFlagsForContext } from './shared/flags'
 import { getConsequenceForContext } from './shared/transcriptConsequence'
 
 const EXAC_VARIANT_INDEX = 'exac_variants'
@@ -75,7 +75,7 @@ export const fetchVariantById = async (esClient: any, variantIdOrRsid: any) => {
 
   const variant = response.body.hits.hits[0]._source.value
 
-  const flags = getFlagsForContext({ type: 'region' })(variant)
+  const flags = getLofteeFlagsForContext({ type: 'region' })(variant)
 
   const lofCurationResults = await fetchLofCurationResultsByVariant(esClient, variant.variant_id)
 
@@ -111,7 +111,7 @@ export const fetchVariantById = async (esClient: any, variantIdOrRsid: any) => {
 
 const shapeVariantSummary = (context: any) => {
   const getConsequence = getConsequenceForContext(context)
-  const getFlags = getFlagsForContext(context)
+  const getFlags = getLofteeFlagsForContext(context)
 
   return (variant: any) => {
     const transcriptConsequence = getConsequence(variant) || {}

--- a/graphql-api/src/queries/variant-datasets/exac-variant-queries.ts
+++ b/graphql-api/src/queries/variant-datasets/exac-variant-queries.ts
@@ -97,6 +97,7 @@ export const fetchVariantById = async (esClient: any, variantIdOrRsid: any) => {
         },
         site_quality_metrics: variant.exome.quality_metrics.site_quality_metrics,
       },
+      flags: variant.exome.flags || [],
     },
     genome: null,
     flags,

--- a/graphql-api/src/queries/variant-datasets/gnomad-v2-variant-queries.ts
+++ b/graphql-api/src/queries/variant-datasets/gnomad-v2-variant-queries.ts
@@ -12,7 +12,7 @@ import {
   fetchLofCurationResultsByRegion,
 } from '../lof-curation-result-queries'
 
-import { getFlagsForContext } from './shared/flags'
+import { getLofteeFlagsForContext } from './shared/flags'
 import { getConsequenceForContext } from './shared/transcriptConsequence'
 
 const GNOMAD_V2_VARIANT_INDEX = 'gnomad_v2_variants'
@@ -116,7 +116,7 @@ const fetchVariantById = async (esClient: any, variantIdOrRsid: any, subset: any
     genomeFilters.push('AC0')
   }
 
-  const flags = getFlagsForContext({ type: 'region' })(variant)
+  const flags = getLofteeFlagsForContext({ type: 'region' })(variant)
 
   const lofCurationResults = await fetchLofCurationResultsByVariant(esClient, variant.variant_id)
 
@@ -154,7 +154,7 @@ const fetchVariantById = async (esClient: any, variantIdOrRsid: any, subset: any
 
 const shapeVariantSummary = (exomeSubset: any, genomeSubset: any, context: any) => {
   const getConsequence = getConsequenceForContext(context)
-  const getFlags = getFlagsForContext(context)
+  const getFlags = getLofteeFlagsForContext(context)
 
   return (variant: any) => {
     const transcriptConsequence = getConsequence(variant) || {}

--- a/graphql-api/src/queries/variant-datasets/gnomad-v2-variant-queries.ts
+++ b/graphql-api/src/queries/variant-datasets/gnomad-v2-variant-queries.ts
@@ -117,6 +117,8 @@ const fetchVariantById = async (esClient: any, variantIdOrRsid: any, subset: any
   }
 
   const flags = getLofteeFlagsForContext({ type: 'region' })(variant)
+  const exomeFlags = variant.exome.flags || []
+  const genomeFlags = variant.genome.flags || []
 
   const lofCurationResults = await fetchLofCurationResultsByVariant(esClient, variant.variant_id)
 
@@ -131,6 +133,7 @@ const fetchVariantById = async (esClient: any, variantIdOrRsid: any, subset: any
           quality_metrics: formatVariantQualityMetrics(variant.exome.quality_metrics),
           age_distribution: variant.exome.age_distribution[exomeSubset],
           filters: exomeFilters,
+          flags: exomeFlags,
         }
       : null,
     genome: variant.genome.freq[genomeSubset].ac_raw
@@ -140,6 +143,7 @@ const fetchVariantById = async (esClient: any, variantIdOrRsid: any, subset: any
           quality_metrics: formatVariantQualityMetrics(variant.genome.quality_metrics),
           age_distribution: variant.genome.age_distribution[genomeSubset],
           filters: genomeFilters,
+          flags: genomeFlags,
         }
       : null,
     flags,
@@ -162,6 +166,8 @@ const shapeVariantSummary = (exomeSubset: any, genomeSubset: any, context: any) 
 
     const exomeFilters = variant.exome.filters || []
     const genomeFilters = variant.genome.filters || []
+    const exomeFlags = variant.exome.flags || []
+    const genomeFlags = variant.genome.flags || []
 
     if (variant.exome.freq[exomeSubset].ac === 0 && !exomeFilters.includes('AC0')) {
       exomeFilters.push('AC0')
@@ -181,6 +187,7 @@ const shapeVariantSummary = (exomeSubset: any, genomeSubset: any, context: any) 
               (pop: any) => !(pop.id.includes('_') || pop.id === 'XX' || pop.id === 'XY')
             ),
             filters: exomeFilters,
+            flags: exomeFlags,
           }
         : null,
       genome: variant.genome.freq[genomeSubset].ac_raw
@@ -191,6 +198,7 @@ const shapeVariantSummary = (exomeSubset: any, genomeSubset: any, context: any) 
               (pop: any) => !(pop.id.includes('_') || pop.id === 'XX' || pop.id === 'XY')
             ),
             filters: genomeFilters,
+            flags: genomeFlags,
           }
         : null,
       flags,
@@ -238,6 +246,8 @@ const fetchVariantsByGene = async (esClient: any, gene: any, subset: any) => {
       `value.genome.freq.${genomeSubset}`,
       'value.exome.filters',
       'value.genome.filters',
+      'value.exome.flags',
+      'value.genome.flags',
       'value.alt',
       'value.caid',
       'value.chrom',

--- a/graphql-api/src/queries/variant-datasets/gnomad-v3-variant-queries.ts
+++ b/graphql-api/src/queries/variant-datasets/gnomad-v3-variant-queries.ts
@@ -8,7 +8,7 @@ import { fetchLocalAncestryPopulationsByVariant } from '../local-ancestry-querie
 import { fetchAllSearchResults } from '../helpers/elasticsearch-helpers'
 import { mergeOverlappingRegions } from '../helpers/region-helpers'
 
-import { getFlagsForContext } from './shared/flags'
+import { getLofteeFlagsForContext } from './shared/flags'
 import { getConsequenceForContext } from './shared/transcriptConsequence'
 
 const GNOMAD_V3_VARIANT_INDEX = 'gnomad_v3_variants'
@@ -84,7 +84,7 @@ const fetchVariantById = async (esClient: any, variantIdOrRsid: any, subset: any
     filters.push('AC0')
   }
 
-  const flags = getFlagsForContext({ type: 'region' })(variant)
+  const flags = getLofteeFlagsForContext({ type: 'region' })(variant)
 
   let { populations } = variant.genome.freq[subset]
 
@@ -196,7 +196,7 @@ const fetchVariantById = async (esClient: any, variantIdOrRsid: any, subset: any
 
 const shapeVariantSummary = (subset: any, context: any) => {
   const getConsequence = getConsequenceForContext(context)
-  const getFlags = getFlagsForContext(context)
+  const getFlags = getLofteeFlagsForContext(context)
 
   return (variant: any) => {
     const transcriptConsequence = getConsequence(variant) || {}

--- a/graphql-api/src/queries/variant-datasets/gnomad-v3-variant-queries.ts
+++ b/graphql-api/src/queries/variant-datasets/gnomad-v3-variant-queries.ts
@@ -85,6 +85,7 @@ const fetchVariantById = async (esClient: any, variantIdOrRsid: any, subset: any
   }
 
   const flags = getLofteeFlagsForContext({ type: 'region' })(variant)
+  const genomeFlags = variant.genome.flags || []
 
   let { populations } = variant.genome.freq[subset]
 
@@ -180,6 +181,7 @@ const fetchVariantById = async (esClient: any, variantIdOrRsid: any, subset: any
         ),
       },
       local_ancestry_populations: localAncestryPopulations.genome,
+      flags: genomeFlags,
     },
     flags,
     // TODO: Include RefSeq transcripts once the browser supports them.
@@ -201,6 +203,7 @@ const shapeVariantSummary = (subset: any, context: any) => {
   return (variant: any) => {
     const transcriptConsequence = getConsequence(variant) || {}
     const flags = getFlags(variant)
+    const genomeFlags = variant.genome.flags || []
 
     const filters = variant.genome.filters || []
 
@@ -223,6 +226,7 @@ const shapeVariantSummary = (subset: any, context: any) => {
           (pop: any) => !(pop.id.includes('_') || pop.id === 'XX' || pop.id === 'XY')
         ),
         filters,
+        flags: genomeFlags,
       },
       flags,
       transcript_consequence: transcriptConsequence,
@@ -264,6 +268,7 @@ const fetchVariantsByGene = async (esClient: any, gene: any, subset: any) => {
     _source: [
       `value.genome.freq.${subset}`,
       'value.genome.filters',
+      'value.genome.flags',
       'value.alleles',
       'value.caid',
       'value.locus',

--- a/graphql-api/src/queries/variant-datasets/gnomad-v4-variant-queries.ts
+++ b/graphql-api/src/queries/variant-datasets/gnomad-v4-variant-queries.ts
@@ -8,7 +8,7 @@ import { fetchLocalAncestryPopulationsByVariant } from '../local-ancestry-querie
 import { fetchAllSearchResults } from '../helpers/elasticsearch-helpers'
 import { mergeOverlappingRegions } from '../helpers/region-helpers'
 
-import { getFlagsForContext } from './shared/flags'
+import { getLofteeFlagsForContext } from './shared/flags'
 import { getConsequenceForContext } from './shared/transcriptConsequence'
 import largeGenes from '../helpers/large-genes'
 
@@ -111,7 +111,7 @@ const fetchVariantById = async (esClient: any, variantId: any, subset: Subset) =
     genomeFilters.push('AC0')
   }
 
-  const flags = getFlagsForContext({ type: 'region' })(variant)
+  const flags = getLofteeFlagsForContext({ type: 'region' })(variant)
 
   let genome_ancestry_groups = subsetGenomeFreq.ancestry_groups || []
   // Include HGDP and 1KG populations with gnomAD subsets
@@ -276,7 +276,7 @@ const createInSilicoPredictorsList = (variant: any) => {
 
 const shapeVariantSummary = (subset: Subset, context: any) => {
   const getConsequence = getConsequenceForContext(context)
-  const getFlags = getFlagsForContext(context)
+  const getFlags = getLofteeFlagsForContext(context)
 
   return (variant: any) => {
     const transcriptConsequence = getConsequence(variant) || {}

--- a/graphql-api/src/queries/variant-datasets/gnomad-v4-variant-queries.ts
+++ b/graphql-api/src/queries/variant-datasets/gnomad-v4-variant-queries.ts
@@ -154,6 +154,7 @@ const fetchVariantById = async (esClient: any, variantId: any, subset: Subset) =
       ...variant.exome,
       ...variant.exome.freq[subset],
       filters: exomeFilters,
+      flags: variant.exome.flags || [],
       populations: variant.exome.freq[subset].ancestry_groups,
       faf95: hasExomeVariant &&
         variant.exome.faf95 && {
@@ -185,6 +186,7 @@ const fetchVariantById = async (esClient: any, variantId: any, subset: Subset) =
       ...variant.genome,
       ...subsetGenomeFreq,
       filters: genomeFilters,
+      flags: variant.genome.flags || [],
       populations: genome_ancestry_groups,
       faf95: hasGenomeVariant &&
         variant.genome.faf95 && {
@@ -285,6 +287,8 @@ const shapeVariantSummary = (subset: Subset, context: any) => {
     const exomeFilters = variant.exome.filters || []
     const genomeFilters = variant.genome.filters || []
     const jointFilters = variant.joint.filter || []
+    const exomeFlags = variant.exome.flags || []
+    const genomeFlags = variant.genome.flags || []
 
     const subsetGenomeFreq = variant.genome.freq.all || {}
     const subsetJointFreq = variant.joint.freq[subset] || {}
@@ -322,6 +326,7 @@ const shapeVariantSummary = (subset: Subset, context: any) => {
               (pop: any) => !(pop.id.includes('_') || pop.id === 'XX' || pop.id === 'XY')
             ),
             filters: exomeFilters,
+            flags: exomeFlags,
             fafmax: variant.exome.fafmax[subset],
           }
         : null,
@@ -344,6 +349,7 @@ const shapeVariantSummary = (subset: Subset, context: any) => {
             ),
             filters: jointFilters,
             fafmax: variant.joint.fafmax,
+            flags: genomeFlags,
           }
         : null,
       flags,
@@ -363,8 +369,10 @@ const getMultiVariantSourceFields = (
     `value.genome.freq.${genomeSubset}`,
     `value.joint.freq.${jointSubset}`,
     'value.exome.filters',
+    'value.exome.flags',
     'value.exome.fafmax',
     'value.genome.filters',
+    'value.genome.flags',
     'value.joint.filters',
     'value.alleles',
     // 'value.caid',

--- a/graphql-api/src/queries/variant-datasets/shared/flags.spec.ts
+++ b/graphql-api/src/queries/variant-datasets/shared/flags.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from '@jest/globals'
 
-const { getFlagsForContext } = require('./flags')
+const { getLofteeFlagsForContext } = require('./flags')
 
 describe('LOFTEE', () => {
   describe('lc_lof', () => {
@@ -41,16 +41,16 @@ describe('LOFTEE', () => {
       ])(
         'should be included only if there are LOFTEE annotated consequences in the specified gene, none of them are annotated HC, the highest ranked transcript is LOFTEE annotated, and the highest ranked transcript is not OS',
         (geneId, expected) => {
-          expect(getFlagsForContext({ type: 'gene', geneId })(variant).includes('lc_lof')).toBe(
-            expected
-          )
+          expect(
+            getLofteeFlagsForContext({ type: 'gene', geneId })(variant).includes('lc_lof')
+          ).toBe(expected)
         }
       )
 
       it('should not be included for variants without consequences', () => {
-        expect(getFlagsForContext({ type: 'gene', geneId: 'G1' })({}).includes('lc_lof')).toBe(
-          false
-        )
+        expect(
+          getLofteeFlagsForContext({ type: 'gene', geneId: 'G1' })({}).includes('lc_lof')
+        ).toBe(false)
       })
     })
 
@@ -108,7 +108,9 @@ describe('LOFTEE', () => {
       ])(
         'should be included only if there are LOFTEE annotated consequences, none of them are annotated HC, the highest ranked transcript is LOFTEE annotated, and the highest ranked transcript is not OS',
         (variant, expected) => {
-          expect(getFlagsForContext({ type: 'region' })(variant).includes('lc_lof')).toBe(expected)
+          expect(getLofteeFlagsForContext({ type: 'region' })(variant).includes('lc_lof')).toBe(
+            expected
+          )
         }
       )
     })
@@ -133,14 +135,18 @@ describe('LOFTEE', () => {
         'should be included only if the consequence in the specified transcript is LOFTEE annotated LC',
         (transcriptId, expected) => {
           expect(
-            getFlagsForContext({ type: 'transcript', transcriptId })(variant).includes('lc_lof')
+            getLofteeFlagsForContext({ type: 'transcript', transcriptId })(variant).includes(
+              'lc_lof'
+            )
           ).toBe(expected)
         }
       )
 
       it('should not be included for variants without consequences', () => {
         expect(
-          getFlagsForContext({ type: 'transcript', transcriptId: 'T1' })({}).includes('lc_lof')
+          getLofteeFlagsForContext({ type: 'transcript', transcriptId: 'T1' })({}).includes(
+            'lc_lof'
+          )
         ).toBe(false)
       })
     })
@@ -174,16 +180,16 @@ describe('LOFTEE', () => {
       ])(
         'should be included only if there are LOFTEE annotated consequences in the specified gene and all of them are LOFTEE flagged',
         (geneId, expected) => {
-          expect(getFlagsForContext({ type: 'gene', geneId })(variant).includes('lof_flag')).toBe(
-            expected
-          )
+          expect(
+            getLofteeFlagsForContext({ type: 'gene', geneId })(variant).includes('lof_flag')
+          ).toBe(expected)
         }
       )
 
       it('should not be included for variants without consequences', () => {
-        expect(getFlagsForContext({ type: 'gene', geneId: 'G1' })({}).includes('lof_flag')).toBe(
-          false
-        )
+        expect(
+          getLofteeFlagsForContext({ type: 'gene', geneId: 'G1' })({}).includes('lof_flag')
+        ).toBe(false)
       })
     })
 
@@ -231,7 +237,7 @@ describe('LOFTEE', () => {
       ])(
         'should be included only if there are LOFTEE annotated consequences and all of them are LOFTEE flagged',
         (variant, expected) => {
-          expect(getFlagsForContext({ type: 'region' })(variant).includes('lof_flag')).toBe(
+          expect(getLofteeFlagsForContext({ type: 'region' })(variant).includes('lof_flag')).toBe(
             expected
           )
         }
@@ -256,14 +262,18 @@ describe('LOFTEE', () => {
         'should be included only if the consequence in the specified transcript is LOFTEE annotated and LOFTEE flagged',
         (transcriptId, expected) => {
           expect(
-            getFlagsForContext({ type: 'transcript', transcriptId })(variant).includes('lof_flag')
+            getLofteeFlagsForContext({ type: 'transcript', transcriptId })(variant).includes(
+              'lof_flag'
+            )
           ).toBe(expected)
         }
       )
 
       it('should not be included for variants without consequences', () => {
         expect(
-          getFlagsForContext({ type: 'transcript', transcriptId: 'T1' })({}).includes('lof_flag')
+          getLofteeFlagsForContext({ type: 'transcript', transcriptId: 'T1' })({}).includes(
+            'lof_flag'
+          )
         ).toBe(false)
       })
     })
@@ -292,14 +302,14 @@ describe('LOFTEE', () => {
         'it should be included only if the most severe consequence in the specified gene is pLoF according to VEP but not LOFTEE annotated',
         (geneId, expected) => {
           expect(
-            getFlagsForContext({ type: 'gene', geneId })(variant).includes('nc_transcript')
+            getLofteeFlagsForContext({ type: 'gene', geneId })(variant).includes('nc_transcript')
           ).toBe(expected)
         }
       )
 
       it('should not be included for variants without consequences', () => {
         expect(
-          getFlagsForContext({ type: 'gene', geneId: 'G1' })({}).includes('nc_transcript')
+          getLofteeFlagsForContext({ type: 'gene', geneId: 'G1' })({}).includes('nc_transcript')
         ).toBe(false)
       })
     })
@@ -337,9 +347,9 @@ describe('LOFTEE', () => {
       ])(
         'it should be included only if the most severe consequence is pLoF according to VEP but not LOFTEE annotated',
         (variant, expected) => {
-          expect(getFlagsForContext({ type: 'region' })(variant).includes('nc_transcript')).toBe(
-            expected
-          )
+          expect(
+            getLofteeFlagsForContext({ type: 'region' })(variant).includes('nc_transcript')
+          ).toBe(expected)
         }
       )
     })
@@ -377,7 +387,7 @@ describe('LOFTEE', () => {
         'it should be included only if the consequence in the specified transcript is pLoF according to VEP but not LOFTEE annotated',
         (transcriptId, expected) => {
           expect(
-            getFlagsForContext({ type: 'transcript', transcriptId })(variant).includes(
+            getLofteeFlagsForContext({ type: 'transcript', transcriptId })(variant).includes(
               'nc_transcript'
             )
           ).toBe(expected)
@@ -386,7 +396,7 @@ describe('LOFTEE', () => {
 
       it('should not be included for variants without consequences', () => {
         expect(
-          getFlagsForContext({ type: 'transcript', transcriptId: 'T1' })({}).includes(
+          getLofteeFlagsForContext({ type: 'transcript', transcriptId: 'T1' })({}).includes(
             'nc_transcript'
           )
         ).toBe(false)
@@ -419,16 +429,16 @@ describe('LOFTEE', () => {
       ])(
         'it should be included only if the most severe consequence in the specified gene is LOFTEE annotated OS',
         (geneId, expected) => {
-          expect(getFlagsForContext({ type: 'gene', geneId })(variant).includes('os_lof')).toBe(
-            expected
-          )
+          expect(
+            getLofteeFlagsForContext({ type: 'gene', geneId })(variant).includes('os_lof')
+          ).toBe(expected)
         }
       )
 
       it('should not be included for variants without consequences', () => {
-        expect(getFlagsForContext({ type: 'gene', geneId: 'G1' })({}).includes('os_lof')).toBe(
-          false
-        )
+        expect(
+          getLofteeFlagsForContext({ type: 'gene', geneId: 'G1' })({}).includes('os_lof')
+        ).toBe(false)
       })
     })
 
@@ -457,7 +467,9 @@ describe('LOFTEE', () => {
       ])(
         'it should be included only if the most severe consequence is LOFTEE annotated OS',
         (variant, expected) => {
-          expect(getFlagsForContext({ type: 'region' })(variant).includes('os_lof')).toBe(expected)
+          expect(getLofteeFlagsForContext({ type: 'region' })(variant).includes('os_lof')).toBe(
+            expected
+          )
         }
       )
     })
@@ -482,14 +494,18 @@ describe('LOFTEE', () => {
         'it should be included only if the consequence in the specified transcript is LOFTEE annotated OS',
         (transcriptId, expected) => {
           expect(
-            getFlagsForContext({ type: 'transcript', transcriptId })(variant).includes('os_lof')
+            getLofteeFlagsForContext({ type: 'transcript', transcriptId })(variant).includes(
+              'os_lof'
+            )
           ).toBe(expected)
         }
       )
 
       it('should not be included for variants without consequences', () => {
         expect(
-          getFlagsForContext({ type: 'transcript', transcriptId: 'T1' })({}).includes('os_lof')
+          getLofteeFlagsForContext({ type: 'transcript', transcriptId: 'T1' })({}).includes(
+            'os_lof'
+          )
         ).toBe(false)
       })
     })

--- a/graphql-api/src/queries/variant-datasets/shared/flags.spec.ts
+++ b/graphql-api/src/queries/variant-datasets/shared/flags.spec.ts
@@ -1,513 +1,578 @@
 import { describe, it, expect } from '@jest/globals'
 
-const { getLofteeFlagsForContext } = require('./flags')
+const { getFlagsForContext } = require('./flags')
 
-describe('LOFTEE', () => {
-  describe('lc_lof', () => {
-    describe('gene context', () => {
-      const variant = {
-        transcript_consequences: [
-          { gene_id: 'G1', lof: 'LC' },
-          { gene_id: 'G1', lof: 'LC' },
-          { gene_id: 'G2', lof: 'LC' },
-          { gene_id: 'G2', lof: '' },
-          { gene_id: 'G3', lof: 'LC' },
-          { gene_id: 'G3', lof: 'OS' },
-          { gene_id: 'G4', lof: 'LC' },
-          { gene_id: 'G4', lof: 'HC' },
-          { gene_id: 'G5', lof: 'HC' },
-          { gene_id: 'G6', lof: '' },
-          // This can happen for non-coding transcripts where LOFTEE
-          // does not annotate a transcript that VEP marks as pLoF
-          { gene_id: 'G7', lof: '' },
-          { gene_id: 'G7', lof: 'LC' },
-          // This should not flag OS as lc_lof because it's rare enough that there
-          //   is effectively no confidence
-          { gene_id: 'G8', lof: 'OS' },
-          { gene_id: 'G8', lof: 'OS' },
-          { gene_id: 'G8', lof: '' },
-        ],
-      }
-
-      it.each([
-        ['G1', true],
-        ['G2', true],
-        ['G3', true],
-        ['G4', false],
-        ['G5', false],
-        ['G6', false],
-        ['G7', false],
-        ['G8', false],
-      ])(
-        'should be included only if there are LOFTEE annotated consequences in the specified gene, none of them are annotated HC, the highest ranked transcript is LOFTEE annotated, and the highest ranked transcript is not OS',
-        (geneId, expected) => {
-          expect(
-            getLofteeFlagsForContext({ type: 'gene', geneId })(variant).includes('lc_lof')
-          ).toBe(expected)
+describe('getFlagsForContext', () => {
+  describe('LOFTEE', () => {
+    describe('lc_lof', () => {
+      describe('gene context', () => {
+        const variant = {
+          transcript_consequences: [
+            { gene_id: 'G1', lof: 'LC' },
+            { gene_id: 'G1', lof: 'LC' },
+            { gene_id: 'G2', lof: 'LC' },
+            { gene_id: 'G2', lof: '' },
+            { gene_id: 'G3', lof: 'LC' },
+            { gene_id: 'G3', lof: 'OS' },
+            { gene_id: 'G4', lof: 'LC' },
+            { gene_id: 'G4', lof: 'HC' },
+            { gene_id: 'G5', lof: 'HC' },
+            { gene_id: 'G6', lof: '' },
+            // This can happen for non-coding transcripts where LOFTEE
+            // does not annotate a transcript that VEP marks as pLoF
+            { gene_id: 'G7', lof: '' },
+            { gene_id: 'G7', lof: 'LC' },
+            // This should not flag OS as lc_lof because it's rare enough that there
+            //   is effectively no confidence
+            { gene_id: 'G8', lof: 'OS' },
+            { gene_id: 'G8', lof: 'OS' },
+            { gene_id: 'G8', lof: '' },
+          ],
+          flags: [],
         }
-      )
 
-      it('should not be included for variants without consequences', () => {
-        expect(
-          getLofteeFlagsForContext({ type: 'gene', geneId: 'G1' })({}).includes('lc_lof')
-        ).toBe(false)
+        it.each([
+          ['G1', true],
+          ['G2', true],
+          ['G3', true],
+          ['G4', false],
+          ['G5', false],
+          ['G6', false],
+          ['G7', false],
+          ['G8', false],
+        ])(
+          'should be included only if there are LOFTEE annotated consequences in the specified gene, none of them are annotated HC, the highest ranked transcript is LOFTEE annotated, and the highest ranked transcript is not OS',
+          (geneId, expected) => {
+            expect(
+              getFlagsForContext({ type: 'gene', geneId }, variant).variantFlags.includes('lc_lof')
+            ).toBe(expected)
+          }
+        )
+
+        it('should not be included for variants without consequences', () => {
+          expect(
+            getFlagsForContext({ type: 'gene', geneId: 'G1' }, {}).variantFlags.includes('lc_lof')
+          ).toBe(false)
+        })
+      })
+
+      describe('region context', () => {
+        it.each([
+          [
+            {
+              transcript_consequences: [{ lof: 'LC' }, { lof: 'LC' }, { lof: '' }],
+            },
+            true,
+          ],
+          [
+            {
+              transcript_consequences: [{ lof: 'LC' }, { lof: 'OS' }],
+            },
+            true,
+          ],
+          [
+            {
+              transcript_consequences: [{ lof: 'LC' }, { lof: 'HC' }],
+            },
+            false,
+          ],
+          [
+            {
+              transcript_consequences: [{ lof: '' }, { lof: '' }],
+            },
+            false,
+          ],
+          [{ transcript_consequences: [] }, false],
+          [{}, false],
+          [
+            {
+              transcript_consequences: [
+                // This can happen for non-coding transcripts where LOFTEE
+                // does not annotate a transcript that VEP marks as pLoF
+                { lof: '' },
+                { lof: 'LC' },
+              ],
+            },
+            false,
+          ],
+          [
+            {
+              transcript_consequences: [
+                // This should not flag OS as lc_lof because it's rare enough that there
+                //   is effectively no confidence
+                { lof: 'OS' },
+                { lof: 'OS' },
+                { lof: '' },
+              ],
+            },
+            false,
+          ],
+        ])(
+          'should be included only if there are LOFTEE annotated consequences, none of them are annotated HC, the highest ranked transcript is LOFTEE annotated, and the highest ranked transcript is not OS',
+          (variant, expected) => {
+            expect(
+              getFlagsForContext({ type: 'region' }, variant).variantFlags.includes('lc_lof')
+            ).toBe(expected)
+          }
+        )
+      })
+
+      describe('transcript context', () => {
+        const variant = {
+          transcript_consequences: [
+            { transcript_id: 'T1', lof: 'LC' },
+            { transcript_id: 'T2', lof: 'OS' },
+            { transcript_id: 'T3', lof: 'HC' },
+            { transcript_id: 'T4', lof: '' },
+          ],
+        }
+
+        it.each([
+          ['T1', true],
+          ['T2', false],
+          ['T3', false],
+          ['T4', false],
+          ['T5', false],
+        ])(
+          'should be included only if the consequence in the specified transcript is LOFTEE annotated LC',
+          (transcriptId, expected) => {
+            expect(
+              getFlagsForContext(
+                { type: 'transcript', transcriptId },
+                variant
+              ).variantFlags.includes('lc_lof')
+            ).toBe(expected)
+          }
+        )
+
+        it('should not be included for variants without consequences', () => {
+          expect(
+            getFlagsForContext(
+              { type: 'transcript', transcriptId: 'T1' },
+              {}
+            ).variantFlags.includes('lc_lof')
+          ).toBe(false)
+        })
       })
     })
 
-    describe('region context', () => {
-      it.each([
-        [
-          {
-            transcript_consequences: [{ lof: 'LC' }, { lof: 'LC' }, { lof: '' }],
-          },
-          true,
-        ],
-        [
-          {
-            transcript_consequences: [{ lof: 'LC' }, { lof: 'OS' }],
-          },
-          true,
-        ],
-        [
-          {
-            transcript_consequences: [{ lof: 'LC' }, { lof: 'HC' }],
-          },
-          false,
-        ],
-        [
-          {
-            transcript_consequences: [{ lof: '' }, { lof: '' }],
-          },
-          false,
-        ],
-        [{ transcript_consequences: [] }, false],
-        [{}, false],
-        [
-          {
-            transcript_consequences: [
-              // This can happen for non-coding transcripts where LOFTEE
-              // does not annotate a transcript that VEP marks as pLoF
-              { lof: '' },
-              { lof: 'LC' },
-            ],
-          },
-          false,
-        ],
-        [
-          {
-            transcript_consequences: [
-              // This should not flag OS as lc_lof because it's rare enough that there
-              //   is effectively no confidence
-              { lof: 'OS' },
-              { lof: 'OS' },
-              { lof: '' },
-            ],
-          },
-          false,
-        ],
-      ])(
-        'should be included only if there are LOFTEE annotated consequences, none of them are annotated HC, the highest ranked transcript is LOFTEE annotated, and the highest ranked transcript is not OS',
-        (variant, expected) => {
-          expect(getLofteeFlagsForContext({ type: 'region' })(variant).includes('lc_lof')).toBe(
-            expected
-          )
+    describe('lof_flag', () => {
+      describe('gene context', () => {
+        const variant = {
+          transcript_consequences: [
+            { gene_id: 'G1', lof: 'HC', lof_flags: 'SOME_FLAG' },
+            { gene_id: 'G1', lof: 'HC', lof_flags: 'SOME_FLAG' },
+            { gene_id: 'G2', lof: 'LC', lof_flags: 'SOME_FLAG' },
+            { gene_id: 'G2', lof: 'OS', lof_flags: 'SOME_FLAG' },
+            { gene_id: 'G3', lof: 'LC', lof_flags: 'SOME_FLAG' },
+            { gene_id: 'G3', lof: '', lof_flags: '' },
+            { gene_id: 'G4', lof: 'HC', lof_flags: 'SOME_FLAG' },
+            { gene_id: 'G4', lof: 'HC', lof_flags: '' },
+            { gene_id: 'G5', lof: 'HC', lof_flags: '' },
+            { gene_id: 'G6', lof: '', lof_flags: '' },
+          ],
         }
-      )
-    })
 
-    describe('transcript context', () => {
-      const variant = {
-        transcript_consequences: [
-          { transcript_id: 'T1', lof: 'LC' },
-          { transcript_id: 'T2', lof: 'OS' },
-          { transcript_id: 'T3', lof: 'HC' },
-          { transcript_id: 'T4', lof: '' },
-        ],
-      }
+        it.each([
+          ['G1', true],
+          ['G2', true],
+          ['G3', true],
+          ['G4', false],
+          ['G5', false],
+          ['G6', false],
+          ['G7', false],
+        ])(
+          'should be included only if there are LOFTEE annotated consequences in the specified gene and all of them are LOFTEE flagged',
+          (geneId, expected) => {
+            expect(
+              getFlagsForContext({ type: 'gene', geneId }, variant).variantFlags.includes(
+                'lof_flag'
+              )
+            ).toBe(expected)
+          }
+        )
 
-      it.each([
-        ['T1', true],
-        ['T2', false],
-        ['T3', false],
-        ['T4', false],
-        ['T5', false],
-      ])(
-        'should be included only if the consequence in the specified transcript is LOFTEE annotated LC',
-        (transcriptId, expected) => {
+        it('should not be included for variants without consequences', () => {
           expect(
-            getLofteeFlagsForContext({ type: 'transcript', transcriptId })(variant).includes(
-              'lc_lof'
-            )
-          ).toBe(expected)
-        }
-      )
-
-      it('should not be included for variants without consequences', () => {
-        expect(
-          getLofteeFlagsForContext({ type: 'transcript', transcriptId: 'T1' })({}).includes(
-            'lc_lof'
-          )
-        ).toBe(false)
+            getFlagsForContext({ type: 'gene', geneId: 'G1' }, {}).variantFlags.includes('lof_flag')
+          ).toBe(false)
+        })
       })
-    })
-  })
 
-  describe('lof_flag', () => {
-    describe('gene context', () => {
-      const variant = {
-        transcript_consequences: [
-          { gene_id: 'G1', lof: 'HC', lof_flags: 'SOME_FLAG' },
-          { gene_id: 'G1', lof: 'HC', lof_flags: 'SOME_FLAG' },
-          { gene_id: 'G2', lof: 'LC', lof_flags: 'SOME_FLAG' },
-          { gene_id: 'G2', lof: 'OS', lof_flags: 'SOME_FLAG' },
-          { gene_id: 'G3', lof: 'LC', lof_flags: 'SOME_FLAG' },
-          { gene_id: 'G3', lof: '', lof_flags: '' },
-          { gene_id: 'G4', lof: 'HC', lof_flags: 'SOME_FLAG' },
-          { gene_id: 'G4', lof: 'HC', lof_flags: '' },
-          { gene_id: 'G5', lof: 'HC', lof_flags: '' },
-          { gene_id: 'G6', lof: '', lof_flags: '' },
-        ],
-      }
+      describe('region context', () => {
+        it.each([
+          [
+            {
+              transcript_consequences: [
+                { lof: 'LC', lof_flags: 'SOME_FLAG' },
+                { lof: 'LC', lof_flags: 'SOME_FLAG' },
+                { lof: '', lof_flags: '' },
+              ],
+            },
+            true,
+          ],
+          [
+            {
+              transcript_consequences: [
+                { lof: 'HC', lof_flags: '' },
+                { lof: 'HC', lof_flags: 'SOME_FLAG' },
+              ],
+            },
+            false,
+          ],
+          [
+            {
+              transcript_consequences: [
+                { lof: 'HC', lof_flags: '' },
+                { lof: 'LC', lof_flags: '' },
+              ],
+            },
+            false,
+          ],
+          [
+            {
+              transcript_consequences: [
+                { lof: '', lof_flags: '' },
+                { lof: '', lof_flags: '' },
+              ],
+            },
+            false,
+          ],
+          [{ transcript_consequences: [] }, false],
+          [{}, false],
+        ])(
+          'should be included only if there are LOFTEE annotated consequences and all of them are LOFTEE flagged',
+          (variant, expected) => {
+            expect(
+              getFlagsForContext({ type: 'region' }, variant).variantFlags.includes('lof_flag')
+            ).toBe(expected)
+          }
+        )
+      })
 
-      it.each([
-        ['G1', true],
-        ['G2', true],
-        ['G3', true],
-        ['G4', false],
-        ['G5', false],
-        ['G6', false],
-        ['G7', false],
-      ])(
-        'should be included only if there are LOFTEE annotated consequences in the specified gene and all of them are LOFTEE flagged',
-        (geneId, expected) => {
-          expect(
-            getLofteeFlagsForContext({ type: 'gene', geneId })(variant).includes('lof_flag')
-          ).toBe(expected)
+      describe('transcript context', () => {
+        const variant = {
+          transcript_consequences: [
+            { transcript_id: 'T1', lof: 'HC', lof_flags: 'SOME_FLAG' },
+            { transcript_id: 'T2', lof: 'LC', lof_flags: 'SOME_FLAG' },
+            { transcript_id: 'T3', lof: '', lof_flags: '' },
+          ],
         }
-      )
 
-      it('should not be included for variants without consequences', () => {
-        expect(
-          getLofteeFlagsForContext({ type: 'gene', geneId: 'G1' })({}).includes('lof_flag')
-        ).toBe(false)
+        it.each([
+          ['T1', true],
+          ['T2', true],
+          ['T3', false],
+          ['T4', false],
+        ])(
+          'should be included only if the consequence in the specified transcript is LOFTEE annotated and LOFTEE flagged',
+          (transcriptId, expected) => {
+            expect(
+              getFlagsForContext(
+                { type: 'transcript', transcriptId },
+                variant
+              ).variantFlags.includes('lof_flag')
+            ).toBe(expected)
+          }
+        )
+
+        it('should not be included for variants without consequences', () => {
+          expect(
+            getFlagsForContext(
+              { type: 'transcript', transcriptId: 'T1' },
+              {}
+            ).variantFlags.includes('lof_flag')
+          ).toBe(false)
+        })
       })
     })
 
-    describe('region context', () => {
-      it.each([
-        [
-          {
-            transcript_consequences: [
-              { lof: 'LC', lof_flags: 'SOME_FLAG' },
-              { lof: 'LC', lof_flags: 'SOME_FLAG' },
-              { lof: '', lof_flags: '' },
-            ],
-          },
-          true,
-        ],
-        [
-          {
-            transcript_consequences: [
-              { lof: 'HC', lof_flags: '' },
-              { lof: 'HC', lof_flags: 'SOME_FLAG' },
-            ],
-          },
-          false,
-        ],
-        [
-          {
-            transcript_consequences: [
-              { lof: 'HC', lof_flags: '' },
-              { lof: 'LC', lof_flags: '' },
-            ],
-          },
-          false,
-        ],
-        [
-          {
-            transcript_consequences: [
-              { lof: '', lof_flags: '' },
-              { lof: '', lof_flags: '' },
-            ],
-          },
-          false,
-        ],
-        [{ transcript_consequences: [] }, false],
-        [{}, false],
-      ])(
-        'should be included only if there are LOFTEE annotated consequences and all of them are LOFTEE flagged',
-        (variant, expected) => {
-          expect(getLofteeFlagsForContext({ type: 'region' })(variant).includes('lof_flag')).toBe(
-            expected
-          )
+    describe('nc_transcript', () => {
+      describe('gene context', () => {
+        const variant = {
+          transcript_consequences: [
+            { gene_id: 'G1', lof: '', major_consequence: 'frameshift_variant' },
+            { gene_id: 'G2', lof: 'HC', major_consequence: 'frameshift_variant' },
+            // This can happen when a coding consequence is sorted above a non-coding consequence
+            { gene_id: 'G3', lof: '', major_consequence: 'missense_variant' },
+            { gene_id: 'G3', lof: '', major_consequence: 'frameshift_variant' },
+            { gene_id: 'G4', lof: '', major_consequence: 'missense_variant' },
+          ],
         }
-      )
-    })
 
-    describe('transcript context', () => {
-      const variant = {
-        transcript_consequences: [
-          { transcript_id: 'T1', lof: 'HC', lof_flags: 'SOME_FLAG' },
-          { transcript_id: 'T2', lof: 'LC', lof_flags: 'SOME_FLAG' },
-          { transcript_id: 'T3', lof: '', lof_flags: '' },
-        ],
-      }
+        it.each([
+          ['G1', true],
+          ['G2', false],
+          ['G3', false],
+          ['G4', false],
+          ['G5', false],
+        ])(
+          'it should be included only if the most severe consequence in the specified gene is pLoF according to VEP but not LOFTEE annotated',
+          (geneId, expected) => {
+            expect(
+              getFlagsForContext({ type: 'gene', geneId }, variant).variantFlags.includes(
+                'nc_transcript'
+              )
+            ).toBe(expected)
+          }
+        )
 
-      it.each([
-        ['T1', true],
-        ['T2', true],
-        ['T3', false],
-        ['T4', false],
-      ])(
-        'should be included only if the consequence in the specified transcript is LOFTEE annotated and LOFTEE flagged',
-        (transcriptId, expected) => {
+        it('should not be included for variants without consequences', () => {
           expect(
-            getLofteeFlagsForContext({ type: 'transcript', transcriptId })(variant).includes(
-              'lof_flag'
-            )
-          ).toBe(expected)
-        }
-      )
-
-      it('should not be included for variants without consequences', () => {
-        expect(
-          getLofteeFlagsForContext({ type: 'transcript', transcriptId: 'T1' })({}).includes(
-            'lof_flag'
-          )
-        ).toBe(false)
-      })
-    })
-  })
-
-  describe('nc_transcript', () => {
-    describe('gene context', () => {
-      const variant = {
-        transcript_consequences: [
-          { gene_id: 'G1', lof: '', major_consequence: 'frameshift_variant' },
-          { gene_id: 'G2', lof: 'HC', major_consequence: 'frameshift_variant' },
-          // This can happen when a coding consequence is sorted above a non-coding consequence
-          { gene_id: 'G3', lof: '', major_consequence: 'missense_variant' },
-          { gene_id: 'G3', lof: '', major_consequence: 'frameshift_variant' },
-          { gene_id: 'G4', lof: '', major_consequence: 'missense_variant' },
-        ],
-      }
-
-      it.each([
-        ['G1', true],
-        ['G2', false],
-        ['G3', false],
-        ['G4', false],
-        ['G5', false],
-      ])(
-        'it should be included only if the most severe consequence in the specified gene is pLoF according to VEP but not LOFTEE annotated',
-        (geneId, expected) => {
-          expect(
-            getLofteeFlagsForContext({ type: 'gene', geneId })(variant).includes('nc_transcript')
-          ).toBe(expected)
-        }
-      )
-
-      it('should not be included for variants without consequences', () => {
-        expect(
-          getLofteeFlagsForContext({ type: 'gene', geneId: 'G1' })({}).includes('nc_transcript')
-        ).toBe(false)
-      })
-    })
-
-    describe('region context', () => {
-      it.each([
-        [
-          {
-            transcript_consequences: [
-              { lof: '', major_consequence: 'frameshift_variant', category: 'lof' },
-              { lof: 'HC', major_consequence: 'frameshift_variant', category: 'lof' },
-            ],
-          },
-          true,
-        ],
-        [
-          {
-            transcript_consequences: [
-              { lof: 'HC', major_consequence: 'frameshift_variant', category: 'lof' },
-              { lof: '', major_consequence: 'missense_variant', category: 'missense' },
-            ],
-          },
-          false,
-        ],
-        [
-          {
-            transcript_consequences: [
-              { lof: '', major_consequence: 'synonymous_variant', category: 'synonymous' },
-            ],
-          },
-          false,
-        ],
-        [{ transcript_consequences: [] }, false],
-        [{}, false],
-      ])(
-        'it should be included only if the most severe consequence is pLoF according to VEP but not LOFTEE annotated',
-        (variant, expected) => {
-          expect(
-            getLofteeFlagsForContext({ type: 'region' })(variant).includes('nc_transcript')
-          ).toBe(expected)
-        }
-      )
-    })
-
-    describe('transcript context', () => {
-      const variant = {
-        transcript_consequences: [
-          {
-            transcript_id: 'T1',
-            lof: '',
-            major_consequence: 'frameshift_variant',
-            category: 'lof',
-          },
-          {
-            transcript_id: 'T2',
-            lof: 'HC',
-            major_consequence: 'frameshift_variant',
-            category: 'lof',
-          },
-          {
-            transcript_id: 'T3',
-            lof: '',
-            major_consequence: 'missense_variant',
-            category: 'missense',
-          },
-        ],
-      }
-
-      it.each([
-        ['T1', true],
-        ['T2', false],
-        ['T3', false],
-        ['T4', false],
-      ])(
-        'it should be included only if the consequence in the specified transcript is pLoF according to VEP but not LOFTEE annotated',
-        (transcriptId, expected) => {
-          expect(
-            getLofteeFlagsForContext({ type: 'transcript', transcriptId })(variant).includes(
+            getFlagsForContext({ type: 'gene', geneId: 'G1' }, {}).variantFlags.includes(
               'nc_transcript'
             )
-          ).toBe(expected)
-        }
-      )
+          ).toBe(false)
+        })
+      })
 
-      it('should not be included for variants without consequences', () => {
-        expect(
-          getLofteeFlagsForContext({ type: 'transcript', transcriptId: 'T1' })({}).includes(
-            'nc_transcript'
-          )
-        ).toBe(false)
+      describe('region context', () => {
+        it.each([
+          [
+            {
+              transcript_consequences: [
+                { lof: '', major_consequence: 'frameshift_variant', category: 'lof' },
+                { lof: 'HC', major_consequence: 'frameshift_variant', category: 'lof' },
+              ],
+            },
+            true,
+          ],
+          [
+            {
+              transcript_consequences: [
+                { lof: 'HC', major_consequence: 'frameshift_variant', category: 'lof' },
+                { lof: '', major_consequence: 'missense_variant', category: 'missense' },
+              ],
+            },
+            false,
+          ],
+          [
+            {
+              transcript_consequences: [
+                { lof: '', major_consequence: 'synonymous_variant', category: 'synonymous' },
+              ],
+            },
+            false,
+          ],
+          [{ transcript_consequences: [] }, false],
+          [{}, false],
+        ])(
+          'it should be included only if the most severe consequence is pLoF according to VEP but not LOFTEE annotated',
+          (variant, expected) => {
+            expect(
+              getFlagsForContext({ type: 'region' }, variant).variantFlags.includes('nc_transcript')
+            ).toBe(expected)
+          }
+        )
+      })
+
+      describe('transcript context', () => {
+        const variant = {
+          transcript_consequences: [
+            {
+              transcript_id: 'T1',
+              lof: '',
+              major_consequence: 'frameshift_variant',
+              category: 'lof',
+            },
+            {
+              transcript_id: 'T2',
+              lof: 'HC',
+              major_consequence: 'frameshift_variant',
+              category: 'lof',
+            },
+            {
+              transcript_id: 'T3',
+              lof: '',
+              major_consequence: 'missense_variant',
+              category: 'missense',
+            },
+          ],
+        }
+
+        it.each([
+          ['T1', true],
+          ['T2', false],
+          ['T3', false],
+          ['T4', false],
+        ])(
+          'it should be included only if the consequence in the specified transcript is pLoF according to VEP but not LOFTEE annotated',
+          (transcriptId, expected) => {
+            expect(
+              getFlagsForContext(
+                { type: 'transcript', transcriptId },
+                variant
+              ).variantFlags.includes('nc_transcript')
+            ).toBe(expected)
+          }
+        )
+
+        it('should not be included for variants without consequences', () => {
+          expect(
+            getFlagsForContext(
+              { type: 'transcript', transcriptId: 'T1' },
+              {}
+            ).variantFlags.includes('nc_transcript')
+          ).toBe(false)
+        })
+      })
+    })
+
+    describe('os_lof', () => {
+      describe('gene context', () => {
+        const variant = {
+          transcript_consequences: [
+            { gene_id: 'G1', lof: 'OS' },
+            { gene_id: 'G1', lof: 'LC' },
+            { gene_id: 'G2', lof: 'LC' },
+            { gene_id: 'G2', lof: 'OS' },
+            { gene_id: 'G3', lof: '' },
+            { gene_id: 'G3', lof: 'OS' },
+            { gene_id: 'G4', lof: 'HC' },
+            { gene_id: 'G5', lof: '' },
+          ],
+        }
+
+        it.each([
+          ['G1', true],
+          ['G2', false],
+          ['G3', false],
+          ['G4', false],
+          ['G5', false],
+          ['G6', false],
+        ])(
+          'it should be included only if the most severe consequence in the specified gene is LOFTEE annotated OS',
+          (geneId, expected) => {
+            expect(
+              getFlagsForContext({ type: 'gene', geneId }, variant).variantFlags.includes('os_lof')
+            ).toBe(expected)
+          }
+        )
+
+        it('should not be included for variants without consequences', () => {
+          expect(
+            getFlagsForContext({ type: 'gene', geneId: 'G1' }, {}).variantFlags.includes('os_lof')
+          ).toBe(false)
+        })
+      })
+
+      describe('region context', () => {
+        it.each([
+          [
+            {
+              transcript_consequences: [{ lof: 'OS' }, { lof: 'HC' }],
+            },
+            true,
+          ],
+          [
+            {
+              transcript_consequences: [{ lof: 'HC' }, { lof: 'OS' }],
+            },
+            false,
+          ],
+          [
+            {
+              transcript_consequences: [{ lof: '' }],
+            },
+            false,
+          ],
+          [{ transcript_consequences: [] }, false],
+          [{}, false],
+        ])(
+          'it should be included only if the most severe consequence is LOFTEE annotated OS',
+          (variant, expected) => {
+            expect(
+              getFlagsForContext({ type: 'region' }, variant).variantFlags.includes('os_lof')
+            ).toBe(expected)
+          }
+        )
+      })
+
+      describe('transcript context', () => {
+        const variant = {
+          transcript_consequences: [
+            { transcript_id: 'T1', lof: 'OS' },
+            { transcript_id: 'T2', lof: 'HC' },
+            { transcript_id: 'T3', lof: 'LC' },
+            { transcript_id: 'T4', lof: '' },
+          ],
+        }
+
+        it.each([
+          ['T1', true],
+          ['T2', false],
+          ['T3', false],
+          ['T4', false],
+          ['T5', false],
+        ])(
+          'it should be included only if the consequence in the specified transcript is LOFTEE annotated OS',
+          (transcriptId, expected) => {
+            expect(
+              getFlagsForContext(
+                { type: 'transcript', transcriptId },
+                variant
+              ).variantFlags.includes('os_lof')
+            ).toBe(expected)
+          }
+        )
+
+        it('should not be included for variants without consequences', () => {
+          expect(
+            getFlagsForContext(
+              { type: 'transcript', transcriptId: 'T1' },
+              {}
+            ).variantFlags.includes('os_lof')
+          ).toBe(false)
+        })
       })
     })
   })
 
-  describe('os_lof', () => {
-    describe('gene context', () => {
-      const variant = {
-        transcript_consequences: [
-          { gene_id: 'G1', lof: 'OS' },
-          { gene_id: 'G1', lof: 'LC' },
-          { gene_id: 'G2', lof: 'LC' },
-          { gene_id: 'G2', lof: 'OS' },
-          { gene_id: 'G3', lof: '' },
-          { gene_id: 'G3', lof: 'OS' },
-          { gene_id: 'G4', lof: 'HC' },
-          { gene_id: 'G5', lof: '' },
-        ],
+  describe.each(['par', 'segdup', 'lcr'])('regional flag "%s"', (flag) => {
+    const variantWithExome = { flags: ['v_a', 'v_b'], exome: { flags: ['ex_a', flag, 'ex_b'] } }
+    const variantWithGenome = { flags: ['v_a', 'v_b'], genome: { flags: ['g_a', flag, 'g_b'] } }
+    const variantWithBoth = {
+      flags: ['v_a', 'v_b'],
+      exome: { flags: ['ex_a', flag, 'ex_b'] },
+      genome: { flags: ['g_a', flag, 'g_b'] },
+    }
+
+    const geneContext = { type: 'gene', geneId: 'ENSG0123456789' }
+    const regionContext = { type: 'region' }
+    const transcriptContext = { type: 'transcript', transcriptId: 'ENST0123456789' }
+    const contextsByType = {
+      gene: geneContext,
+      region: regionContext,
+      transcript: transcriptContext,
+    } as const
+
+    describe.each(['gene', 'region', 'transcript'] as (keyof typeof contextsByType)[])(
+      'in the %s context',
+      (contextType) => {
+        test('is extracted from exome/genome flags and put in variant flags', () => {
+          const context = contextsByType[contextType]
+
+          const exomeResults = getFlagsForContext(context, variantWithExome)
+          const genomeResults = getFlagsForContext(context, variantWithGenome)
+          const bothResults = getFlagsForContext(context, variantWithBoth)
+
+          expect(exomeResults).toEqual({
+            variantFlags: ['v_a', 'v_b', flag],
+            exomeFlags: ['ex_a', 'ex_b'],
+            genomeFlags: [],
+          })
+          expect(genomeResults).toEqual({
+            variantFlags: ['v_a', 'v_b', flag],
+            exomeFlags: [],
+            genomeFlags: ['g_a', 'g_b'],
+          })
+          expect(bothResults).toEqual({
+            variantFlags: ['v_a', 'v_b', flag],
+            exomeFlags: ['ex_a', 'ex_b'],
+            genomeFlags: ['g_a', 'g_b'],
+          })
+        })
       }
-
-      it.each([
-        ['G1', true],
-        ['G2', false],
-        ['G3', false],
-        ['G4', false],
-        ['G5', false],
-        ['G6', false],
-      ])(
-        'it should be included only if the most severe consequence in the specified gene is LOFTEE annotated OS',
-        (geneId, expected) => {
-          expect(
-            getLofteeFlagsForContext({ type: 'gene', geneId })(variant).includes('os_lof')
-          ).toBe(expected)
-        }
-      )
-
-      it('should not be included for variants without consequences', () => {
-        expect(
-          getLofteeFlagsForContext({ type: 'gene', geneId: 'G1' })({}).includes('os_lof')
-        ).toBe(false)
-      })
-    })
-
-    describe('region context', () => {
-      it.each([
-        [
-          {
-            transcript_consequences: [{ lof: 'OS' }, { lof: 'HC' }],
-          },
-          true,
-        ],
-        [
-          {
-            transcript_consequences: [{ lof: 'HC' }, { lof: 'OS' }],
-          },
-          false,
-        ],
-        [
-          {
-            transcript_consequences: [{ lof: '' }],
-          },
-          false,
-        ],
-        [{ transcript_consequences: [] }, false],
-        [{}, false],
-      ])(
-        'it should be included only if the most severe consequence is LOFTEE annotated OS',
-        (variant, expected) => {
-          expect(getLofteeFlagsForContext({ type: 'region' })(variant).includes('os_lof')).toBe(
-            expected
-          )
-        }
-      )
-    })
-
-    describe('transcript context', () => {
-      const variant = {
-        transcript_consequences: [
-          { transcript_id: 'T1', lof: 'OS' },
-          { transcript_id: 'T2', lof: 'HC' },
-          { transcript_id: 'T3', lof: 'LC' },
-          { transcript_id: 'T4', lof: '' },
-        ],
-      }
-
-      it.each([
-        ['T1', true],
-        ['T2', false],
-        ['T3', false],
-        ['T4', false],
-        ['T5', false],
-      ])(
-        'it should be included only if the consequence in the specified transcript is LOFTEE annotated OS',
-        (transcriptId, expected) => {
-          expect(
-            getLofteeFlagsForContext({ type: 'transcript', transcriptId })(variant).includes(
-              'os_lof'
-            )
-          ).toBe(expected)
-        }
-      )
-
-      it('should not be included for variants without consequences', () => {
-        expect(
-          getLofteeFlagsForContext({ type: 'transcript', transcriptId: 'T1' })({}).includes(
-            'os_lof'
-          )
-        ).toBe(false)
-      })
-    })
+    )
   })
 })

--- a/graphql-api/src/queries/variant-datasets/shared/flags.ts
+++ b/graphql-api/src/queries/variant-datasets/shared/flags.ts
@@ -9,7 +9,7 @@ const LOF_CONSEQUENCE_TERMS = new Set([
 const isLofOnNonCodingTranscript = (transcriptConsequence: any) =>
   LOF_CONSEQUENCE_TERMS.has(transcriptConsequence.major_consequence) && !transcriptConsequence.lof
 
-const getFlagsForGeneContext = (variant: any, geneId: any) => {
+const getLofteeFlagsForGeneContext = (variant: any, geneId: any) => {
   const flags = variant.flags || []
 
   const allConsequences = variant.transcript_consequences || []
@@ -48,7 +48,7 @@ const getFlagsForGeneContext = (variant: any, geneId: any) => {
   return flags
 }
 
-const getFlagsForRegionContext = (variant: any) => {
+const getLofteeFlagsForRegionContext = (variant: any) => {
   const flags = variant.flags || []
 
   const allConsequences = variant.transcript_consequences || []
@@ -85,7 +85,7 @@ const getFlagsForRegionContext = (variant: any) => {
   return flags
 }
 
-const getFlagsForTranscriptContext = (variant: any, transcriptId: any) => {
+const getLofteeFlagsForTranscriptContext = (variant: any, transcriptId: any) => {
   const flags = variant.flags || []
 
   const allConsequences = variant.transcript_consequences || []
@@ -114,14 +114,14 @@ const getFlagsForTranscriptContext = (variant: any, transcriptId: any) => {
   return flags
 }
 
-export const getFlagsForContext = (context: any) => {
+export const getLofteeFlagsForContext = (context: any) => {
   switch (context.type) {
     case 'gene':
-      return (variant: any) => getFlagsForGeneContext(variant, context.geneId)
+      return (variant: any) => getLofteeFlagsForGeneContext(variant, context.geneId)
     case 'region':
-      return getFlagsForRegionContext
+      return getLofteeFlagsForRegionContext
     case 'transcript':
-      return (variant: any) => getFlagsForTranscriptContext(variant, context.transcriptId)
+      return (variant: any) => getLofteeFlagsForTranscriptContext(variant, context.transcriptId)
     default:
       throw Error(`Invalid context for getFlags: ${context.type}`)
   }


### PR DESCRIPTION
This updates the API and frontend to support flags both on a variant generally, or on the exome and/or genome specifically, and fixes a number of related bugs related to display of flags.

fixes #1614 