### PR TITLE
Update ClinVar pipeline for new XML format

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,3 @@
 nodejs 18.17.1
 pnpm 8.14.3
+python 3.9.17

--- a/browser/src/ClinvarVariantsTrack/ClinvarVariantDetails.tsx
+++ b/browser/src/ClinvarVariantsTrack/ClinvarVariantDetails.tsx
@@ -137,7 +137,7 @@ const ClinvarVariantDetails = ({
               []
             )}
         </AttributeListItem>
-        <AttributeListItem label="Clinical significance">
+        <AttributeListItem label="Germline classification">
           {clinvarVariant.clinical_significance}
         </AttributeListItem>
         <AttributeListItem label="Review status">

--- a/browser/src/ClinvarVariantsTrack/ClinvarVariantTooltip.tsx
+++ b/browser/src/ClinvarVariantsTrack/ClinvarVariantTooltip.tsx
@@ -72,7 +72,7 @@ const ClinvarVariantTooltip = ({ variant }: ClinvarVariantTooltipProps) => (
     <strong>{variant.variant_id}</strong>
     <ClinvarVariantAttributeList>
       <div>
-        <dt>Clinical significance</dt>
+        <dt>Germline classification</dt>
         <dd>{variant.clinical_significance}</dd>
       </div>
       <div>

--- a/browser/src/ClinvarVariantsTrack/clinvarVariantCategories.ts
+++ b/browser/src/ClinvarVariantsTrack/clinvarVariantCategories.ts
@@ -13,6 +13,7 @@ const CLINICAL_SIGNIFICANCE_GROUPS = {
   uncertain: new Set([
     'Uncertain significance',
     'Conflicting interpretations of pathogenicity',
+    'Conflicting classifications of pathogenicity',
     'conflicting data from submitters',
   ]),
   benign: new Set(['Benign', 'Likely benign', 'Benign/Likely benign']),
@@ -22,6 +23,7 @@ const CLINICAL_SIGNIFICANCE_GROUPS = {
     'Affects',
     'protective',
     'no interpretation for the single variant',
+    'no classification for the single variant',
     'not provided',
     'association not found',
   ]),

--- a/browser/src/SubmissionsList.tsx
+++ b/browser/src/SubmissionsList.tsx
@@ -45,7 +45,7 @@ const SubmissionsList = ({ submissions }: SubmissionsListProps) => (
               // @ts-expect-error TS(2769) FIXME: No overload matches this call.
               .reduce((acc, el, i) => (i === 0 ? [...acc, el] : [...acc, ', ', el]), [])}
           </AttributeListItem>
-          <AttributeListItem label="Clinical significance">
+          <AttributeListItem label="Germline classification">
             {submission.clinical_significance || '–'}
           </AttributeListItem>
           <AttributeListItem label="Review status">{submission.review_status}</AttributeListItem>

--- a/browser/src/VariantPage/VariantClinvarInfo.tsx
+++ b/browser/src/VariantPage/VariantClinvarInfo.tsx
@@ -50,7 +50,7 @@ const VariantClinvarInfo = ({ clinvar }: VariantClinvarInfoProps) => {
               []
             )}
         </AttributeListItem>
-        <AttributeListItem label="Clinical significance">
+        <AttributeListItem label="Germline classification">
           {clinvar.clinical_significance}
         </AttributeListItem>
         <AttributeListItem label="Review status">

--- a/browser/src/__snapshots__/SubmissionsList.spec.tsx.snap
+++ b/browser/src/__snapshots__/SubmissionsList.spec.tsx.snap
@@ -19,7 +19,7 @@ exports[`SubmissionsList has no unexpected changes 1`] = `
         </Link__ExternalLink>
       </AttributeListItem>
       <AttributeListItem
-        label="Clinical significance"
+        label="Germline classification"
       >
         Benign
       </AttributeListItem>
@@ -52,7 +52,7 @@ exports[`SubmissionsList has no unexpected changes 1`] = `
         </Link__ExternalLink>
       </AttributeListItem>
       <AttributeListItem
-        label="Clinical significance"
+        label="Germline classification"
       >
         Benign
       </AttributeListItem>

--- a/data-pipeline/requirements.txt
+++ b/data-pipeline/requirements.txt
@@ -1,5 +1,5 @@
 elasticsearch~=7.17
-hail==0.2.127
+hail==0.2.128
 tqdm
 loguru
 attrs

--- a/data-pipeline/src/data_pipeline/datasets/clinvar.py
+++ b/data-pipeline/src/data_pipeline/datasets/clinvar.py
@@ -21,14 +21,19 @@ CLINVAR_XML_URL = "https://ftp.ncbi.nlm.nih.gov/pub/clinvar/xml/clinvar_variatio
 
 
 CLINVAR_GOLD_STARS = {
+    None: 0,
+    "no classification for the single variant": 0,
+    "no interpretation for the single variant": 0,
+    "no classification provided": 0,
+    "no assertion provided": 0,
+    "no classifications from unflagged records": 0,
+    "no assertion criteria provided": 0,
+    "criteria provided, single submitter": 1,
+    "criteria provided, conflicting classifications": 1,
     "criteria provided, conflicting interpretations": 1,
     "criteria provided, multiple submitters, no conflicts": 2,
-    "criteria provided, single submitter": 1,
-    "no assertion criteria provided": 0,
-    "no assertion provided": 0,
-    "no interpretation for the single variant": 0,
-    "practice guideline": 4,
     "reviewed by expert panel": 3,
+    "practice guideline": 4,
 }
 
 

--- a/data-pipeline/src/data_pipeline/pipeline.py
+++ b/data-pipeline/src/data_pipeline/pipeline.py
@@ -100,7 +100,7 @@ class DownloadTask:
 
             stop = time.perf_counter()
             elapsed = stop - start
-            logger.info("Finished %s in %.0fm%02.2fs", self._name, elapsed // 60, elapsed % 60)
+            logger.info(f"Finished {self._name} in {int(elapsed // 60)}m{elapsed % 60:.2f}s")
         else:
             logger.info(f"Skipping {self._name}")
 

--- a/data-pipeline/src/data_pipeline/pipelines/genes.py
+++ b/data-pipeline/src/data_pipeline/pipelines/genes.py
@@ -329,6 +329,8 @@ pipeline.add_task(
     f"/{genes_subdir}/gnomad.browser.GRCh37.GENCODEv19.ht",
     {
         "genes_path": pipeline.get_task("annotate_grch37_genes_step_5"),
+    },
+    {
         "keep_mane_version_global_annotation": False,
     },
 )
@@ -396,7 +398,6 @@ pipeline.add_task(
     },
 )
 
-
 # naming scheme follows methods naming scheme for consistency
 pipeline.add_task(
     "prepare_grch38_genes_table_for_public_release",
@@ -404,6 +405,8 @@ pipeline.add_task(
     f"/{genes_subdir}/gnomad.browser.GRCh38.GENCODEv39.ht",
     {
         "genes_path": pipeline.get_task("remove_grch38_genes_constraint_for_release"),
+    },
+    {
         "keep_mane_version_global_annotation": True,
     },
 )

--- a/graphql-api/src/queries/clinvar-variant-queries.ts
+++ b/graphql-api/src/queries/clinvar-variant-queries.ts
@@ -26,7 +26,9 @@ const _fetchClinvarReleaseDate = async (esClient: any) => {
   const releaseDates = metadata.map((m) => m.table_globals.clinvar_release_date)
 
   if (releaseDates[0] !== releaseDates[1]) {
-    logger.error({ message: 'ClinVar release dates do not match' })
+    logger.error({
+      message: `ClinVar release dates do not match. GRCh38: ${releaseDates[1]}, GRCh37: ${releaseDates[0]}`,
+    })
   }
 
   return releaseDates[0]

--- a/graphql-api/src/queries/clinvar-variant-queries.ts
+++ b/graphql-api/src/queries/clinvar-variant-queries.ts
@@ -9,8 +9,12 @@ import { getConsequenceForContext } from './variant-datasets/shared/transcriptCo
 import largeGenes from './helpers/large-genes'
 
 const CLINVAR_VARIANT_INDICES = {
-  GRCh37: 'clinvar_grch37_variants',
-  GRCh38: 'clinvar_grch38_variants',
+  // GRCh37: 'clinvar_grch37_variants',
+  // GRCh38: 'clinvar_grch38_variants',
+  // TODO: revert back to using alias'ed indexes once we are confident this is
+  //   stable in production
+  GRCh37: 'clinvar_grch37_variants-2024-11-08--19-22',
+  GRCh38: 'clinvar_grch38_variants-2024-11-08--13-08',
 }
 
 // ================================================================================================


### PR DESCRIPTION
Resolves #1569 

- Updates the ClinVar pipeline's XML parsing step to parse the new ClinVar XML format
- Minor edits to accomodate ClinVar updates
	- On the frontend, renames ClinVar's 'Clinical significance" to "germline classification", following ClinVar's change in terminology
	- Adds entries to the Gold Star mapping dictionary to accomodate new terminology
- Bumps Hail to 0.2.128 to allow for VEPing of GRCh37 varints using Hail's built in convenience function
- Still includes the commented out Aliases for ClinVar indices along with a "TODO:" comment. Following the practice of several previous PRs, temporarily specifying an index, rather than an alias, in this PR will allow for an easy rollback if needed. Once this proves stable in production, another PR will go back to using the aliases
 
---

Screenshots of a local browser and API querying an indice in the production ES cluster that uses data from the output of this PR:

- ![Screenshot 2024-11-08 at 16 00 52](https://github.com/user-attachments/assets/306e2fd8-1712-4934-b04e-244c8cf1c639)

- ![Screenshot 2024-11-08 at 16 01 06](https://github.com/user-attachments/assets/1ab844ac-af75-479b-af75-e897bce6f5c9)

- ![Screenshot 2024-11-08 at 16 01 09](https://github.com/user-attachments/assets/f604afbb-0601-4498-8614-607ebb73b009)

- ![Screenshot 2024-11-08 at 16 01 19](https://github.com/user-attachments/assets/853dd4ad-e7ca-47e6-9270-aa5b8cb9d08f)

- ![Screenshot 2024-11-08 at 16 02 31](https://github.com/user-attachments/assets/659eaadc-9fb6-4604-9b58-6e9a943797e0)

- ![Screenshot 2024-11-08 at 16 02 37](https://github.com/user-attachments/assets/2867c587-e342-4220-ad58-20bb90f63a89)