### PR TITLE
Render fafs of 0 as '-' character on variant pages

### DIFF
--- a/browser/src/VariantPage/VariantOccurrenceTable.tsx
+++ b/browser/src/VariantPage/VariantOccurrenceTable.tsx
@@ -109,12 +109,11 @@ const FilteringAlleleFrequency = ({
   popmax,
   popmax_population: popmaxPopulation,
 }: FilteringAlleleFrequencyProps) => {
-  if (popmax === null) {
+  // popmax (now called fafmax) of 0 is filtered out of the faf array of candidates
+  //   instead, now display '-' rather than 0 to match the logic in the pipeline
+  //   and in the method team's release process
+  if (popmax === null || popmax === 0) {
     return <span>—</span>
-  }
-
-  if (popmax === 0) {
-    return <span>0</span>
   }
 
   return (

--- a/data-pipeline/src/data_pipeline/datasets/gnomad_v4/gnomad_v4_variants.py
+++ b/data-pipeline/src/data_pipeline/datasets/gnomad_v4/gnomad_v4_variants.py
@@ -177,7 +177,7 @@ def prepare_gnomad_v4_variants_helper(input_path: str, exomes_or_genomes: str):
                             hl.struct(faf=ds.faf[g.faf_index_dict[f"{pop}_adj"]].faf95, population=pop)
                             for pop in faf_populations
                         ]
-                    ),
+                    ).filter(lambda f: f.faf > 0),
                     key=lambda f: (-f.faf, f.population),
                 ),
                 lambda fafs: hl.if_else(
@@ -193,7 +193,7 @@ def prepare_gnomad_v4_variants_helper(input_path: str, exomes_or_genomes: str):
                             hl.struct(faf=ds.faf[g.faf_index_dict[f"{pop}_adj"]].faf99, population=pop)
                             for pop in faf_populations
                         ]
-                    ),
+                    ).filter(lambda f: f.faf > 0),
                     key=lambda f: (-f.faf, f.population),
                 ),
                 lambda fafs: hl.if_else(


### PR DESCRIPTION
Previously, our variant pipeline took the `faf` array, took the relevant genetic ancestry group's filtered AFs from this array, filtered out all the entries of this smaller list where the faf was 0, then took the max of this array to render as the "Grpmax filtering AF (95% confidence)".

With v4, the step that filtered out entries from this reduced array with a faf of 0 was mistakenly dropped. This led to the fafmax for a given variant being possible to be 0, where it was previously not able to be. In these cases, the methods team calls the fafmax for these variants as missing, rather than 0.

This PR does two small things
- Re-adds the filter to remove fafmax array entries with a faf of 0
- Changes the frontend to display '-', rather than 0, when the fafmax for a variant is 0

This achieves both a quick fix that does not require a variant reload, and fixes the problem more systematically when the v4 variants pipeline is next rerun.