### PR TITLE
Update gencode version text on gene page

### DIFF
--- a/browser/src/GenePage/GeneInfo.tsx
+++ b/browser/src/GenePage/GeneInfo.tsx
@@ -77,7 +77,7 @@ const GeneInfo = ({ gene }: GeneInfoProps) => {
     : null
 
   const ucscReferenceGenomeId = gene.reference_genome === 'GRCh37' ? 'hg19' : 'hg38'
-  const gencodeVersion = gene.reference_genome === 'GRCh37' ? '19' : '35'
+  const gencodeVersion = gene.reference_genome === 'GRCh37' ? '19' : '39'
 
   const otherTranscripts = gene.transcripts.filter(
     (transcript) =>


### PR DESCRIPTION
Qin noticed this still says v35. I've honestly never seen this text, it seems to only show up if there's a differing gene symbol between gencode and other sources.

<img src="https://github.com/user-attachments/assets/7d19040b-1f60-4311-ac8a-f0ed7ad93f6d" alt="" width="575px"/>

While grepping for gencode v35, I noticed the readviz still uses v35 -- worth double checking there if that's intended.
