### PR TITLE
Allow viewing single source grp freqs on variant page

### DIFF
--- a/browser/src/VariantPage/GnomadPopulationsTable.spec.tsx
+++ b/browser/src/VariantPage/GnomadPopulationsTable.spec.tsx
@@ -3,7 +3,7 @@ import { describe, expect, test } from '@jest/globals'
 import renderer from 'react-test-renderer'
 
 import { GnomadPopulationsTable } from './GnomadPopulationsTable'
-import { allDatasetIds } from '@gnomad/dataset-metadata/metadata'
+import { allDatasetIds, getTopLevelDataset } from '@gnomad/dataset-metadata/metadata'
 import { createAncestryGroupObjects } from '../__factories__/Variant'
 
 describe('GnomadPopulationsTable', () => {
@@ -44,16 +44,19 @@ describe('GnomadPopulationsTable', () => {
       expect(tree).toMatchSnapshot()
     })
     test('has no unexpected changes when missing genetic ancestry groups are filled in', () => {
-      const jointGeneticAncestryGroupObjects = createAncestryGroupObjects(
-        [
-          { id: 'afr', value: 1 },
-          { id: 'remaining', value: 2 },
-          { id: 'eur', value: 4 },
-          { id: 'XX', value: 8 },
-          { id: 'XY', value: 16 },
-        ],
-        true
-      )
+      const jointGeneticAncestryGroupObjects =
+        getTopLevelDataset(dataset) === 'v4'
+          ? createAncestryGroupObjects(
+              [
+                { id: 'afr', value: 1 },
+                { id: 'remaining', value: 2 },
+                { id: 'eur', value: 4 },
+                { id: 'XX', value: 8 },
+                { id: 'XY', value: 16 },
+              ],
+              true
+            )
+          : null
 
       const tree = renderer.create(
         <GnomadPopulationsTable

--- a/browser/src/VariantPage/PopulationsTable.tsx
+++ b/browser/src/VariantPage/PopulationsTable.tsx
@@ -45,21 +45,25 @@ const SEX_IDENTIFIERS = ['XX', 'XY']
 const isSexSpecificPopulation = (pop: any) =>
   SEX_IDENTIFIERS.includes(pop.id) || SEX_IDENTIFIERS.some((id) => pop.id.endsWith(`_${id}`))
 
-// if the allele number (denominator) is 0, return a non-number
-//   to signal to users that there is no information to be displayed about
-//   the frequency, rather than artificially calling it 0
-const calculatePopAF = (ac: number, an: number) => {
+// if the allele number (denominator) is 0, return a sentinel value of -1
+//   this sorts this grp to the end of the table, and can be used to render
+//   a special symbol
+const calculatePopAF = (ac: number, an: number): number => {
   if (an === 0) {
-    return '-'
+    return -1
   }
   return ac / an
 }
 
-const renderPopAF = (af: number | string) => {
-  if (typeof af === 'number') {
-    return af.toPrecision(4)
+// When rendering AFs, the sentinel value of -1 denotes grps with an AN of 0
+//   in this case, render a '-' character to communicate to users that
+//   there is no data to be displayed
+const renderPopAF = (af: number) => {
+  if (af === -1) {
+    return '-'
   }
-  return af
+
+  return af.toPrecision(4)
 }
 
 type OwnPopulationsTableProps = {

--- a/browser/src/VariantPage/__snapshots__/GnomadPopulationsTable.spec.tsx.snap
+++ b/browser/src/VariantPage/__snapshots__/GnomadPopulationsTable.spec.tsx.snap
@@ -106,6 +106,80 @@ exports[`GnomadPopulationsTable with a dataset of exac has no unexpected changes
           rowSpan={1}
           scope="row"
         >
+          African/African American
+        </th>
+        <td
+          className="right-align"
+        >
+          33
+        </td>
+        <td
+          className="right-align"
+        >
+          330
+        </td>
+        <td
+          className="right-align"
+        >
+          37
+        </td>
+        <td
+          style={
+            {
+              "paddingLeft": "25px",
+            }
+          }
+        >
+          0.1000
+        </td>
+      </tr>
+    </tbody>
+    <tbody
+      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
+    >
+      <tr>
+        <th
+          colSpan={2}
+          rowSpan={1}
+          scope="row"
+        >
+          Remaining
+        </th>
+        <td
+          className="right-align"
+        >
+          66
+        </td>
+        <td
+          className="right-align"
+        >
+          660
+        </td>
+        <td
+          className="right-align"
+        >
+          70
+        </td>
+        <td
+          style={
+            {
+              "paddingLeft": "25px",
+            }
+          }
+        >
+          0.1000
+        </td>
+      </tr>
+    </tbody>
+    <tbody
+      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
+    >
+      <tr>
+        <th
+          colSpan={2}
+          rowSpan={1}
+          scope="row"
+        >
           <button
             className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
             onClick={[Function]}
@@ -137,43 +211,6 @@ exports[`GnomadPopulationsTable with a dataset of exac has no unexpected changes
           }
         >
           -
-        </td>
-      </tr>
-    </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
-        <th
-          colSpan={2}
-          rowSpan={1}
-          scope="row"
-        >
-          African/African American
-        </th>
-        <td
-          className="right-align"
-        >
-          33
-        </td>
-        <td
-          className="right-align"
-        >
-          330
-        </td>
-        <td
-          className="right-align"
-        >
-          37
-        </td>
-        <td
-          style={
-            {
-              "paddingLeft": "25px",
-            }
-          }
-        >
-          0.1000
         </td>
       </tr>
     </tbody>
@@ -346,43 +383,6 @@ exports[`GnomadPopulationsTable with a dataset of exac has no unexpected changes
           }
         >
           -
-        </td>
-      </tr>
-    </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
-        <th
-          colSpan={2}
-          rowSpan={1}
-          scope="row"
-        >
-          Remaining
-        </th>
-        <td
-          className="right-align"
-        >
-          66
-        </td>
-        <td
-          className="right-align"
-        >
-          660
-        </td>
-        <td
-          className="right-align"
-        >
-          70
-        </td>
-        <td
-          style={
-            {
-              "paddingLeft": "25px",
-            }
-          }
-        >
-          0.1000
         </td>
       </tr>
     </tbody>
@@ -1149,6 +1149,43 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_cnv_r4 has no unexpecte
           rowSpan={1}
           scope="row"
         >
+          Remaining
+        </th>
+        <td
+          className="right-align"
+        >
+          66
+        </td>
+        <td
+          className="right-align"
+        >
+          660
+        </td>
+        <td
+          className="right-align"
+        >
+          70
+        </td>
+        <td
+          style={
+            {
+              "paddingLeft": "25px",
+            }
+          }
+        >
+          0.1000
+        </td>
+      </tr>
+    </tbody>
+    <tbody
+      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
+    >
+      <tr>
+        <th
+          colSpan={2}
+          rowSpan={1}
+          scope="row"
+        >
           <button
             className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
             onClick={[Function]}
@@ -1481,43 +1518,6 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_cnv_r4 has no unexpecte
           }
         >
           -
-        </td>
-      </tr>
-    </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
-        <th
-          colSpan={2}
-          rowSpan={1}
-          scope="row"
-        >
-          Remaining
-        </th>
-        <td
-          className="right-align"
-        >
-          66
-        </td>
-        <td
-          className="right-align"
-        >
-          660
-        </td>
-        <td
-          className="right-align"
-        >
-          70
-        </td>
-        <td
-          style={
-            {
-              "paddingLeft": "25px",
-            }
-          }
-        >
-          0.1000
         </td>
       </tr>
     </tbody>
@@ -1813,6 +1813,43 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_cnv_r4 has no unexpecte
           rowSpan={1}
           scope="row"
         >
+          Remaining
+        </th>
+        <td
+          className="right-align"
+        >
+          2
+        </td>
+        <td
+          className="right-align"
+        >
+          20
+        </td>
+        <td
+          className="right-align"
+        >
+          4
+        </td>
+        <td
+          style={
+            {
+              "paddingLeft": "25px",
+            }
+          }
+        >
+          0.1000
+        </td>
+      </tr>
+    </tbody>
+    <tbody
+      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
+    >
+      <tr>
+        <th
+          colSpan={2}
+          rowSpan={1}
+          scope="row"
+        >
           <button
             className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
             onClick={[Function]}
@@ -2151,43 +2188,6 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_cnv_r4 has no unexpecte
     <tbody
       className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
     >
-      <tr>
-        <th
-          colSpan={2}
-          rowSpan={1}
-          scope="row"
-        >
-          Remaining
-        </th>
-        <td
-          className="right-align"
-        >
-          2
-        </td>
-        <td
-          className="right-align"
-        >
-          20
-        </td>
-        <td
-          className="right-align"
-        >
-          4
-        </td>
-        <td
-          style={
-            {
-              "paddingLeft": "25px",
-            }
-          }
-        >
-          0.1000
-        </td>
-      </tr>
-    </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
       <tr
         className="border"
       >
@@ -2440,6 +2440,43 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1 has no unexpected 
           rowSpan={1}
           scope="row"
         >
+          African/African American
+        </th>
+        <td
+          className="right-align"
+        >
+          33
+        </td>
+        <td
+          className="right-align"
+        >
+          330
+        </td>
+        <td
+          className="right-align"
+        >
+          37
+        </td>
+        <td
+          style={
+            {
+              "paddingLeft": "25px",
+            }
+          }
+        >
+          0.1000
+        </td>
+      </tr>
+    </tbody>
+    <tbody
+      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
+    >
+      <tr>
+        <th
+          colSpan={2}
+          rowSpan={1}
+          scope="row"
+        >
           <button
             className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
             onClick={[Function]}
@@ -2514,43 +2551,6 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1 has no unexpected 
           }
         >
           -
-        </td>
-      </tr>
-    </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
-        <th
-          colSpan={2}
-          rowSpan={1}
-          scope="row"
-        >
-          African/African American
-        </th>
-        <td
-          className="right-align"
-        >
-          33
-        </td>
-        <td
-          className="right-align"
-        >
-          330
-        </td>
-        <td
-          className="right-align"
-        >
-          37
-        </td>
-        <td
-          style={
-            {
-              "paddingLeft": "25px",
-            }
-          }
-        >
-          0.1000
         </td>
       </tr>
     </tbody>
@@ -3541,6 +3541,43 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_controls has no un
           rowSpan={1}
           scope="row"
         >
+          African/African American
+        </th>
+        <td
+          className="right-align"
+        >
+          33
+        </td>
+        <td
+          className="right-align"
+        >
+          330
+        </td>
+        <td
+          className="right-align"
+        >
+          37
+        </td>
+        <td
+          style={
+            {
+              "paddingLeft": "25px",
+            }
+          }
+        >
+          0.1000
+        </td>
+      </tr>
+    </tbody>
+    <tbody
+      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
+    >
+      <tr>
+        <th
+          colSpan={2}
+          rowSpan={1}
+          scope="row"
+        >
           <button
             className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
             onClick={[Function]}
@@ -3615,43 +3652,6 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_controls has no un
           }
         >
           -
-        </td>
-      </tr>
-    </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
-        <th
-          colSpan={2}
-          rowSpan={1}
-          scope="row"
-        >
-          African/African American
-        </th>
-        <td
-          className="right-align"
-        >
-          33
-        </td>
-        <td
-          className="right-align"
-        >
-          330
-        </td>
-        <td
-          className="right-align"
-        >
-          37
-        </td>
-        <td
-          style={
-            {
-              "paddingLeft": "25px",
-            }
-          }
-        >
-          0.1000
         </td>
       </tr>
     </tbody>
@@ -4642,6 +4642,43 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_cancer has no 
           rowSpan={1}
           scope="row"
         >
+          African/African American
+        </th>
+        <td
+          className="right-align"
+        >
+          33
+        </td>
+        <td
+          className="right-align"
+        >
+          330
+        </td>
+        <td
+          className="right-align"
+        >
+          37
+        </td>
+        <td
+          style={
+            {
+              "paddingLeft": "25px",
+            }
+          }
+        >
+          0.1000
+        </td>
+      </tr>
+    </tbody>
+    <tbody
+      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
+    >
+      <tr>
+        <th
+          colSpan={2}
+          rowSpan={1}
+          scope="row"
+        >
           <button
             className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
             onClick={[Function]}
@@ -4716,43 +4753,6 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_cancer has no 
           }
         >
           -
-        </td>
-      </tr>
-    </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
-        <th
-          colSpan={2}
-          rowSpan={1}
-          scope="row"
-        >
-          African/African American
-        </th>
-        <td
-          className="right-align"
-        >
-          33
-        </td>
-        <td
-          className="right-align"
-        >
-          330
-        </td>
-        <td
-          className="right-align"
-        >
-          37
-        </td>
-        <td
-          style={
-            {
-              "paddingLeft": "25px",
-            }
-          }
-        >
-          0.1000
         </td>
       </tr>
     </tbody>
@@ -5743,6 +5743,43 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_neuro has no u
           rowSpan={1}
           scope="row"
         >
+          African/African American
+        </th>
+        <td
+          className="right-align"
+        >
+          33
+        </td>
+        <td
+          className="right-align"
+        >
+          330
+        </td>
+        <td
+          className="right-align"
+        >
+          37
+        </td>
+        <td
+          style={
+            {
+              "paddingLeft": "25px",
+            }
+          }
+        >
+          0.1000
+        </td>
+      </tr>
+    </tbody>
+    <tbody
+      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
+    >
+      <tr>
+        <th
+          colSpan={2}
+          rowSpan={1}
+          scope="row"
+        >
           <button
             className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
             onClick={[Function]}
@@ -5817,43 +5854,6 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_neuro has no u
           }
         >
           -
-        </td>
-      </tr>
-    </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
-        <th
-          colSpan={2}
-          rowSpan={1}
-          scope="row"
-        >
-          African/African American
-        </th>
-        <td
-          className="right-align"
-        >
-          33
-        </td>
-        <td
-          className="right-align"
-        >
-          330
-        </td>
-        <td
-          className="right-align"
-        >
-          37
-        </td>
-        <td
-          style={
-            {
-              "paddingLeft": "25px",
-            }
-          }
-        >
-          0.1000
         </td>
       </tr>
     </tbody>
@@ -6844,6 +6844,43 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_topmed has no 
           rowSpan={1}
           scope="row"
         >
+          African/African American
+        </th>
+        <td
+          className="right-align"
+        >
+          33
+        </td>
+        <td
+          className="right-align"
+        >
+          330
+        </td>
+        <td
+          className="right-align"
+        >
+          37
+        </td>
+        <td
+          style={
+            {
+              "paddingLeft": "25px",
+            }
+          }
+        >
+          0.1000
+        </td>
+      </tr>
+    </tbody>
+    <tbody
+      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
+    >
+      <tr>
+        <th
+          colSpan={2}
+          rowSpan={1}
+          scope="row"
+        >
           <button
             className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
             onClick={[Function]}
@@ -6918,43 +6955,6 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_topmed has no 
           }
         >
           -
-        </td>
-      </tr>
-    </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
-        <th
-          colSpan={2}
-          rowSpan={1}
-          scope="row"
-        >
-          African/African American
-        </th>
-        <td
-          className="right-align"
-        >
-          33
-        </td>
-        <td
-          className="right-align"
-        >
-          330
-        </td>
-        <td
-          className="right-align"
-        >
-          37
-        </td>
-        <td
-          style={
-            {
-              "paddingLeft": "25px",
-            }
-          }
-        >
-          0.1000
         </td>
       </tr>
     </tbody>
@@ -7945,6 +7945,43 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3 has no unexpected ch
           rowSpan={1}
           scope="row"
         >
+          African/African American
+        </th>
+        <td
+          className="right-align"
+        >
+          33
+        </td>
+        <td
+          className="right-align"
+        >
+          330
+        </td>
+        <td
+          className="right-align"
+        >
+          37
+        </td>
+        <td
+          style={
+            {
+              "paddingLeft": "25px",
+            }
+          }
+        >
+          0.1000
+        </td>
+      </tr>
+    </tbody>
+    <tbody
+      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
+    >
+      <tr>
+        <th
+          colSpan={2}
+          rowSpan={1}
+          scope="row"
+        >
           <button
             className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
             onClick={[Function]}
@@ -8191,43 +8228,6 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3 has no unexpected ch
           }
         >
           -
-        </td>
-      </tr>
-    </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
-        <th
-          colSpan={2}
-          rowSpan={1}
-          scope="row"
-        >
-          African/African American
-        </th>
-        <td
-          className="right-align"
-        >
-          33
-        </td>
-        <td
-          className="right-align"
-        >
-          330
-        </td>
-        <td
-          className="right-align"
-        >
-          37
-        </td>
-        <td
-          style={
-            {
-              "paddingLeft": "25px",
-            }
-          }
-        >
-          0.1000
         </td>
       </tr>
     </tbody>
@@ -9215,6 +9215,43 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_controls_and_biobank
           rowSpan={1}
           scope="row"
         >
+          African/African American
+        </th>
+        <td
+          className="right-align"
+        >
+          33
+        </td>
+        <td
+          className="right-align"
+        >
+          330
+        </td>
+        <td
+          className="right-align"
+        >
+          37
+        </td>
+        <td
+          style={
+            {
+              "paddingLeft": "25px",
+            }
+          }
+        >
+          0.1000
+        </td>
+      </tr>
+    </tbody>
+    <tbody
+      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
+    >
+      <tr>
+        <th
+          colSpan={2}
+          rowSpan={1}
+          scope="row"
+        >
           <button
             className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
             onClick={[Function]}
@@ -9461,43 +9498,6 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_controls_and_biobank
           }
         >
           -
-        </td>
-      </tr>
-    </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
-        <th
-          colSpan={2}
-          rowSpan={1}
-          scope="row"
-        >
-          African/African American
-        </th>
-        <td
-          className="right-align"
-        >
-          33
-        </td>
-        <td
-          className="right-align"
-        >
-          330
-        </td>
-        <td
-          className="right-align"
-        >
-          37
-        </td>
-        <td
-          style={
-            {
-              "paddingLeft": "25px",
-            }
-          }
-        >
-          0.1000
         </td>
       </tr>
     </tbody>
@@ -10485,6 +10485,43 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_cancer has no un
           rowSpan={1}
           scope="row"
         >
+          African/African American
+        </th>
+        <td
+          className="right-align"
+        >
+          33
+        </td>
+        <td
+          className="right-align"
+        >
+          330
+        </td>
+        <td
+          className="right-align"
+        >
+          37
+        </td>
+        <td
+          style={
+            {
+              "paddingLeft": "25px",
+            }
+          }
+        >
+          0.1000
+        </td>
+      </tr>
+    </tbody>
+    <tbody
+      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
+    >
+      <tr>
+        <th
+          colSpan={2}
+          rowSpan={1}
+          scope="row"
+        >
           <button
             className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
             onClick={[Function]}
@@ -10731,43 +10768,6 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_cancer has no un
           }
         >
           -
-        </td>
-      </tr>
-    </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
-        <th
-          colSpan={2}
-          rowSpan={1}
-          scope="row"
-        >
-          African/African American
-        </th>
-        <td
-          className="right-align"
-        >
-          33
-        </td>
-        <td
-          className="right-align"
-        >
-          330
-        </td>
-        <td
-          className="right-align"
-        >
-          37
-        </td>
-        <td
-          style={
-            {
-              "paddingLeft": "25px",
-            }
-          }
-        >
-          0.1000
         </td>
       </tr>
     </tbody>
@@ -11755,6 +11755,43 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_neuro has no une
           rowSpan={1}
           scope="row"
         >
+          African/African American
+        </th>
+        <td
+          className="right-align"
+        >
+          33
+        </td>
+        <td
+          className="right-align"
+        >
+          330
+        </td>
+        <td
+          className="right-align"
+        >
+          37
+        </td>
+        <td
+          style={
+            {
+              "paddingLeft": "25px",
+            }
+          }
+        >
+          0.1000
+        </td>
+      </tr>
+    </tbody>
+    <tbody
+      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
+    >
+      <tr>
+        <th
+          colSpan={2}
+          rowSpan={1}
+          scope="row"
+        >
           <button
             className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
             onClick={[Function]}
@@ -12001,43 +12038,6 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_neuro has no une
           }
         >
           -
-        </td>
-      </tr>
-    </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
-        <th
-          colSpan={2}
-          rowSpan={1}
-          scope="row"
-        >
-          African/African American
-        </th>
-        <td
-          className="right-align"
-        >
-          33
-        </td>
-        <td
-          className="right-align"
-        >
-          330
-        </td>
-        <td
-          className="right-align"
-        >
-          37
-        </td>
-        <td
-          style={
-            {
-              "paddingLeft": "25px",
-            }
-          }
-        >
-          0.1000
         </td>
       </tr>
     </tbody>
@@ -13025,6 +13025,43 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_topmed has no un
           rowSpan={1}
           scope="row"
         >
+          African/African American
+        </th>
+        <td
+          className="right-align"
+        >
+          33
+        </td>
+        <td
+          className="right-align"
+        >
+          330
+        </td>
+        <td
+          className="right-align"
+        >
+          37
+        </td>
+        <td
+          style={
+            {
+              "paddingLeft": "25px",
+            }
+          }
+        >
+          0.1000
+        </td>
+      </tr>
+    </tbody>
+    <tbody
+      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
+    >
+      <tr>
+        <th
+          colSpan={2}
+          rowSpan={1}
+          scope="row"
+        >
           <button
             className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
             onClick={[Function]}
@@ -13271,43 +13308,6 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_topmed has no un
           }
         >
           -
-        </td>
-      </tr>
-    </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
-        <th
-          colSpan={2}
-          rowSpan={1}
-          scope="row"
-        >
-          African/African American
-        </th>
-        <td
-          className="right-align"
-        >
-          33
-        </td>
-        <td
-          className="right-align"
-        >
-          330
-        </td>
-        <td
-          className="right-align"
-        >
-          37
-        </td>
-        <td
-          style={
-            {
-              "paddingLeft": "25px",
-            }
-          }
-        >
-          0.1000
         </td>
       </tr>
     </tbody>
@@ -14295,6 +14295,43 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_v2 has no unexpe
           rowSpan={1}
           scope="row"
         >
+          African/African American
+        </th>
+        <td
+          className="right-align"
+        >
+          33
+        </td>
+        <td
+          className="right-align"
+        >
+          330
+        </td>
+        <td
+          className="right-align"
+        >
+          37
+        </td>
+        <td
+          style={
+            {
+              "paddingLeft": "25px",
+            }
+          }
+        >
+          0.1000
+        </td>
+      </tr>
+    </tbody>
+    <tbody
+      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
+    >
+      <tr>
+        <th
+          colSpan={2}
+          rowSpan={1}
+          scope="row"
+        >
           <button
             className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
             onClick={[Function]}
@@ -14541,43 +14578,6 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_v2 has no unexpe
           }
         >
           -
-        </td>
-      </tr>
-    </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
-        <th
-          colSpan={2}
-          rowSpan={1}
-          scope="row"
-        >
-          African/African American
-        </th>
-        <td
-          className="right-align"
-        >
-          33
-        </td>
-        <td
-          className="right-align"
-        >
-          330
-        </td>
-        <td
-          className="right-align"
-        >
-          37
-        </td>
-        <td
-          style={
-            {
-              "paddingLeft": "25px",
-            }
-          }
-        >
-          0.1000
         </td>
       </tr>
     </tbody>
@@ -15602,6 +15602,43 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4 has no unexpected ch
           rowSpan={1}
           scope="row"
         >
+          Remaining
+        </th>
+        <td
+          className="right-align"
+        >
+          66
+        </td>
+        <td
+          className="right-align"
+        >
+          660
+        </td>
+        <td
+          className="right-align"
+        >
+          70
+        </td>
+        <td
+          style={
+            {
+              "paddingLeft": "25px",
+            }
+          }
+        >
+          0.1000
+        </td>
+      </tr>
+    </tbody>
+    <tbody
+      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
+    >
+      <tr>
+        <th
+          colSpan={2}
+          rowSpan={1}
+          scope="row"
+        >
           <button
             className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
             onClick={[Function]}
@@ -15934,43 +15971,6 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4 has no unexpected ch
           }
         >
           -
-        </td>
-      </tr>
-    </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
-        <th
-          colSpan={2}
-          rowSpan={1}
-          scope="row"
-        >
-          Remaining
-        </th>
-        <td
-          className="right-align"
-        >
-          66
-        </td>
-        <td
-          className="right-align"
-        >
-          660
-        </td>
-        <td
-          className="right-align"
-        >
-          70
-        </td>
-        <td
-          style={
-            {
-              "paddingLeft": "25px",
-            }
-          }
-        >
-          0.1000
         </td>
       </tr>
     </tbody>
@@ -16266,6 +16266,43 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4 has no unexpected ch
           rowSpan={1}
           scope="row"
         >
+          Remaining
+        </th>
+        <td
+          className="right-align"
+        >
+          2
+        </td>
+        <td
+          className="right-align"
+        >
+          20
+        </td>
+        <td
+          className="right-align"
+        >
+          4
+        </td>
+        <td
+          style={
+            {
+              "paddingLeft": "25px",
+            }
+          }
+        >
+          0.1000
+        </td>
+      </tr>
+    </tbody>
+    <tbody
+      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
+    >
+      <tr>
+        <th
+          colSpan={2}
+          rowSpan={1}
+          scope="row"
+        >
           <button
             className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
             onClick={[Function]}
@@ -16598,43 +16635,6 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4 has no unexpected ch
           }
         >
           -
-        </td>
-      </tr>
-    </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
-        <th
-          colSpan={2}
-          rowSpan={1}
-          scope="row"
-        >
-          Remaining
-        </th>
-        <td
-          className="right-align"
-        >
-          2
-        </td>
-        <td
-          className="right-align"
-        >
-          20
-        </td>
-        <td
-          className="right-align"
-        >
-          4
-        </td>
-        <td
-          style={
-            {
-              "paddingLeft": "25px",
-            }
-          }
-        >
-          0.1000
         </td>
       </tr>
     </tbody>
@@ -16930,6 +16930,43 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4_non_ukb has no unexp
           rowSpan={1}
           scope="row"
         >
+          Remaining
+        </th>
+        <td
+          className="right-align"
+        >
+          66
+        </td>
+        <td
+          className="right-align"
+        >
+          660
+        </td>
+        <td
+          className="right-align"
+        >
+          70
+        </td>
+        <td
+          style={
+            {
+              "paddingLeft": "25px",
+            }
+          }
+        >
+          0.1000
+        </td>
+      </tr>
+    </tbody>
+    <tbody
+      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
+    >
+      <tr>
+        <th
+          colSpan={2}
+          rowSpan={1}
+          scope="row"
+        >
           <button
             className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
             onClick={[Function]}
@@ -17262,43 +17299,6 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4_non_ukb has no unexp
           }
         >
           -
-        </td>
-      </tr>
-    </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
-        <th
-          colSpan={2}
-          rowSpan={1}
-          scope="row"
-        >
-          Remaining
-        </th>
-        <td
-          className="right-align"
-        >
-          66
-        </td>
-        <td
-          className="right-align"
-        >
-          660
-        </td>
-        <td
-          className="right-align"
-        >
-          70
-        </td>
-        <td
-          style={
-            {
-              "paddingLeft": "25px",
-            }
-          }
-        >
-          0.1000
         </td>
       </tr>
     </tbody>
@@ -17594,6 +17594,43 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4_non_ukb has no unexp
           rowSpan={1}
           scope="row"
         >
+          Remaining
+        </th>
+        <td
+          className="right-align"
+        >
+          2
+        </td>
+        <td
+          className="right-align"
+        >
+          20
+        </td>
+        <td
+          className="right-align"
+        >
+          4
+        </td>
+        <td
+          style={
+            {
+              "paddingLeft": "25px",
+            }
+          }
+        >
+          0.1000
+        </td>
+      </tr>
+    </tbody>
+    <tbody
+      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
+    >
+      <tr>
+        <th
+          colSpan={2}
+          rowSpan={1}
+          scope="row"
+        >
           <button
             className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
             onClick={[Function]}
@@ -17926,43 +17963,6 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4_non_ukb has no unexp
           }
         >
           -
-        </td>
-      </tr>
-    </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
-        <th
-          colSpan={2}
-          rowSpan={1}
-          scope="row"
-        >
-          Remaining
-        </th>
-        <td
-          className="right-align"
-        >
-          2
-        </td>
-        <td
-          className="right-align"
-        >
-          20
-        </td>
-        <td
-          className="right-align"
-        >
-          4
-        </td>
-        <td
-          style={
-            {
-              "paddingLeft": "25px",
-            }
-          }
-        >
-          0.1000
         </td>
       </tr>
     </tbody>
@@ -19500,6 +19500,43 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r4 has no unexpected
           rowSpan={1}
           scope="row"
         >
+          Remaining
+        </th>
+        <td
+          className="right-align"
+        >
+          66
+        </td>
+        <td
+          className="right-align"
+        >
+          660
+        </td>
+        <td
+          className="right-align"
+        >
+          70
+        </td>
+        <td
+          style={
+            {
+              "paddingLeft": "25px",
+            }
+          }
+        >
+          0.1000
+        </td>
+      </tr>
+    </tbody>
+    <tbody
+      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
+    >
+      <tr>
+        <th
+          colSpan={2}
+          rowSpan={1}
+          scope="row"
+        >
           <button
             className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
             onClick={[Function]}
@@ -19832,43 +19869,6 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r4 has no unexpected
           }
         >
           -
-        </td>
-      </tr>
-    </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
-        <th
-          colSpan={2}
-          rowSpan={1}
-          scope="row"
-        >
-          Remaining
-        </th>
-        <td
-          className="right-align"
-        >
-          66
-        </td>
-        <td
-          className="right-align"
-        >
-          660
-        </td>
-        <td
-          className="right-align"
-        >
-          70
-        </td>
-        <td
-          style={
-            {
-              "paddingLeft": "25px",
-            }
-          }
-        >
-          0.1000
         </td>
       </tr>
     </tbody>
@@ -20164,6 +20164,43 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r4 has no unexpected
           rowSpan={1}
           scope="row"
         >
+          Remaining
+        </th>
+        <td
+          className="right-align"
+        >
+          2
+        </td>
+        <td
+          className="right-align"
+        >
+          20
+        </td>
+        <td
+          className="right-align"
+        >
+          4
+        </td>
+        <td
+          style={
+            {
+              "paddingLeft": "25px",
+            }
+          }
+        >
+          0.1000
+        </td>
+      </tr>
+    </tbody>
+    <tbody
+      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
+    >
+      <tr>
+        <th
+          colSpan={2}
+          rowSpan={1}
+          scope="row"
+        >
           <button
             className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
             onClick={[Function]}
@@ -20496,43 +20533,6 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r4 has no unexpected
           }
         >
           -
-        </td>
-      </tr>
-    </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
-        <th
-          colSpan={2}
-          rowSpan={1}
-          scope="row"
-        >
-          Remaining
-        </th>
-        <td
-          className="right-align"
-        >
-          2
-        </td>
-        <td
-          className="right-align"
-        >
-          20
-        </td>
-        <td
-          className="right-align"
-        >
-          4
-        </td>
-        <td
-          style={
-            {
-              "paddingLeft": "25px",
-            }
-          }
-        >
-          0.1000
         </td>
       </tr>
     </tbody>

--- a/browser/src/VariantPage/__snapshots__/GnomadPopulationsTable.spec.tsx.snap
+++ b/browser/src/VariantPage/__snapshots__/GnomadPopulationsTable.spec.tsx.snap
@@ -684,22 +684,28 @@ exports[`GnomadPopulationsTable with a dataset of exac has no unexpected changes
           rowSpan={1}
           scope="row"
         >
-          African/African American
+          <button
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            onClick={[Function]}
+            type="button"
+          >
+            African/African American
+          </button>
         </th>
         <td
           className="right-align"
         >
-          1
+          0
         </td>
         <td
           className="right-align"
         >
-          10
+          0
         </td>
         <td
           className="right-align"
         >
-          3
+          0
         </td>
         <td
           style={
@@ -708,7 +714,7 @@ exports[`GnomadPopulationsTable with a dataset of exac has no unexpected changes
             }
           }
         >
-          0.1000
+          -
         </td>
       </tr>
     </tbody>
@@ -893,22 +899,28 @@ exports[`GnomadPopulationsTable with a dataset of exac has no unexpected changes
           rowSpan={1}
           scope="row"
         >
-          Remaining
+          <button
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            onClick={[Function]}
+            type="button"
+          >
+            Remaining
+          </button>
         </th>
         <td
           className="right-align"
         >
-          2
+          0
         </td>
         <td
           className="right-align"
         >
-          20
+          0
         </td>
         <td
           className="right-align"
         >
-          4
+          0
         </td>
         <td
           style={
@@ -917,83 +929,7 @@ exports[`GnomadPopulationsTable with a dataset of exac has no unexpected changes
             }
           }
         >
-          0.1000
-        </td>
-      </tr>
-    </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr
-        className="border"
-      >
-        <th
-          colSpan={2}
-          rowSpan={1}
-          scope="row"
-        >
-          XX
-        </th>
-        <td
-          className="right-align"
-        >
-          8
-        </td>
-        <td
-          className="right-align"
-        >
-          80
-        </td>
-        <td
-          className="right-align"
-        >
-          10
-        </td>
-        <td
-          style={
-            {
-              "paddingLeft": "25px",
-            }
-          }
-        >
-          0.1000
-        </td>
-      </tr>
-    </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
-        <th
-          colSpan={2}
-          rowSpan={1}
-          scope="row"
-        >
-          XY
-        </th>
-        <td
-          className="right-align"
-        >
-          16
-        </td>
-        <td
-          className="right-align"
-        >
-          160
-        </td>
-        <td
-          className="right-align"
-        >
-          18
-        </td>
-        <td
-          style={
-            {
-              "paddingLeft": "25px",
-            }
-          }
-        >
-          0.1000
+          -
         </td>
       </tr>
     </tbody>
@@ -1010,17 +946,17 @@ exports[`GnomadPopulationsTable with a dataset of exac has no unexpected changes
         <td
           className="right-align"
         >
-          3
+          0
         </td>
         <td
           className="right-align"
         >
-          30
+          0
         </td>
         <td
           className="right-align"
         >
-          7
+          0
         </td>
         <td
           style={
@@ -1029,7 +965,7 @@ exports[`GnomadPopulationsTable with a dataset of exac has no unexpected changes
             }
           }
         >
-          0.1000
+          0.000
         </td>
       </tr>
     </tfoot>
@@ -2371,9 +2307,9 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_cnv_r4 has no unexpecte
       htmlFor="includeExomePopulations"
     >
       <input
-        checked={false}
+        checked={true}
         className="Checkbox__CheckboxInput-sc-hrpa6b-1 lmKUES"
-        disabled={true}
+        disabled={false}
         id="includeExomePopulations"
         onChange={[Function]}
         type="checkbox"
@@ -2385,9 +2321,9 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_cnv_r4 has no unexpecte
       htmlFor="includeGenomePopulations"
     >
       <input
-        checked={false}
+        checked={true}
         className="Checkbox__CheckboxInput-sc-hrpa6b-1 lmKUES"
-        disabled={true}
+        disabled={false}
         id="includeGenomePopulations"
         onChange={[Function]}
         type="checkbox"
@@ -3177,22 +3113,28 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1 has no unexpected 
           rowSpan={1}
           scope="row"
         >
-          African/African American
+          <button
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            onClick={[Function]}
+            type="button"
+          >
+            African/African American
+          </button>
         </th>
         <td
           className="right-align"
         >
-          1
+          0
         </td>
         <td
           className="right-align"
         >
-          10
+          0
         </td>
         <td
           className="right-align"
         >
-          3
+          0
         </td>
         <td
           style={
@@ -3201,7 +3143,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1 has no unexpected 
             }
           }
         >
-          0.1000
+          -
         </td>
       </tr>
     </tbody>
@@ -3420,82 +3362,6 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1 has no unexpected 
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr
-        className="border"
-      >
-        <th
-          colSpan={2}
-          rowSpan={1}
-          scope="row"
-        >
-          XX
-        </th>
-        <td
-          className="right-align"
-        >
-          8
-        </td>
-        <td
-          className="right-align"
-        >
-          80
-        </td>
-        <td
-          className="right-align"
-        >
-          10
-        </td>
-        <td
-          style={
-            {
-              "paddingLeft": "25px",
-            }
-          }
-        >
-          0.1000
-        </td>
-      </tr>
-    </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
-        <th
-          colSpan={2}
-          rowSpan={1}
-          scope="row"
-        >
-          XY
-        </th>
-        <td
-          className="right-align"
-        >
-          16
-        </td>
-        <td
-          className="right-align"
-        >
-          160
-        </td>
-        <td
-          className="right-align"
-        >
-          18
-        </td>
-        <td
-          style={
-            {
-              "paddingLeft": "25px",
-            }
-          }
-        >
-          0.1000
-        </td>
-      </tr>
-    </tbody>
     <tfoot>
       <tr
         className="border"
@@ -3509,17 +3375,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1 has no unexpected 
         <td
           className="right-align"
         >
-          1
+          0
         </td>
         <td
           className="right-align"
         >
-          10
+          0
         </td>
         <td
           className="right-align"
         >
-          3
+          0
         </td>
         <td
           style={
@@ -3528,7 +3394,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1 has no unexpected 
             }
           }
         >
-          0.1000
+          0.000
         </td>
       </tr>
     </tfoot>
@@ -4348,22 +4214,28 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_controls has no un
           rowSpan={1}
           scope="row"
         >
-          African/African American
+          <button
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            onClick={[Function]}
+            type="button"
+          >
+            African/African American
+          </button>
         </th>
         <td
           className="right-align"
         >
-          1
+          0
         </td>
         <td
           className="right-align"
         >
-          10
+          0
         </td>
         <td
           className="right-align"
         >
-          3
+          0
         </td>
         <td
           style={
@@ -4372,7 +4244,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_controls has no un
             }
           }
         >
-          0.1000
+          -
         </td>
       </tr>
     </tbody>
@@ -4591,82 +4463,6 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_controls has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr
-        className="border"
-      >
-        <th
-          colSpan={2}
-          rowSpan={1}
-          scope="row"
-        >
-          XX
-        </th>
-        <td
-          className="right-align"
-        >
-          8
-        </td>
-        <td
-          className="right-align"
-        >
-          80
-        </td>
-        <td
-          className="right-align"
-        >
-          10
-        </td>
-        <td
-          style={
-            {
-              "paddingLeft": "25px",
-            }
-          }
-        >
-          0.1000
-        </td>
-      </tr>
-    </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
-        <th
-          colSpan={2}
-          rowSpan={1}
-          scope="row"
-        >
-          XY
-        </th>
-        <td
-          className="right-align"
-        >
-          16
-        </td>
-        <td
-          className="right-align"
-        >
-          160
-        </td>
-        <td
-          className="right-align"
-        >
-          18
-        </td>
-        <td
-          style={
-            {
-              "paddingLeft": "25px",
-            }
-          }
-        >
-          0.1000
-        </td>
-      </tr>
-    </tbody>
     <tfoot>
       <tr
         className="border"
@@ -4680,17 +4476,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_controls has no un
         <td
           className="right-align"
         >
-          1
+          0
         </td>
         <td
           className="right-align"
         >
-          10
+          0
         </td>
         <td
           className="right-align"
         >
-          3
+          0
         </td>
         <td
           style={
@@ -4699,7 +4495,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_controls has no un
             }
           }
         >
-          0.1000
+          0.000
         </td>
       </tr>
     </tfoot>
@@ -5519,22 +5315,28 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_cancer has no 
           rowSpan={1}
           scope="row"
         >
-          African/African American
+          <button
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            onClick={[Function]}
+            type="button"
+          >
+            African/African American
+          </button>
         </th>
         <td
           className="right-align"
         >
-          1
+          0
         </td>
         <td
           className="right-align"
         >
-          10
+          0
         </td>
         <td
           className="right-align"
         >
-          3
+          0
         </td>
         <td
           style={
@@ -5543,7 +5345,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_cancer has no 
             }
           }
         >
-          0.1000
+          -
         </td>
       </tr>
     </tbody>
@@ -5762,82 +5564,6 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_cancer has no 
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr
-        className="border"
-      >
-        <th
-          colSpan={2}
-          rowSpan={1}
-          scope="row"
-        >
-          XX
-        </th>
-        <td
-          className="right-align"
-        >
-          8
-        </td>
-        <td
-          className="right-align"
-        >
-          80
-        </td>
-        <td
-          className="right-align"
-        >
-          10
-        </td>
-        <td
-          style={
-            {
-              "paddingLeft": "25px",
-            }
-          }
-        >
-          0.1000
-        </td>
-      </tr>
-    </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
-        <th
-          colSpan={2}
-          rowSpan={1}
-          scope="row"
-        >
-          XY
-        </th>
-        <td
-          className="right-align"
-        >
-          16
-        </td>
-        <td
-          className="right-align"
-        >
-          160
-        </td>
-        <td
-          className="right-align"
-        >
-          18
-        </td>
-        <td
-          style={
-            {
-              "paddingLeft": "25px",
-            }
-          }
-        >
-          0.1000
-        </td>
-      </tr>
-    </tbody>
     <tfoot>
       <tr
         className="border"
@@ -5851,17 +5577,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_cancer has no 
         <td
           className="right-align"
         >
-          1
+          0
         </td>
         <td
           className="right-align"
         >
-          10
+          0
         </td>
         <td
           className="right-align"
         >
-          3
+          0
         </td>
         <td
           style={
@@ -5870,7 +5596,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_cancer has no 
             }
           }
         >
-          0.1000
+          0.000
         </td>
       </tr>
     </tfoot>
@@ -6690,22 +6416,28 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_neuro has no u
           rowSpan={1}
           scope="row"
         >
-          African/African American
+          <button
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            onClick={[Function]}
+            type="button"
+          >
+            African/African American
+          </button>
         </th>
         <td
           className="right-align"
         >
-          1
+          0
         </td>
         <td
           className="right-align"
         >
-          10
+          0
         </td>
         <td
           className="right-align"
         >
-          3
+          0
         </td>
         <td
           style={
@@ -6714,7 +6446,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_neuro has no u
             }
           }
         >
-          0.1000
+          -
         </td>
       </tr>
     </tbody>
@@ -6933,82 +6665,6 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_neuro has no u
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr
-        className="border"
-      >
-        <th
-          colSpan={2}
-          rowSpan={1}
-          scope="row"
-        >
-          XX
-        </th>
-        <td
-          className="right-align"
-        >
-          8
-        </td>
-        <td
-          className="right-align"
-        >
-          80
-        </td>
-        <td
-          className="right-align"
-        >
-          10
-        </td>
-        <td
-          style={
-            {
-              "paddingLeft": "25px",
-            }
-          }
-        >
-          0.1000
-        </td>
-      </tr>
-    </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
-        <th
-          colSpan={2}
-          rowSpan={1}
-          scope="row"
-        >
-          XY
-        </th>
-        <td
-          className="right-align"
-        >
-          16
-        </td>
-        <td
-          className="right-align"
-        >
-          160
-        </td>
-        <td
-          className="right-align"
-        >
-          18
-        </td>
-        <td
-          style={
-            {
-              "paddingLeft": "25px",
-            }
-          }
-        >
-          0.1000
-        </td>
-      </tr>
-    </tbody>
     <tfoot>
       <tr
         className="border"
@@ -7022,17 +6678,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_neuro has no u
         <td
           className="right-align"
         >
-          1
+          0
         </td>
         <td
           className="right-align"
         >
-          10
+          0
         </td>
         <td
           className="right-align"
         >
-          3
+          0
         </td>
         <td
           style={
@@ -7041,7 +6697,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_neuro has no u
             }
           }
         >
-          0.1000
+          0.000
         </td>
       </tr>
     </tfoot>
@@ -7861,22 +7517,28 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_topmed has no 
           rowSpan={1}
           scope="row"
         >
-          African/African American
+          <button
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            onClick={[Function]}
+            type="button"
+          >
+            African/African American
+          </button>
         </th>
         <td
           className="right-align"
         >
-          1
+          0
         </td>
         <td
           className="right-align"
         >
-          10
+          0
         </td>
         <td
           className="right-align"
         >
-          3
+          0
         </td>
         <td
           style={
@@ -7885,7 +7547,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_topmed has no 
             }
           }
         >
-          0.1000
+          -
         </td>
       </tr>
     </tbody>
@@ -8104,82 +7766,6 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_topmed has no 
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr
-        className="border"
-      >
-        <th
-          colSpan={2}
-          rowSpan={1}
-          scope="row"
-        >
-          XX
-        </th>
-        <td
-          className="right-align"
-        >
-          8
-        </td>
-        <td
-          className="right-align"
-        >
-          80
-        </td>
-        <td
-          className="right-align"
-        >
-          10
-        </td>
-        <td
-          style={
-            {
-              "paddingLeft": "25px",
-            }
-          }
-        >
-          0.1000
-        </td>
-      </tr>
-    </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
-        <th
-          colSpan={2}
-          rowSpan={1}
-          scope="row"
-        >
-          XY
-        </th>
-        <td
-          className="right-align"
-        >
-          16
-        </td>
-        <td
-          className="right-align"
-        >
-          160
-        </td>
-        <td
-          className="right-align"
-        >
-          18
-        </td>
-        <td
-          style={
-            {
-              "paddingLeft": "25px",
-            }
-          }
-        >
-          0.1000
-        </td>
-      </tr>
-    </tbody>
     <tfoot>
       <tr
         className="border"
@@ -8193,17 +7779,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_topmed has no 
         <td
           className="right-align"
         >
-          1
+          0
         </td>
         <td
           className="right-align"
         >
-          10
+          0
         </td>
         <td
           className="right-align"
         >
-          3
+          0
         </td>
         <td
           style={
@@ -8212,7 +7798,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_topmed has no 
             }
           }
         >
-          0.1000
+          0.000
         </td>
       </tr>
     </tfoot>
@@ -9287,22 +8873,28 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3 has no unexpected ch
           rowSpan={1}
           scope="row"
         >
-          African/African American
+          <button
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            onClick={[Function]}
+            type="button"
+          >
+            African/African American
+          </button>
         </th>
         <td
           className="right-align"
         >
-          1
+          0
         </td>
         <td
           className="right-align"
         >
-          10
+          0
         </td>
         <td
           className="right-align"
         >
-          3
+          0
         </td>
         <td
           style={
@@ -9311,7 +8903,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3 has no unexpected ch
             }
           }
         >
-          0.1000
+          -
         </td>
       </tr>
     </tbody>
@@ -9444,82 +9036,6 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3 has no unexpected ch
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr
-        className="border"
-      >
-        <th
-          colSpan={2}
-          rowSpan={1}
-          scope="row"
-        >
-          XX
-        </th>
-        <td
-          className="right-align"
-        >
-          8
-        </td>
-        <td
-          className="right-align"
-        >
-          80
-        </td>
-        <td
-          className="right-align"
-        >
-          10
-        </td>
-        <td
-          style={
-            {
-              "paddingLeft": "25px",
-            }
-          }
-        >
-          0.1000
-        </td>
-      </tr>
-    </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
-        <th
-          colSpan={2}
-          rowSpan={1}
-          scope="row"
-        >
-          XY
-        </th>
-        <td
-          className="right-align"
-        >
-          16
-        </td>
-        <td
-          className="right-align"
-        >
-          160
-        </td>
-        <td
-          className="right-align"
-        >
-          18
-        </td>
-        <td
-          style={
-            {
-              "paddingLeft": "25px",
-            }
-          }
-        >
-          0.1000
-        </td>
-      </tr>
-    </tbody>
     <tfoot>
       <tr
         className="border"
@@ -9533,17 +9049,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3 has no unexpected ch
         <td
           className="right-align"
         >
-          1
+          0
         </td>
         <td
           className="right-align"
         >
-          10
+          0
         </td>
         <td
           className="right-align"
         >
-          3
+          0
         </td>
         <td
           style={
@@ -9552,7 +9068,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3 has no unexpected ch
             }
           }
         >
-          0.1000
+          0.000
         </td>
       </tr>
     </tfoot>
@@ -10627,22 +10143,28 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_controls_and_biobank
           rowSpan={1}
           scope="row"
         >
-          African/African American
+          <button
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            onClick={[Function]}
+            type="button"
+          >
+            African/African American
+          </button>
         </th>
         <td
           className="right-align"
         >
-          1
+          0
         </td>
         <td
           className="right-align"
         >
-          10
+          0
         </td>
         <td
           className="right-align"
         >
-          3
+          0
         </td>
         <td
           style={
@@ -10651,7 +10173,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_controls_and_biobank
             }
           }
         >
-          0.1000
+          -
         </td>
       </tr>
     </tbody>
@@ -10784,82 +10306,6 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_controls_and_biobank
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr
-        className="border"
-      >
-        <th
-          colSpan={2}
-          rowSpan={1}
-          scope="row"
-        >
-          XX
-        </th>
-        <td
-          className="right-align"
-        >
-          8
-        </td>
-        <td
-          className="right-align"
-        >
-          80
-        </td>
-        <td
-          className="right-align"
-        >
-          10
-        </td>
-        <td
-          style={
-            {
-              "paddingLeft": "25px",
-            }
-          }
-        >
-          0.1000
-        </td>
-      </tr>
-    </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
-        <th
-          colSpan={2}
-          rowSpan={1}
-          scope="row"
-        >
-          XY
-        </th>
-        <td
-          className="right-align"
-        >
-          16
-        </td>
-        <td
-          className="right-align"
-        >
-          160
-        </td>
-        <td
-          className="right-align"
-        >
-          18
-        </td>
-        <td
-          style={
-            {
-              "paddingLeft": "25px",
-            }
-          }
-        >
-          0.1000
-        </td>
-      </tr>
-    </tbody>
     <tfoot>
       <tr
         className="border"
@@ -10873,17 +10319,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_controls_and_biobank
         <td
           className="right-align"
         >
-          1
+          0
         </td>
         <td
           className="right-align"
         >
-          10
+          0
         </td>
         <td
           className="right-align"
         >
-          3
+          0
         </td>
         <td
           style={
@@ -10892,7 +10338,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_controls_and_biobank
             }
           }
         >
-          0.1000
+          0.000
         </td>
       </tr>
     </tfoot>
@@ -11967,22 +11413,28 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_cancer has no un
           rowSpan={1}
           scope="row"
         >
-          African/African American
+          <button
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            onClick={[Function]}
+            type="button"
+          >
+            African/African American
+          </button>
         </th>
         <td
           className="right-align"
         >
-          1
+          0
         </td>
         <td
           className="right-align"
         >
-          10
+          0
         </td>
         <td
           className="right-align"
         >
-          3
+          0
         </td>
         <td
           style={
@@ -11991,7 +11443,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_cancer has no un
             }
           }
         >
-          0.1000
+          -
         </td>
       </tr>
     </tbody>
@@ -12124,82 +11576,6 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_cancer has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr
-        className="border"
-      >
-        <th
-          colSpan={2}
-          rowSpan={1}
-          scope="row"
-        >
-          XX
-        </th>
-        <td
-          className="right-align"
-        >
-          8
-        </td>
-        <td
-          className="right-align"
-        >
-          80
-        </td>
-        <td
-          className="right-align"
-        >
-          10
-        </td>
-        <td
-          style={
-            {
-              "paddingLeft": "25px",
-            }
-          }
-        >
-          0.1000
-        </td>
-      </tr>
-    </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
-        <th
-          colSpan={2}
-          rowSpan={1}
-          scope="row"
-        >
-          XY
-        </th>
-        <td
-          className="right-align"
-        >
-          16
-        </td>
-        <td
-          className="right-align"
-        >
-          160
-        </td>
-        <td
-          className="right-align"
-        >
-          18
-        </td>
-        <td
-          style={
-            {
-              "paddingLeft": "25px",
-            }
-          }
-        >
-          0.1000
-        </td>
-      </tr>
-    </tbody>
     <tfoot>
       <tr
         className="border"
@@ -12213,17 +11589,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_cancer has no un
         <td
           className="right-align"
         >
-          1
+          0
         </td>
         <td
           className="right-align"
         >
-          10
+          0
         </td>
         <td
           className="right-align"
         >
-          3
+          0
         </td>
         <td
           style={
@@ -12232,7 +11608,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_cancer has no un
             }
           }
         >
-          0.1000
+          0.000
         </td>
       </tr>
     </tfoot>
@@ -13307,22 +12683,28 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_neuro has no une
           rowSpan={1}
           scope="row"
         >
-          African/African American
+          <button
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            onClick={[Function]}
+            type="button"
+          >
+            African/African American
+          </button>
         </th>
         <td
           className="right-align"
         >
-          1
+          0
         </td>
         <td
           className="right-align"
         >
-          10
+          0
         </td>
         <td
           className="right-align"
         >
-          3
+          0
         </td>
         <td
           style={
@@ -13331,7 +12713,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_neuro has no une
             }
           }
         >
-          0.1000
+          -
         </td>
       </tr>
     </tbody>
@@ -13464,82 +12846,6 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_neuro has no une
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr
-        className="border"
-      >
-        <th
-          colSpan={2}
-          rowSpan={1}
-          scope="row"
-        >
-          XX
-        </th>
-        <td
-          className="right-align"
-        >
-          8
-        </td>
-        <td
-          className="right-align"
-        >
-          80
-        </td>
-        <td
-          className="right-align"
-        >
-          10
-        </td>
-        <td
-          style={
-            {
-              "paddingLeft": "25px",
-            }
-          }
-        >
-          0.1000
-        </td>
-      </tr>
-    </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
-        <th
-          colSpan={2}
-          rowSpan={1}
-          scope="row"
-        >
-          XY
-        </th>
-        <td
-          className="right-align"
-        >
-          16
-        </td>
-        <td
-          className="right-align"
-        >
-          160
-        </td>
-        <td
-          className="right-align"
-        >
-          18
-        </td>
-        <td
-          style={
-            {
-              "paddingLeft": "25px",
-            }
-          }
-        >
-          0.1000
-        </td>
-      </tr>
-    </tbody>
     <tfoot>
       <tr
         className="border"
@@ -13553,17 +12859,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_neuro has no une
         <td
           className="right-align"
         >
-          1
+          0
         </td>
         <td
           className="right-align"
         >
-          10
+          0
         </td>
         <td
           className="right-align"
         >
-          3
+          0
         </td>
         <td
           style={
@@ -13572,7 +12878,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_neuro has no une
             }
           }
         >
-          0.1000
+          0.000
         </td>
       </tr>
     </tfoot>
@@ -14647,22 +13953,28 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_topmed has no un
           rowSpan={1}
           scope="row"
         >
-          African/African American
+          <button
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            onClick={[Function]}
+            type="button"
+          >
+            African/African American
+          </button>
         </th>
         <td
           className="right-align"
         >
-          1
+          0
         </td>
         <td
           className="right-align"
         >
-          10
+          0
         </td>
         <td
           className="right-align"
         >
-          3
+          0
         </td>
         <td
           style={
@@ -14671,7 +13983,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_topmed has no un
             }
           }
         >
-          0.1000
+          -
         </td>
       </tr>
     </tbody>
@@ -14804,82 +14116,6 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_topmed has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr
-        className="border"
-      >
-        <th
-          colSpan={2}
-          rowSpan={1}
-          scope="row"
-        >
-          XX
-        </th>
-        <td
-          className="right-align"
-        >
-          8
-        </td>
-        <td
-          className="right-align"
-        >
-          80
-        </td>
-        <td
-          className="right-align"
-        >
-          10
-        </td>
-        <td
-          style={
-            {
-              "paddingLeft": "25px",
-            }
-          }
-        >
-          0.1000
-        </td>
-      </tr>
-    </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
-        <th
-          colSpan={2}
-          rowSpan={1}
-          scope="row"
-        >
-          XY
-        </th>
-        <td
-          className="right-align"
-        >
-          16
-        </td>
-        <td
-          className="right-align"
-        >
-          160
-        </td>
-        <td
-          className="right-align"
-        >
-          18
-        </td>
-        <td
-          style={
-            {
-              "paddingLeft": "25px",
-            }
-          }
-        >
-          0.1000
-        </td>
-      </tr>
-    </tbody>
     <tfoot>
       <tr
         className="border"
@@ -14893,17 +14129,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_topmed has no un
         <td
           className="right-align"
         >
-          1
+          0
         </td>
         <td
           className="right-align"
         >
-          10
+          0
         </td>
         <td
           className="right-align"
         >
-          3
+          0
         </td>
         <td
           style={
@@ -14912,7 +14148,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_topmed has no un
             }
           }
         >
-          0.1000
+          0.000
         </td>
       </tr>
     </tfoot>
@@ -15987,22 +15223,28 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_v2 has no unexpe
           rowSpan={1}
           scope="row"
         >
-          African/African American
+          <button
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            onClick={[Function]}
+            type="button"
+          >
+            African/African American
+          </button>
         </th>
         <td
           className="right-align"
         >
-          1
+          0
         </td>
         <td
           className="right-align"
         >
-          10
+          0
         </td>
         <td
           className="right-align"
         >
-          3
+          0
         </td>
         <td
           style={
@@ -16011,7 +15253,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_v2 has no unexpe
             }
           }
         >
-          0.1000
+          -
         </td>
       </tr>
     </tbody>
@@ -16144,82 +15386,6 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_v2 has no unexpe
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr
-        className="border"
-      >
-        <th
-          colSpan={2}
-          rowSpan={1}
-          scope="row"
-        >
-          XX
-        </th>
-        <td
-          className="right-align"
-        >
-          8
-        </td>
-        <td
-          className="right-align"
-        >
-          80
-        </td>
-        <td
-          className="right-align"
-        >
-          10
-        </td>
-        <td
-          style={
-            {
-              "paddingLeft": "25px",
-            }
-          }
-        >
-          0.1000
-        </td>
-      </tr>
-    </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
-        <th
-          colSpan={2}
-          rowSpan={1}
-          scope="row"
-        >
-          XY
-        </th>
-        <td
-          className="right-align"
-        >
-          16
-        </td>
-        <td
-          className="right-align"
-        >
-          160
-        </td>
-        <td
-          className="right-align"
-        >
-          18
-        </td>
-        <td
-          style={
-            {
-              "paddingLeft": "25px",
-            }
-          }
-        >
-          0.1000
-        </td>
-      </tr>
-    </tbody>
     <tfoot>
       <tr
         className="border"
@@ -16233,17 +15399,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_v2 has no unexpe
         <td
           className="right-align"
         >
-          1
+          0
         </td>
         <td
           className="right-align"
         >
-          10
+          0
         </td>
         <td
           className="right-align"
         >
-          3
+          0
         </td>
         <td
           style={
@@ -16252,7 +15418,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_v2 has no unexpe
             }
           }
         >
-          0.1000
+          0.000
         </td>
       </tr>
     </tfoot>
@@ -17594,9 +16760,9 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4 has no unexpected ch
       htmlFor="includeExomePopulations"
     >
       <input
-        checked={false}
+        checked={true}
         className="Checkbox__CheckboxInput-sc-hrpa6b-1 lmKUES"
-        disabled={true}
+        disabled={false}
         id="includeExomePopulations"
         onChange={[Function]}
         type="checkbox"
@@ -17608,9 +16774,9 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4 has no unexpected ch
       htmlFor="includeGenomePopulations"
     >
       <input
-        checked={false}
+        checked={true}
         className="Checkbox__CheckboxInput-sc-hrpa6b-1 lmKUES"
-        disabled={true}
+        disabled={false}
         id="includeGenomePopulations"
         onChange={[Function]}
         type="checkbox"
@@ -18922,9 +18088,9 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4_non_ukb has no unexp
       htmlFor="includeExomePopulations"
     >
       <input
-        checked={false}
+        checked={true}
         className="Checkbox__CheckboxInput-sc-hrpa6b-1 lmKUES"
-        disabled={true}
+        disabled={false}
         id="includeExomePopulations"
         onChange={[Function]}
         type="checkbox"
@@ -18936,9 +18102,9 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4_non_ukb has no unexp
       htmlFor="includeGenomePopulations"
     >
       <input
-        checked={false}
+        checked={true}
         className="Checkbox__CheckboxInput-sc-hrpa6b-1 lmKUES"
-        disabled={true}
+        disabled={false}
         id="includeGenomePopulations"
         onChange={[Function]}
         type="checkbox"
@@ -19290,80 +18456,6 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r2_1 has no unexpect
         </th>
       </tr>
     </thead>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
-        <th
-          colSpan={2}
-          rowSpan={1}
-          scope="row"
-        >
-          XX
-        </th>
-        <td
-          className="right-align"
-        >
-          8
-        </td>
-        <td
-          className="right-align"
-        >
-          80
-        </td>
-        <td
-          className="right-align"
-        >
-          10
-        </td>
-        <td
-          style={
-            {
-              "paddingLeft": "25px",
-            }
-          }
-        >
-          0.1000
-        </td>
-      </tr>
-    </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
-        <th
-          colSpan={2}
-          rowSpan={1}
-          scope="row"
-        >
-          XY
-        </th>
-        <td
-          className="right-align"
-        >
-          16
-        </td>
-        <td
-          className="right-align"
-        >
-          160
-        </td>
-        <td
-          className="right-align"
-        >
-          18
-        </td>
-        <td
-          style={
-            {
-              "paddingLeft": "25px",
-            }
-          }
-        >
-          0.1000
-        </td>
-      </tr>
-    </tbody>
     <tfoot>
       <tr
         className="border"
@@ -19778,80 +18870,6 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r2_1_controls has no
         </th>
       </tr>
     </thead>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
-        <th
-          colSpan={2}
-          rowSpan={1}
-          scope="row"
-        >
-          XX
-        </th>
-        <td
-          className="right-align"
-        >
-          8
-        </td>
-        <td
-          className="right-align"
-        >
-          80
-        </td>
-        <td
-          className="right-align"
-        >
-          10
-        </td>
-        <td
-          style={
-            {
-              "paddingLeft": "25px",
-            }
-          }
-        >
-          0.1000
-        </td>
-      </tr>
-    </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
-        <th
-          colSpan={2}
-          rowSpan={1}
-          scope="row"
-        >
-          XY
-        </th>
-        <td
-          className="right-align"
-        >
-          16
-        </td>
-        <td
-          className="right-align"
-        >
-          160
-        </td>
-        <td
-          className="right-align"
-        >
-          18
-        </td>
-        <td
-          style={
-            {
-              "paddingLeft": "25px",
-            }
-          }
-        >
-          0.1000
-        </td>
-      </tr>
-    </tbody>
     <tfoot>
       <tr
         className="border"
@@ -20266,80 +19284,6 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r2_1_non_neuro has n
         </th>
       </tr>
     </thead>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
-        <th
-          colSpan={2}
-          rowSpan={1}
-          scope="row"
-        >
-          XX
-        </th>
-        <td
-          className="right-align"
-        >
-          8
-        </td>
-        <td
-          className="right-align"
-        >
-          80
-        </td>
-        <td
-          className="right-align"
-        >
-          10
-        </td>
-        <td
-          style={
-            {
-              "paddingLeft": "25px",
-            }
-          }
-        >
-          0.1000
-        </td>
-      </tr>
-    </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
-        <th
-          colSpan={2}
-          rowSpan={1}
-          scope="row"
-        >
-          XY
-        </th>
-        <td
-          className="right-align"
-        >
-          16
-        </td>
-        <td
-          className="right-align"
-        >
-          160
-        </td>
-        <td
-          className="right-align"
-        >
-          18
-        </td>
-        <td
-          style={
-            {
-              "paddingLeft": "25px",
-            }
-          }
-        >
-          0.1000
-        </td>
-      </tr>
-    </tbody>
     <tfoot>
       <tr
         className="border"
@@ -21714,9 +20658,9 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r4 has no unexpected
       htmlFor="includeExomePopulations"
     >
       <input
-        checked={false}
+        checked={true}
         className="Checkbox__CheckboxInput-sc-hrpa6b-1 lmKUES"
-        disabled={true}
+        disabled={false}
         id="includeExomePopulations"
         onChange={[Function]}
         type="checkbox"
@@ -21728,9 +20672,9 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r4 has no unexpected
       htmlFor="includeGenomePopulations"
     >
       <input
-        checked={false}
+        checked={true}
         className="Checkbox__CheckboxInput-sc-hrpa6b-1 lmKUES"
-        disabled={true}
+        disabled={false}
         id="includeGenomePopulations"
         onChange={[Function]}
         type="checkbox"


### PR DESCRIPTION
Previously, if a variant was only present in a single data source (exome or genome) the Genetic Ancestry Group frequency table on the bottom half of the variant page would show the joint frequency data, while the UI would imply that these are the numbers for the single source (e.g. if a variant was in exomes, but not in genomes, the numbers shown were for joint, but the checkboxes had exomes selected and genomes not selected)

This PR allows toggling off of the source without a variant to view the single source frequency information. This way, if a variant is only present in one data source, when the table is displaying joint frequency information, it reflects this in the buttons below, and the user can turn off the opposite source to view just the single source's frequency information (e.g. if a variant is present in exomes, but not in genomes, the numbers shown are for joint, and both exomes and genomes are toggled on. Users can then toggle off genomes to view just the exome frequencies). 

---

Also includes a commit to fix sorting on AF -- the `-` character being rendered for grps with an `AN` of 0 caused certain variants to mistakenly sort on AF lexicographically, rather than numerically.