### PR TITLE
Add useTableSort hook

### DIFF
--- a/browser/src/CopyNumberVariantPage/CNVPopulationsTable.tsx
+++ b/browser/src/CopyNumberVariantPage/CNVPopulationsTable.tsx
@@ -89,18 +89,21 @@ type CNVPopulationsTableState = any
 type CNVPopulationsTableProps = OwnPopulationsTableProps & typeof CNVPopulationsTable.defaultProps
 
 export class CNVPopulationsTable extends Component<
-  CNVPopulationsTableProps & { variant: CopyNumberVariant},
+  CNVPopulationsTableProps & { variant: CopyNumberVariant },
   CNVPopulationsTableState
 > {
   static defaultProps = {
     columnLabels: {},
     initiallyExpandRows: false,
-    variant: {}
+    variant: {},
   }
 
-  constructor(props: CNVPopulationsTableProps ) {
+  constructor(props: CNVPopulationsTableProps) {
     super(props)
 
+    // If/when we change this to a functional component, we can replace the
+    // following sorting logic and some other associated code by employing
+    // useTableSort.
     this.state = {
       sortBy: 'sf',
       sortAscending: false,

--- a/browser/src/MitochondrialVariantPage/MitochondrialVariantHaplogroupFrequenciesTable.tsx
+++ b/browser/src/MitochondrialVariantPage/MitochondrialVariantHaplogroupFrequenciesTable.tsx
@@ -51,6 +51,9 @@ class MitochondrialVariantHaplogroupFrequenciesTable extends Component<Props, St
     sortAscending: false,
   }
 
+  // If/when we change this to a functional component, we can replace the
+  // following sorting logic and some other associated code by employing
+  // useTableSort.
   setSortBy(sortBy: any) {
     this.setState((state: any) => ({
       sortBy,

--- a/browser/src/MitochondrialVariantPage/MitochondrialVariantPage.tsx
+++ b/browser/src/MitochondrialVariantPage/MitochondrialVariantPage.tsx
@@ -82,6 +82,13 @@ export type GenotypeQualityFilter = {
   filtered: Histogram | null
 }
 
+export type MitochondrialVariantPopulation = {
+  id: PopulationId
+  an: number
+  ac_het: number
+  ac_hom: number
+}
+
 export type MitochondrialVariant = {
   alt: string
   an: number
@@ -99,12 +106,7 @@ export type MitochondrialVariant = {
     ac_het: number
   }[]
   max_heteroplasmy: number | null
-  populations: {
-    id: PopulationId
-    an: number
-    ac_het: number
-    ac_hom: number
-  }[]
+  populations: MitochondrialVariantPopulation[]
   pos: number
   ref: string
   reference_genome: string

--- a/browser/src/MitochondrialVariantPage/MitochondrialVariantPopulationFrequenciesTable.spec.tsx
+++ b/browser/src/MitochondrialVariantPage/MitochondrialVariantPopulationFrequenciesTable.spec.tsx
@@ -1,0 +1,244 @@
+import React from 'react'
+import mitochondrialVariantFactory, {
+  populationFactory,
+} from '../__factories__/MitochondrialVariant'
+import { describe, expect, test } from '@jest/globals'
+import { render, screen } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
+import { PopulationId } from '@gnomad/dataset-metadata/gnomadPopulations'
+
+import MitochondrialVariantPopulationFrequenciesTable from './MitochondrialVariantPopulationFrequenciesTable'
+
+describe('MitochondrialVariantPopulationFrequenciesTable', () => {
+  test('has no unexpected regressions', () => {
+    const variant = mitochondrialVariantFactory.build()
+    const tree = render(<MitochondrialVariantPopulationFrequenciesTable variant={variant} />)
+    expect(tree).toMatchSnapshot()
+  })
+
+  // Odd ordering is intentional, to help ensure sort is actually sorting
+  const ids: PopulationId[] = ['fin', 'amr', 'sas', 'afr', 'asj']
+  const numericValues = [2, 5, 1, 3, 4]
+
+  describe('sorting', () => {
+    test('sorts by ID', async () => {
+      const populations = ids.map((id) => populationFactory.build({ id }))
+      const variant = mitochondrialVariantFactory.build({ populations })
+
+      const user = userEvent.setup()
+      const tree = render(<MitochondrialVariantPopulationFrequenciesTable variant={variant} />)
+      expect(tree).toMatchSnapshot()
+
+      const idButton = screen.getByText('Genetic Ancestry Group')
+
+      await user.click(idButton)
+      const descendingIdCells = screen.queryAllByRole('rowheader')
+      const descendingIds = descendingIdCells.map((cell) => cell.innerHTML)
+      expect(descendingIds).toEqual([
+        'South Asian',
+        'European (Finnish)',
+        'Ashkenazi Jewish',
+        'African/African American',
+        'Admixed American',
+        'Total',
+      ])
+
+      await user.click(idButton)
+      const ascendingIdCells = screen.queryAllByRole('rowheader')
+      const ascendingIds = ascendingIdCells.map((cell) => cell.innerHTML)
+      expect(ascendingIds).toEqual([
+        'Admixed American',
+        'African/African American',
+        'Ashkenazi Jewish',
+        'European (Finnish)',
+        'South Asian',
+        'Total',
+      ])
+    })
+
+    test('sorts by an', async () => {
+      const populations = ids.map((id, i) => populationFactory.build({ id, an: numericValues[i] }))
+      const variant = mitochondrialVariantFactory.build({ populations })
+
+      const user = userEvent.setup()
+      const tree = render(<MitochondrialVariantPopulationFrequenciesTable variant={variant} />)
+      expect(tree).toMatchSnapshot()
+
+      const anButton = screen.getByText('Allele Number')
+
+      await user.click(anButton)
+      const descendingIdCells = screen.queryAllByRole('rowheader')
+      const descendingIds = descendingIdCells.map((cell) => cell.innerHTML)
+      expect(descendingIds).toEqual([
+        'Admixed American',
+        'Ashkenazi Jewish',
+        'African/African American',
+        'European (Finnish)',
+        'South Asian',
+        'Total',
+      ])
+
+      await user.click(anButton)
+      const ascendingIdCells = screen.queryAllByRole('rowheader')
+      const ascendingIds = ascendingIdCells.map((cell) => cell.innerHTML)
+      expect(ascendingIds).toEqual([
+        'South Asian',
+        'European (Finnish)',
+        'African/African American',
+        'Ashkenazi Jewish',
+        'Admixed American',
+        'Total',
+      ])
+    })
+
+    test('sorts by ac_het', async () => {
+      const populations = ids.map((id, i) =>
+        populationFactory.build({ id, ac_het: numericValues[i] })
+      )
+      const variant = mitochondrialVariantFactory.build({ populations })
+
+      const user = userEvent.setup()
+      const tree = render(<MitochondrialVariantPopulationFrequenciesTable variant={variant} />)
+      expect(tree).toMatchSnapshot()
+
+      const acHetButton = screen.getByText('Heteroplasmic AC')
+
+      await user.click(acHetButton)
+      const descendingIdCells = screen.queryAllByRole('rowheader')
+      const descendingIds = descendingIdCells.map((cell) => cell.innerHTML)
+      expect(descendingIds).toEqual([
+        'Admixed American',
+        'Ashkenazi Jewish',
+        'African/African American',
+        'European (Finnish)',
+        'South Asian',
+        'Total',
+      ])
+
+      await user.click(acHetButton)
+      const ascendingIdCells = screen.queryAllByRole('rowheader')
+      const ascendingIds = ascendingIdCells.map((cell) => cell.innerHTML)
+      expect(ascendingIds).toEqual([
+        'South Asian',
+        'European (Finnish)',
+        'African/African American',
+        'Ashkenazi Jewish',
+        'Admixed American',
+        'Total',
+      ])
+    })
+
+    test('sorts by ac_hom', async () => {
+      const populations = ids.map((id, i) =>
+        populationFactory.build({ id, ac_hom: numericValues[i] })
+      )
+      const variant = mitochondrialVariantFactory.build({ populations })
+
+      const user = userEvent.setup()
+      const tree = render(<MitochondrialVariantPopulationFrequenciesTable variant={variant} />)
+      expect(tree).toMatchSnapshot()
+
+      const acHomButton = screen.getByText('Homoplasmic AC')
+
+      await user.click(acHomButton)
+      const descendingIdCells = screen.queryAllByRole('rowheader')
+      const descendingIds = descendingIdCells.map((cell) => cell.innerHTML)
+      expect(descendingIds).toEqual([
+        'Admixed American',
+        'Ashkenazi Jewish',
+        'African/African American',
+        'European (Finnish)',
+        'South Asian',
+        'Total',
+      ])
+
+      await user.click(acHomButton)
+      const ascendingIdCells = screen.queryAllByRole('rowheader')
+      const ascendingIds = ascendingIdCells.map((cell) => cell.innerHTML)
+      expect(ascendingIds).toEqual([
+        'South Asian',
+        'European (Finnish)',
+        'African/African American',
+        'Ashkenazi Jewish',
+        'Admixed American',
+        'Total',
+      ])
+    })
+
+    test('sorts by af_het', async () => {
+      const populations = ids.map((id, i) =>
+        populationFactory.build({ id, ac_het: numericValues[i], an: 100 })
+      )
+      const variant = mitochondrialVariantFactory.build({ populations })
+
+      const user = userEvent.setup()
+      const tree = render(<MitochondrialVariantPopulationFrequenciesTable variant={variant} />)
+      expect(tree).toMatchSnapshot()
+
+      const afHetButton = screen.getByText('Heteroplasmic AF')
+
+      await user.click(afHetButton)
+      const descendingIdCells = screen.queryAllByRole('rowheader')
+      const descendingIds = descendingIdCells.map((cell) => cell.innerHTML)
+      expect(descendingIds).toEqual([
+        'Admixed American',
+        'Ashkenazi Jewish',
+        'African/African American',
+        'European (Finnish)',
+        'South Asian',
+        'Total',
+      ])
+
+      await user.click(afHetButton)
+      const ascendingIdCells = screen.queryAllByRole('rowheader')
+      const ascendingIds = ascendingIdCells.map((cell) => cell.innerHTML)
+      expect(ascendingIds).toEqual([
+        'South Asian',
+        'European (Finnish)',
+        'African/African American',
+        'Ashkenazi Jewish',
+        'Admixed American',
+        'Total',
+      ])
+    })
+
+    test('sorts by af_hom', async () => {
+      const populations = ids.map((id, i) =>
+        populationFactory.build({ id, ac_hom: numericValues[i], an: 100 })
+      )
+      const variant = mitochondrialVariantFactory.build({ populations })
+
+      const user = userEvent.setup()
+      const tree = render(<MitochondrialVariantPopulationFrequenciesTable variant={variant} />)
+      expect(tree).toMatchSnapshot()
+
+      const afHomButton = screen.getByText('Homoplasmic AF')
+
+      // af_hom is our default sort, so first click will give us ascending order,
+      // rather than descending like the other columns
+      await user.click(afHomButton)
+      const ascendingIdCells = screen.queryAllByRole('rowheader')
+      const ascendingIds = ascendingIdCells.map((cell) => cell.innerHTML)
+      expect(ascendingIds).toEqual([
+        'South Asian',
+        'European (Finnish)',
+        'African/African American',
+        'Ashkenazi Jewish',
+        'Admixed American',
+        'Total',
+      ])
+
+      await user.click(afHomButton)
+      const descendingIdCells = screen.queryAllByRole('rowheader')
+      const descendingIds = descendingIdCells.map((cell) => cell.innerHTML)
+      expect(descendingIds).toEqual([
+        'Admixed American',
+        'Ashkenazi Jewish',
+        'African/African American',
+        'European (Finnish)',
+        'South Asian',
+        'Total',
+      ])
+    })
+  })
+})

--- a/browser/src/MitochondrialVariantPage/MitochondrialVariantPopulationFrequenciesTable.tsx
+++ b/browser/src/MitochondrialVariantPage/MitochondrialVariantPopulationFrequenciesTable.tsx
@@ -31,7 +31,8 @@ const Table = styled(BaseTable)`
   }
 `
 
-type SortKey = 'id' | 'an' | 'af_het' | 'af_hom' | 'ac_het' | 'ac_hom'
+export const sortKeys = ['id', 'an', 'af_het', 'af_hom', 'ac_het', 'ac_hom'] as const
+type SortKey = (typeof sortKeys)[number]
 
 const useSort = (
   defaultSortKey: SortKey
@@ -94,7 +95,9 @@ const MitochondrialVariantPopulationFrequenciesTable = ({
       const [population1, population2] = sortAscending ? [a, b] : [b, a]
 
       return sortBy === 'id'
-        ? population1.id.localeCompare(population2.id)
+        ? GNOMAD_POPULATION_NAMES[population1.id].localeCompare(
+            GNOMAD_POPULATION_NAMES[population2.id]
+          )
         : population1[sortBy] - population2[sortBy]
     })
 

--- a/browser/src/MitochondrialVariantPage/MitochondrialVariantPopulationFrequenciesTable.tsx
+++ b/browser/src/MitochondrialVariantPage/MitochondrialVariantPopulationFrequenciesTable.tsx
@@ -1,11 +1,11 @@
-import React, { useCallback, useState } from 'react'
+import React, { ReactNode, useCallback, useState } from 'react'
 import styled from 'styled-components'
 
 import { BaseTable, TooltipAnchor, TooltipHint } from '@gnomad/ui'
 
 import { GNOMAD_POPULATION_NAMES } from '@gnomad/dataset-metadata/gnomadPopulations'
 
-import { MitochondrialVariant } from './MitochondrialVariantPage'
+import { MitochondrialVariant, MitochondrialVariantPopulation } from './MitochondrialVariantPage'
 
 const CountCell = styled.span`
   display: inline-block;
@@ -31,37 +31,23 @@ const Table = styled(BaseTable)`
   }
 `
 
-export const sortKeys = ['id', 'an', 'af_het', 'af_hom', 'ac_het', 'ac_hom'] as const
-type SortKey = (typeof sortKeys)[number]
+type RowCompareFunction<RowData> = (a: RowData, b: RowData) => number
 
-const useSort = <K extends string>(
-  defaultSortKey: K
-): [{ key: K; ascending: boolean }, (key: K) => void] => {
-  const [key, setKey] = useState<K>(defaultSortKey)
-  const [ascending, setAscending] = useState<boolean>(false)
-
-  const setSortKey = useCallback(
-    (newKey: K) => {
-      setKey(newKey)
-      setAscending(newKey === key ? !ascending : false)
-    },
-    [key, ascending]
-  )
-
-  return [{ key, ascending }, setSortKey]
+type ColumnSpecifier<RowData> = {
+  key: keyof RowData
+  label: string
+  tooltip: string | null
+  compareValueFunction: RowCompareFunction<RowData>
 }
 
-type MitochondrialVariantPopulationFrequenciesTableProps = {
-  variant: MitochondrialVariant
-}
-
-const renderColumnHeader = <K extends string>(
-  key: K,
-  sortBy: K,
-  setSortBy: (key: K) => void,
+const renderColumnHeader = <RowData,>(
+  key: keyof RowData,
+  sortBy: keyof RowData,
+  setSortBy: (key: keyof RowData) => void,
   sortAscending: boolean,
   label: string,
-  tooltip: string | null
+  tooltip: string | null,
+  compareValueFunction: RowCompareFunction<RowData>
 ) => {
   let ariaSortAttr: React.AriaAttributes['aria-sort'] = 'none'
   if (sortBy === key) {
@@ -72,7 +58,7 @@ const renderColumnHeader = <K extends string>(
     <th aria-sort={ariaSortAttr} scope="col">
       {/* @ts-expect-error TS(2322) FIXME: Type '{ children: Element; tooltip: any; }' is not... Remove this comment to see the full error message */}
       <TooltipAnchor tooltip={tooltip}>
-        <button type="button" onClick={() => setSortBy(key as K)}>
+        <button type="button" onClick={() => setSortBy(key)}>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
           <TooltipHint>{label}</TooltipHint>
         </button>
@@ -80,45 +66,156 @@ const renderColumnHeader = <K extends string>(
     </th>
   ) : (
     <th aria-sort={ariaSortAttr} scope="col">
-      <button type="button" onClick={() => setSortBy(key as K)}>
+      <button type="button" onClick={() => setSortBy(key)}>
         {label}
       </button>
     </th>
   )
 }
 
+//  .sort((a, b) => {
+//   const [population1, population2] = sortAscending ? [a, b] : [b, a]
+//
+//   return sortBy === 'id'
+//     ? GNOMAD_POPULATION_NAMES[population1.id].localeCompare(
+//         GNOMAD_POPULATION_NAMES[population2.id]
+//       )
+//     : population1[sortBy] - population2[sortBy]
+// }) */
+
+const useSort = <RowData,>(
+  columnSpecifiers: ColumnSpecifier<RowData>[],
+  defaultSortKey: keyof RowData,
+  rowData: RowData[]
+): { headers: ReactNode; sortedRowData: RowData[] } => {
+  const [key, setKey] = useState<keyof RowData>(defaultSortKey)
+  const [ascending, setAscending] = useState<boolean>(false)
+
+  const setSortKey = useCallback(
+    (newKey: keyof RowData) => {
+      setKey(newKey)
+      setAscending(newKey === key ? !ascending : false)
+    },
+    [key, ascending]
+  )
+
+  const { compareValueFunction } = columnSpecifiers.find((column) => column.key === key)!
+  const sortedRowData = [...rowData].sort((a, b) => {
+    const ascendingCompare = compareValueFunction(a, b)
+    return ascending ? ascendingCompare : -ascendingCompare
+  })
+
+  const headers = (
+    <>
+      {columnSpecifiers.map((columnSpecifier) =>
+        renderColumnHeader(
+          columnSpecifier.key,
+          key,
+          setSortKey,
+          ascending,
+          columnSpecifier.label,
+          columnSpecifier.tooltip,
+          columnSpecifier.compareValueFunction
+        )
+      )}
+    </>
+  )
+  return { headers, sortedRowData }
+}
+
+type MitochondrialVariantPopulationFrequenciesTableProps = {
+  variant: MitochondrialVariant
+}
+
+type MitochondrialVariantPopulationWithFrequency = MitochondrialVariantPopulation & {
+  af_hom: number
+  af_het: number
+}
+
+type NumberHolder<Key extends string> = {
+  [K in Key]: number
+}
+
+export const numericCompareFunction =
+  <Key extends string>(key: Key) =>
+  <RowData extends NumberHolder<Key>>(a: RowData, b: RowData) =>
+    a[key] - b[key]
+
+const comparePopulationNames = (
+  a: MitochondrialVariantPopulationWithFrequency,
+  b: MitochondrialVariantPopulationWithFrequency
+) => GNOMAD_POPULATION_NAMES[a.id].localeCompare(GNOMAD_POPULATION_NAMES[b.id])
+
+const columnSpecifiers: ColumnSpecifier<MitochondrialVariantPopulationWithFrequency>[] = [
+  {
+    key: 'id',
+    label: 'Genetic Ancestry Group',
+    tooltip: null,
+    compareValueFunction: comparePopulationNames,
+  },
+  {
+    key: 'an',
+    label: 'Allele Number',
+    tooltip:
+      'Total number of individuals in this population with high quality sequence at this position.',
+    compareValueFunction: numericCompareFunction('an'),
+  },
+  {
+    key: 'ac_hom',
+    label: 'Homoplasmic AC',
+    tooltip:
+      'Number of individuals in this population with homoplasmic or near-homoplasmic variant (heteroplasmy level ≥ 0.95).',
+    compareValueFunction: numericCompareFunction('ac_hom'),
+  },
+  {
+    key: 'af_hom',
+    label: 'Homoplasmic AF',
+    tooltip:
+      'Proportion of individuals in this population with homoplasmic or near-homoplasmic variant (heteroplasmy level ≥ 0.95).',
+    compareValueFunction: numericCompareFunction('af_hom'),
+  },
+  {
+    key: 'ac_het',
+    label: 'Heteroplasmic AC',
+    tooltip:
+      'Number of individuals in this population with a variant at heteroplasmy level 0.10 - 0.95.',
+    compareValueFunction: numericCompareFunction('ac_het'),
+  },
+  {
+    key: 'af_het',
+    label: 'Heteroplasmic AF',
+    tooltip:
+      'Proportion of individuals in this population with a variant at heteroplasmy level 0.10 - 0.95.',
+    compareValueFunction: numericCompareFunction('af_het'),
+  },
+]
+
 const MitochondrialVariantPopulationFrequenciesTable = ({
   variant,
 }: MitochondrialVariantPopulationFrequenciesTableProps) => {
-  const [{ key: sortBy, ascending: sortAscending }, setSortBy] = useSort<SortKey>('af_hom')
+  const populationsWithFrequencies = variant.populations.map((population) => ({
+    ...population,
+    af_hom: population.an !== 0 ? population.ac_hom / population.an : 0,
+    af_het: population.an !== 0 ? population.ac_het / population.an : 0,
+  }))
 
-  const renderedPopulations = variant.populations
-    .map((population) => ({
-      ...population,
-      af_hom: population.an !== 0 ? population.ac_hom / population.an : 0,
-      af_het: population.an !== 0 ? population.ac_het / population.an : 0,
-    }))
-    .sort((a, b) => {
-      const [population1, population2] = sortAscending ? [a, b] : [b, a]
+  const { headers, sortedRowData } = useSort<MitochondrialVariantPopulationWithFrequency>(
+    columnSpecifiers,
+    'af_hom',
+    populationsWithFrequencies
+  )
 
-      return sortBy === 'id'
-        ? GNOMAD_POPULATION_NAMES[population1.id].localeCompare(
-            GNOMAD_POPULATION_NAMES[population2.id]
-          )
-        : population1[sortBy] - population2[sortBy]
-    })
-
-  const totalAlleleNumber = renderedPopulations
+  const totalAlleleNumber = sortedRowData
     .map((population) => population.an)
     .reduce((acc, n) => acc + n, 0)
 
-  const totalHomoplasmicAlleleCount = renderedPopulations
+  const totalHomoplasmicAlleleCount = sortedRowData
     .map((population) => population.ac_hom)
     .reduce((acc, n) => acc + n, 0)
   const totalHomoplasmicAlleleFrequency =
     totalAlleleNumber !== 0 ? totalHomoplasmicAlleleCount / totalAlleleNumber : 0
 
-  const totalHeteroplasmicAlleleCount = renderedPopulations
+  const totalHeteroplasmicAlleleCount = sortedRowData
     .map((population) => population.ac_het)
     .reduce((acc, n) => acc + n, 0)
   const totalHeteroplasmicAlleleFrequency =
@@ -127,59 +224,10 @@ const MitochondrialVariantPopulationFrequenciesTable = ({
   return (
     <Table>
       <thead>
-        <tr>
-          {renderColumnHeader(
-            'id',
-            sortBy,
-            setSortBy,
-            sortAscending,
-            'Genetic Ancestry Group',
-            null
-          )}
-          {renderColumnHeader(
-            'an',
-            sortBy,
-            setSortBy,
-            sortAscending,
-            'Allele Number',
-            'Total number of individuals in this population with high quality sequence at this position.'
-          )}
-          {renderColumnHeader(
-            'ac_hom',
-            sortBy,
-            setSortBy,
-            sortAscending,
-            'Homoplasmic AC',
-            'Number of individuals in this population with homoplasmic or near-homoplasmic variant (heteroplasmy level ≥ 0.95).'
-          )}
-          {renderColumnHeader(
-            'af_hom',
-            sortBy,
-            setSortBy,
-            sortAscending,
-            'Homoplasmic AF',
-            'Proportion of individuals in this population with homoplasmic or near-homoplasmic variant (heteroplasmy level ≥ 0.95).'
-          )}
-          {renderColumnHeader(
-            'ac_het',
-            sortBy,
-            setSortBy,
-            sortAscending,
-            'Heteroplasmic AC',
-            'Number of individuals in this population with a variant at heteroplasmy level 0.10 - 0.95.'
-          )}
-          {renderColumnHeader(
-            'af_het',
-            sortBy,
-            setSortBy,
-            sortAscending,
-            'Heteroplasmic AF',
-            'Proportion of individuals in this population with a variant at heteroplasmy level 0.10 - 0.95.'
-          )}
-        </tr>
+        <tr>{headers}</tr>
       </thead>
       <tbody>
-        {renderedPopulations.map((population) => (
+        {sortedRowData.map((population) => (
           <tr key={population.id}>
             <th scope="row">{GNOMAD_POPULATION_NAMES[population.id]}</th>
             <td>

--- a/browser/src/MitochondrialVariantPage/MitochondrialVariantPopulationFrequenciesTable.tsx
+++ b/browser/src/MitochondrialVariantPage/MitochondrialVariantPopulationFrequenciesTable.tsx
@@ -34,14 +34,14 @@ const Table = styled(BaseTable)`
 export const sortKeys = ['id', 'an', 'af_het', 'af_hom', 'ac_het', 'ac_hom'] as const
 type SortKey = (typeof sortKeys)[number]
 
-const useSort = (
-  defaultSortKey: SortKey
-): [{ key: SortKey; ascending: boolean }, (key: SortKey) => void] => {
-  const [key, setKey] = useState<SortKey>(defaultSortKey)
+const useSort = <K extends string>(
+  defaultSortKey: K
+): [{ key: K; ascending: boolean }, (key: K) => void] => {
+  const [key, setKey] = useState<K>(defaultSortKey)
   const [ascending, setAscending] = useState<boolean>(false)
 
   const setSortKey = useCallback(
-    (newKey: SortKey) => {
+    (newKey: K) => {
       setKey(newKey)
       setAscending(newKey === key ? !ascending : false)
     },
@@ -55,35 +55,42 @@ type MitochondrialVariantPopulationFrequenciesTableProps = {
   variant: MitochondrialVariant
 }
 
+const renderColumnHeader = <K extends string>(
+  key: K,
+  sortBy: K,
+  setSortBy: (key: K) => void,
+  sortAscending: boolean,
+  label: string,
+  tooltip: string | null
+) => {
+  let ariaSortAttr: React.AriaAttributes['aria-sort'] = 'none'
+  if (sortBy === key) {
+    ariaSortAttr = sortAscending ? 'ascending' : 'descending'
+  }
+
+  return tooltip ? (
+    <th aria-sort={ariaSortAttr} scope="col">
+      {/* @ts-expect-error TS(2322) FIXME: Type '{ children: Element; tooltip: any; }' is not... Remove this comment to see the full error message */}
+      <TooltipAnchor tooltip={tooltip}>
+        <button type="button" onClick={() => setSortBy(key as K)}>
+          {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+          <TooltipHint>{label}</TooltipHint>
+        </button>
+      </TooltipAnchor>
+    </th>
+  ) : (
+    <th aria-sort={ariaSortAttr} scope="col">
+      <button type="button" onClick={() => setSortBy(key as K)}>
+        {label}
+      </button>
+    </th>
+  )
+}
+
 const MitochondrialVariantPopulationFrequenciesTable = ({
   variant,
 }: MitochondrialVariantPopulationFrequenciesTableProps) => {
-  const [{ key: sortBy, ascending: sortAscending }, setSortBy] = useSort('af_hom')
-
-  const renderColumnHeader = (key: any, label: any, tooltip: any) => {
-    let ariaSortAttr: React.AriaAttributes['aria-sort'] = 'none'
-    if (sortBy === key) {
-      ariaSortAttr = sortAscending ? 'ascending' : 'descending'
-    }
-
-    return tooltip ? (
-      <th aria-sort={ariaSortAttr} scope="col">
-        {/* @ts-expect-error TS(2322) FIXME: Type '{ children: Element; tooltip: any; }' is not... Remove this comment to see the full error message */}
-        <TooltipAnchor tooltip={tooltip}>
-          <button type="button" onClick={() => setSortBy(key)}>
-            {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
-            <TooltipHint>{label}</TooltipHint>
-          </button>
-        </TooltipAnchor>
-      </th>
-    ) : (
-      <th aria-sort={ariaSortAttr} scope="col">
-        <button type="button" onClick={() => setSortBy(key)}>
-          {label}
-        </button>
-      </th>
-    )
-  }
+  const [{ key: sortBy, ascending: sortAscending }, setSortBy] = useSort<SortKey>('af_hom')
 
   const renderedPopulations = variant.populations
     .map((population) => ({
@@ -121,29 +128,51 @@ const MitochondrialVariantPopulationFrequenciesTable = ({
     <Table>
       <thead>
         <tr>
-          {renderColumnHeader('id', 'Genetic Ancestry Group', null)}
+          {renderColumnHeader(
+            'id',
+            sortBy,
+            setSortBy,
+            sortAscending,
+            'Genetic Ancestry Group',
+            null
+          )}
           {renderColumnHeader(
             'an',
+            sortBy,
+            setSortBy,
+            sortAscending,
             'Allele Number',
             'Total number of individuals in this population with high quality sequence at this position.'
           )}
           {renderColumnHeader(
             'ac_hom',
+            sortBy,
+            setSortBy,
+            sortAscending,
             'Homoplasmic AC',
             'Number of individuals in this population with homoplasmic or near-homoplasmic variant (heteroplasmy level ≥ 0.95).'
           )}
           {renderColumnHeader(
             'af_hom',
+            sortBy,
+            setSortBy,
+            sortAscending,
             'Homoplasmic AF',
             'Proportion of individuals in this population with homoplasmic or near-homoplasmic variant (heteroplasmy level ≥ 0.95).'
           )}
           {renderColumnHeader(
             'ac_het',
+            sortBy,
+            setSortBy,
+            sortAscending,
             'Heteroplasmic AC',
             'Number of individuals in this population with a variant at heteroplasmy level 0.10 - 0.95.'
           )}
           {renderColumnHeader(
             'af_het',
+            sortBy,
+            setSortBy,
+            sortAscending,
             'Heteroplasmic AF',
             'Proportion of individuals in this population with a variant at heteroplasmy level 0.10 - 0.95.'
           )}

--- a/browser/src/MitochondrialVariantPage/__snapshots__/MitochondrialVariantPopulationFrequenciesTable.spec.tsx.snap
+++ b/browser/src/MitochondrialVariantPage/__snapshots__/MitochondrialVariantPopulationFrequenciesTable.spec.tsx.snap
@@ -1,0 +1,4307 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MitochondrialVariantPopulationFrequenciesTable has no unexpected regressions 1`] = `
+{
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <table
+        class="Table__BaseTable-sc-7fgtt2-0 MitochondrialVariantPopulationFrequenciesTable__Table-sc-1esr108-1 ihCgBR"
+      >
+        <thead>
+          <tr>
+            <th
+              aria-sort="none"
+              scope="col"
+            >
+              <button
+                type="button"
+              >
+                Genetic Ancestry Group
+              </button>
+            </th>
+            <th
+              aria-sort="none"
+              scope="col"
+            >
+              <button
+                type="button"
+              >
+                <span
+                  class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                >
+                  Allele Number
+                </span>
+              </button>
+            </th>
+            <th
+              aria-sort="none"
+              scope="col"
+            >
+              <button
+                type="button"
+              >
+                <span
+                  class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                >
+                  Homoplasmic AC
+                </span>
+              </button>
+            </th>
+            <th
+              aria-sort="descending"
+              scope="col"
+            >
+              <button
+                type="button"
+              >
+                <span
+                  class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                >
+                  Homoplasmic AF
+                </span>
+              </button>
+            </th>
+            <th
+              aria-sort="none"
+              scope="col"
+            >
+              <button
+                type="button"
+              >
+                <span
+                  class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                >
+                  Heteroplasmic AC
+                </span>
+              </button>
+            </th>
+            <th
+              aria-sort="none"
+              scope="col"
+            >
+              <button
+                type="button"
+              >
+                <span
+                  class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                >
+                  Heteroplasmic AF
+                </span>
+              </button>
+            </th>
+          </tr>
+        </thead>
+        <tbody />
+        <tfoot>
+          <tr
+            class="border"
+          >
+            <th
+              scope="row"
+            >
+              Total
+            </th>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+          </tr>
+        </tfoot>
+      </table>
+    </div>
+    <div />
+    <div />
+    <div />
+    <div />
+    <div />
+  </body>,
+  "container": <div>
+    <table
+      class="Table__BaseTable-sc-7fgtt2-0 MitochondrialVariantPopulationFrequenciesTable__Table-sc-1esr108-1 ihCgBR"
+    >
+      <thead>
+        <tr>
+          <th
+            aria-sort="none"
+            scope="col"
+          >
+            <button
+              type="button"
+            >
+              Genetic Ancestry Group
+            </button>
+          </th>
+          <th
+            aria-sort="none"
+            scope="col"
+          >
+            <button
+              type="button"
+            >
+              <span
+                class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+              >
+                Allele Number
+              </span>
+            </button>
+          </th>
+          <th
+            aria-sort="none"
+            scope="col"
+          >
+            <button
+              type="button"
+            >
+              <span
+                class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+              >
+                Homoplasmic AC
+              </span>
+            </button>
+          </th>
+          <th
+            aria-sort="descending"
+            scope="col"
+          >
+            <button
+              type="button"
+            >
+              <span
+                class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+              >
+                Homoplasmic AF
+              </span>
+            </button>
+          </th>
+          <th
+            aria-sort="none"
+            scope="col"
+          >
+            <button
+              type="button"
+            >
+              <span
+                class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+              >
+                Heteroplasmic AC
+              </span>
+            </button>
+          </th>
+          <th
+            aria-sort="none"
+            scope="col"
+          >
+            <button
+              type="button"
+            >
+              <span
+                class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+              >
+                Heteroplasmic AF
+              </span>
+            </button>
+          </th>
+        </tr>
+      </thead>
+      <tbody />
+      <tfoot>
+        <tr
+          class="border"
+        >
+          <th
+            scope="row"
+          >
+            Total
+          </th>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+        </tr>
+      </tfoot>
+    </table>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`MitochondrialVariantPopulationFrequenciesTable sorting sorts by ID 1`] = `
+{
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <table
+        class="Table__BaseTable-sc-7fgtt2-0 MitochondrialVariantPopulationFrequenciesTable__Table-sc-1esr108-1 ihCgBR"
+      >
+        <thead>
+          <tr>
+            <th
+              aria-sort="none"
+              scope="col"
+            >
+              <button
+                type="button"
+              >
+                Genetic Ancestry Group
+              </button>
+            </th>
+            <th
+              aria-sort="none"
+              scope="col"
+            >
+              <button
+                type="button"
+              >
+                <span
+                  class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                >
+                  Allele Number
+                </span>
+              </button>
+            </th>
+            <th
+              aria-sort="none"
+              scope="col"
+            >
+              <button
+                type="button"
+              >
+                <span
+                  class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                >
+                  Homoplasmic AC
+                </span>
+              </button>
+            </th>
+            <th
+              aria-sort="descending"
+              scope="col"
+            >
+              <button
+                type="button"
+              >
+                <span
+                  class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                >
+                  Homoplasmic AF
+                </span>
+              </button>
+            </th>
+            <th
+              aria-sort="none"
+              scope="col"
+            >
+              <button
+                type="button"
+              >
+                <span
+                  class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                >
+                  Heteroplasmic AC
+                </span>
+              </button>
+            </th>
+            <th
+              aria-sort="none"
+              scope="col"
+            >
+              <button
+                type="button"
+              >
+                <span
+                  class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                >
+                  Heteroplasmic AF
+                </span>
+              </button>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th
+              scope="row"
+            >
+              European (Finnish)
+            </th>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+          </tr>
+          <tr>
+            <th
+              scope="row"
+            >
+              Admixed American
+            </th>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+          </tr>
+          <tr>
+            <th
+              scope="row"
+            >
+              South Asian
+            </th>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+          </tr>
+          <tr>
+            <th
+              scope="row"
+            >
+              African/African American
+            </th>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+          </tr>
+          <tr>
+            <th
+              scope="row"
+            >
+              Ashkenazi Jewish
+            </th>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+          </tr>
+        </tbody>
+        <tfoot>
+          <tr
+            class="border"
+          >
+            <th
+              scope="row"
+            >
+              Total
+            </th>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+          </tr>
+        </tfoot>
+      </table>
+    </div>
+    <div />
+    <div />
+    <div />
+    <div />
+    <div />
+  </body>,
+  "container": <div>
+    <table
+      class="Table__BaseTable-sc-7fgtt2-0 MitochondrialVariantPopulationFrequenciesTable__Table-sc-1esr108-1 ihCgBR"
+    >
+      <thead>
+        <tr>
+          <th
+            aria-sort="none"
+            scope="col"
+          >
+            <button
+              type="button"
+            >
+              Genetic Ancestry Group
+            </button>
+          </th>
+          <th
+            aria-sort="none"
+            scope="col"
+          >
+            <button
+              type="button"
+            >
+              <span
+                class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+              >
+                Allele Number
+              </span>
+            </button>
+          </th>
+          <th
+            aria-sort="none"
+            scope="col"
+          >
+            <button
+              type="button"
+            >
+              <span
+                class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+              >
+                Homoplasmic AC
+              </span>
+            </button>
+          </th>
+          <th
+            aria-sort="descending"
+            scope="col"
+          >
+            <button
+              type="button"
+            >
+              <span
+                class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+              >
+                Homoplasmic AF
+              </span>
+            </button>
+          </th>
+          <th
+            aria-sort="none"
+            scope="col"
+          >
+            <button
+              type="button"
+            >
+              <span
+                class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+              >
+                Heteroplasmic AC
+              </span>
+            </button>
+          </th>
+          <th
+            aria-sort="none"
+            scope="col"
+          >
+            <button
+              type="button"
+            >
+              <span
+                class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+              >
+                Heteroplasmic AF
+              </span>
+            </button>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th
+            scope="row"
+          >
+            European (Finnish)
+          </th>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+        </tr>
+        <tr>
+          <th
+            scope="row"
+          >
+            Admixed American
+          </th>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+        </tr>
+        <tr>
+          <th
+            scope="row"
+          >
+            South Asian
+          </th>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+        </tr>
+        <tr>
+          <th
+            scope="row"
+          >
+            African/African American
+          </th>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+        </tr>
+        <tr>
+          <th
+            scope="row"
+          >
+            Ashkenazi Jewish
+          </th>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+        </tr>
+      </tbody>
+      <tfoot>
+        <tr
+          class="border"
+        >
+          <th
+            scope="row"
+          >
+            Total
+          </th>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+        </tr>
+      </tfoot>
+    </table>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`MitochondrialVariantPopulationFrequenciesTable sorting sorts by ac_het 1`] = `
+{
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <table
+        class="Table__BaseTable-sc-7fgtt2-0 MitochondrialVariantPopulationFrequenciesTable__Table-sc-1esr108-1 ihCgBR"
+      >
+        <thead>
+          <tr>
+            <th
+              aria-sort="none"
+              scope="col"
+            >
+              <button
+                type="button"
+              >
+                Genetic Ancestry Group
+              </button>
+            </th>
+            <th
+              aria-sort="none"
+              scope="col"
+            >
+              <button
+                type="button"
+              >
+                <span
+                  class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                >
+                  Allele Number
+                </span>
+              </button>
+            </th>
+            <th
+              aria-sort="none"
+              scope="col"
+            >
+              <button
+                type="button"
+              >
+                <span
+                  class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                >
+                  Homoplasmic AC
+                </span>
+              </button>
+            </th>
+            <th
+              aria-sort="descending"
+              scope="col"
+            >
+              <button
+                type="button"
+              >
+                <span
+                  class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                >
+                  Homoplasmic AF
+                </span>
+              </button>
+            </th>
+            <th
+              aria-sort="none"
+              scope="col"
+            >
+              <button
+                type="button"
+              >
+                <span
+                  class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                >
+                  Heteroplasmic AC
+                </span>
+              </button>
+            </th>
+            <th
+              aria-sort="none"
+              scope="col"
+            >
+              <button
+                type="button"
+              >
+                <span
+                  class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                >
+                  Heteroplasmic AF
+                </span>
+              </button>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th
+              scope="row"
+            >
+              European (Finnish)
+            </th>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                2
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+          </tr>
+          <tr>
+            <th
+              scope="row"
+            >
+              Admixed American
+            </th>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                5
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+          </tr>
+          <tr>
+            <th
+              scope="row"
+            >
+              South Asian
+            </th>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                1
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+          </tr>
+          <tr>
+            <th
+              scope="row"
+            >
+              African/African American
+            </th>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                3
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+          </tr>
+          <tr>
+            <th
+              scope="row"
+            >
+              Ashkenazi Jewish
+            </th>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                4
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+          </tr>
+        </tbody>
+        <tfoot>
+          <tr
+            class="border"
+          >
+            <th
+              scope="row"
+            >
+              Total
+            </th>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                15
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+          </tr>
+        </tfoot>
+      </table>
+    </div>
+    <div />
+    <div />
+    <div />
+    <div />
+    <div />
+  </body>,
+  "container": <div>
+    <table
+      class="Table__BaseTable-sc-7fgtt2-0 MitochondrialVariantPopulationFrequenciesTable__Table-sc-1esr108-1 ihCgBR"
+    >
+      <thead>
+        <tr>
+          <th
+            aria-sort="none"
+            scope="col"
+          >
+            <button
+              type="button"
+            >
+              Genetic Ancestry Group
+            </button>
+          </th>
+          <th
+            aria-sort="none"
+            scope="col"
+          >
+            <button
+              type="button"
+            >
+              <span
+                class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+              >
+                Allele Number
+              </span>
+            </button>
+          </th>
+          <th
+            aria-sort="none"
+            scope="col"
+          >
+            <button
+              type="button"
+            >
+              <span
+                class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+              >
+                Homoplasmic AC
+              </span>
+            </button>
+          </th>
+          <th
+            aria-sort="descending"
+            scope="col"
+          >
+            <button
+              type="button"
+            >
+              <span
+                class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+              >
+                Homoplasmic AF
+              </span>
+            </button>
+          </th>
+          <th
+            aria-sort="none"
+            scope="col"
+          >
+            <button
+              type="button"
+            >
+              <span
+                class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+              >
+                Heteroplasmic AC
+              </span>
+            </button>
+          </th>
+          <th
+            aria-sort="none"
+            scope="col"
+          >
+            <button
+              type="button"
+            >
+              <span
+                class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+              >
+                Heteroplasmic AF
+              </span>
+            </button>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th
+            scope="row"
+          >
+            European (Finnish)
+          </th>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              2
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+        </tr>
+        <tr>
+          <th
+            scope="row"
+          >
+            Admixed American
+          </th>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              5
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+        </tr>
+        <tr>
+          <th
+            scope="row"
+          >
+            South Asian
+          </th>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              1
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+        </tr>
+        <tr>
+          <th
+            scope="row"
+          >
+            African/African American
+          </th>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              3
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+        </tr>
+        <tr>
+          <th
+            scope="row"
+          >
+            Ashkenazi Jewish
+          </th>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              4
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+        </tr>
+      </tbody>
+      <tfoot>
+        <tr
+          class="border"
+        >
+          <th
+            scope="row"
+          >
+            Total
+          </th>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              15
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+        </tr>
+      </tfoot>
+    </table>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`MitochondrialVariantPopulationFrequenciesTable sorting sorts by ac_hom 1`] = `
+{
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <table
+        class="Table__BaseTable-sc-7fgtt2-0 MitochondrialVariantPopulationFrequenciesTable__Table-sc-1esr108-1 ihCgBR"
+      >
+        <thead>
+          <tr>
+            <th
+              aria-sort="none"
+              scope="col"
+            >
+              <button
+                type="button"
+              >
+                Genetic Ancestry Group
+              </button>
+            </th>
+            <th
+              aria-sort="none"
+              scope="col"
+            >
+              <button
+                type="button"
+              >
+                <span
+                  class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                >
+                  Allele Number
+                </span>
+              </button>
+            </th>
+            <th
+              aria-sort="none"
+              scope="col"
+            >
+              <button
+                type="button"
+              >
+                <span
+                  class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                >
+                  Homoplasmic AC
+                </span>
+              </button>
+            </th>
+            <th
+              aria-sort="descending"
+              scope="col"
+            >
+              <button
+                type="button"
+              >
+                <span
+                  class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                >
+                  Homoplasmic AF
+                </span>
+              </button>
+            </th>
+            <th
+              aria-sort="none"
+              scope="col"
+            >
+              <button
+                type="button"
+              >
+                <span
+                  class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                >
+                  Heteroplasmic AC
+                </span>
+              </button>
+            </th>
+            <th
+              aria-sort="none"
+              scope="col"
+            >
+              <button
+                type="button"
+              >
+                <span
+                  class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                >
+                  Heteroplasmic AF
+                </span>
+              </button>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th
+              scope="row"
+            >
+              European (Finnish)
+            </th>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                2
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+          </tr>
+          <tr>
+            <th
+              scope="row"
+            >
+              Admixed American
+            </th>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                5
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+          </tr>
+          <tr>
+            <th
+              scope="row"
+            >
+              South Asian
+            </th>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                1
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+          </tr>
+          <tr>
+            <th
+              scope="row"
+            >
+              African/African American
+            </th>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                3
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+          </tr>
+          <tr>
+            <th
+              scope="row"
+            >
+              Ashkenazi Jewish
+            </th>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                4
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+          </tr>
+        </tbody>
+        <tfoot>
+          <tr
+            class="border"
+          >
+            <th
+              scope="row"
+            >
+              Total
+            </th>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                15
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+          </tr>
+        </tfoot>
+      </table>
+    </div>
+    <div />
+    <div />
+    <div />
+    <div />
+    <div />
+  </body>,
+  "container": <div>
+    <table
+      class="Table__BaseTable-sc-7fgtt2-0 MitochondrialVariantPopulationFrequenciesTable__Table-sc-1esr108-1 ihCgBR"
+    >
+      <thead>
+        <tr>
+          <th
+            aria-sort="none"
+            scope="col"
+          >
+            <button
+              type="button"
+            >
+              Genetic Ancestry Group
+            </button>
+          </th>
+          <th
+            aria-sort="none"
+            scope="col"
+          >
+            <button
+              type="button"
+            >
+              <span
+                class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+              >
+                Allele Number
+              </span>
+            </button>
+          </th>
+          <th
+            aria-sort="none"
+            scope="col"
+          >
+            <button
+              type="button"
+            >
+              <span
+                class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+              >
+                Homoplasmic AC
+              </span>
+            </button>
+          </th>
+          <th
+            aria-sort="descending"
+            scope="col"
+          >
+            <button
+              type="button"
+            >
+              <span
+                class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+              >
+                Homoplasmic AF
+              </span>
+            </button>
+          </th>
+          <th
+            aria-sort="none"
+            scope="col"
+          >
+            <button
+              type="button"
+            >
+              <span
+                class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+              >
+                Heteroplasmic AC
+              </span>
+            </button>
+          </th>
+          <th
+            aria-sort="none"
+            scope="col"
+          >
+            <button
+              type="button"
+            >
+              <span
+                class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+              >
+                Heteroplasmic AF
+              </span>
+            </button>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th
+            scope="row"
+          >
+            European (Finnish)
+          </th>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              2
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+        </tr>
+        <tr>
+          <th
+            scope="row"
+          >
+            Admixed American
+          </th>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              5
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+        </tr>
+        <tr>
+          <th
+            scope="row"
+          >
+            South Asian
+          </th>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              1
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+        </tr>
+        <tr>
+          <th
+            scope="row"
+          >
+            African/African American
+          </th>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              3
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+        </tr>
+        <tr>
+          <th
+            scope="row"
+          >
+            Ashkenazi Jewish
+          </th>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              4
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+        </tr>
+      </tbody>
+      <tfoot>
+        <tr
+          class="border"
+        >
+          <th
+            scope="row"
+          >
+            Total
+          </th>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              15
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+        </tr>
+      </tfoot>
+    </table>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`MitochondrialVariantPopulationFrequenciesTable sorting sorts by af_het 1`] = `
+{
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <table
+        class="Table__BaseTable-sc-7fgtt2-0 MitochondrialVariantPopulationFrequenciesTable__Table-sc-1esr108-1 ihCgBR"
+      >
+        <thead>
+          <tr>
+            <th
+              aria-sort="none"
+              scope="col"
+            >
+              <button
+                type="button"
+              >
+                Genetic Ancestry Group
+              </button>
+            </th>
+            <th
+              aria-sort="none"
+              scope="col"
+            >
+              <button
+                type="button"
+              >
+                <span
+                  class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                >
+                  Allele Number
+                </span>
+              </button>
+            </th>
+            <th
+              aria-sort="none"
+              scope="col"
+            >
+              <button
+                type="button"
+              >
+                <span
+                  class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                >
+                  Homoplasmic AC
+                </span>
+              </button>
+            </th>
+            <th
+              aria-sort="descending"
+              scope="col"
+            >
+              <button
+                type="button"
+              >
+                <span
+                  class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                >
+                  Homoplasmic AF
+                </span>
+              </button>
+            </th>
+            <th
+              aria-sort="none"
+              scope="col"
+            >
+              <button
+                type="button"
+              >
+                <span
+                  class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                >
+                  Heteroplasmic AC
+                </span>
+              </button>
+            </th>
+            <th
+              aria-sort="none"
+              scope="col"
+            >
+              <button
+                type="button"
+              >
+                <span
+                  class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                >
+                  Heteroplasmic AF
+                </span>
+              </button>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th
+              scope="row"
+            >
+              European (Finnish)
+            </th>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                100
+              </span>
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                2
+              </span>
+            </td>
+            <td>
+              0.02000
+            </td>
+          </tr>
+          <tr>
+            <th
+              scope="row"
+            >
+              Admixed American
+            </th>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                100
+              </span>
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                5
+              </span>
+            </td>
+            <td>
+              0.05000
+            </td>
+          </tr>
+          <tr>
+            <th
+              scope="row"
+            >
+              South Asian
+            </th>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                100
+              </span>
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                1
+              </span>
+            </td>
+            <td>
+              0.01000
+            </td>
+          </tr>
+          <tr>
+            <th
+              scope="row"
+            >
+              African/African American
+            </th>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                100
+              </span>
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                3
+              </span>
+            </td>
+            <td>
+              0.03000
+            </td>
+          </tr>
+          <tr>
+            <th
+              scope="row"
+            >
+              Ashkenazi Jewish
+            </th>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                100
+              </span>
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                4
+              </span>
+            </td>
+            <td>
+              0.04000
+            </td>
+          </tr>
+        </tbody>
+        <tfoot>
+          <tr
+            class="border"
+          >
+            <th
+              scope="row"
+            >
+              Total
+            </th>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                500
+              </span>
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                15
+              </span>
+            </td>
+            <td>
+              0.03000
+            </td>
+          </tr>
+        </tfoot>
+      </table>
+    </div>
+    <div />
+    <div />
+    <div />
+    <div />
+    <div />
+  </body>,
+  "container": <div>
+    <table
+      class="Table__BaseTable-sc-7fgtt2-0 MitochondrialVariantPopulationFrequenciesTable__Table-sc-1esr108-1 ihCgBR"
+    >
+      <thead>
+        <tr>
+          <th
+            aria-sort="none"
+            scope="col"
+          >
+            <button
+              type="button"
+            >
+              Genetic Ancestry Group
+            </button>
+          </th>
+          <th
+            aria-sort="none"
+            scope="col"
+          >
+            <button
+              type="button"
+            >
+              <span
+                class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+              >
+                Allele Number
+              </span>
+            </button>
+          </th>
+          <th
+            aria-sort="none"
+            scope="col"
+          >
+            <button
+              type="button"
+            >
+              <span
+                class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+              >
+                Homoplasmic AC
+              </span>
+            </button>
+          </th>
+          <th
+            aria-sort="descending"
+            scope="col"
+          >
+            <button
+              type="button"
+            >
+              <span
+                class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+              >
+                Homoplasmic AF
+              </span>
+            </button>
+          </th>
+          <th
+            aria-sort="none"
+            scope="col"
+          >
+            <button
+              type="button"
+            >
+              <span
+                class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+              >
+                Heteroplasmic AC
+              </span>
+            </button>
+          </th>
+          <th
+            aria-sort="none"
+            scope="col"
+          >
+            <button
+              type="button"
+            >
+              <span
+                class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+              >
+                Heteroplasmic AF
+              </span>
+            </button>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th
+            scope="row"
+          >
+            European (Finnish)
+          </th>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              100
+            </span>
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              2
+            </span>
+          </td>
+          <td>
+            0.02000
+          </td>
+        </tr>
+        <tr>
+          <th
+            scope="row"
+          >
+            Admixed American
+          </th>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              100
+            </span>
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              5
+            </span>
+          </td>
+          <td>
+            0.05000
+          </td>
+        </tr>
+        <tr>
+          <th
+            scope="row"
+          >
+            South Asian
+          </th>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              100
+            </span>
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              1
+            </span>
+          </td>
+          <td>
+            0.01000
+          </td>
+        </tr>
+        <tr>
+          <th
+            scope="row"
+          >
+            African/African American
+          </th>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              100
+            </span>
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              3
+            </span>
+          </td>
+          <td>
+            0.03000
+          </td>
+        </tr>
+        <tr>
+          <th
+            scope="row"
+          >
+            Ashkenazi Jewish
+          </th>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              100
+            </span>
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              4
+            </span>
+          </td>
+          <td>
+            0.04000
+          </td>
+        </tr>
+      </tbody>
+      <tfoot>
+        <tr
+          class="border"
+        >
+          <th
+            scope="row"
+          >
+            Total
+          </th>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              500
+            </span>
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              15
+            </span>
+          </td>
+          <td>
+            0.03000
+          </td>
+        </tr>
+      </tfoot>
+    </table>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`MitochondrialVariantPopulationFrequenciesTable sorting sorts by af_hom 1`] = `
+{
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <table
+        class="Table__BaseTable-sc-7fgtt2-0 MitochondrialVariantPopulationFrequenciesTable__Table-sc-1esr108-1 ihCgBR"
+      >
+        <thead>
+          <tr>
+            <th
+              aria-sort="none"
+              scope="col"
+            >
+              <button
+                type="button"
+              >
+                Genetic Ancestry Group
+              </button>
+            </th>
+            <th
+              aria-sort="none"
+              scope="col"
+            >
+              <button
+                type="button"
+              >
+                <span
+                  class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                >
+                  Allele Number
+                </span>
+              </button>
+            </th>
+            <th
+              aria-sort="none"
+              scope="col"
+            >
+              <button
+                type="button"
+              >
+                <span
+                  class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                >
+                  Homoplasmic AC
+                </span>
+              </button>
+            </th>
+            <th
+              aria-sort="descending"
+              scope="col"
+            >
+              <button
+                type="button"
+              >
+                <span
+                  class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                >
+                  Homoplasmic AF
+                </span>
+              </button>
+            </th>
+            <th
+              aria-sort="none"
+              scope="col"
+            >
+              <button
+                type="button"
+              >
+                <span
+                  class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                >
+                  Heteroplasmic AC
+                </span>
+              </button>
+            </th>
+            <th
+              aria-sort="none"
+              scope="col"
+            >
+              <button
+                type="button"
+              >
+                <span
+                  class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                >
+                  Heteroplasmic AF
+                </span>
+              </button>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th
+              scope="row"
+            >
+              Admixed American
+            </th>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                100
+              </span>
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                5
+              </span>
+            </td>
+            <td>
+              0.05000
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+          </tr>
+          <tr>
+            <th
+              scope="row"
+            >
+              Ashkenazi Jewish
+            </th>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                100
+              </span>
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                4
+              </span>
+            </td>
+            <td>
+              0.04000
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+          </tr>
+          <tr>
+            <th
+              scope="row"
+            >
+              African/African American
+            </th>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                100
+              </span>
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                3
+              </span>
+            </td>
+            <td>
+              0.03000
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+          </tr>
+          <tr>
+            <th
+              scope="row"
+            >
+              European (Finnish)
+            </th>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                100
+              </span>
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                2
+              </span>
+            </td>
+            <td>
+              0.02000
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+          </tr>
+          <tr>
+            <th
+              scope="row"
+            >
+              South Asian
+            </th>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                100
+              </span>
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                1
+              </span>
+            </td>
+            <td>
+              0.01000
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+          </tr>
+        </tbody>
+        <tfoot>
+          <tr
+            class="border"
+          >
+            <th
+              scope="row"
+            >
+              Total
+            </th>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                500
+              </span>
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                15
+              </span>
+            </td>
+            <td>
+              0.03000
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+          </tr>
+        </tfoot>
+      </table>
+    </div>
+    <div />
+    <div />
+    <div />
+    <div />
+    <div />
+  </body>,
+  "container": <div>
+    <table
+      class="Table__BaseTable-sc-7fgtt2-0 MitochondrialVariantPopulationFrequenciesTable__Table-sc-1esr108-1 ihCgBR"
+    >
+      <thead>
+        <tr>
+          <th
+            aria-sort="none"
+            scope="col"
+          >
+            <button
+              type="button"
+            >
+              Genetic Ancestry Group
+            </button>
+          </th>
+          <th
+            aria-sort="none"
+            scope="col"
+          >
+            <button
+              type="button"
+            >
+              <span
+                class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+              >
+                Allele Number
+              </span>
+            </button>
+          </th>
+          <th
+            aria-sort="none"
+            scope="col"
+          >
+            <button
+              type="button"
+            >
+              <span
+                class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+              >
+                Homoplasmic AC
+              </span>
+            </button>
+          </th>
+          <th
+            aria-sort="descending"
+            scope="col"
+          >
+            <button
+              type="button"
+            >
+              <span
+                class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+              >
+                Homoplasmic AF
+              </span>
+            </button>
+          </th>
+          <th
+            aria-sort="none"
+            scope="col"
+          >
+            <button
+              type="button"
+            >
+              <span
+                class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+              >
+                Heteroplasmic AC
+              </span>
+            </button>
+          </th>
+          <th
+            aria-sort="none"
+            scope="col"
+          >
+            <button
+              type="button"
+            >
+              <span
+                class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+              >
+                Heteroplasmic AF
+              </span>
+            </button>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th
+            scope="row"
+          >
+            Admixed American
+          </th>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              100
+            </span>
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              5
+            </span>
+          </td>
+          <td>
+            0.05000
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+        </tr>
+        <tr>
+          <th
+            scope="row"
+          >
+            Ashkenazi Jewish
+          </th>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              100
+            </span>
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              4
+            </span>
+          </td>
+          <td>
+            0.04000
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+        </tr>
+        <tr>
+          <th
+            scope="row"
+          >
+            African/African American
+          </th>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              100
+            </span>
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              3
+            </span>
+          </td>
+          <td>
+            0.03000
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+        </tr>
+        <tr>
+          <th
+            scope="row"
+          >
+            European (Finnish)
+          </th>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              100
+            </span>
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              2
+            </span>
+          </td>
+          <td>
+            0.02000
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+        </tr>
+        <tr>
+          <th
+            scope="row"
+          >
+            South Asian
+          </th>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              100
+            </span>
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              1
+            </span>
+          </td>
+          <td>
+            0.01000
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+        </tr>
+      </tbody>
+      <tfoot>
+        <tr
+          class="border"
+        >
+          <th
+            scope="row"
+          >
+            Total
+          </th>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              500
+            </span>
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              15
+            </span>
+          </td>
+          <td>
+            0.03000
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+        </tr>
+      </tfoot>
+    </table>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`MitochondrialVariantPopulationFrequenciesTable sorting sorts by an 1`] = `
+{
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <table
+        class="Table__BaseTable-sc-7fgtt2-0 MitochondrialVariantPopulationFrequenciesTable__Table-sc-1esr108-1 ihCgBR"
+      >
+        <thead>
+          <tr>
+            <th
+              aria-sort="none"
+              scope="col"
+            >
+              <button
+                type="button"
+              >
+                Genetic Ancestry Group
+              </button>
+            </th>
+            <th
+              aria-sort="none"
+              scope="col"
+            >
+              <button
+                type="button"
+              >
+                <span
+                  class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                >
+                  Allele Number
+                </span>
+              </button>
+            </th>
+            <th
+              aria-sort="none"
+              scope="col"
+            >
+              <button
+                type="button"
+              >
+                <span
+                  class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                >
+                  Homoplasmic AC
+                </span>
+              </button>
+            </th>
+            <th
+              aria-sort="descending"
+              scope="col"
+            >
+              <button
+                type="button"
+              >
+                <span
+                  class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                >
+                  Homoplasmic AF
+                </span>
+              </button>
+            </th>
+            <th
+              aria-sort="none"
+              scope="col"
+            >
+              <button
+                type="button"
+              >
+                <span
+                  class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                >
+                  Heteroplasmic AC
+                </span>
+              </button>
+            </th>
+            <th
+              aria-sort="none"
+              scope="col"
+            >
+              <button
+                type="button"
+              >
+                <span
+                  class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+                >
+                  Heteroplasmic AF
+                </span>
+              </button>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th
+              scope="row"
+            >
+              European (Finnish)
+            </th>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                2
+              </span>
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+          </tr>
+          <tr>
+            <th
+              scope="row"
+            >
+              Admixed American
+            </th>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                5
+              </span>
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+          </tr>
+          <tr>
+            <th
+              scope="row"
+            >
+              South Asian
+            </th>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                1
+              </span>
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+          </tr>
+          <tr>
+            <th
+              scope="row"
+            >
+              African/African American
+            </th>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                3
+              </span>
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+          </tr>
+          <tr>
+            <th
+              scope="row"
+            >
+              Ashkenazi Jewish
+            </th>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                4
+              </span>
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+          </tr>
+        </tbody>
+        <tfoot>
+          <tr
+            class="border"
+          >
+            <th
+              scope="row"
+            >
+              Total
+            </th>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                15
+              </span>
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+            <td>
+              <span
+                class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+              >
+                0
+              </span>
+            </td>
+            <td>
+              0.000
+            </td>
+          </tr>
+        </tfoot>
+      </table>
+    </div>
+    <div />
+    <div />
+    <div />
+    <div />
+    <div />
+  </body>,
+  "container": <div>
+    <table
+      class="Table__BaseTable-sc-7fgtt2-0 MitochondrialVariantPopulationFrequenciesTable__Table-sc-1esr108-1 ihCgBR"
+    >
+      <thead>
+        <tr>
+          <th
+            aria-sort="none"
+            scope="col"
+          >
+            <button
+              type="button"
+            >
+              Genetic Ancestry Group
+            </button>
+          </th>
+          <th
+            aria-sort="none"
+            scope="col"
+          >
+            <button
+              type="button"
+            >
+              <span
+                class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+              >
+                Allele Number
+              </span>
+            </button>
+          </th>
+          <th
+            aria-sort="none"
+            scope="col"
+          >
+            <button
+              type="button"
+            >
+              <span
+                class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+              >
+                Homoplasmic AC
+              </span>
+            </button>
+          </th>
+          <th
+            aria-sort="descending"
+            scope="col"
+          >
+            <button
+              type="button"
+            >
+              <span
+                class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+              >
+                Homoplasmic AF
+              </span>
+            </button>
+          </th>
+          <th
+            aria-sort="none"
+            scope="col"
+          >
+            <button
+              type="button"
+            >
+              <span
+                class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+              >
+                Heteroplasmic AC
+              </span>
+            </button>
+          </th>
+          <th
+            aria-sort="none"
+            scope="col"
+          >
+            <button
+              type="button"
+            >
+              <span
+                class="TooltipHint-sc-1wwbc8j-0 cXXQWi"
+              >
+                Heteroplasmic AF
+              </span>
+            </button>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th
+            scope="row"
+          >
+            European (Finnish)
+          </th>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              2
+            </span>
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+        </tr>
+        <tr>
+          <th
+            scope="row"
+          >
+            Admixed American
+          </th>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              5
+            </span>
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+        </tr>
+        <tr>
+          <th
+            scope="row"
+          >
+            South Asian
+          </th>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              1
+            </span>
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+        </tr>
+        <tr>
+          <th
+            scope="row"
+          >
+            African/African American
+          </th>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              3
+            </span>
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+        </tr>
+        <tr>
+          <th
+            scope="row"
+          >
+            Ashkenazi Jewish
+          </th>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              4
+            </span>
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+        </tr>
+      </tbody>
+      <tfoot>
+        <tr
+          class="border"
+        >
+          <th
+            scope="row"
+          >
+            Total
+          </th>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              15
+            </span>
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+          <td>
+            <span
+              class="MitochondrialVariantPopulationFrequenciesTable__CountCell-sc-1esr108-0 eKdiaC"
+            >
+              0
+            </span>
+          </td>
+          <td>
+            0.000
+          </td>
+        </tr>
+      </tfoot>
+    </table>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;

--- a/browser/src/VariantPage/PopulationsTable.tsx
+++ b/browser/src/VariantPage/PopulationsTable.tsx
@@ -117,6 +117,9 @@ export class PopulationsTable extends Component<PopulationsTableProps, Populatio
   constructor(props: PopulationsTableProps) {
     super(props)
 
+    // If/when we change this to a functional component, we can replace the
+    // following sorting logic and some other associated code by employing
+    // useTableSort.
     this.state = {
       sortBy: 'af',
       sortAscending: false,

--- a/browser/src/__factories__/MitochondrialVariant.ts
+++ b/browser/src/__factories__/MitochondrialVariant.ts
@@ -1,5 +1,8 @@
 import { Factory } from 'fishery'
-import { MitochondrialVariant } from '../MitochondrialVariantPage/MitochondrialVariantPage'
+import {
+  MitochondrialVariant,
+  MitochondrialVariantPopulation,
+} from '../MitochondrialVariantPage/MitochondrialVariantPage'
 import { defaultHistogram } from './Variant'
 
 const mitochondrialVariantFactory = Factory.define<MitochondrialVariant>(
@@ -71,4 +74,8 @@ const mitochondrialVariantFactory = Factory.define<MitochondrialVariant>(
   }
 )
 
+export const populationFactory = Factory.define<MitochondrialVariantPopulation>(({ params }) => {
+  const { id = 'afr', an = 0, ac_hom = 0, ac_het = 0 } = params
+  return { id, an, ac_hom, ac_het }
+})
 export default mitochondrialVariantFactory

--- a/browser/src/useTableSort.tsx
+++ b/browser/src/useTableSort.tsx
@@ -1,0 +1,93 @@
+import React, { useCallback, useState, ReactNode } from 'react'
+import { TooltipAnchor, TooltipHint } from '@gnomad/ui'
+
+export type RowCompareFunction<RowData> = (a: RowData, b: RowData) => number
+
+export type ColumnSpecifier<RowData> = {
+  key: keyof RowData
+  label: string
+  tooltip: string | null
+  compareValueFunction: RowCompareFunction<RowData>
+}
+
+const renderColumnHeader = <RowData,>(
+  key: keyof RowData,
+  sortBy: keyof RowData,
+  setSortBy: (key: keyof RowData) => void,
+  sortAscending: boolean,
+  label: string,
+  tooltip: string | null
+) => {
+  let ariaSortAttr: React.AriaAttributes['aria-sort'] = 'none'
+  if (sortBy === key) {
+    ariaSortAttr = sortAscending ? 'ascending' : 'descending'
+  }
+
+  return tooltip ? (
+    <th aria-sort={ariaSortAttr} scope="col">
+      {/* @ts-expect-error TS(2322) FIXME: Type '{ children: Element; tooltip: any; }' is not... Remove this comment to see the full error message */}
+      <TooltipAnchor tooltip={tooltip}>
+        <button type="button" onClick={() => setSortBy(key)}>
+          {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+          <TooltipHint>{label}</TooltipHint>
+        </button>
+      </TooltipAnchor>
+    </th>
+  ) : (
+    <th aria-sort={ariaSortAttr} scope="col">
+      <button type="button" onClick={() => setSortBy(key)}>
+        {label}
+      </button>
+    </th>
+  )
+}
+
+const useTableSort = <RowData,>(
+  columnSpecifiers: ColumnSpecifier<RowData>[],
+  defaultSortKey: keyof RowData,
+  rowData: RowData[]
+): { headers: ReactNode; sortedRowData: RowData[] } => {
+  const [key, setKey] = useState<keyof RowData>(defaultSortKey)
+  const [ascending, setAscending] = useState<boolean>(false)
+
+  const setSortKey = useCallback(
+    (newKey: keyof RowData) => {
+      setKey(newKey)
+      setAscending(newKey === key ? !ascending : false)
+    },
+    [key, ascending]
+  )
+
+  const { compareValueFunction } = columnSpecifiers.find((column) => column.key === key)!
+  const sortedRowData = [...rowData].sort((a, b) => {
+    const ascendingCompare = compareValueFunction(a, b)
+    return ascending ? ascendingCompare : -ascendingCompare
+  })
+
+  const headers = (
+    <>
+      {columnSpecifiers.map((columnSpecifier) =>
+        renderColumnHeader(
+          columnSpecifier.key,
+          key,
+          setSortKey,
+          ascending,
+          columnSpecifier.label,
+          columnSpecifier.tooltip
+        )
+      )}
+    </>
+  )
+  return { headers, sortedRowData }
+}
+
+type NumberHolder<Key extends string> = {
+  [K in Key]: number
+}
+
+export const numericCompareFunction =
+  <Key extends string>(key: Key) =>
+  <RowData extends NumberHolder<Key>>(a: RowData, b: RowData) =>
+    a[key] - b[key]
+
+export default useTableSort


### PR DESCRIPTION
This takes some rendering and sorting logic that originated in the mitochondrial variant population frequency table and extracts it into a hook we can re-use in other functional components, such as the upcoming revisions to the short tandem repeats table.