### PR TITLE
Fix single source exome/genome values in variant table

### DIFF
--- a/browser/src/VariantList/Variants.tsx
+++ b/browser/src/VariantList/Variants.tsx
@@ -164,6 +164,7 @@ const Variants = ({
     return mergeExomeAndGenomeData({
       datasetId,
       variants: filterVariants(variants, filter, renderedTableColumns),
+      preferJointData: filter.includeExomes && filter.includeGenomes,
     })
   }, [datasetId, variants, filter, renderedTableColumns])
 

--- a/browser/src/VariantList/mergeExomeAndGenomeData.ts
+++ b/browser/src/VariantList/mergeExomeAndGenomeData.ts
@@ -125,14 +125,16 @@ type MergedVariant = Variant & {
 export const mergeExomeAndGenomeData = ({
   datasetId,
   variants,
+  preferJointData = false,
 }: {
   datasetId?: DatasetId
   variants: Variant[]
+  preferJointData?: boolean
 }): MergedVariant[] => {
   const mergedVariants = variants.map((variant: Variant) => {
     const { exome, genome, joint } = variant
 
-    if (joint) {
+    if (joint && preferJointData) {
       const exomeFilters = exome ? exome.filters : []
       const genomeFilters = genome ? genome.filters : []
       const jointFilters = exomeFilters.concat(genomeFilters, joint.filters)


### PR DESCRIPTION
Resolves #1639 

When the `joint` frequency data was added as a 3rd source of truth for frequency information, the function that merges exome and genome data was modified to preferentially use the `joint` values if they exist. This caused the table to not update AC and AN values when a user de-selected either the exomes or genomes.

This PR passes an additional prop to the merging function to have it only preferentially use the `joint` data when both the exome and genome data are selected by the user. This way, when a source is de-selected, the function falls back to using only the data source selected.