### PR TITLE
Update demo_ingress to expect a reads service name instead of managing services

### DIFF
--- a/deploy/deployctl/subcommands/browser_deployments.py
+++ b/deploy/deployctl/subcommands/browser_deployments.py
@@ -58,6 +58,35 @@ patches:
                     value: 'gs://{cluster_name}-gene-cache/2024-04-24'
 """
 
+DEMO_DEPLOYMENT_KUSTOMIZATION = """
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: gnomad-api
+      spec:
+        template:
+          spec:
+            tolerations:
+              - key: "volatile"
+                operator: "Equal"
+                value: "true"
+                effect: "NoSchedule"
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: gnomad-browser
+      spec:
+        template:
+          spec:
+            tolerations:
+              - key: "volatile"
+                operator: "Equal"
+                value: "true"
+                effect: "NoSchedule"
+"""
+
 
 def deployments_directory() -> str:
     path = os.path.realpath(os.path.join(os.path.dirname(__file__), "../../manifests/browser/deployments"))
@@ -81,7 +110,7 @@ def list_deployments() -> None:
         print(deployment[len("gnomad-browser-") :])
 
 
-def create_deployment(name: str, browser_tag: str = None, api_tag: str = None) -> None:
+def create_deployment(name: str, browser_tag: str = None, api_tag: str = None, demo: bool = False) -> None:
     if not name:
         name = datetime.datetime.now().strftime("%Y%m%d-%H%M")
     else:
@@ -123,6 +152,9 @@ def create_deployment(name: str, browser_tag: str = None, api_tag: str = None) -
             project=config.project,
             cluster_name=config.gke_cluster_name,
         )
+
+        if demo:
+            kustomization = kustomization + DEMO_DEPLOYMENT_KUSTOMIZATION
 
         kustomization_file.write(kustomization)
 
@@ -174,6 +206,7 @@ def main(argv: typing.List[str]) -> None:
     create_parser.add_argument("--name")
     create_parser.add_argument("--browser-tag")
     create_parser.add_argument("--api-tag")
+    create_parser.add_argument("--demo", action="store_true")
 
     apply_parser = subparsers.add_parser("apply")
     apply_parser.set_defaults(action=apply_deployment)

--- a/deploy/deployctl/subcommands/browser_deployments.py
+++ b/deploy/deployctl/subcommands/browser_deployments.py
@@ -85,6 +85,26 @@ DEMO_DEPLOYMENT_KUSTOMIZATION = """
                 operator: "Equal"
                 value: "true"
                 effect: "NoSchedule"
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: gnomad-api
+      spec:
+        template:
+          spec:
+            nodeSelector:
+              cloud.google.com/gke-nodepool: 'demo-pool'
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: gnomad-browser
+      spec:
+        template:
+          spec:
+            nodeSelector:
+              cloud.google.com/gke-nodepool: 'demo-pool'
 """
 
 

--- a/deploy/deployctl/subcommands/ingress_demo.py
+++ b/deploy/deployctl/subcommands/ingress_demo.py
@@ -21,21 +21,6 @@ spec:
   ports:
     - port: 80
       targetPort: 80
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: gnomad-reads-demo-{name}
-  labels:
-    tier: demo
-spec:
-  type: NodePort
-  selector:
-    name: gnomad-reads
-    deployment: '{reads_deployment}'
-  ports:
-    - port: 80
-      targetPort: 80
 """
 
 INGRESS_MANIFEST_TEMPLATE = """---
@@ -54,14 +39,14 @@ spec:
             pathType: ImplementationSpecific
             backend:
               service:
-                name: gnomad-reads-demo-{name}
+                name: {reads_service}
                 port:
                   number: 80
           - path: /reads/*
             pathType: ImplementationSpecific
             backend:
               service:
-                name: gnomad-reads-demo-{name}
+                name: {reads_service}
                 port:
                   number: 80
           - path:
@@ -92,41 +77,32 @@ def list_demo_ingresses() -> None:
 def describe_services(name: str) -> None:
     try:
         browser_manifest = json.loads(kubectl(["get", "service", f"gnomad-browser-demo-{name}", "--output=json"]))
-        reads_manifest = json.loads(kubectl(["get", "service", f"gnomad-reads-demo-{name}", "--output=json"]))
 
         browser_deployment = browser_manifest["spec"]["selector"]["deployment"]
-        reads_deployment = reads_manifest["spec"]["selector"]["deployment"]
 
         print("active browser deployment:", browser_deployment)
-        print("active reads deployment:", reads_deployment)
     except Exception:  # pylint: disable=broad-except
         print(f"Could not get services for '{name}' demo environment")
 
 
-def apply_services(name: str, browser_deployment: str = None, reads_deployment: str = None) -> None:
+def apply_services(name: str, browser_deployment: str = None) -> None:
     if browser_deployment:
         if not k8s_deployment_exists(f"gnomad-browser-{browser_deployment}"):
             raise RuntimeError(f"browser deployment {browser_deployment} not found")
     else:
         browser_deployment = get_most_recent_k8s_deployment("component=gnomad-browser")[len("gnomad-browser-") :]
 
-    if reads_deployment:
-        if not k8s_deployment_exists(f"gnomad-reads-{reads_deployment}"):
-            raise RuntimeError(f"reads deployment {reads_deployment} not found")
-    else:
-        reads_deployment = get_most_recent_k8s_deployment("component=gnomad-reads")[len("gnomad-reads-") :]
-
-    manifest = SERVICES_MANIFEST_TEMPLATE.format(
-        name=name, browser_deployment=browser_deployment, reads_deployment=reads_deployment
-    )
+    manifest = SERVICES_MANIFEST_TEMPLATE.format(name=name, browser_deployment=browser_deployment)
 
     kubectl(["apply", "-f", "-"], input=manifest)
 
 
-def apply_ingress(name: str, browser_deployment: str = None, reads_deployment: str = None) -> None:
-    apply_services(name, browser_deployment, reads_deployment)
+def apply_ingress(
+    name: str, browser_deployment: str = None, reads_service: str = "reads-bluegreen-active-prod"
+) -> None:
+    apply_services(name, browser_deployment)
 
-    manifest = INGRESS_MANIFEST_TEMPLATE.format(name=name)
+    manifest = INGRESS_MANIFEST_TEMPLATE.format(name=name, reads_service=reads_service)
 
     kubectl(["apply", "-f", "-"], input=manifest)
 
@@ -154,13 +130,13 @@ def main(argv: typing.List[str]) -> None:
     apply_services_parser.set_defaults(action=apply_services)
     apply_services_parser.add_argument("name")
     apply_services_parser.add_argument("--browser-deployment")
-    apply_services_parser.add_argument("--reads-deployment")
+    apply_services_parser.add_argument("--reads-service")
 
     apply_ingress_parser = subparsers.add_parser("apply-ingress")
     apply_ingress_parser.set_defaults(action=apply_ingress)
     apply_ingress_parser.add_argument("name")
     apply_ingress_parser.add_argument("--browser-deployment")
-    apply_ingress_parser.add_argument("--reads-deployment")
+    apply_ingress_parser.add_argument("--reads-service")
 
     delete_ingress_and_services_parser = subparsers.add_parser("delete")
     delete_ingress_and_services_parser.set_defaults(action=delete_ingress_and_services)

--- a/deploy/docs/Deployment.md
+++ b/deploy/docs/Deployment.md
@@ -157,8 +157,10 @@ There exist several Python scripts in the `deployctl` package that make this pro
 2. Create a local manifest file that describes the deployment with:
 
    ```
-   ./deployctl deployments create --name <DEPLOYMENT_NAME> --browser-tag <BROWSER_IMAGE_TAG> --api-tag <API_IMAGE_TAG>
+   ./deployctl deployments create --name <DEPLOYMENT_NAME> --browser-tag <BROWSER_IMAGE_TAG> --api-tag <API_IMAGE_TAG> --demo
    ```
+
+   Note the `--demo` flag is optional, but it will cause your deployment to run on an autoscaling demo pool, so that you don't have to ensure capacity on the prod pool.
 
 - 'Apply' the deployment, assigning pods to run it in the [Google Kubernetes Engine](https://console.cloud.google.com/kubernetes/workload/overview?project=exac-gnomad):
 


### PR DESCRIPTION
This addresses an issue that Phil ran into earlier this week after we rolled out reads using the new deployment methodology. Spinning up demos depended on being able to ask the k8s API what the current reads deployment was, and then generated a new Service object for you. Often times this just ended up being a new Service object called "gnomad-reads-demo-foobar" that pointed at the current production deployment pods, which didn't feel particularly useful.

I thought about this for a bit, and decided that managing the extra service object here was probably unnecessary? With these assumptions:
- If you don't care which reads service you get and just want to point at prod, there's already a Service you can wire up the ingress to
- If you **do** care which reads deployment your demo uses, you probably already spun one up and have a Service to point at it?

With those in mind, I've updated this script to just accept a reads Service name, and it uses that to configure the ingress instead of creating a bunch of extra Services. If you don't specify a service name, it just points /reads on your demo to the active prod service.

How do folks feel about that process, and are those assumptions I've made correct?