### PR TITLE
Update deployctl output to note demos

### DIFF
--- a/deploy/deployctl/subcommands/browser_deployments.py
+++ b/deploy/deployctl/subcommands/browser_deployments.py
@@ -115,19 +115,38 @@ def deployments_directory() -> str:
     return path
 
 
+def print_pool_name(pool: str) -> str:
+    if pool == "demo-pool":
+        return "(demo-pool)"
+    if pool == "main-pool":
+        return ""
+
+    return pool
+
+
+def determine_deployment_pool(path: str) -> str:
+    with open(path) as f:
+        content = f.read()
+    return "demo-pool" if "'demo-pool'" in content or '"demo-pool"' in content else "main-pool"
+
+
 def list_deployments() -> None:
     print("Local configurations")
     print("====================")
     paths = reversed(sorted(glob.iglob(f"{deployments_directory()}/*/kustomization.yaml"), key=os.path.getmtime))
     for path in paths:
-        print(os.path.basename(os.path.dirname(path)))
+        name = os.path.basename(os.path.dirname(path))
+        pool = determine_deployment_pool(path)
+        print(f"{name} {print_pool_name(pool)}")
 
     print()
 
     print("Cluster deployments")
     print("===================")
-    for deployment in get_k8s_deployments("component=gnomad-browser"):
-        print(deployment[len("gnomad-browser-") :])
+    for deployment, pool in get_k8s_deployments("component=gnomad-browser"):
+        print(f"{deployment[len('gnomad-browser-'):]} {print_pool_name(pool)}")
+
+    print()
 
 
 def create_deployment(name: str, browser_tag: str = None, api_tag: str = None, demo: bool = False) -> None:


### PR DESCRIPTION
Makes a minor modification to the `deployctl deployments list` command to note when local and cluster deployments are going to be/are deployed using auto scaling demo pool.

This was a minor thing I wanted, I figure just open the PR and if we don't want it, we don't have to merge it.

---

Output with this PR's changes:

```
❯ ./deployctl deployments list

Local configurations
====================
green
blue
v4-rmc-demo (demo-pool)

Cluster deployments
===================
v4-rmc-demo (demo-pool)
blue
react-18 (demo-pool)
green
```

Output previously:

```
❯ ./deployctl deployments list

Local configurations
====================
green
blue
v4-rmc-demo

Cluster deployments
===================
v4-rmc-demo
blue
react-18
green
```