### PR TITLE
Fix filtered variants in variant table bug

### DIFF
--- a/browser/src/VariantList/filterVariants.ts
+++ b/browser/src/VariantList/filterVariants.ts
@@ -91,10 +91,8 @@ const filterVariants = (variants: Variant[], filter: VariantFilterState, selecte
 
   filteredVariants = filteredVariants.filter((v: Variant) => v.exome || v.genome)
 
-  if (filter.searchText) {
-    if (!filter.includeContext && filter.includeFilteredVariants) {
-      filteredVariants = getFilteredVariants(filter, variants, selectedColumns)
-    }
+  if (filter.searchText && !filter.includeContext) {
+    filteredVariants = getFilteredVariants(filter, filteredVariants, selectedColumns)
   }
 
   // Indel and Snp filters.

--- a/browser/src/VariantList/filterVariants.ts
+++ b/browser/src/VariantList/filterVariants.ts
@@ -91,8 +91,10 @@ const filterVariants = (variants: Variant[], filter: VariantFilterState, selecte
 
   filteredVariants = filteredVariants.filter((v: Variant) => v.exome || v.genome)
 
-  if (filter.searchText && !filter.includeContext) {
-    filteredVariants = getFilteredVariants(filter, variants, selectedColumns)
+  if (filter.searchText) {
+    if (!filter.includeContext && filter.includeFilteredVariants) {
+      filteredVariants = getFilteredVariants(filter, variants, selectedColumns)
+    }
   }
 
   // Indel and Snp filters.


### PR DESCRIPTION
Resolves #1466

Fixes bug where the "Display neighboring variants" filtering was interferring with the "Filtered variants" filter by being able to receive filtered variants in the search results even when the filter was not checked on.