### PR TITLE
Use ExternalLink for changelog references

### DIFF
--- a/browser/src/DataPage/GnomadV4Downloads.tsx
+++ b/browser/src/DataPage/GnomadV4Downloads.tsx
@@ -270,9 +270,10 @@ const GnomadV4Downloads = () => {
 
         <p>
           For more information about these files, see our{' '}
-          <Link to="https://gnomad.broadinstitute.org/news/2024-08-release-gnomad-browser-tables">
+          {/* @ts-expect-error TS(2786) FIXME: 'ExternalLink' cannot be used as a JSX component. */}
+          <ExternalLink href="https://gnomad.broadinstitute.org/news/2024-08-release-gnomad-browser-tables">
             changelog entry
-          </Link>{' '}
+          </ExternalLink>{' '}
           on the browser tables, and the <Link to="/help/v4-browser-hts">help text</Link>.
         </p>
 
@@ -537,9 +538,10 @@ const GnomadV4Downloads = () => {
         <SectionTitle id="v4-de-novo">De novo variants (DNVs)</SectionTitle>
         <p>
           For more information on DNVs, see the{' '}
-          <Link to="https://gnomad.broadinstitute.org/news/2025-03-de-novo-variants-in-gnomad-v4-exomes/">
+          {/* @ts-expect-error TS(2786) FIXME: 'ExternalLink' cannot be used as a JSX component. */}
+          <ExternalLink href="https://gnomad.broadinstitute.org/news/2025-03-de-novo-variants-in-gnomad-v4-exomes">
             DNVs changelog
-          </Link>{' '}
+          </ExternalLink>{' '}
         </p>
         <FileList>
           {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}

--- a/browser/src/DataPage/__snapshots__/DataPage.spec.tsx.snap
+++ b/browser/src/DataPage/__snapshots__/DataPage.spec.tsx.snap
@@ -7432,9 +7432,10 @@ exports[`Data Page has no unexpected changes 1`] = `
         For more information about these files, see our
          
         <a
-          className="-Link c13"
+          className="c11"
           href="https://gnomad.broadinstitute.org/news/2024-08-release-gnomad-browser-tables"
-          onClick={[Function]}
+          rel="noopener noreferrer"
+          target="_blank"
         >
           changelog entry
         </a>
@@ -8753,9 +8754,10 @@ exports[`Data Page has no unexpected changes 1`] = `
         For more information on DNVs, see the
          
         <a
-          className="-Link c13"
-          href="https://gnomad.broadinstitute.org/news/2025-03-de-novo-variants-in-gnomad-v4-exomes/"
-          onClick={[Function]}
+          className="c11"
+          href="https://gnomad.broadinstitute.org/news/2025-03-de-novo-variants-in-gnomad-v4-exomes"
+          rel="noopener noreferrer"
+          target="_blank"
         >
           DNVs changelog
         </a>


### PR DESCRIPTION
Fixes two links that mistakenly use the `<Link>` component, which is intended for routing within the application, leading to a malformed URL being linked to.