### PR TITLE
Use ES aliases again in production

### DIFF
--- a/graphql-api/src/queries/clinvar-variant-queries.ts
+++ b/graphql-api/src/queries/clinvar-variant-queries.ts
@@ -9,12 +9,8 @@ import { getConsequenceForContext } from './variant-datasets/shared/transcriptCo
 import largeGenes from './helpers/large-genes'
 
 const CLINVAR_VARIANT_INDICES = {
-  // GRCh37: 'clinvar_grch37_variants',
-  // GRCh38: 'clinvar_grch38_variants',
-  // TODO: revert back to using alias'ed indexes once we are confident this is
-  //   stable in production
-  GRCh37: 'clinvar_grch37_variants-2024-11-08--19-22',
-  GRCh38: 'clinvar_grch38_variants-2024-11-08--13-08',
+  GRCh37: 'clinvar_grch37_variants',
+  GRCh38: 'clinvar_grch38_variants',
 }
 
 // ================================================================================================

--- a/graphql-api/src/queries/gene-queries.ts
+++ b/graphql-api/src/queries/gene-queries.ts
@@ -3,10 +3,8 @@ import { withCache } from '../cache'
 import { fetchAllSearchResults } from './helpers/elasticsearch-helpers'
 
 const GENE_INDICES = {
-  // GRCh37: 'genes_grch37',
-  // GRCh38: 'genes_grch38',
-  GRCh37: 'genes_grch37-2024-11-15--15-23',
-  GRCh38: 'genes_grch38-2024-11-20--16-28',
+  GRCh37: 'genes_grch37',
+  GRCh38: 'genes_grch38',
 }
 
 const _fetchGeneById = async (esClient: any, geneId: any, referenceGenome: any) => {


### PR DESCRIPTION
In two prior PRs, indices were used over aliases to allow for ease of rollbacks if needed. Since these two feature (v4 pext and clinvar with new XML format) have been stable, this PR goes back to using aliases.

The aliases now point to previously hard coded indices:
```
❯ curl -u "elastic:$ELASTICSEARCH_PASSWORD" http://localhost:9200/_cat/aliases\?pretty\&v\=true\&s\=index:asc

alias                                index                                                  filter routing.index routing.search is_write_index
...
clinvar_grch37_variants              clinvar_grch37_variants-2024-11-08--19-22              -      -             -              -
clinvar_grch38_variants              clinvar_grch38_variants-2024-11-08--13-08              -      -             -              -
...
genes_grch37                         genes_grch37-2024-11-15--15-23                         -      -             -              -
genes_grch38                         genes_grch38-2024-11-20--16-28                         -      -             -              -
...
```
