### PR TITLE
fix(browser): correctly sort transcripts without tissue expression

### DIFF
--- a/browser/src/GenePage/sortedTranscripts.ts
+++ b/browser/src/GenePage/sortedTranscripts.ts
@@ -27,8 +27,12 @@ const sortedTranscripts = (
       }
     }
 
-    const t1Mean = mean(t1.gtex_tissue_expression!.map((tissue) => tissue.value)) || 0
-    const t2Mean = mean(t2.gtex_tissue_expression!.map((tissue) => tissue.value)) || 0
+    const t1Mean = t1.gtex_tissue_expression
+      ? mean(t1.gtex_tissue_expression.map((tissue) => tissue.value)) || 0
+      : 0
+    const t2Mean = t2.gtex_tissue_expression
+      ? mean(t2.gtex_tissue_expression.map((tissue) => tissue.value)) || 0
+      : 0
 
     if (t1Mean === t2Mean) {
       return t1.transcript_id.localeCompare(t2.transcript_id)


### PR DESCRIPTION
Handles null gtex expression correctly to allow viewing of sorted transcript for genes without gtex, e.g. NEB.

![Screenshot 2024-11-22 at 08 56 58](https://github.com/user-attachments/assets/3591440f-4c5b-46a1-b3eb-3c589a62a387)
