### PR TITLE
Sort ClinVar consequence in table by pathogenicity

### DIFF
--- a/browser/help/topics/clinvar-variant-categories.md
+++ b/browser/help/topics/clinvar-variant-categories.md
@@ -3,27 +3,27 @@ id: clinvar-variant-categories
 title: ClinVar variant categories
 ---
 
-ClinVar variants shown in this track are divided into four categories based on clinical significance.
+ClinVar variants shown in this track are divided into four categories based on germline classification, formerly called clinical significance.
 
-* Pathogenic / likely pathogenic
-  * Pathogenic
-  * Likely pathogenic
-  * Pathogenic/Likely pathogenic
-  * association
-  * risk factor
-* Uncertain significance / conflicting
-  * Uncertain significance
-  * Conflicting interpretations of pathogenicity
-  * conflicting data from submitters
-* Benign / likely benign
-  * Benign
-  * Likely benign
-  * Benign/Likely benign
-* Other
-  * other
-  * drug response
-  * Affects
-  * protective
-  * no interpretation for the single variant
-  * not provided
-  * association not found
+- Pathogenic / likely pathogenic
+  - Pathogenic
+  - Likely pathogenic
+  - Pathogenic/Likely pathogenic
+  - association
+  - risk factor
+- Uncertain significance / conflicting
+  - Uncertain significance
+  - Conflicting interpretations of pathogenicity
+  - conflicting data from submitters
+- Benign / likely benign
+  - Benign
+  - Likely benign
+  - Benign/Likely benign
+- Other
+  - other
+  - drug response
+  - Affects
+  - protective
+  - no interpretation for the single variant
+  - not provided
+  - association not found

--- a/browser/src/ClinvarVariantsTrack/clinvarVariantCategories.ts
+++ b/browser/src/ClinvarVariantsTrack/clinvarVariantCategories.ts
@@ -5,8 +5,8 @@ export const CLINICAL_SIGNIFICANCE_CATEGORIES = ['pathogenic', 'uncertain', 'ben
 const CLINICAL_SIGNIFICANCE_GROUPS = {
   pathogenic: new Set([
     'Pathogenic',
-    'Likely pathogenic',
     'Pathogenic/Likely pathogenic',
+    'Likely pathogenic',
     'association',
     'risk factor',
   ]),
@@ -16,7 +16,7 @@ const CLINICAL_SIGNIFICANCE_GROUPS = {
     'Conflicting classifications of pathogenicity',
     'conflicting data from submitters',
   ]),
-  benign: new Set(['Benign', 'Likely benign', 'Benign/Likely benign']),
+  benign: new Set(['Likely benign', 'Benign/Likely benign', 'Benign']),
   other: new Set([
     'other',
     'drug response',
@@ -28,6 +28,23 @@ const CLINICAL_SIGNIFICANCE_GROUPS = {
     'association not found',
   ]),
 } as const
+
+const buildPriorityMapping = () => {
+  const mapping: { [key: string]: number } = {}
+
+  return CLINICAL_SIGNIFICANCE_CATEGORIES.reduce((acc, category, categoryIndex) => {
+    const group = CLINICAL_SIGNIFICANCE_GROUPS[category as ClinicalSignificance]
+    const groupArray = Array.from(group)
+
+    groupArray.forEach((significance, index) => {
+      acc[significance] = categoryIndex * groupArray.length + index + 1
+    })
+
+    return acc
+  }, mapping)
+}
+
+export const CLINICAL_SIGNIFICANCE_SORT_PRIORITY = buildPriorityMapping()
 
 export type ClinicalSignificance = keyof typeof CLINICAL_SIGNIFICANCE_GROUPS
 

--- a/browser/src/MitochondrialVariantList/ExportMitochondrialVariantsButton.tsx
+++ b/browser/src/MitochondrialVariantList/ExportMitochondrialVariantsButton.tsx
@@ -26,7 +26,7 @@ const BASE_COLUMNS = [
       variant.consequence ? getLabelForConsequenceTerm(variant.consequence) : '',
   },
   {
-    label: 'ClinVar Clinical Significance',
+    label: 'ClinVar Germline Classification',
     getValue: (variant: any) => variant.clinical_significance || '',
   },
   {

--- a/browser/src/MitochondrialVariantList/MitochondrialVariants.tsx
+++ b/browser/src/MitochondrialVariantList/MitochondrialVariants.tsx
@@ -78,7 +78,7 @@ const MitochondrialVariants = ({
     if ((columnsForContext as any).clinical_significance) {
       ;(
         columnsForContext as any
-      ).clinical_significance.description = `ClinVar clinical significance, based on ClinVar's ${formatClinvarDate(
+      ).clinical_significance.description = `ClinVar germline classification, formerly called clinical significance. Based on ClinVar's ${formatClinvarDate(
         clinvarReleaseDate
       )} release`
     }

--- a/browser/src/MitochondrialVariantList/mitochondrialVariantTableColumns.tsx
+++ b/browser/src/MitochondrialVariantList/mitochondrialVariantTableColumns.tsx
@@ -7,7 +7,11 @@ import Link from '../Link'
 import { Cell, NumericCell, renderAlleleCountCell, renderAlleleFrequencyCell } from '../tableCells'
 import { getCategoryFromConsequence, getLabelForConsequenceTerm } from '../vepConsequences'
 import SampleSourceIcon from '../VariantList/SampleSourceIcon'
-import { makeNumericCompareFunction, makeStringCompareFunction } from '../VariantList/sortUtilities'
+import {
+  makeClinvarCompareFunction,
+  makeNumericCompareFunction,
+  makeStringCompareFunction,
+} from '../VariantList/sortUtilities'
 import VariantCategoryMarker from '../VariantList/VariantCategoryMarker'
 import VariantFlag from '../VariantList/VariantFlag'
 
@@ -97,11 +101,11 @@ const mitochondrialVariantTableColumns = [
 
   {
     key: 'clinical_significance',
-    heading: 'Clinical Significance',
-    description: 'ClinVar clinical significance',
+    heading: 'Germline classification',
+    description: 'ClinVar germline classification, formerly called clinical significance',
     grow: 1,
     minWidth: 150,
-    compareFunction: makeStringCompareFunction('clinical_significance'),
+    compareFunction: makeClinvarCompareFunction('clinical_significance'),
     getSearchTerms: (variant: any) => [variant.clinical_significance],
     render: (variant: any, _: any, { highlightWords }: any) => (
       <Cell>

--- a/browser/src/VariantList/ExportVariantsButton.tsx
+++ b/browser/src/VariantList/ExportVariantsButton.tsx
@@ -313,7 +313,7 @@ const exportVariantsToCsv = (
       getValue: (variant: VariantTableVariant) => variant.consequence || '',
     },
     {
-      label: 'ClinVar Clinical Significance',
+      label: 'ClinVar Germline Classification',
       getValue: (variant: VariantTableVariant) => variant.clinical_significance || '',
     },
     {

--- a/browser/src/VariantList/Variants.tsx
+++ b/browser/src/VariantList/Variants.tsx
@@ -104,7 +104,7 @@ const Variants = ({
     if ((columnsForContext as any).clinical_significance) {
       ;(
         columnsForContext as any
-      ).clinical_significance.description = `ClinVar clinical significance, based on ClinVar's ${formatClinvarDate(
+      ).clinical_significance.description = `ClinVar germline classification, formerly called clinical significance. Based on ClinVar's ${formatClinvarDate(
         clinvarReleaseDate
       )} release`
     }

--- a/browser/src/VariantList/sortUtilities.ts
+++ b/browser/src/VariantList/sortUtilities.ts
@@ -1,3 +1,5 @@
+import { CLINICAL_SIGNIFICANCE_SORT_PRIORITY } from '../ClinvarVariantsTrack/clinvarVariantCategories'
+
 export const isEmpty = (val: any) => val === undefined || val === null || val === ''
 
 export const makeCompareFunction =
@@ -29,3 +31,11 @@ export const makeStringCompareFunction = (key: any) =>
 
 export const makeNumericCompareFunction = (key: any) =>
   makeCompareFunction(key, (v1: any, v2: any) => v1 - v2)
+
+export const makeClinvarCompareFunction = (key: any) =>
+  makeCompareFunction(key, (v1: string, v2: string) => {
+    return (
+      (CLINICAL_SIGNIFICANCE_SORT_PRIORITY[v2] ?? 999) -
+      (CLINICAL_SIGNIFICANCE_SORT_PRIORITY[v1] ?? 999)
+    )
+  })

--- a/browser/src/VariantList/variantTableColumns.tsx
+++ b/browser/src/VariantList/variantTableColumns.tsx
@@ -123,8 +123,8 @@ const variantTableColumns: VariantTableColumn[] = [
 
   {
     key: 'clinical_significance',
-    heading: 'Clinical Significance',
-    description: 'ClinVar clinical significance',
+    heading: 'Germline classification',
+    description: 'ClinVar germline classification, formerly called clinical significance',
     grow: 1,
     minWidth: 150,
     compareFunction: makeClinvarCompareFunction('clinical_significance'),

--- a/browser/src/VariantList/variantTableColumns.tsx
+++ b/browser/src/VariantList/variantTableColumns.tsx
@@ -8,6 +8,7 @@ import { Cell, NumericCell, renderAlleleCountCell, renderAlleleFrequencyCell } f
 import { getCategoryFromConsequence, getLabelForConsequenceTerm } from '../vepConsequences'
 import SampleSourceIcon from './SampleSourceIcon'
 import {
+  makeClinvarCompareFunction,
   makeCompareFunction,
   makeNumericCompareFunction,
   makeStringCompareFunction,
@@ -126,7 +127,7 @@ const variantTableColumns: VariantTableColumn[] = [
     description: 'ClinVar clinical significance',
     grow: 1,
     minWidth: 150,
-    compareFunction: makeStringCompareFunction('clinical_significance'),
+    compareFunction: makeClinvarCompareFunction('clinical_significance'),
     getSearchTerms: (variant: any) => variant.clinical_significance,
     render: (variant: any, _: any, { highlightWords }: any) => (
       <Cell>


### PR DESCRIPTION
Resolves #1656 

When sorting the variant table by ClinVa, sort it by Pathogenicity rather than lexicographically.

Right now it sorts to more pathogenic first on first click, as I suspect that's what users are more likely to want to see, that's very easy to change if needed.

---

Also currently includes a commit to rename 'clinical significance' to 'germline classification' in the relevant locations. ClinVar moved to [several different](https://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/#:~:text=Prior%20to%202024%2C%20ClinVar%20had%20a%20single,somatic%20classification%20of%20clinical%20impact%2C%20and%20oncogenicity.) classifications, and the germline classification one is the one that we have always displayed as the "clinical significance".


Sorted descending:
![Screenshot 2024-11-21 at 14 01 20](https://github.com/user-attachments/assets/44ec7468-8f57-479d-adee-fd5f3ba7167a)

Sorted ascending
![Screenshot 2024-11-21 at 14 01 23](https://github.com/user-attachments/assets/b4f02488-21f3-426d-93ec-a273842e0f85)

Unsorted:
![Screenshot 2024-11-21 at 13 58 47](https://github.com/user-attachments/assets/6afeef93-03eb-47dd-9d82-16d5e6fb48f4)

