### PR TITLE
Split exome and genome frequencies in VA data

### DIFF
--- a/graphql-api/src/graphql/resolvers/va.spec.ts
+++ b/graphql-api/src/graphql/resolvers/va.spec.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from '@jest/globals'
 
 import {
-  resolveVACohortAlleleFrequencies,
+  resolveVAExome,
+  resolveVAGenome,
   resolveVAAllele,
   Allele as VAAllele,
   CohortAlleleFrequency,
@@ -60,19 +61,29 @@ describe('resolveVACohortAlleleFrequency', () => {
     ancestry_groups: [],
   }
 
+  const genomeEsDocument = {
+    ac: 18,
+    an: 200,
+    hemizygote_count: 4,
+    homozygote_count: 5,
+    faf95: { popmax: 0.234, popmax_population: 'eas' },
+    ancestry_groups: [],
+  }
+
   const variantESDocument = {
     ...alleleEsDocument,
     variant_id: '1-123-G-A',
     exome: exomeEsDocument,
+    genome: genomeEsDocument,
     joint: { fafmax: { faf95_max: 0.234, faf95_max_gen_anc: 'amr' } },
   }
 
-  test('parses a single CohortAlleleFrequency correctly', async () => {
-    const resolved = await resolveVACohortAlleleFrequencies(variantESDocument, null, null)
+  test('parses a single CohortAlleleFrequency exome correctly', async () => {
+    const resolved = await resolveVAExome(variantESDocument, null, null)
     const expected: CohortAlleleFrequency[] = [
       {
         id: 'gnomad4:1-123-G-A',
-        label: 'Overall Cohort Allele Frequency for 1-123-G-A',
+        label: 'Exome Cohort Allele Frequency for 1-123-G-A',
         type: 'CohortAlleleFrequency',
         focusAllele: expectedAllele,
         derivedFrom: {
@@ -84,7 +95,7 @@ describe('resolveVACohortAlleleFrequency', () => {
         focusAlleleCount: 5,
         locusAlleleCount: 100,
         alleleFrequency: 0.05,
-        cohort: { id: 'ALL', label: 'Overall', characteristics: null },
+        cohort: { id: 'ALL', label: 'Exome', characteristics: null },
         ancillaryResults: {
           grpMaxFAF95: { frequency: 0.123, confidenceInterval: 0.95, groupId: 'afr' },
           jointGrpMaxFAF95: { frequency: 0.234, confidenceInterval: 0.95, groupId: 'amr' },
@@ -96,6 +107,44 @@ describe('resolveVACohortAlleleFrequency', () => {
     ]
 
     expect(resolved).toEqual(expected)
+  })
+
+  test('parses a single CohortAlleleFrequency genome correctly', async () => {
+    const resolved = await resolveVAGenome(variantESDocument, null, null)
+    const expected: CohortAlleleFrequency[] = [
+      {
+        id: 'gnomad4:1-123-G-A',
+        label: 'Genome Cohort Allele Frequency for 1-123-G-A',
+        type: 'CohortAlleleFrequency',
+        focusAllele: expectedAllele,
+        derivedFrom: {
+          id: 'gnomad4.1.0',
+          type: 'DataSet',
+          label: 'gnomAD v4.1.0',
+          version: '4.1.0',
+        },
+        focusAlleleCount: 18,
+        locusAlleleCount: 200,
+        alleleFrequency: 0.09,
+        cohort: { id: 'ALL', label: 'Genome', characteristics: null },
+        ancillaryResults: {
+          grpMaxFAF95: { frequency: 0.234, confidenceInterval: 0.95, groupId: 'eas' },
+          jointGrpMaxFAF95: { frequency: 0.234, confidenceInterval: 0.95, groupId: 'amr' },
+          homozygotes: 5,
+          hemizygotes: 4,
+        },
+        subcohortFrequency: [],
+      },
+    ]
+
+    expect(resolved).toEqual(expected)
+  })
+
+  test('gracefully handles missing exome or genome', async () => {
+    const exomeOnlyDocument = { ...variantESDocument, genome: null }
+    const genomeOnlyDocument = { ...variantESDocument, exome: null }
+    expect(await resolveVAExome(genomeOnlyDocument, null, null)).toBeNull()
+    expect(await resolveVAGenome(exomeOnlyDocument, null, null)).toBeNull()
   })
 
   test('has the correct subcohortAlleleFrequency when there are multiple CAFs', async () => {
@@ -121,55 +170,62 @@ describe('resolveVACohortAlleleFrequency', () => {
     const fullDocument = {
       ...variantESDocument,
       exome: { ...exomeEsDocument, ancestry_groups: subcohortDocuments },
+      genome: { ...genomeEsDocument, ancestry_groups: subcohortDocuments },
     }
 
-    const resolved = await resolveVACohortAlleleFrequencies(fullDocument, null, null)
-    expect(resolved && resolved.length === subcohortIds.length + 1).toEqual(true)
+    const exomeResolved = await resolveVAExome(fullDocument, null, null)
+    const genomeResolved = await resolveVAGenome(fullDocument, null, null)
 
-    const subcohortMap: Record<string, string[]> = resolved!.reduce(
-      (acc, cohort) => ({
-        ...acc,
-        [cohort.id]: cohort.subcohortFrequency.map((subcohort) => subcohort.id),
-      }),
-      {}
-    )
+    const results: CohortAlleleFrequency[][] = [exomeResolved!, genomeResolved!]
 
-    expect(subcohortMap['gnomad4:1-123-G-A']!.sort()).toEqual(
-      subcohortIds.map((cohortId) => `gnomad4:1-123-G-A.${cohortId}`).sort()
-    )
+    results.forEach((resolved: CohortAlleleFrequency[]) => {
+      expect(resolved && resolved.length === subcohortIds.length + 1).toEqual(true)
 
-    expect(subcohortMap['gnomad4:1-123-G-A.XX'].sort()).toEqual([
-      'gnomad4:1-123-G-A.ami_XX',
-      'gnomad4:1-123-G-A.amr_XX',
-      'gnomad4:1-123-G-A.eur_XX',
-    ])
+      const subcohortMap: Record<string, string[]> = resolved!.reduce(
+        (acc, cohort) => ({
+          ...acc,
+          [cohort.id]: cohort.subcohortFrequency.map((subcohort) => subcohort.id),
+        }),
+        {}
+      )
 
-    expect(subcohortMap['gnomad4:1-123-G-A.XY'].sort()).toEqual([
-      'gnomad4:1-123-G-A.ami_XY',
-      'gnomad4:1-123-G-A.amr_XY',
-      'gnomad4:1-123-G-A.eur_XY',
-    ])
+      expect(subcohortMap['gnomad4:1-123-G-A']!.sort()).toEqual(
+        subcohortIds.map((cohortId) => `gnomad4:1-123-G-A.${cohortId}`).sort()
+      )
 
-    expect(subcohortMap['gnomad4:1-123-G-A.ami'].sort()).toEqual([
-      'gnomad4:1-123-G-A.ami_XX',
-      'gnomad4:1-123-G-A.ami_XY',
-    ])
+      expect(subcohortMap['gnomad4:1-123-G-A.XX'].sort()).toEqual([
+        'gnomad4:1-123-G-A.ami_XX',
+        'gnomad4:1-123-G-A.amr_XX',
+        'gnomad4:1-123-G-A.eur_XX',
+      ])
 
-    expect(subcohortMap['gnomad4:1-123-G-A.amr'].sort()).toEqual([
-      'gnomad4:1-123-G-A.amr_XX',
-      'gnomad4:1-123-G-A.amr_XY',
-    ])
+      expect(subcohortMap['gnomad4:1-123-G-A.XY'].sort()).toEqual([
+        'gnomad4:1-123-G-A.ami_XY',
+        'gnomad4:1-123-G-A.amr_XY',
+        'gnomad4:1-123-G-A.eur_XY',
+      ])
 
-    expect(subcohortMap['gnomad4:1-123-G-A.eur'].sort()).toEqual([
-      'gnomad4:1-123-G-A.eur_XX',
-      'gnomad4:1-123-G-A.eur_XY',
-    ])
+      expect(subcohortMap['gnomad4:1-123-G-A.ami'].sort()).toEqual([
+        'gnomad4:1-123-G-A.ami_XX',
+        'gnomad4:1-123-G-A.ami_XY',
+      ])
 
-    expect(subcohortMap['gnomad4:1-123-G-A.ami_XX']).toEqual([])
-    expect(subcohortMap['gnomad4:1-123-G-A.ami_XY']).toEqual([])
-    expect(subcohortMap['gnomad4:1-123-G-A.amr_XX']).toEqual([])
-    expect(subcohortMap['gnomad4:1-123-G-A.amr_XY']).toEqual([])
-    expect(subcohortMap['gnomad4:1-123-G-A.eur_XX']).toEqual([])
-    expect(subcohortMap['gnomad4:1-123-G-A.eur_XY']).toEqual([])
+      expect(subcohortMap['gnomad4:1-123-G-A.amr'].sort()).toEqual([
+        'gnomad4:1-123-G-A.amr_XX',
+        'gnomad4:1-123-G-A.amr_XY',
+      ])
+
+      expect(subcohortMap['gnomad4:1-123-G-A.eur'].sort()).toEqual([
+        'gnomad4:1-123-G-A.eur_XX',
+        'gnomad4:1-123-G-A.eur_XY',
+      ])
+
+      expect(subcohortMap['gnomad4:1-123-G-A.ami_XX']).toEqual([])
+      expect(subcohortMap['gnomad4:1-123-G-A.ami_XY']).toEqual([])
+      expect(subcohortMap['gnomad4:1-123-G-A.amr_XX']).toEqual([])
+      expect(subcohortMap['gnomad4:1-123-G-A.amr_XY']).toEqual([])
+      expect(subcohortMap['gnomad4:1-123-G-A.eur_XX']).toEqual([])
+      expect(subcohortMap['gnomad4:1-123-G-A.eur_XY']).toEqual([])
+    })
   })
 })

--- a/graphql-api/src/graphql/resolvers/variant-fields.ts
+++ b/graphql-api/src/graphql/resolvers/variant-fields.ts
@@ -1,14 +1,20 @@
-import { resolveVACohortAlleleFrequencies, resolveVAAllele } from './va'
+import { resolveVAExome, resolveVAGenome, resolveVAAllele } from './va'
 
 const resolvers = {
   Variant: {
     rsids: (obj: any) => obj.rsids || [],
-    va: resolveVACohortAlleleFrequencies,
+    va: (obj: any, ctx: any, args: any) => ({
+      exome: resolveVAExome(obj, ctx, args),
+      genome: resolveVAGenome(obj, ctx, args),
+    }),
     vrs: resolveVAAllele,
   },
   VariantDetails: {
     rsids: (obj: any) => obj.rsids || [],
-    va: resolveVACohortAlleleFrequencies,
+    va: (obj: any, ctx: any, args: any) => ({
+      exome: resolveVAExome(obj, ctx, args),
+      genome: resolveVAGenome(obj, ctx, args),
+    }),
     vrs: resolveVAAllele,
   },
 }

--- a/graphql-api/src/graphql/types/va.graphql
+++ b/graphql-api/src/graphql/types/va.graphql
@@ -100,8 +100,7 @@ type VAQualityMeasures {
   heterozygousSkewedAlleleCount: Int
 }
 
-"A measure of the frequency of an Allele in a cohort."
-type VACohortAlleleFrequency {
+type VACohortAlleleFrequencyData {
   id: String!
   type: String!
   label: String
@@ -124,10 +123,11 @@ type VACohortAlleleFrequency {
   This creates a recursive relationship and subcohorts can be further subdivided into more subcohorts.
   This enables, for example, the description of different ancestry groups and sexes among those ancestry groups.
   """
-  subcohortFrequency: [VACohortAlleleFrequency]
+  subcohortFrequency: [VACohortAlleleFrequencyData]
 }
 
-type VA {
-  va: [VACohortAlleleFrequency!]
-  vrs: [VAAllele!]
+"A measure of the frequency of an Allele in a cohort."
+type VACohortAlleleFrequency {
+  exome: [VACohortAlleleFrequencyData!]
+  genome: [VACohortAlleleFrequencyData!]
 }

--- a/graphql-api/src/graphql/types/va.graphql
+++ b/graphql-api/src/graphql/types/va.graphql
@@ -123,7 +123,7 @@ type VACohortAlleleFrequencyData {
   This creates a recursive relationship and subcohorts can be further subdivided into more subcohorts.
   This enables, for example, the description of different ancestry groups and sexes among those ancestry groups.
   """
-  subcohortFrequency: [VACohortAlleleFrequencyData]
+  subcohortFrequency: [VACohortAlleleFrequencyData!]
 }
 
 "A measure of the frequency of an Allele in a cohort."

--- a/graphql-api/src/graphql/types/variant.graphql
+++ b/graphql-api/src/graphql/types/variant.graphql
@@ -192,7 +192,7 @@ type Variant {
   hgvs: String
 
   # GA4GH-format data
-  va: [VACohortAlleleFrequency!]
+  va: VACohortAlleleFrequency!
   vrs: VAAllele
 }
 
@@ -322,7 +322,7 @@ type VariantDetails {
   multiNucleotideVariants: [MultiNucleotideVariantSummary!]
   sortedTranscriptConsequences: [TranscriptConsequence!]
 
-  va: [VACohortAlleleFrequency!]
+  va: VACohortAlleleFrequency!
   vrs: VAAllele
 }
 


### PR DESCRIPTION
VA data was previously always using exome frequencies if available, genome if not. However, given that this is a general-purpose API, it's hard to say if users will want exomes, genomes, or both for their use cases. Hence, rather than try to make that decision for them, we allow (and require) them now to say which they want in their queries.