### PR TITLE
Add GTEx link on Gene page

### DIFF
--- a/browser/src/GenePage/GeneReferences.spec.tsx
+++ b/browser/src/GenePage/GeneReferences.spec.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { describe, expect, test } from '@jest/globals'
+
+import GeneReferences from './GeneReferences'
+
+import geneFactory from '../__factories__/Gene'
+
+describe('GeneReferences', () => {
+  test('snapshot has no unexpected changes', () => {
+    const testGene = geneFactory.build()
+
+    const tree = renderer.create(<GeneReferences gene={testGene} />)
+
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/browser/src/GenePage/GeneReferences.tsx
+++ b/browser/src/GenePage/GeneReferences.tsx
@@ -38,6 +38,8 @@ const GeneReferences = ({ gene }: Props) => {
   const ucscReferenceGenomeId = referenceGenome === 'GRCh37' ? 'hg19' : 'hg38'
   const ucscUrl = `https://genome.ucsc.edu/cgi-bin/hgTracks?db=${ucscReferenceGenomeId}&position=chr${chrom}%3A${start}-${stop}`
 
+  const gtexUrl = `https://gtexportal.org/home/gene/${geneId}`
+
   return (
     <React.Fragment>
       {/* @ts-expect-error TS(2786) FIXME: 'ExternalLink' cannot be used as a JSX component. */}
@@ -141,6 +143,11 @@ const GeneReferences = ({ gene }: Props) => {
                   >
                     NCBI Genome Data Viewer
                   </ExternalLink>
+                </ListItem>
+                {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+                <ListItem>
+                  {/* @ts-expect-error TS(2786) FIXME: 'ExternalLink' cannot be used as a JSX component. */}
+                  <ExternalLink href={gtexUrl}>GTEx</ExternalLink>
                 </ListItem>
               </>
             )}

--- a/browser/src/GenePage/__snapshots__/GeneReferences.spec.tsx.snap
+++ b/browser/src/GenePage/__snapshots__/GeneReferences.spec.tsx.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`GeneReferences snapshot has no unexpected changes 1`] = `
+[
+  <a
+    className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+    href="https://grch37.ensembl.org/Homo_sapiens/Gene/Summary?g=dummy_gene-1"
+    rel="noopener noreferrer"
+    target="_blank"
+  >
+    Ensembl
+  </a>,
+  ",",
+  " ",
+  <a
+    className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 haNmsP"
+    href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr13%3A123-321"
+    rel="noopener noreferrer"
+    target="_blank"
+  >
+    UCSC Browser
+  </a>,
+  ",",
+  " ",
+  <button
+    className="Button__TextButton-sc-1eobygi-3 gWkUTz"
+    onClick={[Function]}
+    type="button"
+  >
+    and more
+  </button>,
+]
+`;


### PR DESCRIPTION
Resolves #1691

Adds link to GTEx from the gene page

---

![Screenshot 2025-05-05 at 14 51 04](https://github.com/user-attachments/assets/0983b890-f4cc-4145-b202-16dbacc8cf5b)