### PR TITLE
Direct /awesome queries to v4 by default

### DIFF
--- a/browser/src/DataPage/GnomadV4Downloads.tsx
+++ b/browser/src/DataPage/GnomadV4Downloads.tsx
@@ -271,8 +271,7 @@ const GnomadV4Downloads = () => {
         <p>
           For more information about these files, see our{' '}
           <Link to="https://gnomad.broadinstitute.org/news/2024-08-release-gnomad-browser-tables">
-            https://gnomad.broadinstitute.org/news/2024-08-release-gnomad-browser-tables/ changelog
-            entry
+            changelog entry
           </Link>{' '}
           on the browser tables, and the <Link to="/help/v4-browser-hts">help text</Link>.
         </p>

--- a/browser/src/DataPage/__snapshots__/DataPage.spec.tsx.snap
+++ b/browser/src/DataPage/__snapshots__/DataPage.spec.tsx.snap
@@ -7436,7 +7436,7 @@ exports[`Data Page has no unexpected changes 1`] = `
           href="https://gnomad.broadinstitute.org/news/2024-08-release-gnomad-browser-tables"
           onClick={[Function]}
         >
-          https://gnomad.broadinstitute.org/news/2024-08-release-gnomad-browser-tables/ changelog entry
+          changelog entry
         </a>
          
         on the browser tables, and the 

--- a/browser/src/SearchRedirectPage.tsx
+++ b/browser/src/SearchRedirectPage.tsx
@@ -9,7 +9,7 @@ import StatusMessage from './StatusMessage'
 import { fetchSearchResults } from './search'
 import useRequest from './useRequest'
 
-const defaultSearchDataset = 'gnomad_r2_1'
+const defaultSearchDataset = 'gnomad_r4'
 
 type SearchRedirectProps = {
   query: string


### PR DESCRIPTION
e.g. 
  http://localhost:8008/awesome?query=gpld1 now redirects to 
  http://localhost:8008/gene/ENSG00000112293?dataset=gnomad_r4