### PR TITLE
Repartition gene model release tables

### DIFF
--- a/browser/help/topics/v4-browser-hts.md
+++ b/browser/help/topics/v4-browser-hts.md
@@ -182,12 +182,15 @@ Row fields:
   - `xstart`: Transcript genomic start position (format: chromosomeposition).
   - `xstop`: Transcript genomic stop position (format: chromosomeposition).
   - `exons`: Array containing transcript exon information.
-  - `feature_type`: Exon type (e.g., CDS).
-  - `start`: Exon genomic start position (position only).
-  - `stop`: Exon genomic stop position (position only).
-  - `xstart`: Exon genomic start position (format: chromosomeposition).
-  - `xstop`: Exon genomic start position (format: chromosomeposition).
+    - `feature_type`: Exon type (e.g., CDS).
+    - `start`: Exon genomic start position (position only).
+    - `stop`: Exon genomic stop position (position only).
+    - `xstart`: Exon genomic start position (format: chromosomeposition).
+    - `xstop`: Exon genomic start position (format: chromosomeposition).
   - `reference_genome`: Reference genome associated with this transcript.
+  - `gtex_tissue_expression`: Array containing [GTEx](https://gtexportal.org/home/) v10 information.
+    - `tissue`: The tissue type, e.g. 'brain_cerebellum'.
+    - `value`: The Transript Per Million (TPM) value associated with the tissue.
   - `refseq_id`: Transcript RefSeq ID.
   - `refseq_version`: RefSeq version.
 - `hgnc_id`: HGNC gene ID.
@@ -208,6 +211,15 @@ Row fields:
   - `ensembl_version`: Ensembl version.
   - `refseq_id`: Transcript RefSeq ID.
   - `refseq_version`: RefSeq version.
+- `pext`: Struct containing [pext](https://gnomad.broadinstitute.org/help/pext) information.
+  - `regions`: Array containing pext information by region.
+    - `chrom`: The chromosome in which the region is located.
+    - `start`: Region genomic start position (position only).
+    - `stop`: Region genomic stop position (position only).
+    - `mean`: Mean expression across all tissues for the region.
+    - `tissues`: Array containing tissue information.
+      - `tissue`: The tissue type, e.g. 'brain_cerebellum'.
+      - `value`: The pext score for the tissue in the region.
 - `preferred_transcript_id`: Transcript shown on the gene page by default. Field contains MANE Select transcript ID if it exists, otherwise contains Ensembl canonical transcript ID.
 - `preferred_transcript_source`: Source of transcript ID used for `preferred_transcript_id` field; either "`mane_select`" or "`ensembl_canonical`".
 - `gnomad_constraint`: Struct containing gnomAD constraint information for gene. Struct is only present on the GRCh37 Hail Table.

--- a/browser/src/DataPage/GnomadV2Downloads.tsx
+++ b/browser/src/DataPage/GnomadV2Downloads.tsx
@@ -303,7 +303,7 @@ const GnomadV2Downloads = () => {
           <ListItem>
             <GetUrlButtons
               label="Browser GRCh37 gene models Hail Table"
-              path="/resources/grch37/browser/gnomad.genes.GRCh37.GENCODEv19.ht"
+              path="/resources/grch37/browser/gnomad.genes.GRCh37.GENCODEv19.pext.ht"
             />
           </ListItem>
         </FileList>

--- a/browser/src/DataPage/GnomadV4Downloads.tsx
+++ b/browser/src/DataPage/GnomadV4Downloads.tsx
@@ -293,7 +293,7 @@ const GnomadV4Downloads = () => {
           <ListItem>
             <GetUrlButtons
               label="Browser GRCh38 gene models Hail Table"
-              path="/resources/grch38/browser/gnomad.genes.GRCh38.GENCODEv39.ht"
+              path="/resources/grch38/browser/gnomad.genes.GRCh38.GENCODEv39.pext.ht"
             />
           </ListItem>
         </FileList>

--- a/browser/src/GenePage/GenePage.tsx
+++ b/browser/src/GenePage/GenePage.tsx
@@ -574,6 +574,7 @@ const GenePage = ({ datasetId, gene, geneId }: Props) => {
             includeNonCodingTranscripts={includeNonCodingTranscripts}
             includeUTRs={includeUTRs}
             zoomRegion={zoomRegion}
+            hasOnlyNonCodingTranscripts={!hasCodingExons && hasNonCodingTranscripts}
           />
         )}
       </RegionViewer>

--- a/browser/src/GenePage/VariantsInGene.tsx
+++ b/browser/src/GenePage/VariantsInGene.tsx
@@ -82,6 +82,7 @@ type OwnVariantsInGeneProps = {
     start: number
     stop: number
   }
+  hasOnlyNonCodingTranscripts?: boolean
 }
 
 // @ts-expect-error TS(2456) FIXME: Type alias 'VariantsInGeneProps' circularly refere... Remove this comment to see the full error message
@@ -97,6 +98,7 @@ const VariantsInGene = ({
   includeUTRs,
   variants,
   zoomRegion,
+  hasOnlyNonCodingTranscripts,
 }: VariantsInGeneProps) => {
   const datasetLabel = labelForDataset(datasetId)
 
@@ -134,9 +136,12 @@ const VariantsInGene = ({
           <Badge level={includeNonCodingTranscripts || includeUTRs ? 'warning' : 'info'}>
             {includeNonCodingTranscripts || includeUTRs ? 'Warning' : 'Note'}
           </Badge>{' '}
-          Only variants located in or within 75 base pairs of a coding exon are shown here. To see
-          variants in UTRs or introns, use the{' '}
-          <Link to={`/region/${gene.chrom}-${gene.start}-${gene.stop}`}>region view</Link>.
+          {hasOnlyNonCodingTranscripts && <>This gene has no coding transcripts. </>}
+          Only variants located in or within 75 base pairs of{' '}
+          {!hasOnlyNonCodingTranscripts ? <>a coding exon (CDS)</> : <>an exon</>} are shown here.
+          To see variants {!hasOnlyNonCodingTranscripts ? <>in UTRs or introns</> : <>in introns</>}
+          , use the <Link to={`/region/${gene.chrom}-${gene.start}-${gene.stop}`}>region view</Link>
+          .
         </p>
         <p>
           The table below shows the HGVS consequence and VEP annotation for each variant&apos;s most

--- a/data-pipeline/src/data_pipeline/data_types/gene.py
+++ b/data-pipeline/src/data_pipeline/data_types/gene.py
@@ -234,7 +234,7 @@ def prepare_gene_table_for_release(genes_path, keep_mane_version_global_annotati
     else:
         ds = ds.select_globals()
 
-    ds = ds.repartition(50)
+    ds = ds.repartition(100)
     return ds
 
 

--- a/data-pipeline/src/data_pipeline/pipelines/genes.py
+++ b/data-pipeline/src/data_pipeline/pipelines/genes.py
@@ -401,7 +401,7 @@ pipeline.add_task(
 pipeline.add_task(
     "prepare_grch37_genes_table_for_public_release",
     prepare_gene_table_for_release,
-    f"/{genes_subdir}/gnomad.browser.GRCh37.GENCODEv19.ht",
+    f"/{genes_subdir}/gnomad.browser.GRCh37.GENCODEv19.pext.ht",
     {
         "genes_path": pipeline.get_task("annotate_grch37_genes_step_5"),
     },
@@ -489,7 +489,7 @@ pipeline.add_task(
 pipeline.add_task(
     "prepare_grch38_genes_table_for_public_release",
     prepare_gene_table_for_release,
-    f"/{genes_subdir}/gnomad.browser.GRCh38.GENCODEv39.ht",
+    f"/{genes_subdir}/gnomad.browser.GRCh38.GENCODEv39.pext.ht",
     {
         "genes_path": pipeline.get_task("remove_grch38_genes_constraint_for_release"),
     },


### PR DESCRIPTION
Resolves #1643

- Minor update to gene pipeline task to change amount of partitions the gene model tables get reduced as part of preparing the public release table
- Updates downloads page to point to the new paths
- Updates the help text to include the GTEx/pext information now included in the public release gene model hail tables
---
- Updates note on gene page to be more specific about what variants are displayed