### PR TITLE
Filter gene variant queries to exons consistently

### DIFF
--- a/graphql-api/src/queries/clinvar-variant-queries.ts
+++ b/graphql-api/src/queries/clinvar-variant-queries.ts
@@ -7,6 +7,7 @@ import { fetchAllSearchResults, fetchIndexMetadata } from './helpers/elasticsear
 import { mergeOverlappingRegions } from './helpers/region-helpers'
 import { getConsequenceForContext } from './variant-datasets/shared/transcriptConsequence'
 import largeGenes from './helpers/large-genes'
+import { getFilteredRegions } from './variant-datasets/gnomad-v4-variant-queries'
 
 const CLINVAR_VARIANT_INDICES = {
   GRCh37: 'clinvar_grch37_variants',
@@ -166,7 +167,7 @@ const shapeVariantSummary = (context: any) => {
 // ================================================================================================
 
 const _fetchClinvarVariantsByGene = async (esClient: any, referenceGenome: any, gene: any) => {
-  const filteredRegions = gene.exons.filter((exon: any) => exon.feature_type === 'CDS')
+  const filteredRegions = getFilteredRegions(gene.exons)
   const sortedRegions = filteredRegions.sort((r1: any, r2: any) => r1.xstart - r2.xstart)
   const padding = 75
   const paddedRegions = sortedRegions.map((r: any) => ({
@@ -266,7 +267,7 @@ const _fetchClinvarVariantsByTranscript = async (
   referenceGenome: any,
   transcript: any
 ) => {
-  const filteredRegions = transcript.exons.filter((exon: any) => exon.feature_type === 'CDS')
+  const filteredRegions = getFilteredRegions(transcript.exons)
   const sortedRegions = filteredRegions.sort((r1: any, r2: any) => r1.xstart - r2.xstart)
   const padding = 75
   const paddedRegions = sortedRegions.map((r: any) => ({

--- a/graphql-api/src/queries/mitochondrial-variant-datasets/gnomad-v3-mitochondrial-variant-queries.ts
+++ b/graphql-api/src/queries/mitochondrial-variant-datasets/gnomad-v3-mitochondrial-variant-queries.ts
@@ -4,6 +4,7 @@ import { fetchAllSearchResults } from '../helpers/elasticsearch-helpers'
 import { mergeOverlappingRegions } from '../helpers/region-helpers'
 import { getFlagsForContext } from '../variant-datasets/shared/flags'
 import { getConsequenceForContext } from '../variant-datasets/shared/transcriptConsequence'
+import { getFilteredRegions } from '../variant-datasets/gnomad-v4-variant-queries'
 
 const GNOMAD_V3_MITOCHONDRIAL_VARIANT_INDEX = 'gnomad_v3_mitochondrial_variants'
 
@@ -97,7 +98,7 @@ const shapeMitochondrialVariantSummary = (context: any) => {
 // ================================================================================================
 
 const fetchMitochondrialVariantsByGene = async (esClient: any, gene: any) => {
-  const filteredRegions = gene.exons.filter((exon: any) => exon.feature_type === 'CDS')
+  const filteredRegions = getFilteredRegions(gene.exons)
   const sortedRegions = filteredRegions.sort((r1: any, r2: any) => r1.xstart - r2.xstart)
   const padding = 75
   const paddedRegions = sortedRegions.map((r: any) => ({

--- a/graphql-api/src/queries/variant-datasets/exac-variant-queries.ts
+++ b/graphql-api/src/queries/variant-datasets/exac-variant-queries.ts
@@ -12,6 +12,7 @@ import {
 
 import { getFlagsForContext } from './shared/flags'
 import { getConsequenceForContext } from './shared/transcriptConsequence'
+import { getFilteredRegions } from './gnomad-v4-variant-queries'
 
 const EXAC_VARIANT_INDEX = 'exac_variants'
 
@@ -131,7 +132,7 @@ const shapeVariantSummary = (context: any) => {
 // ================================================================================================
 
 export const fetchVariantsByGene = async (esClient: any, gene: any) => {
-  const filteredRegions = gene.exons.filter((exon: any) => exon.feature_type === 'CDS')
+  const filteredRegions = getFilteredRegions(gene.exons)
   const sortedRegions = filteredRegions.sort((r1: any, r2: any) => r1.xstart - r2.xstart)
   const padding = 75
   const paddedRegions = sortedRegions.map((r: any) => ({
@@ -278,7 +279,7 @@ export const fetchVariantsByRegion = async (esClient: any, region: any) => {
 // ================================================================================================
 
 export const fetchVariantsByTranscript = async (esClient: any, transcript: any) => {
-  const filteredRegions = transcript.exons.filter((exon: any) => exon.feature_type === 'CDS')
+  const filteredRegions = getFilteredRegions(transcript.exons)
   const sortedRegions = filteredRegions.sort((r1: any, r2: any) => r1.xstart - r2.xstart)
   const padding = 75
   const paddedRegions = sortedRegions.map((r: any) => ({

--- a/graphql-api/src/queries/variant-datasets/getFilteredRegions.spec.ts
+++ b/graphql-api/src/queries/variant-datasets/getFilteredRegions.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from '@jest/globals'
+
+import { getFilteredRegions, type Exon } from './gnomad-v4-variant-queries'
+
+describe('getFilteredRegion', () => {
+  it('only returns CDS exons when at least 1 CDS exon is present', () => {
+    const testExons: Exon[] = [
+      { feature_type: 'UTR' },
+      { feature_type: 'UTR' },
+      { feature_type: 'CDS' },
+      { feature_type: 'exon' },
+      { feature_type: 'CDS' },
+      { feature_type: 'CDS' },
+      { feature_type: 'exon' },
+    ]
+    const result = getFilteredRegions(testExons)
+
+    const expectedExons: Exon[] = [
+      { feature_type: 'CDS' },
+      { feature_type: 'CDS' },
+      { feature_type: 'CDS' },
+    ]
+
+    expect(result).toEqual(expectedExons)
+  })
+
+  it('only returns non UTR/CDS exons when no CDS exons are present', () => {
+    const testExons: Exon[] = [
+      { feature_type: 'UTR' },
+      { feature_type: 'UTR' },
+      { feature_type: 'exon' },
+      { feature_type: 'UTR' },
+      { feature_type: 'exon' },
+      { feature_type: 'exon' },
+    ]
+    const result = getFilteredRegions(testExons)
+
+    const expectedExons: any[] = [
+      { feature_type: 'exon' },
+      { feature_type: 'exon' },
+      { feature_type: 'exon' },
+    ]
+
+    expect(result).toEqual(expectedExons)
+  })
+})

--- a/graphql-api/src/queries/variant-datasets/gnomad-v2-variant-queries.ts
+++ b/graphql-api/src/queries/variant-datasets/gnomad-v2-variant-queries.ts
@@ -14,6 +14,7 @@ import {
 
 import { getFlagsForContext } from './shared/flags'
 import { getConsequenceForContext } from './shared/transcriptConsequence'
+import { getFilteredRegions } from './gnomad-v4-variant-queries'
 
 const GNOMAD_V2_VARIANT_INDEX = 'gnomad_v2_variants'
 
@@ -207,7 +208,7 @@ const shapeVariantSummary = (exomeSubset: any, genomeSubset: any, context: any) 
 // ================================================================================================
 
 const fetchVariantsByGene = async (esClient: any, gene: any, subset: any) => {
-  const filteredRegions = gene.exons.filter((exon: any) => exon.feature_type === 'CDS')
+  const filteredRegions = getFilteredRegions(gene.exons)
   const sortedRegions = filteredRegions.sort((r1: any, r2: any) => r1.xstart - r2.xstart)
   const padding = 75
   const paddedRegions = sortedRegions.map((r: any) => ({
@@ -376,7 +377,7 @@ const fetchVariantsByRegion = async (esClient: any, region: any, subset: any) =>
 // ================================================================================================
 
 const fetchVariantsByTranscript = async (esClient: any, transcript: any, subset: any) => {
-  const filteredRegions = transcript.exons.filter((exon: any) => exon.feature_type === 'CDS')
+  const filteredRegions = getFilteredRegions(transcript.exons)
   const sortedRegions = filteredRegions.sort((r1: any, r2: any) => r1.xstart - r2.xstart)
   const padding = 75
   const paddedRegions = sortedRegions.map((r: any) => ({

--- a/graphql-api/src/queries/variant-datasets/gnomad-v3-variant-queries.ts
+++ b/graphql-api/src/queries/variant-datasets/gnomad-v3-variant-queries.ts
@@ -10,6 +10,7 @@ import { mergeOverlappingRegions } from '../helpers/region-helpers'
 
 import { getFlagsForContext } from './shared/flags'
 import { getConsequenceForContext } from './shared/transcriptConsequence'
+import { getFilteredRegions } from './gnomad-v4-variant-queries'
 
 const GNOMAD_V3_VARIANT_INDEX = 'gnomad_v3_variants'
 
@@ -236,7 +237,7 @@ const shapeVariantSummary = (subset: any, context: any) => {
 // ================================================================================================
 
 const fetchVariantsByGene = async (esClient: any, gene: any, subset: any) => {
-  const filteredRegions = gene.exons.filter((exon: any) => exon.feature_type === 'CDS')
+  const filteredRegions = getFilteredRegions(gene.exons)
   const sortedRegions = filteredRegions.sort((r1: any, r2: any) => r1.xstart - r2.xstart)
   const padding = 75
   const paddedRegions = sortedRegions.map((r: any) => ({
@@ -341,7 +342,7 @@ const fetchVariantsByRegion = async (esClient: any, region: any, subset: any) =>
 // ================================================================================================
 
 const fetchVariantsByTranscript = async (esClient: any, transcript: any, subset: any) => {
-  const filteredRegions = transcript.exons.filter((exon: any) => exon.feature_type === 'CDS')
+  const filteredRegions = getFilteredRegions(transcript.exons)
   const sortedRegions = filteredRegions.sort((r1: any, r2: any) => r1.xstart - r2.xstart)
   const padding = 75
   const paddedRegions = sortedRegions.map((r: any) => ({

--- a/graphql-api/src/queries/variant-datasets/gnomad-v4-variant-queries.ts
+++ b/graphql-api/src/queries/variant-datasets/gnomad-v4-variant-queries.ts
@@ -391,6 +391,22 @@ const getMultiVariantSourceFields = (
 }
 
 // ================================================================================================
+// Helpers
+// ================================================================================================
+
+export type Exon = {
+  feature_type: 'CDS' | 'exon' | 'UTR'
+}
+
+export const getFilteredRegions = (exons: Exon[]) => {
+  const hasCDS = exons.some((exon) => exon.feature_type === 'CDS')
+  const filteredRegions = hasCDS
+    ? exons.filter((exon) => exon.feature_type === 'CDS')
+    : exons.filter((exon) => exon.feature_type === 'exon')
+  return filteredRegions
+}
+
+// ================================================================================================
 // Gene query
 // ================================================================================================
 
@@ -404,7 +420,7 @@ const fetchVariantsByGene = async (esClient: any, gene: any, subset: Subset) => 
   const pageSize = isLargeGene ? 500 : 10000
 
   try {
-    const filteredRegions = gene.exons.filter((exon: any) => exon.feature_type === 'CDS')
+    const filteredRegions = getFilteredRegions(gene.exons)
     const sortedRegions = filteredRegions.sort((r1: any, r2: any) => r1.xstart - r2.xstart)
     const padding = 75
     const paddedRegions = sortedRegions.map((r: any) => ({
@@ -515,7 +531,7 @@ const fetchVariantsByTranscript = async (esClient: any, transcript: any, subset:
     )
   }
 
-  const filteredRegions = transcript.exons.filter((exon: any) => exon.feature_type === 'CDS')
+  const filteredRegions = getFilteredRegions(transcript.exons)
   const sortedRegions = filteredRegions.sort((r1: any, r2: any) => r1.xstart - r2.xstart)
   const padding = 75
   const paddedRegions = sortedRegions.map((r: any) => ({


### PR DESCRIPTION
Currently, our frontend determines what to display in the region viewer based partially on the presence of CDS exons: https://github.com/broadinstitute/gnomad-browser/blob/c7276f25d160059429f039ad0b7e0f445fcdc491/browser/src/GenePage/GenePage.tsx#L315-L353

In the case of non-coding genes, this results in the Coverage track and Frequency-Bubble track filtering variants on non-coding genes in the case where there are coding transcripts, but the variant table including variants from those non-coding transcripts. Since one of these filters occurs on the frontend only for the region viewer, we are displaying inconsistent numbers of variants between the track and the table, and between which component on the frontend a user looks at vs the API response.

---

This PR updates our API to filter the variant response for non coding genes to only include variants in the padded exons regions, to match the frontend region viewer logic. This should increase consistency in how we display different views.