### PR TITLE
Update variant page grp frequency table styling

### DIFF
--- a/browser/src/StructuralVariantPage/__snapshots__/StructuralVariantPage.spec.tsx.snap
+++ b/browser/src/StructuralVariantPage/__snapshots__/StructuralVariantPage.spec.tsx.snap
@@ -403,7 +403,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with a complex varian
       Genetic Ancestry Group Frequencies
     </h2>
     <table
-      className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+      className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
     >
       <thead>
         <tr>
@@ -499,7 +499,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with a complex varian
       </thead>
       <tfoot>
         <tr
-          className="border"
+          className="strong-border"
         >
           <th
             colSpan={2}
@@ -1012,7 +1012,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with interchromosomal
       Genetic Ancestry Group Frequencies
     </h2>
     <table
-      className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+      className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
     >
       <thead>
         <tr>
@@ -1108,7 +1108,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with interchromosomal
       </thead>
       <tfoot>
         <tr
-          className="border"
+          className="strong-border"
         >
           <th
             colSpan={2}
@@ -1621,7 +1621,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with interchromosomal
       Genetic Ancestry Group Frequencies
     </h2>
     <table
-      className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+      className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
     >
       <thead>
         <tr>
@@ -1717,7 +1717,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with interchromosomal
       </thead>
       <tfoot>
         <tr
-          className="border"
+          className="strong-border"
         >
           <th
             colSpan={2}
@@ -2212,7 +2212,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
       Genetic Ancestry Group Frequencies
     </h2>
     <table
-      className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+      className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
     >
       <thead>
         <tr>
@@ -2308,7 +2308,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
       </thead>
       <tfoot>
         <tr
-          className="border"
+          className="strong-border"
         >
           <th
             colSpan={2}
@@ -2803,7 +2803,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
       Genetic Ancestry Group Frequencies
     </h2>
     <table
-      className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+      className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
     >
       <thead>
         <tr>
@@ -2899,7 +2899,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
       </thead>
       <tfoot>
         <tr
-          className="border"
+          className="strong-border"
         >
           <th
             colSpan={2}
@@ -3392,7 +3392,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
       Genetic Ancestry Group Frequencies
     </h2>
     <table
-      className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+      className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
     >
       <thead>
         <tr>
@@ -3488,7 +3488,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
       </thead>
       <tfoot>
         <tr
-          className="border"
+          className="strong-border"
         >
           <th
             colSpan={2}
@@ -3983,7 +3983,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
       Genetic Ancestry Group Frequencies
     </h2>
     <table
-      className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+      className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
     >
       <thead>
         <tr>
@@ -4079,7 +4079,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
       </thead>
       <tfoot>
         <tr
-          className="border"
+          className="strong-border"
         >
           <th
             colSpan={2}
@@ -4574,7 +4574,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
       Genetic Ancestry Group Frequencies
     </h2>
     <table
-      className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+      className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
     >
       <thead>
         <tr>
@@ -4652,7 +4652,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
       </thead>
       <tfoot>
         <tr
-          className="border"
+          className="strong-border"
         >
           <th
             colSpan={2}
@@ -5752,7 +5752,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with a compl
       Genetic Ancestry Group Frequencies
     </h2>
     <table
-      className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+      className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
     >
       <thead>
         <tr>
@@ -5848,7 +5848,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with a compl
       </thead>
       <tfoot>
         <tr
-          className="border"
+          className="strong-border"
         >
           <th
             colSpan={2}
@@ -6361,7 +6361,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with interch
       Genetic Ancestry Group Frequencies
     </h2>
     <table
-      className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+      className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
     >
       <thead>
         <tr>
@@ -6457,7 +6457,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with interch
       </thead>
       <tfoot>
         <tr
-          className="border"
+          className="strong-border"
         >
           <th
             colSpan={2}
@@ -6970,7 +6970,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with interch
       Genetic Ancestry Group Frequencies
     </h2>
     <table
-      className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+      className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
     >
       <thead>
         <tr>
@@ -7066,7 +7066,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with interch
       </thead>
       <tfoot>
         <tr
-          className="border"
+          className="strong-border"
         >
           <th
             colSpan={2}
@@ -7561,7 +7561,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
       Genetic Ancestry Group Frequencies
     </h2>
     <table
-      className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+      className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
     >
       <thead>
         <tr>
@@ -7657,7 +7657,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
       </thead>
       <tfoot>
         <tr
-          className="border"
+          className="strong-border"
         >
           <th
             colSpan={2}
@@ -8152,7 +8152,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
       Genetic Ancestry Group Frequencies
     </h2>
     <table
-      className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+      className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
     >
       <thead>
         <tr>
@@ -8248,7 +8248,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
       </thead>
       <tfoot>
         <tr
-          className="border"
+          className="strong-border"
         >
           <th
             colSpan={2}
@@ -8741,7 +8741,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
       Genetic Ancestry Group Frequencies
     </h2>
     <table
-      className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+      className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
     >
       <thead>
         <tr>
@@ -8837,7 +8837,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
       </thead>
       <tfoot>
         <tr
-          className="border"
+          className="strong-border"
         >
           <th
             colSpan={2}
@@ -9332,7 +9332,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
       Genetic Ancestry Group Frequencies
     </h2>
     <table
-      className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+      className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
     >
       <thead>
         <tr>
@@ -9428,7 +9428,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
       </thead>
       <tfoot>
         <tr
-          className="border"
+          className="strong-border"
         >
           <th
             colSpan={2}
@@ -9923,7 +9923,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
       Genetic Ancestry Group Frequencies
     </h2>
     <table
-      className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+      className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
     >
       <thead>
         <tr>
@@ -10001,7 +10001,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
       </thead>
       <tfoot>
         <tr
-          className="border"
+          className="strong-border"
         >
           <th
             colSpan={2}
@@ -11101,7 +11101,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with a comp
       Genetic Ancestry Group Frequencies
     </h2>
     <table
-      className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+      className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
     >
       <thead>
         <tr>
@@ -11197,7 +11197,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with a comp
       </thead>
       <tfoot>
         <tr
-          className="border"
+          className="strong-border"
         >
           <th
             colSpan={2}
@@ -11710,7 +11710,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with interc
       Genetic Ancestry Group Frequencies
     </h2>
     <table
-      className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+      className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
     >
       <thead>
         <tr>
@@ -11806,7 +11806,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with interc
       </thead>
       <tfoot>
         <tr
-          className="border"
+          className="strong-border"
         >
           <th
             colSpan={2}
@@ -12319,7 +12319,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with interc
       Genetic Ancestry Group Frequencies
     </h2>
     <table
-      className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+      className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
     >
       <thead>
         <tr>
@@ -12415,7 +12415,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with interc
       </thead>
       <tfoot>
         <tr
-          className="border"
+          className="strong-border"
         >
           <th
             colSpan={2}
@@ -12910,7 +12910,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
       Genetic Ancestry Group Frequencies
     </h2>
     <table
-      className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+      className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
     >
       <thead>
         <tr>
@@ -13006,7 +13006,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
       </thead>
       <tfoot>
         <tr
-          className="border"
+          className="strong-border"
         >
           <th
             colSpan={2}
@@ -13501,7 +13501,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
       Genetic Ancestry Group Frequencies
     </h2>
     <table
-      className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+      className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
     >
       <thead>
         <tr>
@@ -13597,7 +13597,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
       </thead>
       <tfoot>
         <tr
-          className="border"
+          className="strong-border"
         >
           <th
             colSpan={2}
@@ -14090,7 +14090,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
       Genetic Ancestry Group Frequencies
     </h2>
     <table
-      className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+      className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
     >
       <thead>
         <tr>
@@ -14186,7 +14186,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
       </thead>
       <tfoot>
         <tr
-          className="border"
+          className="strong-border"
         >
           <th
             colSpan={2}
@@ -14681,7 +14681,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
       Genetic Ancestry Group Frequencies
     </h2>
     <table
-      className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+      className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
     >
       <thead>
         <tr>
@@ -14777,7 +14777,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
       </thead>
       <tfoot>
         <tr
-          className="border"
+          className="strong-border"
         >
           <th
             colSpan={2}
@@ -15272,7 +15272,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
       Genetic Ancestry Group Frequencies
     </h2>
     <table
-      className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+      className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
     >
       <thead>
         <tr>
@@ -15350,7 +15350,7 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
       </thead>
       <tfoot>
         <tr
-          className="border"
+          className="strong-border"
         >
           <th
             colSpan={2}

--- a/browser/src/VariantPage/__snapshots__/GnomadPopulationsTable.spec.tsx.snap
+++ b/browser/src/VariantPage/__snapshots__/GnomadPopulationsTable.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`GnomadPopulationsTable with a dataset of exac has no unexpected changes 1`] = `
 [
   <table
-    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
   >
     <thead>
       <tr>
@@ -97,10 +97,10 @@ exports[`GnomadPopulationsTable with a dataset of exac has no unexpected changes
         </th>
       </tr>
     </thead>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="strong-border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
@@ -134,10 +134,10 @@ exports[`GnomadPopulationsTable with a dataset of exac has no unexpected changes
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
@@ -171,17 +171,17 @@ exports[`GnomadPopulationsTable with a dataset of exac has no unexpected changes
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -214,17 +214,17 @@ exports[`GnomadPopulationsTable with a dataset of exac has no unexpected changes
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -257,17 +257,17 @@ exports[`GnomadPopulationsTable with a dataset of exac has no unexpected changes
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -300,17 +300,17 @@ exports[`GnomadPopulationsTable with a dataset of exac has no unexpected changes
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -343,17 +343,17 @@ exports[`GnomadPopulationsTable with a dataset of exac has no unexpected changes
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -386,9 +386,7 @@ exports[`GnomadPopulationsTable with a dataset of exac has no unexpected changes
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
+    <tbody>
       <tr
         className="border"
       >
@@ -425,9 +423,7 @@ exports[`GnomadPopulationsTable with a dataset of exac has no unexpected changes
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
+    <tbody>
       <tr>
         <th
           colSpan={2}
@@ -464,7 +460,7 @@ exports[`GnomadPopulationsTable with a dataset of exac has no unexpected changes
     </tbody>
     <tfoot>
       <tr
-        className="border"
+        className="strong-border"
       >
         <th
           colSpan={2}
@@ -538,7 +534,7 @@ exports[`GnomadPopulationsTable with a dataset of exac has no unexpected changes
 exports[`GnomadPopulationsTable with a dataset of exac has no unexpected changes when missing genetic ancestry groups are filled in 1`] = `
 [
   <table
-    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
   >
     <thead>
       <tr>
@@ -632,17 +628,17 @@ exports[`GnomadPopulationsTable with a dataset of exac has no unexpected changes
         </th>
       </tr>
     </thead>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="strong-border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -675,17 +671,17 @@ exports[`GnomadPopulationsTable with a dataset of exac has no unexpected changes
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -718,17 +714,17 @@ exports[`GnomadPopulationsTable with a dataset of exac has no unexpected changes
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -761,17 +757,17 @@ exports[`GnomadPopulationsTable with a dataset of exac has no unexpected changes
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -804,17 +800,17 @@ exports[`GnomadPopulationsTable with a dataset of exac has no unexpected changes
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -847,17 +843,17 @@ exports[`GnomadPopulationsTable with a dataset of exac has no unexpected changes
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -890,17 +886,17 @@ exports[`GnomadPopulationsTable with a dataset of exac has no unexpected changes
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -935,7 +931,7 @@ exports[`GnomadPopulationsTable with a dataset of exac has no unexpected changes
     </tbody>
     <tfoot>
       <tr
-        className="border"
+        className="strong-border"
       >
         <th
           colSpan={2}
@@ -1009,7 +1005,7 @@ exports[`GnomadPopulationsTable with a dataset of exac has no unexpected changes
 exports[`GnomadPopulationsTable with a dataset of gnomad_cnv_r4 has no unexpected changes 1`] = `
 [
   <table
-    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
   >
     <thead>
       <tr>
@@ -1103,10 +1099,10 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_cnv_r4 has no unexpecte
         </th>
       </tr>
     </thead>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="strong-border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
@@ -1140,10 +1136,10 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_cnv_r4 has no unexpecte
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
@@ -1177,17 +1173,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_cnv_r4 has no unexpecte
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -1220,17 +1216,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_cnv_r4 has no unexpecte
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -1263,17 +1259,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_cnv_r4 has no unexpecte
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -1306,17 +1302,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_cnv_r4 has no unexpecte
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -1349,17 +1345,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_cnv_r4 has no unexpecte
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -1392,17 +1388,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_cnv_r4 has no unexpecte
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -1435,17 +1431,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_cnv_r4 has no unexpecte
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -1478,17 +1474,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_cnv_r4 has no unexpecte
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -1521,9 +1517,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_cnv_r4 has no unexpecte
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
+    <tbody>
       <tr
         className="border"
       >
@@ -1560,9 +1554,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_cnv_r4 has no unexpecte
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
+    <tbody>
       <tr>
         <th
           colSpan={2}
@@ -1599,7 +1591,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_cnv_r4 has no unexpecte
     </tbody>
     <tfoot>
       <tr
-        className="border"
+        className="strong-border"
       >
         <th
           colSpan={2}
@@ -1673,7 +1665,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_cnv_r4 has no unexpecte
 exports[`GnomadPopulationsTable with a dataset of gnomad_cnv_r4 has no unexpected changes when missing genetic ancestry groups are filled in 1`] = `
 [
   <table
-    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
   >
     <thead>
       <tr>
@@ -1767,10 +1759,10 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_cnv_r4 has no unexpecte
         </th>
       </tr>
     </thead>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="strong-border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
@@ -1804,10 +1796,10 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_cnv_r4 has no unexpecte
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
@@ -1841,17 +1833,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_cnv_r4 has no unexpecte
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -1884,17 +1876,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_cnv_r4 has no unexpecte
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -1927,17 +1919,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_cnv_r4 has no unexpecte
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -1970,17 +1962,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_cnv_r4 has no unexpecte
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -2013,17 +2005,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_cnv_r4 has no unexpecte
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -2056,17 +2048,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_cnv_r4 has no unexpecte
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -2099,17 +2091,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_cnv_r4 has no unexpecte
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -2142,17 +2134,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_cnv_r4 has no unexpecte
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -2185,9 +2177,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_cnv_r4 has no unexpecte
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
+    <tbody>
       <tr
         className="border"
       >
@@ -2224,9 +2214,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_cnv_r4 has no unexpecte
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
+    <tbody>
       <tr>
         <th
           colSpan={2}
@@ -2263,7 +2251,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_cnv_r4 has no unexpecte
     </tbody>
     <tfoot>
       <tr
-        className="border"
+        className="strong-border"
       >
         <th
           colSpan={2}
@@ -2337,7 +2325,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_cnv_r4 has no unexpecte
 exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1 has no unexpected changes 1`] = `
 [
   <table
-    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
   >
     <thead>
       <tr>
@@ -2431,10 +2419,10 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1 has no unexpected 
         </th>
       </tr>
     </thead>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="strong-border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
@@ -2468,17 +2456,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1 has no unexpected 
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -2511,17 +2499,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1 has no unexpected 
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -2554,17 +2542,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1 has no unexpected 
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -2597,17 +2585,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1 has no unexpected 
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -2640,17 +2628,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1 has no unexpected 
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -2683,17 +2671,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1 has no unexpected 
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -2726,17 +2714,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1 has no unexpected 
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -2769,9 +2757,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1 has no unexpected 
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
+    <tbody>
       <tr
         className="border"
       >
@@ -2808,9 +2794,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1 has no unexpected 
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
+    <tbody>
       <tr>
         <th
           colSpan={2}
@@ -2847,7 +2831,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1 has no unexpected 
     </tbody>
     <tfoot>
       <tr
-        className="border"
+        className="strong-border"
       >
         <th
           colSpan={2}
@@ -2924,7 +2908,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1 has no unexpected 
 exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1 has no unexpected changes when missing genetic ancestry groups are filled in 1`] = `
 [
   <table
-    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
   >
     <thead>
       <tr>
@@ -3018,17 +3002,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1 has no unexpected 
         </th>
       </tr>
     </thead>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="strong-border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -3061,17 +3045,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1 has no unexpected 
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -3104,17 +3088,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1 has no unexpected 
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -3147,17 +3131,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1 has no unexpected 
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -3190,17 +3174,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1 has no unexpected 
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -3233,17 +3217,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1 has no unexpected 
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -3276,17 +3260,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1 has no unexpected 
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -3319,17 +3303,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1 has no unexpected 
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -3364,7 +3348,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1 has no unexpected 
     </tbody>
     <tfoot>
       <tr
-        className="border"
+        className="strong-border"
       >
         <th
           colSpan={2}
@@ -3438,7 +3422,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1 has no unexpected 
 exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_controls has no unexpected changes 1`] = `
 [
   <table
-    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
   >
     <thead>
       <tr>
@@ -3532,10 +3516,10 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_controls has no un
         </th>
       </tr>
     </thead>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="strong-border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
@@ -3569,17 +3553,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_controls has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -3612,17 +3596,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_controls has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -3655,17 +3639,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_controls has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -3698,17 +3682,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_controls has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -3741,17 +3725,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_controls has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -3784,17 +3768,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_controls has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -3827,17 +3811,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_controls has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -3870,9 +3854,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_controls has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
+    <tbody>
       <tr
         className="border"
       >
@@ -3909,9 +3891,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_controls has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
+    <tbody>
       <tr>
         <th
           colSpan={2}
@@ -3948,7 +3928,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_controls has no un
     </tbody>
     <tfoot>
       <tr
-        className="border"
+        className="strong-border"
       >
         <th
           colSpan={2}
@@ -4025,7 +4005,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_controls has no un
 exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_controls has no unexpected changes when missing genetic ancestry groups are filled in 1`] = `
 [
   <table
-    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
   >
     <thead>
       <tr>
@@ -4119,17 +4099,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_controls has no un
         </th>
       </tr>
     </thead>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="strong-border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -4162,17 +4142,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_controls has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -4205,17 +4185,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_controls has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -4248,17 +4228,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_controls has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -4291,17 +4271,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_controls has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -4334,17 +4314,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_controls has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -4377,17 +4357,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_controls has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -4420,17 +4400,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_controls has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -4465,7 +4445,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_controls has no un
     </tbody>
     <tfoot>
       <tr
-        className="border"
+        className="strong-border"
       >
         <th
           colSpan={2}
@@ -4539,7 +4519,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_controls has no un
 exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_cancer has no unexpected changes 1`] = `
 [
   <table
-    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
   >
     <thead>
       <tr>
@@ -4633,10 +4613,10 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_cancer has no 
         </th>
       </tr>
     </thead>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="strong-border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
@@ -4670,17 +4650,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_cancer has no 
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -4713,17 +4693,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_cancer has no 
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -4756,17 +4736,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_cancer has no 
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -4799,17 +4779,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_cancer has no 
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -4842,17 +4822,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_cancer has no 
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -4885,17 +4865,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_cancer has no 
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -4928,17 +4908,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_cancer has no 
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -4971,9 +4951,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_cancer has no 
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
+    <tbody>
       <tr
         className="border"
       >
@@ -5010,9 +4988,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_cancer has no 
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
+    <tbody>
       <tr>
         <th
           colSpan={2}
@@ -5049,7 +5025,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_cancer has no 
     </tbody>
     <tfoot>
       <tr
-        className="border"
+        className="strong-border"
       >
         <th
           colSpan={2}
@@ -5126,7 +5102,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_cancer has no 
 exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_cancer has no unexpected changes when missing genetic ancestry groups are filled in 1`] = `
 [
   <table
-    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
   >
     <thead>
       <tr>
@@ -5220,17 +5196,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_cancer has no 
         </th>
       </tr>
     </thead>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="strong-border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -5263,17 +5239,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_cancer has no 
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -5306,17 +5282,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_cancer has no 
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -5349,17 +5325,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_cancer has no 
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -5392,17 +5368,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_cancer has no 
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -5435,17 +5411,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_cancer has no 
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -5478,17 +5454,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_cancer has no 
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -5521,17 +5497,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_cancer has no 
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -5566,7 +5542,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_cancer has no 
     </tbody>
     <tfoot>
       <tr
-        className="border"
+        className="strong-border"
       >
         <th
           colSpan={2}
@@ -5640,7 +5616,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_cancer has no 
 exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_neuro has no unexpected changes 1`] = `
 [
   <table
-    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
   >
     <thead>
       <tr>
@@ -5734,10 +5710,10 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_neuro has no u
         </th>
       </tr>
     </thead>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="strong-border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
@@ -5771,17 +5747,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_neuro has no u
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -5814,17 +5790,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_neuro has no u
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -5857,17 +5833,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_neuro has no u
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -5900,17 +5876,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_neuro has no u
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -5943,17 +5919,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_neuro has no u
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -5986,17 +5962,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_neuro has no u
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -6029,17 +6005,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_neuro has no u
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -6072,9 +6048,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_neuro has no u
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
+    <tbody>
       <tr
         className="border"
       >
@@ -6111,9 +6085,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_neuro has no u
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
+    <tbody>
       <tr>
         <th
           colSpan={2}
@@ -6150,7 +6122,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_neuro has no u
     </tbody>
     <tfoot>
       <tr
-        className="border"
+        className="strong-border"
       >
         <th
           colSpan={2}
@@ -6227,7 +6199,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_neuro has no u
 exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_neuro has no unexpected changes when missing genetic ancestry groups are filled in 1`] = `
 [
   <table
-    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
   >
     <thead>
       <tr>
@@ -6321,17 +6293,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_neuro has no u
         </th>
       </tr>
     </thead>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="strong-border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -6364,17 +6336,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_neuro has no u
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -6407,17 +6379,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_neuro has no u
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -6450,17 +6422,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_neuro has no u
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -6493,17 +6465,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_neuro has no u
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -6536,17 +6508,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_neuro has no u
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -6579,17 +6551,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_neuro has no u
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -6622,17 +6594,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_neuro has no u
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -6667,7 +6639,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_neuro has no u
     </tbody>
     <tfoot>
       <tr
-        className="border"
+        className="strong-border"
       >
         <th
           colSpan={2}
@@ -6741,7 +6713,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_neuro has no u
 exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_topmed has no unexpected changes 1`] = `
 [
   <table
-    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
   >
     <thead>
       <tr>
@@ -6835,10 +6807,10 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_topmed has no 
         </th>
       </tr>
     </thead>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="strong-border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
@@ -6872,17 +6844,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_topmed has no 
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -6915,17 +6887,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_topmed has no 
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -6958,17 +6930,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_topmed has no 
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -7001,17 +6973,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_topmed has no 
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -7044,17 +7016,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_topmed has no 
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -7087,17 +7059,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_topmed has no 
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -7130,17 +7102,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_topmed has no 
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -7173,9 +7145,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_topmed has no 
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
+    <tbody>
       <tr
         className="border"
       >
@@ -7212,9 +7182,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_topmed has no 
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
+    <tbody>
       <tr>
         <th
           colSpan={2}
@@ -7251,7 +7219,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_topmed has no 
     </tbody>
     <tfoot>
       <tr
-        className="border"
+        className="strong-border"
       >
         <th
           colSpan={2}
@@ -7328,7 +7296,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_topmed has no 
 exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_topmed has no unexpected changes when missing genetic ancestry groups are filled in 1`] = `
 [
   <table
-    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
   >
     <thead>
       <tr>
@@ -7422,17 +7390,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_topmed has no 
         </th>
       </tr>
     </thead>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="strong-border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -7465,17 +7433,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_topmed has no 
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -7508,17 +7476,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_topmed has no 
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -7551,17 +7519,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_topmed has no 
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -7594,17 +7562,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_topmed has no 
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -7637,17 +7605,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_topmed has no 
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -7680,17 +7648,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_topmed has no 
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -7723,17 +7691,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_topmed has no 
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -7768,7 +7736,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_topmed has no 
     </tbody>
     <tfoot>
       <tr
-        className="border"
+        className="strong-border"
       >
         <th
           colSpan={2}
@@ -7842,7 +7810,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r2_1_non_topmed has no 
 exports[`GnomadPopulationsTable with a dataset of gnomad_r3 has no unexpected changes 1`] = `
 [
   <table
-    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
   >
     <thead>
       <tr>
@@ -7936,10 +7904,10 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3 has no unexpected ch
         </th>
       </tr>
     </thead>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="strong-border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
@@ -7973,17 +7941,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3 has no unexpected ch
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -8016,17 +7984,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3 has no unexpected ch
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -8059,17 +8027,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3 has no unexpected ch
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -8102,17 +8070,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3 has no unexpected ch
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -8145,17 +8113,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3 has no unexpected ch
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -8188,17 +8156,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3 has no unexpected ch
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -8231,17 +8199,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3 has no unexpected ch
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -8274,17 +8242,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3 has no unexpected ch
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -8317,17 +8285,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3 has no unexpected ch
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -8360,9 +8328,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3 has no unexpected ch
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
+    <tbody>
       <tr
         className="border"
       >
@@ -8399,9 +8365,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3 has no unexpected ch
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
+    <tbody>
       <tr>
         <th
           colSpan={2}
@@ -8438,7 +8402,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3 has no unexpected ch
     </tbody>
     <tfoot>
       <tr
-        className="border"
+        className="strong-border"
       >
         <th
           colSpan={2}
@@ -8512,7 +8476,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3 has no unexpected ch
 exports[`GnomadPopulationsTable with a dataset of gnomad_r3 has no unexpected changes when missing genetic ancestry groups are filled in 1`] = `
 [
   <table
-    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
   >
     <thead>
       <tr>
@@ -8606,17 +8570,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3 has no unexpected ch
         </th>
       </tr>
     </thead>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="strong-border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -8649,17 +8613,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3 has no unexpected ch
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -8692,17 +8656,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3 has no unexpected ch
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -8735,17 +8699,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3 has no unexpected ch
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -8778,17 +8742,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3 has no unexpected ch
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -8821,17 +8785,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3 has no unexpected ch
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -8864,17 +8828,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3 has no unexpected ch
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -8907,17 +8871,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3 has no unexpected ch
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -8950,17 +8914,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3 has no unexpected ch
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -8993,17 +8957,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3 has no unexpected ch
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -9038,7 +9002,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3 has no unexpected ch
     </tbody>
     <tfoot>
       <tr
-        className="border"
+        className="strong-border"
       >
         <th
           colSpan={2}
@@ -9112,7 +9076,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3 has no unexpected ch
 exports[`GnomadPopulationsTable with a dataset of gnomad_r3_controls_and_biobanks has no unexpected changes 1`] = `
 [
   <table
-    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
   >
     <thead>
       <tr>
@@ -9206,10 +9170,10 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_controls_and_biobank
         </th>
       </tr>
     </thead>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="strong-border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
@@ -9243,17 +9207,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_controls_and_biobank
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -9286,17 +9250,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_controls_and_biobank
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -9329,17 +9293,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_controls_and_biobank
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -9372,17 +9336,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_controls_and_biobank
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -9415,17 +9379,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_controls_and_biobank
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -9458,17 +9422,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_controls_and_biobank
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -9501,17 +9465,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_controls_and_biobank
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -9544,17 +9508,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_controls_and_biobank
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -9587,17 +9551,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_controls_and_biobank
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -9630,9 +9594,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_controls_and_biobank
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
+    <tbody>
       <tr
         className="border"
       >
@@ -9669,9 +9631,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_controls_and_biobank
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
+    <tbody>
       <tr>
         <th
           colSpan={2}
@@ -9708,7 +9668,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_controls_and_biobank
     </tbody>
     <tfoot>
       <tr
-        className="border"
+        className="strong-border"
       >
         <th
           colSpan={2}
@@ -9782,7 +9742,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_controls_and_biobank
 exports[`GnomadPopulationsTable with a dataset of gnomad_r3_controls_and_biobanks has no unexpected changes when missing genetic ancestry groups are filled in 1`] = `
 [
   <table
-    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
   >
     <thead>
       <tr>
@@ -9876,17 +9836,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_controls_and_biobank
         </th>
       </tr>
     </thead>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="strong-border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -9919,17 +9879,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_controls_and_biobank
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -9962,17 +9922,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_controls_and_biobank
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -10005,17 +9965,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_controls_and_biobank
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -10048,17 +10008,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_controls_and_biobank
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -10091,17 +10051,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_controls_and_biobank
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -10134,17 +10094,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_controls_and_biobank
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -10177,17 +10137,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_controls_and_biobank
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -10220,17 +10180,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_controls_and_biobank
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -10263,17 +10223,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_controls_and_biobank
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -10308,7 +10268,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_controls_and_biobank
     </tbody>
     <tfoot>
       <tr
-        className="border"
+        className="strong-border"
       >
         <th
           colSpan={2}
@@ -10382,7 +10342,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_controls_and_biobank
 exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_cancer has no unexpected changes 1`] = `
 [
   <table
-    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
   >
     <thead>
       <tr>
@@ -10476,10 +10436,10 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_cancer has no un
         </th>
       </tr>
     </thead>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="strong-border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
@@ -10513,17 +10473,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_cancer has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -10556,17 +10516,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_cancer has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -10599,17 +10559,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_cancer has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -10642,17 +10602,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_cancer has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -10685,17 +10645,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_cancer has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -10728,17 +10688,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_cancer has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -10771,17 +10731,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_cancer has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -10814,17 +10774,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_cancer has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -10857,17 +10817,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_cancer has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -10900,9 +10860,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_cancer has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
+    <tbody>
       <tr
         className="border"
       >
@@ -10939,9 +10897,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_cancer has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
+    <tbody>
       <tr>
         <th
           colSpan={2}
@@ -10978,7 +10934,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_cancer has no un
     </tbody>
     <tfoot>
       <tr
-        className="border"
+        className="strong-border"
       >
         <th
           colSpan={2}
@@ -11052,7 +11008,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_cancer has no un
 exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_cancer has no unexpected changes when missing genetic ancestry groups are filled in 1`] = `
 [
   <table
-    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
   >
     <thead>
       <tr>
@@ -11146,17 +11102,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_cancer has no un
         </th>
       </tr>
     </thead>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="strong-border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -11189,17 +11145,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_cancer has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -11232,17 +11188,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_cancer has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -11275,17 +11231,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_cancer has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -11318,17 +11274,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_cancer has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -11361,17 +11317,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_cancer has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -11404,17 +11360,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_cancer has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -11447,17 +11403,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_cancer has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -11490,17 +11446,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_cancer has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -11533,17 +11489,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_cancer has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -11578,7 +11534,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_cancer has no un
     </tbody>
     <tfoot>
       <tr
-        className="border"
+        className="strong-border"
       >
         <th
           colSpan={2}
@@ -11652,7 +11608,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_cancer has no un
 exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_neuro has no unexpected changes 1`] = `
 [
   <table
-    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
   >
     <thead>
       <tr>
@@ -11746,10 +11702,10 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_neuro has no une
         </th>
       </tr>
     </thead>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="strong-border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
@@ -11783,17 +11739,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_neuro has no une
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -11826,17 +11782,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_neuro has no une
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -11869,17 +11825,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_neuro has no une
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -11912,17 +11868,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_neuro has no une
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -11955,17 +11911,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_neuro has no une
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -11998,17 +11954,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_neuro has no une
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -12041,17 +11997,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_neuro has no une
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -12084,17 +12040,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_neuro has no une
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -12127,17 +12083,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_neuro has no une
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -12170,9 +12126,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_neuro has no une
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
+    <tbody>
       <tr
         className="border"
       >
@@ -12209,9 +12163,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_neuro has no une
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
+    <tbody>
       <tr>
         <th
           colSpan={2}
@@ -12248,7 +12200,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_neuro has no une
     </tbody>
     <tfoot>
       <tr
-        className="border"
+        className="strong-border"
       >
         <th
           colSpan={2}
@@ -12322,7 +12274,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_neuro has no une
 exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_neuro has no unexpected changes when missing genetic ancestry groups are filled in 1`] = `
 [
   <table
-    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
   >
     <thead>
       <tr>
@@ -12416,17 +12368,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_neuro has no une
         </th>
       </tr>
     </thead>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="strong-border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -12459,17 +12411,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_neuro has no une
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -12502,17 +12454,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_neuro has no une
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -12545,17 +12497,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_neuro has no une
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -12588,17 +12540,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_neuro has no une
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -12631,17 +12583,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_neuro has no une
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -12674,17 +12626,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_neuro has no une
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -12717,17 +12669,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_neuro has no une
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -12760,17 +12712,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_neuro has no une
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -12803,17 +12755,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_neuro has no une
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -12848,7 +12800,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_neuro has no une
     </tbody>
     <tfoot>
       <tr
-        className="border"
+        className="strong-border"
       >
         <th
           colSpan={2}
@@ -12922,7 +12874,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_neuro has no une
 exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_topmed has no unexpected changes 1`] = `
 [
   <table
-    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
   >
     <thead>
       <tr>
@@ -13016,10 +12968,10 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_topmed has no un
         </th>
       </tr>
     </thead>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="strong-border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
@@ -13053,17 +13005,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_topmed has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -13096,17 +13048,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_topmed has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -13139,17 +13091,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_topmed has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -13182,17 +13134,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_topmed has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -13225,17 +13177,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_topmed has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -13268,17 +13220,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_topmed has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -13311,17 +13263,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_topmed has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -13354,17 +13306,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_topmed has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -13397,17 +13349,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_topmed has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -13440,9 +13392,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_topmed has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
+    <tbody>
       <tr
         className="border"
       >
@@ -13479,9 +13429,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_topmed has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
+    <tbody>
       <tr>
         <th
           colSpan={2}
@@ -13518,7 +13466,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_topmed has no un
     </tbody>
     <tfoot>
       <tr
-        className="border"
+        className="strong-border"
       >
         <th
           colSpan={2}
@@ -13592,7 +13540,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_topmed has no un
 exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_topmed has no unexpected changes when missing genetic ancestry groups are filled in 1`] = `
 [
   <table
-    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
   >
     <thead>
       <tr>
@@ -13686,17 +13634,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_topmed has no un
         </th>
       </tr>
     </thead>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="strong-border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -13729,17 +13677,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_topmed has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -13772,17 +13720,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_topmed has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -13815,17 +13763,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_topmed has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -13858,17 +13806,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_topmed has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -13901,17 +13849,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_topmed has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -13944,17 +13892,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_topmed has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -13987,17 +13935,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_topmed has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -14030,17 +13978,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_topmed has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -14073,17 +14021,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_topmed has no un
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -14118,7 +14066,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_topmed has no un
     </tbody>
     <tfoot>
       <tr
-        className="border"
+        className="strong-border"
       >
         <th
           colSpan={2}
@@ -14192,7 +14140,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_topmed has no un
 exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_v2 has no unexpected changes 1`] = `
 [
   <table
-    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
   >
     <thead>
       <tr>
@@ -14286,10 +14234,10 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_v2 has no unexpe
         </th>
       </tr>
     </thead>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="strong-border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
@@ -14323,17 +14271,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_v2 has no unexpe
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -14366,17 +14314,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_v2 has no unexpe
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -14409,17 +14357,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_v2 has no unexpe
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -14452,17 +14400,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_v2 has no unexpe
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -14495,17 +14443,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_v2 has no unexpe
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -14538,17 +14486,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_v2 has no unexpe
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -14581,17 +14529,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_v2 has no unexpe
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -14624,17 +14572,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_v2 has no unexpe
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -14667,17 +14615,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_v2 has no unexpe
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -14710,9 +14658,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_v2 has no unexpe
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
+    <tbody>
       <tr
         className="border"
       >
@@ -14749,9 +14695,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_v2 has no unexpe
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
+    <tbody>
       <tr>
         <th
           colSpan={2}
@@ -14788,7 +14732,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_v2 has no unexpe
     </tbody>
     <tfoot>
       <tr
-        className="border"
+        className="strong-border"
       >
         <th
           colSpan={2}
@@ -14862,7 +14806,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_v2 has no unexpe
 exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_v2 has no unexpected changes when missing genetic ancestry groups are filled in 1`] = `
 [
   <table
-    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
   >
     <thead>
       <tr>
@@ -14956,17 +14900,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_v2 has no unexpe
         </th>
       </tr>
     </thead>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="strong-border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -14999,17 +14943,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_v2 has no unexpe
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -15042,17 +14986,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_v2 has no unexpe
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -15085,17 +15029,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_v2 has no unexpe
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -15128,17 +15072,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_v2 has no unexpe
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -15171,17 +15115,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_v2 has no unexpe
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -15214,17 +15158,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_v2 has no unexpe
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -15257,17 +15201,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_v2 has no unexpe
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -15300,17 +15244,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_v2 has no unexpe
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -15343,17 +15287,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_v2 has no unexpe
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -15388,7 +15332,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_v2 has no unexpe
     </tbody>
     <tfoot>
       <tr
-        className="border"
+        className="strong-border"
       >
         <th
           colSpan={2}
@@ -15462,7 +15406,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r3_non_v2 has no unexpe
 exports[`GnomadPopulationsTable with a dataset of gnomad_r4 has no unexpected changes 1`] = `
 [
   <table
-    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
   >
     <thead>
       <tr>
@@ -15556,10 +15500,10 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4 has no unexpected ch
         </th>
       </tr>
     </thead>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="strong-border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
@@ -15593,10 +15537,10 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4 has no unexpected ch
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
@@ -15630,17 +15574,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4 has no unexpected ch
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -15673,17 +15617,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4 has no unexpected ch
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -15716,17 +15660,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4 has no unexpected ch
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -15759,17 +15703,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4 has no unexpected ch
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -15802,17 +15746,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4 has no unexpected ch
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -15845,17 +15789,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4 has no unexpected ch
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -15888,17 +15832,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4 has no unexpected ch
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -15931,17 +15875,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4 has no unexpected ch
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -15974,9 +15918,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4 has no unexpected ch
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
+    <tbody>
       <tr
         className="border"
       >
@@ -16013,9 +15955,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4 has no unexpected ch
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
+    <tbody>
       <tr>
         <th
           colSpan={2}
@@ -16052,7 +15992,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4 has no unexpected ch
     </tbody>
     <tfoot>
       <tr
-        className="border"
+        className="strong-border"
       >
         <th
           colSpan={2}
@@ -16126,7 +16066,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4 has no unexpected ch
 exports[`GnomadPopulationsTable with a dataset of gnomad_r4 has no unexpected changes when missing genetic ancestry groups are filled in 1`] = `
 [
   <table
-    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
   >
     <thead>
       <tr>
@@ -16220,10 +16160,10 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4 has no unexpected ch
         </th>
       </tr>
     </thead>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="strong-border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
@@ -16257,10 +16197,10 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4 has no unexpected ch
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
@@ -16294,17 +16234,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4 has no unexpected ch
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -16337,17 +16277,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4 has no unexpected ch
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -16380,17 +16320,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4 has no unexpected ch
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -16423,17 +16363,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4 has no unexpected ch
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -16466,17 +16406,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4 has no unexpected ch
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -16509,17 +16449,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4 has no unexpected ch
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -16552,17 +16492,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4 has no unexpected ch
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -16595,17 +16535,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4 has no unexpected ch
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -16638,9 +16578,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4 has no unexpected ch
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
+    <tbody>
       <tr
         className="border"
       >
@@ -16677,9 +16615,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4 has no unexpected ch
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
+    <tbody>
       <tr>
         <th
           colSpan={2}
@@ -16716,7 +16652,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4 has no unexpected ch
     </tbody>
     <tfoot>
       <tr
-        className="border"
+        className="strong-border"
       >
         <th
           colSpan={2}
@@ -16790,7 +16726,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4 has no unexpected ch
 exports[`GnomadPopulationsTable with a dataset of gnomad_r4_non_ukb has no unexpected changes 1`] = `
 [
   <table
-    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
   >
     <thead>
       <tr>
@@ -16884,10 +16820,10 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4_non_ukb has no unexp
         </th>
       </tr>
     </thead>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="strong-border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
@@ -16921,10 +16857,10 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4_non_ukb has no unexp
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
@@ -16958,17 +16894,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4_non_ukb has no unexp
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -17001,17 +16937,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4_non_ukb has no unexp
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -17044,17 +16980,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4_non_ukb has no unexp
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -17087,17 +17023,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4_non_ukb has no unexp
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -17130,17 +17066,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4_non_ukb has no unexp
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -17173,17 +17109,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4_non_ukb has no unexp
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -17216,17 +17152,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4_non_ukb has no unexp
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -17259,17 +17195,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4_non_ukb has no unexp
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -17302,9 +17238,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4_non_ukb has no unexp
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
+    <tbody>
       <tr
         className="border"
       >
@@ -17341,9 +17275,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4_non_ukb has no unexp
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
+    <tbody>
       <tr>
         <th
           colSpan={2}
@@ -17380,7 +17312,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4_non_ukb has no unexp
     </tbody>
     <tfoot>
       <tr
-        className="border"
+        className="strong-border"
       >
         <th
           colSpan={2}
@@ -17454,7 +17386,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4_non_ukb has no unexp
 exports[`GnomadPopulationsTable with a dataset of gnomad_r4_non_ukb has no unexpected changes when missing genetic ancestry groups are filled in 1`] = `
 [
   <table
-    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
   >
     <thead>
       <tr>
@@ -17548,10 +17480,10 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4_non_ukb has no unexp
         </th>
       </tr>
     </thead>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="strong-border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
@@ -17585,10 +17517,10 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4_non_ukb has no unexp
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
@@ -17622,17 +17554,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4_non_ukb has no unexp
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -17665,17 +17597,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4_non_ukb has no unexp
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -17708,17 +17640,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4_non_ukb has no unexp
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -17751,17 +17683,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4_non_ukb has no unexp
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -17794,17 +17726,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4_non_ukb has no unexp
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -17837,17 +17769,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4_non_ukb has no unexp
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -17880,17 +17812,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4_non_ukb has no unexp
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -17923,17 +17855,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4_non_ukb has no unexp
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -17966,9 +17898,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4_non_ukb has no unexp
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
+    <tbody>
       <tr
         className="border"
       >
@@ -18005,9 +17935,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4_non_ukb has no unexp
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
+    <tbody>
       <tr>
         <th
           colSpan={2}
@@ -18044,7 +17972,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4_non_ukb has no unexp
     </tbody>
     <tfoot>
       <tr
-        className="border"
+        className="strong-border"
       >
         <th
           colSpan={2}
@@ -18118,7 +18046,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_r4_non_ukb has no unexp
 exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r2_1 has no unexpected changes 1`] = `
 [
   <table
-    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
   >
     <thead>
       <tr>
@@ -18212,10 +18140,10 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r2_1 has no unexpect
         </th>
       </tr>
     </thead>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="strong-border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
@@ -18249,9 +18177,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r2_1 has no unexpect
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
+    <tbody>
       <tr>
         <th
           colSpan={2}
@@ -18288,7 +18214,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r2_1 has no unexpect
     </tbody>
     <tfoot>
       <tr
-        className="border"
+        className="strong-border"
       >
         <th
           colSpan={2}
@@ -18362,7 +18288,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r2_1 has no unexpect
 exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r2_1 has no unexpected changes when missing genetic ancestry groups are filled in 1`] = `
 [
   <table
-    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
   >
     <thead>
       <tr>
@@ -18458,7 +18384,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r2_1 has no unexpect
     </thead>
     <tfoot>
       <tr
-        className="border"
+        className="strong-border"
       >
         <th
           colSpan={2}
@@ -18532,7 +18458,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r2_1 has no unexpect
 exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r2_1_controls has no unexpected changes 1`] = `
 [
   <table
-    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
   >
     <thead>
       <tr>
@@ -18626,10 +18552,10 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r2_1_controls has no
         </th>
       </tr>
     </thead>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="strong-border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
@@ -18663,9 +18589,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r2_1_controls has no
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
+    <tbody>
       <tr>
         <th
           colSpan={2}
@@ -18702,7 +18626,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r2_1_controls has no
     </tbody>
     <tfoot>
       <tr
-        className="border"
+        className="strong-border"
       >
         <th
           colSpan={2}
@@ -18776,7 +18700,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r2_1_controls has no
 exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r2_1_controls has no unexpected changes when missing genetic ancestry groups are filled in 1`] = `
 [
   <table
-    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
   >
     <thead>
       <tr>
@@ -18872,7 +18796,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r2_1_controls has no
     </thead>
     <tfoot>
       <tr
-        className="border"
+        className="strong-border"
       >
         <th
           colSpan={2}
@@ -18946,7 +18870,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r2_1_controls has no
 exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r2_1_non_neuro has no unexpected changes 1`] = `
 [
   <table
-    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
   >
     <thead>
       <tr>
@@ -19040,10 +18964,10 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r2_1_non_neuro has n
         </th>
       </tr>
     </thead>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="strong-border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
@@ -19077,9 +19001,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r2_1_non_neuro has n
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
+    <tbody>
       <tr>
         <th
           colSpan={2}
@@ -19116,7 +19038,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r2_1_non_neuro has n
     </tbody>
     <tfoot>
       <tr
-        className="border"
+        className="strong-border"
       >
         <th
           colSpan={2}
@@ -19190,7 +19112,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r2_1_non_neuro has n
 exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r2_1_non_neuro has no unexpected changes when missing genetic ancestry groups are filled in 1`] = `
 [
   <table
-    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
   >
     <thead>
       <tr>
@@ -19286,7 +19208,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r2_1_non_neuro has n
     </thead>
     <tfoot>
       <tr
-        className="border"
+        className="strong-border"
       >
         <th
           colSpan={2}
@@ -19360,7 +19282,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r2_1_non_neuro has n
 exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r4 has no unexpected changes 1`] = `
 [
   <table
-    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
   >
     <thead>
       <tr>
@@ -19454,10 +19376,10 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r4 has no unexpected
         </th>
       </tr>
     </thead>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="strong-border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
@@ -19491,10 +19413,10 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r4 has no unexpected
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
@@ -19528,17 +19450,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r4 has no unexpected
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -19571,17 +19493,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r4 has no unexpected
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -19614,17 +19536,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r4 has no unexpected
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -19657,17 +19579,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r4 has no unexpected
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -19700,17 +19622,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r4 has no unexpected
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -19743,17 +19665,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r4 has no unexpected
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -19786,17 +19708,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r4 has no unexpected
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -19829,17 +19751,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r4 has no unexpected
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -19872,9 +19794,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r4 has no unexpected
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
+    <tbody>
       <tr
         className="border"
       >
@@ -19911,9 +19831,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r4 has no unexpected
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
+    <tbody>
       <tr>
         <th
           colSpan={2}
@@ -19950,7 +19868,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r4 has no unexpected
     </tbody>
     <tfoot>
       <tr
-        className="border"
+        className="strong-border"
       >
         <th
           colSpan={2}
@@ -20024,7 +19942,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r4 has no unexpected
 exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r4 has no unexpected changes when missing genetic ancestry groups are filled in 1`] = `
 [
   <table
-    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
   >
     <thead>
       <tr>
@@ -20118,10 +20036,10 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r4 has no unexpected
         </th>
       </tr>
     </thead>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="strong-border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
@@ -20155,10 +20073,10 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r4 has no unexpected
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
@@ -20192,17 +20110,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r4 has no unexpected
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -20235,17 +20153,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r4 has no unexpected
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -20278,17 +20196,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r4 has no unexpected
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -20321,17 +20239,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r4 has no unexpected
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -20364,17 +20282,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r4 has no unexpected
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -20407,17 +20325,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r4 has no unexpected
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -20450,17 +20368,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r4 has no unexpected
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -20493,17 +20411,17 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r4 has no unexpected
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={2}
           rowSpan={1}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
             onClick={[Function]}
             type="button"
           >
@@ -20536,9 +20454,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r4 has no unexpected
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
+    <tbody>
       <tr
         className="border"
       >
@@ -20575,9 +20491,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r4 has no unexpected
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
+    <tbody>
       <tr>
         <th
           colSpan={2}
@@ -20614,7 +20528,7 @@ exports[`GnomadPopulationsTable with a dataset of gnomad_sv_r4 has no unexpected
     </tbody>
     <tfoot>
       <tr
-        className="border"
+        className="strong-border"
       >
         <th
           colSpan={2}

--- a/browser/src/VariantPage/__snapshots__/LocalAncestryPopulationsTable.spec.tsx.snap
+++ b/browser/src/VariantPage/__snapshots__/LocalAncestryPopulationsTable.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`local ancestry populations table has no unexpected changes 1`] = `
 <div>
   <table
-    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+    className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
   >
     <thead>
       <tr>
@@ -79,17 +79,17 @@ exports[`local ancestry populations table has no unexpected changes 1`] = `
         </th>
       </tr>
     </thead>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="strong-border"
+      >
         <th
           colSpan={1}
           rowSpan={3}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 gHtnWT"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 ckJgLT"
             onClick={[Function]}
             type="button"
           >
@@ -120,7 +120,7 @@ exports[`local ancestry populations table has no unexpected changes 1`] = `
         </td>
       </tr>
       <tr
-        className="border"
+        className="subtle-border"
       >
         <td>
           European
@@ -170,17 +170,17 @@ exports[`local ancestry populations table has no unexpected changes 1`] = `
         </td>
       </tr>
     </tbody>
-    <tbody
-      className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-    >
-      <tr>
+    <tbody>
+      <tr
+        className="border"
+      >
         <th
           colSpan={1}
           rowSpan={4}
           scope="row"
         >
           <button
-            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 gHtnWT"
+            className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 ckJgLT"
             onClick={[Function]}
             type="button"
           >
@@ -211,7 +211,7 @@ exports[`local ancestry populations table has no unexpected changes 1`] = `
         </td>
       </tr>
       <tr
-        className="border"
+        className="subtle-border"
       >
         <td>
           European
@@ -287,7 +287,7 @@ exports[`local ancestry populations table has no unexpected changes 1`] = `
     </tbody>
     <tfoot>
       <tr
-        className="border"
+        className="strong-border"
       >
         <th
           colSpan={2}

--- a/browser/src/VariantPage/__snapshots__/VariantPage.spec.tsx.snap
+++ b/browser/src/VariantPage/__snapshots__/VariantPage.spec.tsx.snap
@@ -804,7 +804,7 @@ exports[`VariantPage with the dataset "gnomad_r3" has no unexpected changes 1`] 
               className="TableWrapper-sc-1ep26r3-0 edvjZa"
             >
               <table
-                className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+                className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
               >
                 <thead>
                   <tr>
@@ -898,17 +898,17 @@ exports[`VariantPage with the dataset "gnomad_r3" has no unexpected changes 1`] 
                     </th>
                   </tr>
                 </thead>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="strong-border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -941,17 +941,17 @@ exports[`VariantPage with the dataset "gnomad_r3" has no unexpected changes 1`] 
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -984,17 +984,17 @@ exports[`VariantPage with the dataset "gnomad_r3" has no unexpected changes 1`] 
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -1027,17 +1027,17 @@ exports[`VariantPage with the dataset "gnomad_r3" has no unexpected changes 1`] 
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -1070,17 +1070,17 @@ exports[`VariantPage with the dataset "gnomad_r3" has no unexpected changes 1`] 
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -1113,17 +1113,17 @@ exports[`VariantPage with the dataset "gnomad_r3" has no unexpected changes 1`] 
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -1156,17 +1156,17 @@ exports[`VariantPage with the dataset "gnomad_r3" has no unexpected changes 1`] 
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -1199,17 +1199,17 @@ exports[`VariantPage with the dataset "gnomad_r3" has no unexpected changes 1`] 
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -1242,17 +1242,17 @@ exports[`VariantPage with the dataset "gnomad_r3" has no unexpected changes 1`] 
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -1285,17 +1285,17 @@ exports[`VariantPage with the dataset "gnomad_r3" has no unexpected changes 1`] 
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -1330,7 +1330,7 @@ exports[`VariantPage with the dataset "gnomad_r3" has no unexpected changes 1`] 
                 </tbody>
                 <tfoot>
                   <tr
-                    className="border"
+                    className="strong-border"
                   >
                     <th
                       colSpan={2}
@@ -10744,7 +10744,7 @@ exports[`VariantPage with the dataset "gnomad_r3_controls_and_biobanks" has no u
               className="TableWrapper-sc-1ep26r3-0 edvjZa"
             >
               <table
-                className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+                className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
               >
                 <thead>
                   <tr>
@@ -10838,17 +10838,17 @@ exports[`VariantPage with the dataset "gnomad_r3_controls_and_biobanks" has no u
                     </th>
                   </tr>
                 </thead>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="strong-border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -10881,17 +10881,17 @@ exports[`VariantPage with the dataset "gnomad_r3_controls_and_biobanks" has no u
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -10924,17 +10924,17 @@ exports[`VariantPage with the dataset "gnomad_r3_controls_and_biobanks" has no u
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -10967,17 +10967,17 @@ exports[`VariantPage with the dataset "gnomad_r3_controls_and_biobanks" has no u
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -11010,17 +11010,17 @@ exports[`VariantPage with the dataset "gnomad_r3_controls_and_biobanks" has no u
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -11053,17 +11053,17 @@ exports[`VariantPage with the dataset "gnomad_r3_controls_and_biobanks" has no u
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -11096,17 +11096,17 @@ exports[`VariantPage with the dataset "gnomad_r3_controls_and_biobanks" has no u
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -11139,17 +11139,17 @@ exports[`VariantPage with the dataset "gnomad_r3_controls_and_biobanks" has no u
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -11182,17 +11182,17 @@ exports[`VariantPage with the dataset "gnomad_r3_controls_and_biobanks" has no u
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -11225,17 +11225,17 @@ exports[`VariantPage with the dataset "gnomad_r3_controls_and_biobanks" has no u
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -11270,7 +11270,7 @@ exports[`VariantPage with the dataset "gnomad_r3_controls_and_biobanks" has no u
                 </tbody>
                 <tfoot>
                   <tr
-                    className="border"
+                    className="strong-border"
                   >
                     <th
                       colSpan={2}
@@ -20687,7 +20687,7 @@ exports[`VariantPage with the dataset "gnomad_r3_non_cancer" has no unexpected c
               className="TableWrapper-sc-1ep26r3-0 edvjZa"
             >
               <table
-                className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+                className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
               >
                 <thead>
                   <tr>
@@ -20781,17 +20781,17 @@ exports[`VariantPage with the dataset "gnomad_r3_non_cancer" has no unexpected c
                     </th>
                   </tr>
                 </thead>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="strong-border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -20824,17 +20824,17 @@ exports[`VariantPage with the dataset "gnomad_r3_non_cancer" has no unexpected c
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -20867,17 +20867,17 @@ exports[`VariantPage with the dataset "gnomad_r3_non_cancer" has no unexpected c
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -20910,17 +20910,17 @@ exports[`VariantPage with the dataset "gnomad_r3_non_cancer" has no unexpected c
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -20953,17 +20953,17 @@ exports[`VariantPage with the dataset "gnomad_r3_non_cancer" has no unexpected c
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -20996,17 +20996,17 @@ exports[`VariantPage with the dataset "gnomad_r3_non_cancer" has no unexpected c
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -21039,17 +21039,17 @@ exports[`VariantPage with the dataset "gnomad_r3_non_cancer" has no unexpected c
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -21082,17 +21082,17 @@ exports[`VariantPage with the dataset "gnomad_r3_non_cancer" has no unexpected c
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -21125,17 +21125,17 @@ exports[`VariantPage with the dataset "gnomad_r3_non_cancer" has no unexpected c
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -21168,17 +21168,17 @@ exports[`VariantPage with the dataset "gnomad_r3_non_cancer" has no unexpected c
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -21213,7 +21213,7 @@ exports[`VariantPage with the dataset "gnomad_r3_non_cancer" has no unexpected c
                 </tbody>
                 <tfoot>
                   <tr
-                    className="border"
+                    className="strong-border"
                   >
                     <th
                       colSpan={2}
@@ -30630,7 +30630,7 @@ exports[`VariantPage with the dataset "gnomad_r3_non_neuro" has no unexpected ch
               className="TableWrapper-sc-1ep26r3-0 edvjZa"
             >
               <table
-                className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+                className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
               >
                 <thead>
                   <tr>
@@ -30724,17 +30724,17 @@ exports[`VariantPage with the dataset "gnomad_r3_non_neuro" has no unexpected ch
                     </th>
                   </tr>
                 </thead>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="strong-border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -30767,17 +30767,17 @@ exports[`VariantPage with the dataset "gnomad_r3_non_neuro" has no unexpected ch
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -30810,17 +30810,17 @@ exports[`VariantPage with the dataset "gnomad_r3_non_neuro" has no unexpected ch
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -30853,17 +30853,17 @@ exports[`VariantPage with the dataset "gnomad_r3_non_neuro" has no unexpected ch
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -30896,17 +30896,17 @@ exports[`VariantPage with the dataset "gnomad_r3_non_neuro" has no unexpected ch
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -30939,17 +30939,17 @@ exports[`VariantPage with the dataset "gnomad_r3_non_neuro" has no unexpected ch
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -30982,17 +30982,17 @@ exports[`VariantPage with the dataset "gnomad_r3_non_neuro" has no unexpected ch
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -31025,17 +31025,17 @@ exports[`VariantPage with the dataset "gnomad_r3_non_neuro" has no unexpected ch
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -31068,17 +31068,17 @@ exports[`VariantPage with the dataset "gnomad_r3_non_neuro" has no unexpected ch
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -31111,17 +31111,17 @@ exports[`VariantPage with the dataset "gnomad_r3_non_neuro" has no unexpected ch
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -31156,7 +31156,7 @@ exports[`VariantPage with the dataset "gnomad_r3_non_neuro" has no unexpected ch
                 </tbody>
                 <tfoot>
                   <tr
-                    className="border"
+                    className="strong-border"
                   >
                     <th
                       colSpan={2}
@@ -40573,7 +40573,7 @@ exports[`VariantPage with the dataset "gnomad_r3_non_topmed" has no unexpected c
               className="TableWrapper-sc-1ep26r3-0 edvjZa"
             >
               <table
-                className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+                className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
               >
                 <thead>
                   <tr>
@@ -40667,17 +40667,17 @@ exports[`VariantPage with the dataset "gnomad_r3_non_topmed" has no unexpected c
                     </th>
                   </tr>
                 </thead>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="strong-border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -40710,17 +40710,17 @@ exports[`VariantPage with the dataset "gnomad_r3_non_topmed" has no unexpected c
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -40753,17 +40753,17 @@ exports[`VariantPage with the dataset "gnomad_r3_non_topmed" has no unexpected c
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -40796,17 +40796,17 @@ exports[`VariantPage with the dataset "gnomad_r3_non_topmed" has no unexpected c
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -40839,17 +40839,17 @@ exports[`VariantPage with the dataset "gnomad_r3_non_topmed" has no unexpected c
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -40882,17 +40882,17 @@ exports[`VariantPage with the dataset "gnomad_r3_non_topmed" has no unexpected c
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -40925,17 +40925,17 @@ exports[`VariantPage with the dataset "gnomad_r3_non_topmed" has no unexpected c
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -40968,17 +40968,17 @@ exports[`VariantPage with the dataset "gnomad_r3_non_topmed" has no unexpected c
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -41011,17 +41011,17 @@ exports[`VariantPage with the dataset "gnomad_r3_non_topmed" has no unexpected c
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -41054,17 +41054,17 @@ exports[`VariantPage with the dataset "gnomad_r3_non_topmed" has no unexpected c
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -41099,7 +41099,7 @@ exports[`VariantPage with the dataset "gnomad_r3_non_topmed" has no unexpected c
                 </tbody>
                 <tfoot>
                   <tr
-                    className="border"
+                    className="strong-border"
                   >
                     <th
                       colSpan={2}
@@ -50516,7 +50516,7 @@ exports[`VariantPage with the dataset "gnomad_r3_non_v2" has no unexpected chang
               className="TableWrapper-sc-1ep26r3-0 edvjZa"
             >
               <table
-                className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+                className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
               >
                 <thead>
                   <tr>
@@ -50610,17 +50610,17 @@ exports[`VariantPage with the dataset "gnomad_r3_non_v2" has no unexpected chang
                     </th>
                   </tr>
                 </thead>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="strong-border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -50653,17 +50653,17 @@ exports[`VariantPage with the dataset "gnomad_r3_non_v2" has no unexpected chang
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -50696,17 +50696,17 @@ exports[`VariantPage with the dataset "gnomad_r3_non_v2" has no unexpected chang
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -50739,17 +50739,17 @@ exports[`VariantPage with the dataset "gnomad_r3_non_v2" has no unexpected chang
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -50782,17 +50782,17 @@ exports[`VariantPage with the dataset "gnomad_r3_non_v2" has no unexpected chang
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -50825,17 +50825,17 @@ exports[`VariantPage with the dataset "gnomad_r3_non_v2" has no unexpected chang
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -50868,17 +50868,17 @@ exports[`VariantPage with the dataset "gnomad_r3_non_v2" has no unexpected chang
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -50911,17 +50911,17 @@ exports[`VariantPage with the dataset "gnomad_r3_non_v2" has no unexpected chang
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -50954,17 +50954,17 @@ exports[`VariantPage with the dataset "gnomad_r3_non_v2" has no unexpected chang
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -50997,17 +50997,17 @@ exports[`VariantPage with the dataset "gnomad_r3_non_v2" has no unexpected chang
                     </td>
                   </tr>
                 </tbody>
-                <tbody
-                  className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-                >
-                  <tr>
+                <tbody>
+                  <tr
+                    className="border"
+                  >
                     <th
                       colSpan={2}
                       rowSpan={1}
                       scope="row"
                     >
                       <button
-                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                        className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                         onClick={[Function]}
                         type="button"
                       >
@@ -51042,7 +51042,7 @@ exports[`VariantPage with the dataset "gnomad_r3_non_v2" has no unexpected chang
                 </tbody>
                 <tfoot>
                   <tr
-                    className="border"
+                    className="strong-border"
                   >
                     <th
                       colSpan={2}
@@ -60287,7 +60287,7 @@ exports[`VariantPage with the dataset exac has no unexpected changes 1`] = `
         className="TableWrapper-sc-1ep26r3-0 edvjZa"
       >
         <table
-          className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+          className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
         >
           <thead>
             <tr>
@@ -60381,17 +60381,17 @@ exports[`VariantPage with the dataset exac has no unexpected changes 1`] = `
               </th>
             </tr>
           </thead>
-          <tbody
-            className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-          >
-            <tr>
+          <tbody>
+            <tr
+              className="strong-border"
+            >
               <th
                 colSpan={2}
                 rowSpan={1}
                 scope="row"
               >
                 <button
-                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                   onClick={[Function]}
                   type="button"
                 >
@@ -60424,17 +60424,17 @@ exports[`VariantPage with the dataset exac has no unexpected changes 1`] = `
               </td>
             </tr>
           </tbody>
-          <tbody
-            className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-          >
-            <tr>
+          <tbody>
+            <tr
+              className="border"
+            >
               <th
                 colSpan={2}
                 rowSpan={1}
                 scope="row"
               >
                 <button
-                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                   onClick={[Function]}
                   type="button"
                 >
@@ -60467,17 +60467,17 @@ exports[`VariantPage with the dataset exac has no unexpected changes 1`] = `
               </td>
             </tr>
           </tbody>
-          <tbody
-            className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-          >
-            <tr>
+          <tbody>
+            <tr
+              className="border"
+            >
               <th
                 colSpan={2}
                 rowSpan={1}
                 scope="row"
               >
                 <button
-                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                   onClick={[Function]}
                   type="button"
                 >
@@ -60510,17 +60510,17 @@ exports[`VariantPage with the dataset exac has no unexpected changes 1`] = `
               </td>
             </tr>
           </tbody>
-          <tbody
-            className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-          >
-            <tr>
+          <tbody>
+            <tr
+              className="border"
+            >
               <th
                 colSpan={2}
                 rowSpan={1}
                 scope="row"
               >
                 <button
-                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                   onClick={[Function]}
                   type="button"
                 >
@@ -60553,17 +60553,17 @@ exports[`VariantPage with the dataset exac has no unexpected changes 1`] = `
               </td>
             </tr>
           </tbody>
-          <tbody
-            className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-          >
-            <tr>
+          <tbody>
+            <tr
+              className="border"
+            >
               <th
                 colSpan={2}
                 rowSpan={1}
                 scope="row"
               >
                 <button
-                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                   onClick={[Function]}
                   type="button"
                 >
@@ -60596,17 +60596,17 @@ exports[`VariantPage with the dataset exac has no unexpected changes 1`] = `
               </td>
             </tr>
           </tbody>
-          <tbody
-            className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-          >
-            <tr>
+          <tbody>
+            <tr
+              className="border"
+            >
               <th
                 colSpan={2}
                 rowSpan={1}
                 scope="row"
               >
                 <button
-                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                   onClick={[Function]}
                   type="button"
                 >
@@ -60639,17 +60639,17 @@ exports[`VariantPage with the dataset exac has no unexpected changes 1`] = `
               </td>
             </tr>
           </tbody>
-          <tbody
-            className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-          >
-            <tr>
+          <tbody>
+            <tr
+              className="border"
+            >
               <th
                 colSpan={2}
                 rowSpan={1}
                 scope="row"
               >
                 <button
-                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                   onClick={[Function]}
                   type="button"
                 >
@@ -60684,7 +60684,7 @@ exports[`VariantPage with the dataset exac has no unexpected changes 1`] = `
           </tbody>
           <tfoot>
             <tr
-              className="border"
+              className="strong-border"
             >
               <th
                 colSpan={2}
@@ -68258,7 +68258,7 @@ exports[`VariantPage with the dataset gnomad_r2_1 has no unexpected changes 1`] 
         className="TableWrapper-sc-1ep26r3-0 edvjZa"
       >
         <table
-          className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+          className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
         >
           <thead>
             <tr>
@@ -68352,17 +68352,17 @@ exports[`VariantPage with the dataset gnomad_r2_1 has no unexpected changes 1`] 
               </th>
             </tr>
           </thead>
-          <tbody
-            className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-          >
-            <tr>
+          <tbody>
+            <tr
+              className="strong-border"
+            >
               <th
                 colSpan={2}
                 rowSpan={1}
                 scope="row"
               >
                 <button
-                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                   onClick={[Function]}
                   type="button"
                 >
@@ -68395,17 +68395,17 @@ exports[`VariantPage with the dataset gnomad_r2_1 has no unexpected changes 1`] 
               </td>
             </tr>
           </tbody>
-          <tbody
-            className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-          >
-            <tr>
+          <tbody>
+            <tr
+              className="border"
+            >
               <th
                 colSpan={2}
                 rowSpan={1}
                 scope="row"
               >
                 <button
-                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                   onClick={[Function]}
                   type="button"
                 >
@@ -68438,17 +68438,17 @@ exports[`VariantPage with the dataset gnomad_r2_1 has no unexpected changes 1`] 
               </td>
             </tr>
           </tbody>
-          <tbody
-            className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-          >
-            <tr>
+          <tbody>
+            <tr
+              className="border"
+            >
               <th
                 colSpan={2}
                 rowSpan={1}
                 scope="row"
               >
                 <button
-                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                   onClick={[Function]}
                   type="button"
                 >
@@ -68481,17 +68481,17 @@ exports[`VariantPage with the dataset gnomad_r2_1 has no unexpected changes 1`] 
               </td>
             </tr>
           </tbody>
-          <tbody
-            className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-          >
-            <tr>
+          <tbody>
+            <tr
+              className="border"
+            >
               <th
                 colSpan={2}
                 rowSpan={1}
                 scope="row"
               >
                 <button
-                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                   onClick={[Function]}
                   type="button"
                 >
@@ -68524,17 +68524,17 @@ exports[`VariantPage with the dataset gnomad_r2_1 has no unexpected changes 1`] 
               </td>
             </tr>
           </tbody>
-          <tbody
-            className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-          >
-            <tr>
+          <tbody>
+            <tr
+              className="border"
+            >
               <th
                 colSpan={2}
                 rowSpan={1}
                 scope="row"
               >
                 <button
-                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                   onClick={[Function]}
                   type="button"
                 >
@@ -68567,17 +68567,17 @@ exports[`VariantPage with the dataset gnomad_r2_1 has no unexpected changes 1`] 
               </td>
             </tr>
           </tbody>
-          <tbody
-            className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-          >
-            <tr>
+          <tbody>
+            <tr
+              className="border"
+            >
               <th
                 colSpan={2}
                 rowSpan={1}
                 scope="row"
               >
                 <button
-                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                   onClick={[Function]}
                   type="button"
                 >
@@ -68610,17 +68610,17 @@ exports[`VariantPage with the dataset gnomad_r2_1 has no unexpected changes 1`] 
               </td>
             </tr>
           </tbody>
-          <tbody
-            className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-          >
-            <tr>
+          <tbody>
+            <tr
+              className="border"
+            >
               <th
                 colSpan={2}
                 rowSpan={1}
                 scope="row"
               >
                 <button
-                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                   onClick={[Function]}
                   type="button"
                 >
@@ -68653,17 +68653,17 @@ exports[`VariantPage with the dataset gnomad_r2_1 has no unexpected changes 1`] 
               </td>
             </tr>
           </tbody>
-          <tbody
-            className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-          >
-            <tr>
+          <tbody>
+            <tr
+              className="border"
+            >
               <th
                 colSpan={2}
                 rowSpan={1}
                 scope="row"
               >
                 <button
-                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                   onClick={[Function]}
                   type="button"
                 >
@@ -68698,7 +68698,7 @@ exports[`VariantPage with the dataset gnomad_r2_1 has no unexpected changes 1`] 
           </tbody>
           <tfoot>
             <tr
-              className="border"
+              className="strong-border"
             >
               <th
                 colSpan={2}
@@ -78322,7 +78322,7 @@ exports[`VariantPage with the dataset gnomad_r2_1_controls has no unexpected cha
         className="TableWrapper-sc-1ep26r3-0 edvjZa"
       >
         <table
-          className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+          className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
         >
           <thead>
             <tr>
@@ -78416,17 +78416,17 @@ exports[`VariantPage with the dataset gnomad_r2_1_controls has no unexpected cha
               </th>
             </tr>
           </thead>
-          <tbody
-            className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-          >
-            <tr>
+          <tbody>
+            <tr
+              className="strong-border"
+            >
               <th
                 colSpan={2}
                 rowSpan={1}
                 scope="row"
               >
                 <button
-                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                   onClick={[Function]}
                   type="button"
                 >
@@ -78459,17 +78459,17 @@ exports[`VariantPage with the dataset gnomad_r2_1_controls has no unexpected cha
               </td>
             </tr>
           </tbody>
-          <tbody
-            className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-          >
-            <tr>
+          <tbody>
+            <tr
+              className="border"
+            >
               <th
                 colSpan={2}
                 rowSpan={1}
                 scope="row"
               >
                 <button
-                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                   onClick={[Function]}
                   type="button"
                 >
@@ -78502,17 +78502,17 @@ exports[`VariantPage with the dataset gnomad_r2_1_controls has no unexpected cha
               </td>
             </tr>
           </tbody>
-          <tbody
-            className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-          >
-            <tr>
+          <tbody>
+            <tr
+              className="border"
+            >
               <th
                 colSpan={2}
                 rowSpan={1}
                 scope="row"
               >
                 <button
-                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                   onClick={[Function]}
                   type="button"
                 >
@@ -78545,17 +78545,17 @@ exports[`VariantPage with the dataset gnomad_r2_1_controls has no unexpected cha
               </td>
             </tr>
           </tbody>
-          <tbody
-            className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-          >
-            <tr>
+          <tbody>
+            <tr
+              className="border"
+            >
               <th
                 colSpan={2}
                 rowSpan={1}
                 scope="row"
               >
                 <button
-                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                   onClick={[Function]}
                   type="button"
                 >
@@ -78588,17 +78588,17 @@ exports[`VariantPage with the dataset gnomad_r2_1_controls has no unexpected cha
               </td>
             </tr>
           </tbody>
-          <tbody
-            className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-          >
-            <tr>
+          <tbody>
+            <tr
+              className="border"
+            >
               <th
                 colSpan={2}
                 rowSpan={1}
                 scope="row"
               >
                 <button
-                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                   onClick={[Function]}
                   type="button"
                 >
@@ -78631,17 +78631,17 @@ exports[`VariantPage with the dataset gnomad_r2_1_controls has no unexpected cha
               </td>
             </tr>
           </tbody>
-          <tbody
-            className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-          >
-            <tr>
+          <tbody>
+            <tr
+              className="border"
+            >
               <th
                 colSpan={2}
                 rowSpan={1}
                 scope="row"
               >
                 <button
-                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                   onClick={[Function]}
                   type="button"
                 >
@@ -78674,17 +78674,17 @@ exports[`VariantPage with the dataset gnomad_r2_1_controls has no unexpected cha
               </td>
             </tr>
           </tbody>
-          <tbody
-            className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-          >
-            <tr>
+          <tbody>
+            <tr
+              className="border"
+            >
               <th
                 colSpan={2}
                 rowSpan={1}
                 scope="row"
               >
                 <button
-                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                   onClick={[Function]}
                   type="button"
                 >
@@ -78717,17 +78717,17 @@ exports[`VariantPage with the dataset gnomad_r2_1_controls has no unexpected cha
               </td>
             </tr>
           </tbody>
-          <tbody
-            className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-          >
-            <tr>
+          <tbody>
+            <tr
+              className="border"
+            >
               <th
                 colSpan={2}
                 rowSpan={1}
                 scope="row"
               >
                 <button
-                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                   onClick={[Function]}
                   type="button"
                 >
@@ -78762,7 +78762,7 @@ exports[`VariantPage with the dataset gnomad_r2_1_controls has no unexpected cha
           </tbody>
           <tfoot>
             <tr
-              className="border"
+              className="strong-border"
             >
               <th
                 colSpan={2}
@@ -88386,7 +88386,7 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_cancer has no unexpected c
         className="TableWrapper-sc-1ep26r3-0 edvjZa"
       >
         <table
-          className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+          className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
         >
           <thead>
             <tr>
@@ -88480,17 +88480,17 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_cancer has no unexpected c
               </th>
             </tr>
           </thead>
-          <tbody
-            className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-          >
-            <tr>
+          <tbody>
+            <tr
+              className="strong-border"
+            >
               <th
                 colSpan={2}
                 rowSpan={1}
                 scope="row"
               >
                 <button
-                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                   onClick={[Function]}
                   type="button"
                 >
@@ -88523,17 +88523,17 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_cancer has no unexpected c
               </td>
             </tr>
           </tbody>
-          <tbody
-            className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-          >
-            <tr>
+          <tbody>
+            <tr
+              className="border"
+            >
               <th
                 colSpan={2}
                 rowSpan={1}
                 scope="row"
               >
                 <button
-                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                   onClick={[Function]}
                   type="button"
                 >
@@ -88566,17 +88566,17 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_cancer has no unexpected c
               </td>
             </tr>
           </tbody>
-          <tbody
-            className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-          >
-            <tr>
+          <tbody>
+            <tr
+              className="border"
+            >
               <th
                 colSpan={2}
                 rowSpan={1}
                 scope="row"
               >
                 <button
-                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                   onClick={[Function]}
                   type="button"
                 >
@@ -88609,17 +88609,17 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_cancer has no unexpected c
               </td>
             </tr>
           </tbody>
-          <tbody
-            className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-          >
-            <tr>
+          <tbody>
+            <tr
+              className="border"
+            >
               <th
                 colSpan={2}
                 rowSpan={1}
                 scope="row"
               >
                 <button
-                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                   onClick={[Function]}
                   type="button"
                 >
@@ -88652,17 +88652,17 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_cancer has no unexpected c
               </td>
             </tr>
           </tbody>
-          <tbody
-            className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-          >
-            <tr>
+          <tbody>
+            <tr
+              className="border"
+            >
               <th
                 colSpan={2}
                 rowSpan={1}
                 scope="row"
               >
                 <button
-                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                   onClick={[Function]}
                   type="button"
                 >
@@ -88695,17 +88695,17 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_cancer has no unexpected c
               </td>
             </tr>
           </tbody>
-          <tbody
-            className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-          >
-            <tr>
+          <tbody>
+            <tr
+              className="border"
+            >
               <th
                 colSpan={2}
                 rowSpan={1}
                 scope="row"
               >
                 <button
-                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                   onClick={[Function]}
                   type="button"
                 >
@@ -88738,17 +88738,17 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_cancer has no unexpected c
               </td>
             </tr>
           </tbody>
-          <tbody
-            className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-          >
-            <tr>
+          <tbody>
+            <tr
+              className="border"
+            >
               <th
                 colSpan={2}
                 rowSpan={1}
                 scope="row"
               >
                 <button
-                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                   onClick={[Function]}
                   type="button"
                 >
@@ -88781,17 +88781,17 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_cancer has no unexpected c
               </td>
             </tr>
           </tbody>
-          <tbody
-            className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-          >
-            <tr>
+          <tbody>
+            <tr
+              className="border"
+            >
               <th
                 colSpan={2}
                 rowSpan={1}
                 scope="row"
               >
                 <button
-                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                   onClick={[Function]}
                   type="button"
                 >
@@ -88826,7 +88826,7 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_cancer has no unexpected c
           </tbody>
           <tfoot>
             <tr
-              className="border"
+              className="strong-border"
             >
               <th
                 colSpan={2}
@@ -98450,7 +98450,7 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_neuro has no unexpected ch
         className="TableWrapper-sc-1ep26r3-0 edvjZa"
       >
         <table
-          className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+          className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
         >
           <thead>
             <tr>
@@ -98544,17 +98544,17 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_neuro has no unexpected ch
               </th>
             </tr>
           </thead>
-          <tbody
-            className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-          >
-            <tr>
+          <tbody>
+            <tr
+              className="strong-border"
+            >
               <th
                 colSpan={2}
                 rowSpan={1}
                 scope="row"
               >
                 <button
-                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                   onClick={[Function]}
                   type="button"
                 >
@@ -98587,17 +98587,17 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_neuro has no unexpected ch
               </td>
             </tr>
           </tbody>
-          <tbody
-            className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-          >
-            <tr>
+          <tbody>
+            <tr
+              className="border"
+            >
               <th
                 colSpan={2}
                 rowSpan={1}
                 scope="row"
               >
                 <button
-                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                   onClick={[Function]}
                   type="button"
                 >
@@ -98630,17 +98630,17 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_neuro has no unexpected ch
               </td>
             </tr>
           </tbody>
-          <tbody
-            className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-          >
-            <tr>
+          <tbody>
+            <tr
+              className="border"
+            >
               <th
                 colSpan={2}
                 rowSpan={1}
                 scope="row"
               >
                 <button
-                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                   onClick={[Function]}
                   type="button"
                 >
@@ -98673,17 +98673,17 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_neuro has no unexpected ch
               </td>
             </tr>
           </tbody>
-          <tbody
-            className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-          >
-            <tr>
+          <tbody>
+            <tr
+              className="border"
+            >
               <th
                 colSpan={2}
                 rowSpan={1}
                 scope="row"
               >
                 <button
-                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                   onClick={[Function]}
                   type="button"
                 >
@@ -98716,17 +98716,17 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_neuro has no unexpected ch
               </td>
             </tr>
           </tbody>
-          <tbody
-            className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-          >
-            <tr>
+          <tbody>
+            <tr
+              className="border"
+            >
               <th
                 colSpan={2}
                 rowSpan={1}
                 scope="row"
               >
                 <button
-                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                   onClick={[Function]}
                   type="button"
                 >
@@ -98759,17 +98759,17 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_neuro has no unexpected ch
               </td>
             </tr>
           </tbody>
-          <tbody
-            className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-          >
-            <tr>
+          <tbody>
+            <tr
+              className="border"
+            >
               <th
                 colSpan={2}
                 rowSpan={1}
                 scope="row"
               >
                 <button
-                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                   onClick={[Function]}
                   type="button"
                 >
@@ -98802,17 +98802,17 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_neuro has no unexpected ch
               </td>
             </tr>
           </tbody>
-          <tbody
-            className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-          >
-            <tr>
+          <tbody>
+            <tr
+              className="border"
+            >
               <th
                 colSpan={2}
                 rowSpan={1}
                 scope="row"
               >
                 <button
-                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                   onClick={[Function]}
                   type="button"
                 >
@@ -98845,17 +98845,17 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_neuro has no unexpected ch
               </td>
             </tr>
           </tbody>
-          <tbody
-            className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-          >
-            <tr>
+          <tbody>
+            <tr
+              className="border"
+            >
               <th
                 colSpan={2}
                 rowSpan={1}
                 scope="row"
               >
                 <button
-                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                   onClick={[Function]}
                   type="button"
                 >
@@ -98890,7 +98890,7 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_neuro has no unexpected ch
           </tbody>
           <tfoot>
             <tr
-              className="border"
+              className="strong-border"
             >
               <th
                 colSpan={2}
@@ -108514,7 +108514,7 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_topmed has no unexpected c
         className="TableWrapper-sc-1ep26r3-0 edvjZa"
       >
         <table
-          className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 ggAkBv"
+          className="Table__BaseTable-sc-7fgtt2-0 PopulationsTable__Table-sc-sijbl0-0 hRGkzk"
         >
           <thead>
             <tr>
@@ -108608,17 +108608,17 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_topmed has no unexpected c
               </th>
             </tr>
           </thead>
-          <tbody
-            className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-          >
-            <tr>
+          <tbody>
+            <tr
+              className="strong-border"
+            >
               <th
                 colSpan={2}
                 rowSpan={1}
                 scope="row"
               >
                 <button
-                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                   onClick={[Function]}
                   type="button"
                 >
@@ -108651,17 +108651,17 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_topmed has no unexpected c
               </td>
             </tr>
           </tbody>
-          <tbody
-            className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-          >
-            <tr>
+          <tbody>
+            <tr
+              className="border"
+            >
               <th
                 colSpan={2}
                 rowSpan={1}
                 scope="row"
               >
                 <button
-                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                   onClick={[Function]}
                   type="button"
                 >
@@ -108694,17 +108694,17 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_topmed has no unexpected c
               </td>
             </tr>
           </tbody>
-          <tbody
-            className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-          >
-            <tr>
+          <tbody>
+            <tr
+              className="border"
+            >
               <th
                 colSpan={2}
                 rowSpan={1}
                 scope="row"
               >
                 <button
-                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                   onClick={[Function]}
                   type="button"
                 >
@@ -108737,17 +108737,17 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_topmed has no unexpected c
               </td>
             </tr>
           </tbody>
-          <tbody
-            className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-          >
-            <tr>
+          <tbody>
+            <tr
+              className="border"
+            >
               <th
                 colSpan={2}
                 rowSpan={1}
                 scope="row"
               >
                 <button
-                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                   onClick={[Function]}
                   type="button"
                 >
@@ -108780,17 +108780,17 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_topmed has no unexpected c
               </td>
             </tr>
           </tbody>
-          <tbody
-            className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-          >
-            <tr>
+          <tbody>
+            <tr
+              className="border"
+            >
               <th
                 colSpan={2}
                 rowSpan={1}
                 scope="row"
               >
                 <button
-                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                   onClick={[Function]}
                   type="button"
                 >
@@ -108823,17 +108823,17 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_topmed has no unexpected c
               </td>
             </tr>
           </tbody>
-          <tbody
-            className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-          >
-            <tr>
+          <tbody>
+            <tr
+              className="border"
+            >
               <th
                 colSpan={2}
                 rowSpan={1}
                 scope="row"
               >
                 <button
-                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                   onClick={[Function]}
                   type="button"
                 >
@@ -108866,17 +108866,17 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_topmed has no unexpected c
               </td>
             </tr>
           </tbody>
-          <tbody
-            className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-          >
-            <tr>
+          <tbody>
+            <tr
+              className="border"
+            >
               <th
                 colSpan={2}
                 rowSpan={1}
                 scope="row"
               >
                 <button
-                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                   onClick={[Function]}
                   type="button"
                 >
@@ -108909,17 +108909,17 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_topmed has no unexpected c
               </td>
             </tr>
           </tbody>
-          <tbody
-            className="PopulationsTable__PopulationSection-sc-sijbl0-1 doztxS"
-          >
-            <tr>
+          <tbody>
+            <tr
+              className="border"
+            >
               <th
                 colSpan={2}
                 rowSpan={1}
                 scope="row"
               >
                 <button
-                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-2 cdNMTw"
+                  className="Button__TextButton-sc-1eobygi-3 PopulationsTable__TogglePopulationButton-sc-sijbl0-1 cLiTNU"
                   onClick={[Function]}
                   type="button"
                 >
@@ -108954,7 +108954,7 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_topmed has no unexpected c
           </tbody>
           <tfoot>
             <tr
-              className="border"
+              className="strong-border"
             >
               <th
                 colSpan={2}


### PR DESCRIPTION
The Variant page's genetic ancestry group frequency table recently had its styling updated to make the division between genetic ancestry groups more clear, as the subtler grey dividing line between the total freq information and the sex specific freq information in a given ancestry group was thicker than the lines between the groups.

This change unintentionally made the total sex specific (XX/XY) frequencies dividers become less clear. This PR slightly modifies the styling to make the header and footer more distinct than individual rows, and make clear the XX/XY section of the table.

It keeps the changes to thicknesses of lines that were requested and modified in a previous PR.

- Production (current) stylings on left, PR stylings on right
	![Screenshot 2024-11-05 at 16 13 10](https://github.com/user-attachments/assets/43a40cf9-ac21-4549-8804-5117193cd313)

The main change is to make the line dividing XX/XY less distinct than the lines above and below it

i.e. modify stylings here

Production:
	![Screenshot 2024-11-05 at 16 16 23](https://github.com/user-attachments/assets/6b4a2a7a-1903-47fa-880c-da01c4d978a0)

PR:
	![Screenshot 2024-11-05 at 16 15 55](https://github.com/user-attachments/assets/a3eb0992-84af-4659-80fb-df8ac128064a)
