### PR TITLE
Support non-UKB variants with exome AC of 0

### DIFF
--- a/graphql-api/src/queries/variant-datasets/gnomad-v4-variant-queries.ts
+++ b/graphql-api/src/queries/variant-datasets/gnomad-v4-variant-queries.ts
@@ -150,80 +150,86 @@ const fetchVariantById = async (esClient: any, variantId: any, subset: Subset) =
     ref: variant.alleles[0],
     alt: variant.alleles[1],
     colocated_variants: variant.colocated_variants[subset] || [],
-    exome: hasExomeVariant && {
-      ...variant.exome,
-      ...variant.exome.freq[subset],
-      filters: exomeFilters,
-      flags: exomeFlags,
-      populations: variant.exome.freq[subset].ancestry_groups,
-      faf95: hasExomeVariant &&
-        variant.exome.faf95 && {
-          popmax_population: variant.exome.faf95.grpmax_gen_anc,
-          popmax: variant.exome.faf95.grpmax,
-        },
-      quality_metrics: {
-        // TODO: An older version of the data pipeline stored only adj quality metric histograms.
-        // Maintain the same behavior by returning the adj version until the API schema is updated to allow
-        // selecting which version to return.
-        allele_balance: {
-          alt: variant.exome.quality_metrics.allele_balance.alt_adj,
-        },
-        genotype_depth: {
-          alt: variant.exome.quality_metrics.genotype_depth.alt_adj,
-          all: variant.exome.quality_metrics.genotype_depth.all_adj,
-        },
-        genotype_quality: {
-          alt: variant.exome.quality_metrics.genotype_quality.alt_adj,
-          all: variant.exome.quality_metrics.genotype_quality.all_adj,
-        },
-        site_quality_metrics: variant.exome.quality_metrics.site_quality_metrics.filter((m: any) =>
-          Number.isFinite(m.value)
-        ),
-      },
-      local_ancestry_populations: [],
-    },
-    genome: hasGenomeVariant && {
-      ...variant.genome,
-      ...subsetGenomeFreq,
-      filters: genomeFilters,
-      flags: genomeFlags,
-      populations: genome_ancestry_groups,
-      faf95: hasGenomeVariant &&
-        variant.genome.faf95 && {
-          popmax_population: variant.genome.faf95.grpmax_gen_anc,
-          popmax: variant.genome.faf95.grpmax,
-        },
-      quality_metrics: {
-        // TODO: An older version of the data pipeline stored only adj quality metric histograms.
-        // Maintain the same behavior by returning the adj version until the API schema is updated to allow
-        // selecting which version to return.
-        allele_balance: {
-          alt: variant.genome.quality_metrics.allele_balance.alt_adj,
-        },
-        genotype_depth: {
-          alt: variant.genome.quality_metrics.genotype_depth.alt_adj,
-          all: variant.genome.quality_metrics.genotype_depth.all_adj,
-        },
-        genotype_quality: {
-          alt: variant.genome.quality_metrics.genotype_quality.alt_adj,
-          all: variant.genome.quality_metrics.genotype_quality.all_adj,
-        },
-        site_quality_metrics: variant.genome.quality_metrics.site_quality_metrics.filter((m: any) =>
-          Number.isFinite(m.value)
-        ),
-      },
-      local_ancestry_populations: localAncestryPopulations?.genome || null,
-    },
-    joint: hasJointFrequencyData && {
-      ...variant.joint,
-      ...variant.joint.freq[subset],
-      filters: jointFilters,
-      populations: subsetJointFreq.ancestry_groups,
-      faf95: {
-        popmax_population: variant.joint.fafmax.faf95_max_gen_anc,
-        popmax: variant.joint.fafmax.faf95_max,
-      },
-    },
+    exome: hasExomeVariant
+      ? {
+          ...variant.exome,
+          ...variant.exome.freq[subset],
+          filters: exomeFilters,
+          flags: exomeFlags,
+          populations: variant.exome.freq[subset].ancestry_groups,
+          faf95: hasExomeVariant &&
+            variant.exome.faf95 && {
+              popmax_population: variant.exome.faf95.grpmax_gen_anc,
+              popmax: variant.exome.faf95.grpmax,
+            },
+          quality_metrics: {
+            // TODO: An older version of the data pipeline stored only adj quality metric histograms.
+            // Maintain the same behavior by returning the adj version until the API schema is updated to allow
+            // selecting which version to return.
+            allele_balance: {
+              alt: variant.exome.quality_metrics.allele_balance.alt_adj,
+            },
+            genotype_depth: {
+              alt: variant.exome.quality_metrics.genotype_depth.alt_adj,
+              all: variant.exome.quality_metrics.genotype_depth.all_adj,
+            },
+            genotype_quality: {
+              alt: variant.exome.quality_metrics.genotype_quality.alt_adj,
+              all: variant.exome.quality_metrics.genotype_quality.all_adj,
+            },
+            site_quality_metrics: variant.exome.quality_metrics.site_quality_metrics.filter(
+              (m: any) => Number.isFinite(m.value)
+            ),
+          },
+          local_ancestry_populations: [],
+        }
+      : null,
+    genome: hasGenomeVariant
+      ? {
+          ...variant.genome,
+          ...subsetGenomeFreq,
+          filters: genomeFilters,
+          flags: genomeFlags,
+          populations: genome_ancestry_groups,
+          faf95: hasGenomeVariant &&
+            variant.genome.faf95 && {
+              popmax_population: variant.genome.faf95.grpmax_gen_anc,
+              popmax: variant.genome.faf95.grpmax,
+            },
+          quality_metrics: {
+            // TODO: An older version of the data pipeline stored only adj quality metric histograms.
+            // Maintain the same behavior by returning the adj version until the API schema is updated to allow
+            // selecting which version to return.
+            allele_balance: {
+              alt: variant.genome.quality_metrics.allele_balance.alt_adj,
+            },
+            genotype_depth: {
+              alt: variant.genome.quality_metrics.genotype_depth.alt_adj,
+              all: variant.genome.quality_metrics.genotype_depth.all_adj,
+            },
+            genotype_quality: {
+              alt: variant.genome.quality_metrics.genotype_quality.alt_adj,
+              all: variant.genome.quality_metrics.genotype_quality.all_adj,
+            },
+            site_quality_metrics: variant.genome.quality_metrics.site_quality_metrics.filter(
+              (m: any) => Number.isFinite(m.value)
+            ),
+          },
+          local_ancestry_populations: localAncestryPopulations?.genome || null,
+        }
+      : null,
+    joint: hasJointFrequencyData
+      ? {
+          ...variant.joint,
+          ...variant.joint.freq[subset],
+          filters: jointFilters,
+          populations: subsetJointFreq.ancestry_groups,
+          faf95: {
+            popmax_population: variant.joint.fafmax.faf95_max_gen_anc,
+            popmax: variant.joint.fafmax.faf95_max,
+          },
+        }
+      : null,
     flags: variantFlags,
     // TODO: Include RefSeq transcripts once the browser supports them.
     transcript_consequences: (variant.transcript_consequences || []).filter((csq: any) =>


### PR DESCRIPTION
Some variants in gnomad_v4_non_ukb have `variant.exome.freq.non_ukb.ac_raw` set to 0, indicating a variant with exome results in the full v4 dataset but all of whose v4 exome results are in UKB. That ended up getting converted by the API into a variant with an `exome` field, but all the fields of which were `null`, with predictable results.