### PR TITLE
Update variant page content 

### DIFF
--- a/browser/src/VariantPage/ReferenceList.tsx
+++ b/browser/src/VariantPage/ReferenceList.tsx
@@ -71,7 +71,7 @@ export const ReferenceList = ({ variant }: Props) => {
   const ucscURL = `https://genome.ucsc.edu/cgi-bin/hgTracks?db=${ucscReferenceGenomeId}&highlight=${ucscReferenceGenomeId}.chr${chrom}%3A${pos}-${
     pos + (ref.length - 1)
   }&position=chr${chrom}%3A${pos - 25}-${pos + (ref.length - 1) + 25}`
-  const allOfUsURL = `https://databrowser.researchallofus.org/variants/${variant.variant_id}`
+  const allOfUsURL = `https://databrowser.researchallofus.org/snvsindels/${variant.variant_id}`
 
   return (
     // @ts-expect-error TS(2746) FIXME: This JSX tag's 'children' prop expects a single ch... Remove this comment to see the full error message

--- a/browser/src/VariantPage/VariantPage.tsx
+++ b/browser/src/VariantPage/VariantPage.tsx
@@ -385,7 +385,7 @@ export const VariantPageContent = ({ datasetId, variant }: VariantPageContentPro
       </Section>
 
       <Section>
-        <h2>Variant Effect Predictor</h2>
+        <h2>Ensembl Variant Effect Predictor</h2>
         {/* @ts-expect-error TS(2741) FIXME: Property 'reference_genome' is missing in type '{ ... Remove this comment to see the full error message */}
         <VariantTranscriptConsequences variant={variant} />
       </Section>

--- a/browser/src/VariantPage/__snapshots__/VariantPage.spec.tsx.snap
+++ b/browser/src/VariantPage/__snapshots__/VariantPage.spec.tsx.snap
@@ -659,7 +659,7 @@ exports[`VariantPage with the dataset "gnomad_r3" has no unexpected changes 1`] 
         >
           <a
             className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
-            href="https://databrowser.researchallofus.org/variants/13-123-A-C"
+            href="https://databrowser.researchallofus.org/snvsindels/13-123-A-C"
             rel="noopener noreferrer"
             target="_blank"
           >
@@ -10599,7 +10599,7 @@ exports[`VariantPage with the dataset "gnomad_r3_controls_and_biobanks" has no u
         >
           <a
             className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
-            href="https://databrowser.researchallofus.org/variants/13-123-A-C"
+            href="https://databrowser.researchallofus.org/snvsindels/13-123-A-C"
             rel="noopener noreferrer"
             target="_blank"
           >
@@ -20542,7 +20542,7 @@ exports[`VariantPage with the dataset "gnomad_r3_non_cancer" has no unexpected c
         >
           <a
             className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
-            href="https://databrowser.researchallofus.org/variants/13-123-A-C"
+            href="https://databrowser.researchallofus.org/snvsindels/13-123-A-C"
             rel="noopener noreferrer"
             target="_blank"
           >
@@ -30485,7 +30485,7 @@ exports[`VariantPage with the dataset "gnomad_r3_non_neuro" has no unexpected ch
         >
           <a
             className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
-            href="https://databrowser.researchallofus.org/variants/13-123-A-C"
+            href="https://databrowser.researchallofus.org/snvsindels/13-123-A-C"
             rel="noopener noreferrer"
             target="_blank"
           >
@@ -40428,7 +40428,7 @@ exports[`VariantPage with the dataset "gnomad_r3_non_topmed" has no unexpected c
         >
           <a
             className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
-            href="https://databrowser.researchallofus.org/variants/13-123-A-C"
+            href="https://databrowser.researchallofus.org/snvsindels/13-123-A-C"
             rel="noopener noreferrer"
             target="_blank"
           >
@@ -50371,7 +50371,7 @@ exports[`VariantPage with the dataset "gnomad_r3_non_v2" has no unexpected chang
         >
           <a
             className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
-            href="https://databrowser.researchallofus.org/variants/13-123-A-C"
+            href="https://databrowser.researchallofus.org/snvsindels/13-123-A-C"
             rel="noopener noreferrer"
             target="_blank"
           >

--- a/browser/src/VariantPage/__snapshots__/VariantPage.spec.tsx.snap
+++ b/browser/src/VariantPage/__snapshots__/VariantPage.spec.tsx.snap
@@ -1485,7 +1485,7 @@ exports[`VariantPage with the dataset "gnomad_r3" has no unexpected changes 1`] 
       className="VariantPage__Section-sc-hd87ur-0 CMQAN"
     >
       <h2>
-        Variant Effect Predictor
+        Ensembl Variant Effect Predictor
       </h2>
       <div>
         <p>
@@ -11425,7 +11425,7 @@ exports[`VariantPage with the dataset "gnomad_r3_controls_and_biobanks" has no u
       className="VariantPage__Section-sc-hd87ur-0 CMQAN"
     >
       <h2>
-        Variant Effect Predictor
+        Ensembl Variant Effect Predictor
       </h2>
       <div>
         <p>
@@ -21368,7 +21368,7 @@ exports[`VariantPage with the dataset "gnomad_r3_non_cancer" has no unexpected c
       className="VariantPage__Section-sc-hd87ur-0 CMQAN"
     >
       <h2>
-        Variant Effect Predictor
+        Ensembl Variant Effect Predictor
       </h2>
       <div>
         <p>
@@ -31311,7 +31311,7 @@ exports[`VariantPage with the dataset "gnomad_r3_non_neuro" has no unexpected ch
       className="VariantPage__Section-sc-hd87ur-0 CMQAN"
     >
       <h2>
-        Variant Effect Predictor
+        Ensembl Variant Effect Predictor
       </h2>
       <div>
         <p>
@@ -41254,7 +41254,7 @@ exports[`VariantPage with the dataset "gnomad_r3_non_topmed" has no unexpected c
       className="VariantPage__Section-sc-hd87ur-0 CMQAN"
     >
       <h2>
-        Variant Effect Predictor
+        Ensembl Variant Effect Predictor
       </h2>
       <div>
         <p>
@@ -51197,7 +51197,7 @@ exports[`VariantPage with the dataset "gnomad_r3_non_v2" has no unexpected chang
       className="VariantPage__Section-sc-hd87ur-0 CMQAN"
     >
       <h2>
-        Variant Effect Predictor
+        Ensembl Variant Effect Predictor
       </h2>
       <div>
         <p>
@@ -60785,7 +60785,7 @@ exports[`VariantPage with the dataset exac has no unexpected changes 1`] = `
       className="VariantPage__Section-sc-hd87ur-0 CMQAN"
     >
       <h2>
-        Variant Effect Predictor
+        Ensembl Variant Effect Predictor
       </h2>
       <div>
         <p>
@@ -68799,7 +68799,7 @@ exports[`VariantPage with the dataset gnomad_r2_1 has no unexpected changes 1`] 
       className="VariantPage__Section-sc-hd87ur-0 CMQAN"
     >
       <h2>
-        Variant Effect Predictor
+        Ensembl Variant Effect Predictor
       </h2>
       <div>
         <p>
@@ -78863,7 +78863,7 @@ exports[`VariantPage with the dataset gnomad_r2_1_controls has no unexpected cha
       className="VariantPage__Section-sc-hd87ur-0 CMQAN"
     >
       <h2>
-        Variant Effect Predictor
+        Ensembl Variant Effect Predictor
       </h2>
       <div>
         <p>
@@ -88927,7 +88927,7 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_cancer has no unexpected c
       className="VariantPage__Section-sc-hd87ur-0 CMQAN"
     >
       <h2>
-        Variant Effect Predictor
+        Ensembl Variant Effect Predictor
       </h2>
       <div>
         <p>
@@ -98991,7 +98991,7 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_neuro has no unexpected ch
       className="VariantPage__Section-sc-hd87ur-0 CMQAN"
     >
       <h2>
-        Variant Effect Predictor
+        Ensembl Variant Effect Predictor
       </h2>
       <div>
         <p>
@@ -109055,7 +109055,7 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_topmed has no unexpected c
       className="VariantPage__Section-sc-hd87ur-0 CMQAN"
     >
       <h2>
-        Variant Effect Predictor
+        Ensembl Variant Effect Predictor
       </h2>
       <div>
         <p>


### PR DESCRIPTION
Resolves #1693
Resolves #1692

Two quick variant page content updates tossed into a single PR:
- Update broken AoU link (AoU's URL for short variants changed)
- Update "Variant Effect Predictor" -> "Ensembl Variant Effect Predictor" per Ensembl's request