### PR TITLE
Updates ingress_production to use the static service names

### DIFF
--- a/deploy/manifests/ingress/gnomad.ingress.yaml
+++ b/deploy/manifests/ingress/gnomad.ingress.yaml
@@ -15,17 +15,31 @@ spec:
         paths:
           - backend:
               service:
-                name: gnomad-reads
+                name: reads-bluegreen-active-prod
                 port:
                   number: 80
             path: /reads
             pathType: ImplementationSpecific
           - backend:
               service:
-                name: gnomad-reads
+                name: reads-bluegreen-active-prod
                 port:
                   number: 80
             path: /reads/*
+            pathType: ImplementationSpecific
+          - backend:
+              service:
+                name: reads-bluegreen-preview-prod
+                port:
+                  number: 80
+            path: /preview-reads
+            pathType: ImplementationSpecific
+          - backend:
+              service:
+                name: reads-bluegreen-preview-prod
+                port:
+                  number: 80
+            path: /preview-reads/*
             pathType: ImplementationSpecific
           - backend:
               service:


### PR DESCRIPTION
Now that we have static service names for the active/preview reads services, this updates the ingress to use those new services. It also removes the blue/green service manifest generation, since we don't need that extra step in prod anymore.

We now have the following routes for reads:

- https://gnomad.broadinstitute.org/reads -> always points to the "active" prod service
- https://gnomad.broadinstitute.org/preview-reads -> always points to the "preview" prod service
  - the preview service either points to the same pods as "active" if there is no blue green rollout in progress, or points to your next proposed pods if there is a rollout in progress.