### PR TITLE
Update federated page details again

### DIFF
--- a/browser/src/FederationPage.tsx
+++ b/browser/src/FederationPage.tsx
@@ -84,13 +84,14 @@ const datasets: Dataset[] = [
     country: 'Canada',
     samples: '60,000',
     source: 'Canadian Genomic Data Commons',
+    link: 'https://genomicdatacommons.ca',
     lead: 'Jordan Lerner-Ellis',
   },
   {
     country: 'China',
     samples: '10,000',
-    source: 'China Kadoorie Biobank (>500K)',
-    link: 'https://gnomad.org.cn',
+    source:
+      'Advanced Institute of Information Technology-Juno Genomics joint Center for Mendelian Genomics (AIIT-Juno CMG)',
     lead: 'Xiao Li',
   },
   {
@@ -151,8 +152,7 @@ const datasets: Dataset[] = [
   {
     country: 'UK',
     samples: '50,000',
-    source:
-      'Avon Longitudinal Study of Parents and Children (ALSPC), Born in Bradford, Millennium Cohort Study (MCS), Fenland Study',
+    source: 'TBD',
     link: 'https://www.sanger.ac.uk/',
     lead: 'Vivek Iyer',
   },

--- a/browser/src/__snapshots__/FederationPage.spec.tsx.snap
+++ b/browser/src/__snapshots__/FederationPage.spec.tsx.snap
@@ -346,7 +346,12 @@ exports[`Federation Page has no unexpected changes 1`] = `
             60,000
           </td>
           <td>
-            Canadian Genomic Data Commons
+            <a
+              className="c8"
+              href="https://genomicdatacommons.ca"
+            >
+              Canadian Genomic Data Commons
+            </a>
           </td>
           <td>
             Jordan Lerner-Ellis
@@ -360,12 +365,7 @@ exports[`Federation Page has no unexpected changes 1`] = `
             10,000
           </td>
           <td>
-            <a
-              className="c8"
-              href="https://gnomad.org.cn"
-            >
-              China Kadoorie Biobank (&gt;500K)
-            </a>
+            Advanced Institute of Information Technology-Juno Genomics joint Center for Mendelian Genomics (AIIT-Juno CMG)
           </td>
           <td>
             Xiao Li
@@ -530,7 +530,7 @@ exports[`Federation Page has no unexpected changes 1`] = `
               className="c8"
               href="https://www.sanger.ac.uk/"
             >
-              Avon Longitudinal Study of Parents and Children (ALSPC), Born in Bradford, Millennium Cohort Study (MCS), Fenland Study
+              TBD
             </a>
           </td>
           <td>


### PR DESCRIPTION
Updates the federated page with these requests from Slack:

> - For China, please change their name to "Advanced Institute of Information Technology-Juno Genomics joint Center for Mendelian Genomics (AIIT-Juno CMG)" and remove the hyperlink
> - For UK, please change the name to "TBD" but you can keep the link to https://www.sanger.ac.uk/
> - For Canada, please keep their name but add a link to genomicdatacommons.ca