### PR TITLE
Updates to STR pages

### DIFF
--- a/browser/src/ShortTandemRepeatPage/ShortTandemRepeatAdjacentRepeatSection.tsx
+++ b/browser/src/ShortTandemRepeatPage/ShortTandemRepeatAdjacentRepeatSection.tsx
@@ -5,10 +5,9 @@ import { Modal, Select } from '@gnomad/ui'
 import ControlSection from '../VariantPage/ControlSection'
 
 import ShortTandemRepeatPopulationOptions from './ShortTandemRepeatPopulationOptions'
-import { ShortTandemRepeatAdjacentRepeat } from './ShortTandemRepeatPage'
+import { ShortTandemRepeatAdjacentRepeat, Sex } from './ShortTandemRepeatPage'
 import ShortTandemRepeatAlleleSizeDistributionPlot, {
   ScaleType,
-  Sex,
   ColorBy,
 } from './ShortTandemRepeatAlleleSizeDistributionPlot'
 import ShortTandemRepeatGenotypeDistributionPlot, {
@@ -26,7 +25,7 @@ import {
   maxGenotypeDistributionRepeats,
 } from './shortTandemRepeatHelpers'
 import { PopulationId } from '@gnomad/dataset-metadata/gnomadPopulations'
-import styled from "styled-components";
+import styled from 'styled-components'
 
 const Label = styled.label`
   white-space: nowrap;
@@ -35,15 +34,15 @@ const Label = styled.label`
 type Props = {
   adjacentRepeat: ShortTandemRepeatAdjacentRepeat
   selectedScaleType: ScaleType
-  selectedPopulation: PopulationId | ''
-  selectedSex: Sex | ''
-  selectedColorBy: ColorBy | ''
+  selectedPopulation: PopulationId | null
+  selectedSex: Sex | null
+  selectedColorBy: ColorBy | null
   populations: PopulationId[]
   selectedGenotypeDistributionBin: GenotypeBin | null
   setSelectedGenotypeDistributionBin: Dispatch<SetStateAction<GenotypeBin | null>>
   setSelectedScaleType: Dispatch<SetStateAction<ScaleType>>
-  setSelectedPopulation: Dispatch<SetStateAction<PopulationId | ''>>
-  setSelectedSex: Dispatch<SetStateAction<Sex | ''>>
+  setSelectedPopulation: Dispatch<SetStateAction<PopulationId | null>>
+  setSelectedSex: Dispatch<SetStateAction<Sex | null>>
 }
 
 const ShortTandemRepeatAdjacentRepeatSection = ({
@@ -57,15 +56,15 @@ const ShortTandemRepeatAdjacentRepeatSection = ({
   setSelectedPopulation,
   setSelectedSex,
 }: Props) => {
-  const [selectedRepeatUnit, setSelectedRepeatUnit] = useState(
-    adjacentRepeat.repeat_units.length === 1 ? adjacentRepeat.repeat_units[0] : ''
+  const [selectedRepeatUnit, setSelectedRepeatUnit] = useState<string | null>(
+    adjacentRepeat.repeat_units.length === 1 ? adjacentRepeat.repeat_units[0] : null
   )
 
   const genotypeDistributionPairs = genotypeRepunitPairs(adjacentRepeat)
   const defaultGenotypeDistributionRepeatUnits =
-    genotypeDistributionPairs.length === 1 ? genotypeDistributionPairs[0] : ''
+    genotypeDistributionPairs.length === 1 ? genotypeDistributionPairs[0] : null
   const [selectedGenotypeDistributionRepeatUnits, setSelectedGenotypeDistributionRepeatUnits] =
-    useState<string[] | ''>(defaultGenotypeDistributionRepeatUnits)
+    useState<string[] | null>(defaultGenotypeDistributionRepeatUnits)
 
   const [selectedGenotypeDistributionBin, setSelectedGenotypeDistributionBin] =
     useState<GenotypeBin | null>(null)
@@ -155,6 +154,8 @@ const ShortTandemRepeatAdjacentRepeatSection = ({
         }}
         xRanges={[]}
         yRanges={[]}
+        selectedPopulation={selectedPopulation}
+        selectedSex={selectedSex}
       />
 
       <ControlSection>

--- a/browser/src/ShortTandemRepeatPage/ShortTandemRepeatAlleleSizeDistributionPlot.tsx
+++ b/browser/src/ShortTandemRepeatPage/ShortTandemRepeatAlleleSizeDistributionPlot.tsx
@@ -9,7 +9,11 @@ import { AnyD3Scale } from '@visx/scale'
 import { LegendOrdinal } from '@visx/legend'
 
 import { TooltipAnchor } from '@gnomad/ui'
-import { GNOMAD_POPULATION_NAMES, PopulationId } from '@gnomad/dataset-metadata/gnomadPopulations'
+import {
+  GNOMAD_POPULATION_NAMES,
+  PopulationId,
+  getPopulationsInDataset,
+} from '@gnomad/dataset-metadata/gnomadPopulations'
 import { colorByLabels } from './ShortTandemRepeatColorBySelect'
 import {
   genotypeQualityKeys,
@@ -149,7 +153,10 @@ const legendKeys: Record<ColorBy, string[]> = {
   quality_description: [...genotypeQualityKeys],
   q_score: [...qScoreKeys],
   sex: ['XX', 'XY'],
-  population: ['nfe', 'afr', 'fin', 'amr', 'ami', 'asj', 'eas', 'mid', 'oth', 'sas'],
+  // default v4 populations uses "remaining" for "Remaining Individuals" ID, but this data uses the deprecated "oth" ID
+  population: getPopulationsInDataset('gnomad_r4').map((populationId) =>
+    populationId === 'remaining' ? 'oth' : populationId
+  ),
 }
 
 const LegendFromColorBy = ({ colorBy }: { colorBy: ColorBy | null }) => {

--- a/browser/src/ShortTandemRepeatPage/ShortTandemRepeatAlleleSizeDistributionPlot.tsx
+++ b/browser/src/ShortTandemRepeatPage/ShortTandemRepeatAlleleSizeDistributionPlot.tsx
@@ -233,13 +233,13 @@ const ShortTandemRepeatAlleleSizeDistributionPlot = withSize()(
     }, [alleleSizeDistribution, binSize, emptyBins])
 
     const keys = useMemo(() => {
-      const keySet: Record<string, boolean> = data
+      const presentKeys: Record<string, boolean> = data
         .flatMap((bin) => Object.keys(bin))
         .reduce((acc, key) => ({ ...acc, [key]: true }), {})
-      return Object.keys(keySet).filter(
-        (key) => key !== 'index' && key !== 'label' && key !== 'fullFrequency'
-      )
-    }, [data])
+      const allKeys = colorBy ? legendKeys[colorBy] : ['']
+      const keysInLegendOrder = allKeys.filter((key) => presentKeys[key])
+      return keysInLegendOrder
+    }, [data, colorBy])
     // maps binIndex and colorByValue to a y and y start
 
     const xScale = scaleBand<number>()

--- a/browser/src/ShortTandemRepeatPage/ShortTandemRepeatColorBySelect.tsx
+++ b/browser/src/ShortTandemRepeatPage/ShortTandemRepeatColorBySelect.tsx
@@ -11,8 +11,8 @@ const Label = styled.label`
 
 type Props = {
   id: string
-  selectedColorBy: ColorBy | ''
-  setSelectedColorBy: (newColorBy: ColorBy | '') => void
+  selectedColorBy: ColorBy | null
+  setSelectedColorBy: (newColorBy: ColorBy | null) => void
   setSelectedScaleType: Dispatch<SetStateAction<ScaleType>>
 }
 
@@ -34,9 +34,9 @@ const ShortTandemRepeatColorBySelect = ({
       Color by: &nbsp;{/* @ts-expect-error TS(2769) FIXME: No overload matches this call. */}
       <Select
         id={`short-tandem-repeat-${id}-color-by-select`}
-        value={selectedColorBy}
+        value={selectedColorBy || ''}
         onChange={(e: { target: { value: ColorBy | '' } }) => {
-          setSelectedColorBy(e.target.value)
+          setSelectedColorBy(e.target.value === '' ? null : e.target.value)
           if (e.target.value === 'quality_description') {
             setSelectedScaleType('linear-truncated-50')
           }

--- a/browser/src/ShortTandemRepeatPage/ShortTandemRepeatGenotypeDistributionBinDetails.tsx
+++ b/browser/src/ShortTandemRepeatPage/ShortTandemRepeatGenotypeDistributionBinDetails.tsx
@@ -6,17 +6,16 @@ import {
   ShortTandemRepeat,
   ShortTandemRepeatAdjacentRepeat,
   GenotypeDistributionItem,
+  Sex,
 } from './ShortTandemRepeatPage'
 
 import { getSelectedGenotypeDistribution } from './shortTandemRepeatHelpers'
 
-import { Sex } from './ShortTandemRepeatAlleleSizeDistributionPlot'
-
 type Props = {
   shortTandemRepeatOrAdjacentRepeat: ShortTandemRepeat | ShortTandemRepeatAdjacentRepeat
-  selectedPopulation: string | ''
-  selectedSex: Sex | ''
-  selectedRepeatUnits: string[] | ''
+  selectedPopulation: string | null
+  selectedSex: Sex | null
+  selectedRepeatUnits: string[] | null
   repeatUnitPairs: string[][]
   bin: {
     label: string

--- a/browser/src/ShortTandemRepeatPage/ShortTandemRepeatGenotypeDistributionPlot.tsx
+++ b/browser/src/ShortTandemRepeatPage/ShortTandemRepeatGenotypeDistributionPlot.tsx
@@ -6,7 +6,9 @@ import styled from 'styled-components'
 import { AxisBottom, AxisLeft } from '@visx/axis'
 
 import { TooltipAnchor } from '@gnomad/ui'
-import { GenotypeDistributionItem } from './ShortTandemRepeatPage'
+import { GenotypeDistributionItem, Sex } from './ShortTandemRepeatPage'
+
+import { PopulationId } from '@gnomad/dataset-metadata/gnomadPopulations'
 
 // The 100% width/height container is necessary the component
 // to size to fit its container vs staying at its initial size.
@@ -31,6 +33,8 @@ type Props = {
   yRanges: PlotRange[]
   onSelectBin: (bin: Bin) => void
   size: { width: number }
+  selectedPopulation: PopulationId | null
+  selectedSex: Sex | null
 }
 
 export type Bin = {

--- a/browser/src/ShortTandemRepeatPage/ShortTandemRepeatGenotypeDistributionRepeatUnitsSelect.tsx
+++ b/browser/src/ShortTandemRepeatPage/ShortTandemRepeatGenotypeDistributionRepeatUnitsSelect.tsx
@@ -6,8 +6,8 @@ import { genotypeRepunitPairs, isAdjacentRepeat } from './shortTandemRepeatHelpe
 
 type Props = {
   shortTandemRepeatOrAdjacentRepeat: ShortTandemRepeat | ShortTandemRepeatAdjacentRepeat
-  selectedRepeatUnits: string[] | ''
-  setSelectedRepeatUnits: Dispatch<SetStateAction<string[] | ''>>
+  selectedRepeatUnits: string[] | null
+  setSelectedRepeatUnits: Dispatch<SetStateAction<string[] | null>>
 }
 
 const ShortTandemRepeatGenotypeDistributionRepeatUnitsSelect = ({
@@ -37,9 +37,9 @@ const ShortTandemRepeatGenotypeDistributionRepeatUnitsSelect = ({
       Repeat units: {/* @ts-expect-error TS(2769) FIXME: No overload matches this call. */}
       <Select
         id={`short-tandem-repeat-${shortTandemRepeatOrAdjacentRepeat.id}-genotype-distribution-repeat-units`}
-        value={selectedRepeatUnits === '' ? '' : selectedRepeatUnits.join(' / ')}
+        value={selectedRepeatUnits === null ? '' : selectedRepeatUnits.join(' / ')}
         onChange={({ target: { value } }: { target: { value: string } }) => {
-          const newPair: string[] | '' = value === '' ? '' : value.split(' / ')
+          const newPair: string[] | null = value === '' ? null : value.split(' / ')
           setSelectedRepeatUnits(newPair)
         }}
       >

--- a/browser/src/ShortTandemRepeatPage/ShortTandemRepeatPopulationOptions.tsx
+++ b/browser/src/ShortTandemRepeatPage/ShortTandemRepeatPopulationOptions.tsx
@@ -5,7 +5,7 @@ import { Select } from '@gnomad/ui'
 
 import { PopulationId, GNOMAD_POPULATION_NAMES } from '@gnomad/dataset-metadata/gnomadPopulations'
 
-import { Sex } from './ShortTandemRepeatAlleleSizeDistributionPlot'
+import { Sex } from './ShortTandemRepeatPage'
 
 const Wrapper = styled.div`
   @media (max-width: 600px) {
@@ -19,7 +19,6 @@ const Wrapper = styled.div`
   }
 `
 
-
 const Label = styled.label`
   padding-right: 1em;
   white-space: nowrap;
@@ -28,10 +27,10 @@ const Label = styled.label`
 type Props = {
   id: string
   populations: PopulationId[]
-  selectedPopulation: PopulationId | ''
-  selectedSex: Sex | ''
-  setSelectedPopulation: Dispatch<SetStateAction<PopulationId | ''>>
-  setSelectedSex: Dispatch<SetStateAction<Sex | ''>>
+  selectedPopulation: PopulationId | null
+  selectedSex: Sex | null
+  setSelectedPopulation: Dispatch<SetStateAction<PopulationId | null>>
+  setSelectedSex: Dispatch<SetStateAction<Sex | null>>
 }
 
 const ShortTandemRepeatPopulationOptions = ({
@@ -53,9 +52,9 @@ const ShortTandemRepeatPopulationOptions = ({
         {/* @ts-expect-error TS(2769) FIXME: No overload matches this call. */}
         <Select
           id={`short-tandem-repeat-${id}-population-options-population`}
-          value={selectedPopulation}
+          value={selectedPopulation || ''}
           onChange={(e: { target: { value: PopulationId | '' } }) =>
-            setSelectedPopulation(e.target.value)
+            setSelectedPopulation(e.target.value === '' ? null : e.target.value)
           }
         >
           <option value="">Global</option>
@@ -71,8 +70,10 @@ const ShortTandemRepeatPopulationOptions = ({
         Sex: &nbsp;{/* @ts-expect-error TS(2769) FIXME: No overload matches this call. */}
         <Select
           id={`short-tandem-repeat-${id}-population-options-sex`}
-          value={selectedSex}
-          onChange={(e: { target: { value: Sex | '' } }) => setSelectedSex(e.target.value)}
+          value={selectedSex || ''}
+          onChange={(e: { target: { value: Sex | '' } }) =>
+            setSelectedSex(e.target.value === '' ? null : e.target.value)
+          }
         >
           <option value="">All</option>
           <option value="XX">XX</option>

--- a/browser/src/ShortTandemRepeatPage/ShortTandemRepeatReads.tsx
+++ b/browser/src/ShortTandemRepeatPage/ShortTandemRepeatReads.tsx
@@ -482,36 +482,52 @@ const ShortTandemRepeatReadsAllelesFilterControls = ({
             <Label htmlFor={`short-tandem-repeat-reads-filter-allele-${alleleIndex}-min-repeats`}>
               Min repeats {/* @ts-expect-error TS(2769) FIXME: No overload matches this call. */}
               <Input
-                type="number"
+                type="text"
                 id={`short-tandem-repeat-reads-filter-allele-${alleleIndex}-min-repeats`}
                 min={0}
                 max={maxRepeats}
-                value={value[alleleIndex].min_repeats}
-                onChange={(e: any) => {
+                value={undefined}
+                defaultValue={value[alleleIndex].min_repeats}
+                onBlur={(e: React.FocusEvent<HTMLInputElement>) => {
                   const newMinRepeats = Math.max(Math.min(Number(e.target.value), maxRepeats), 0)
-                  onChangeCallback(
-                    value.map((v, i) =>
-                      i === alleleIndex ? { ...v, min_repeats: newMinRepeats } : v
+                  if (newMinRepeats !== value[alleleIndex].min_repeats) {
+                    onChangeCallback(
+                      value.map((v, i) =>
+                        i === alleleIndex ? { ...v, min_repeats: newMinRepeats } : v
+                      )
                     )
-                  )
+                  }
+                }}
+                onKeyDown={(e: React.KeyboardEvent) => {
+                  if (e.code === 'Enter') {
+                    ;(e.target as HTMLInputElement).blur()
+                  }
                 }}
               />
             </Label>{' '}
             <Label htmlFor={`short-tandem-repeat-reads-filter-allele-${alleleIndex}-max-repeats`}>
               Max repeats {/* @ts-expect-error TS(2769) FIXME: No overload matches this call. */}
               <Input
-                type="number"
+                type="text"
                 id={`short-tandem-repeat-reads-filter-allele-${alleleIndex}-max-repeats`}
                 min={0}
                 max={maxRepeats}
-                value={value[alleleIndex].max_repeats}
-                onChange={(e: any) => {
+                value={undefined}
+                defaultValue={value[alleleIndex].max_repeats}
+                onBlur={(e: React.FocusEvent<HTMLInputElement>) => {
                   const newMaxRepeats = Math.max(Math.min(Number(e.target.value), maxRepeats), 0)
-                  onChangeCallback(
-                    value.map((v, i) =>
-                      i === alleleIndex ? { ...v, max_repeats: newMaxRepeats } : v
+                  if (newMaxRepeats !== value[alleleIndex].max_repeats) {
+                    onChangeCallback(
+                      value.map((v, i) =>
+                        i === alleleIndex ? { ...v, max_repeats: newMaxRepeats } : v
+                      )
                     )
-                  )
+                  }
+                }}
+                onKeyDown={(e: React.KeyboardEvent) => {
+                  if (e.code === 'Enter') {
+                    ;(e.target as HTMLInputElement).blur()
+                  }
                 }}
               />
             </Label>

--- a/browser/src/ShortTandemRepeatPage/__snapshots__/ShortTandemRepeatPage.spec.tsx.snap
+++ b/browser/src/ShortTandemRepeatPage/__snapshots__/ShortTandemRepeatPage.spec.tsx.snap
@@ -444,18 +444,18 @@ exports[`ShortTandemRepeatPage with "exac" dataset has no unexected changes 1`] 
       alleleSizeDistribution={
         [
           {
-            "colorByValue": "",
+            "colorByValue": null,
             "frequency": 12,
             "repunit_count": 3,
           },
           {
-            "colorByValue": "",
+            "colorByValue": null,
             "frequency": 123,
             "repunit_count": 4,
           },
         ]
       }
-      colorBy=""
+      colorBy={null}
       maxRepeats={4}
       ranges={[]}
       repeatUnitLength={4}
@@ -475,14 +475,14 @@ exports[`ShortTandemRepeatPage with "exac" dataset has no unexected changes 1`] 
             "asj",
           ]
         }
-        selectedPopulation=""
-        selectedSex=""
+        selectedPopulation={null}
+        selectedSex={null}
         setSelectedPopulation={[Function]}
         setSelectedSex={[Function]}
       />
       <ShortTandemRepeatColorBySelect
         id="STR1-color-by"
-        selectedColorBy=""
+        selectedColorBy={null}
         setSelectedColorBy={[Function]}
         setSelectedScaleType={[Function]}
       />
@@ -584,6 +584,8 @@ exports[`ShortTandemRepeatPage with "exac" dataset has no unexected changes 1`] 
         ]
       }
       onSelectBin={[Function]}
+      selectedPopulation={null}
+      selectedSex={null}
       xRanges={[]}
       yRanges={[]}
     />
@@ -601,8 +603,8 @@ exports[`ShortTandemRepeatPage with "exac" dataset has no unexected changes 1`] 
             "asj",
           ]
         }
-        selectedPopulation=""
-        selectedSex=""
+        selectedPopulation={null}
+        selectedSex={null}
         setSelectedPopulation={[Function]}
         setSelectedSex={[Function]}
       />
@@ -822,26 +824,6 @@ exports[`ShortTandemRepeatPage with "exac" dataset has no unexected changes 1`] 
         topic="str-read-data"
       />
     </h2>
-    <ControlSection
-      style={
-        {
-          "marginBottom": "1em",
-        }
-      }
-    >
-      <ShortTandemRepeatPopulationOptions
-        id="STR1-genotype-distribution"
-        populations={
-          [
-            "asj",
-          ]
-        }
-        selectedPopulation=""
-        selectedSex=""
-        setSelectedPopulation={[Function]}
-        setSelectedSex={[Function]}
-      />
-    </ControlSection>
     <ShortTandemRepeatReadsContainer
       alleleSizeDistributionRepeatUnits={
         [
@@ -849,13 +831,16 @@ exports[`ShortTandemRepeatPage with "exac" dataset has no unexected changes 1`] 
         ]
       }
       datasetId="exac"
-      filter={
-        {
-          "population": "",
-          "sex": "",
-        }
-      }
       maxRepeats={4}
+      populations={
+        [
+          "asj",
+        ]
+      }
+      selectedPopulation={null}
+      selectedSex={null}
+      setSelectedPopulation={[Function]}
+      setSelectedSex={[Function]}
       shortTandemRepeat={
         {
           "adjacent_repeats": [],
@@ -1428,18 +1413,18 @@ exports[`ShortTandemRepeatPage with "gnomad_cnv_r4" dataset has no unexected cha
       alleleSizeDistribution={
         [
           {
-            "colorByValue": "",
+            "colorByValue": null,
             "frequency": 12,
             "repunit_count": 3,
           },
           {
-            "colorByValue": "",
+            "colorByValue": null,
             "frequency": 123,
             "repunit_count": 4,
           },
         ]
       }
-      colorBy=""
+      colorBy={null}
       maxRepeats={4}
       ranges={[]}
       repeatUnitLength={4}
@@ -1459,14 +1444,14 @@ exports[`ShortTandemRepeatPage with "gnomad_cnv_r4" dataset has no unexected cha
             "asj",
           ]
         }
-        selectedPopulation=""
-        selectedSex=""
+        selectedPopulation={null}
+        selectedSex={null}
         setSelectedPopulation={[Function]}
         setSelectedSex={[Function]}
       />
       <ShortTandemRepeatColorBySelect
         id="STR1-color-by"
-        selectedColorBy=""
+        selectedColorBy={null}
         setSelectedColorBy={[Function]}
         setSelectedScaleType={[Function]}
       />
@@ -1568,6 +1553,8 @@ exports[`ShortTandemRepeatPage with "gnomad_cnv_r4" dataset has no unexected cha
         ]
       }
       onSelectBin={[Function]}
+      selectedPopulation={null}
+      selectedSex={null}
       xRanges={[]}
       yRanges={[]}
     />
@@ -1585,8 +1572,8 @@ exports[`ShortTandemRepeatPage with "gnomad_cnv_r4" dataset has no unexected cha
             "asj",
           ]
         }
-        selectedPopulation=""
-        selectedSex=""
+        selectedPopulation={null}
+        selectedSex={null}
         setSelectedPopulation={[Function]}
         setSelectedSex={[Function]}
       />
@@ -1806,26 +1793,6 @@ exports[`ShortTandemRepeatPage with "gnomad_cnv_r4" dataset has no unexected cha
         topic="str-read-data"
       />
     </h2>
-    <ControlSection
-      style={
-        {
-          "marginBottom": "1em",
-        }
-      }
-    >
-      <ShortTandemRepeatPopulationOptions
-        id="STR1-genotype-distribution"
-        populations={
-          [
-            "asj",
-          ]
-        }
-        selectedPopulation=""
-        selectedSex=""
-        setSelectedPopulation={[Function]}
-        setSelectedSex={[Function]}
-      />
-    </ControlSection>
     <ShortTandemRepeatReadsContainer
       alleleSizeDistributionRepeatUnits={
         [
@@ -1833,13 +1800,16 @@ exports[`ShortTandemRepeatPage with "gnomad_cnv_r4" dataset has no unexected cha
         ]
       }
       datasetId="gnomad_cnv_r4"
-      filter={
-        {
-          "population": "",
-          "sex": "",
-        }
-      }
       maxRepeats={4}
+      populations={
+        [
+          "asj",
+        ]
+      }
+      selectedPopulation={null}
+      selectedSex={null}
+      setSelectedPopulation={[Function]}
+      setSelectedSex={[Function]}
       shortTandemRepeat={
         {
           "adjacent_repeats": [],
@@ -2412,18 +2382,18 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1" dataset has no unexected chang
       alleleSizeDistribution={
         [
           {
-            "colorByValue": "",
+            "colorByValue": null,
             "frequency": 12,
             "repunit_count": 3,
           },
           {
-            "colorByValue": "",
+            "colorByValue": null,
             "frequency": 123,
             "repunit_count": 4,
           },
         ]
       }
-      colorBy=""
+      colorBy={null}
       maxRepeats={4}
       ranges={[]}
       repeatUnitLength={4}
@@ -2443,14 +2413,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1" dataset has no unexected chang
             "asj",
           ]
         }
-        selectedPopulation=""
-        selectedSex=""
+        selectedPopulation={null}
+        selectedSex={null}
         setSelectedPopulation={[Function]}
         setSelectedSex={[Function]}
       />
       <ShortTandemRepeatColorBySelect
         id="STR1-color-by"
-        selectedColorBy=""
+        selectedColorBy={null}
         setSelectedColorBy={[Function]}
         setSelectedScaleType={[Function]}
       />
@@ -2552,6 +2522,8 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1" dataset has no unexected chang
         ]
       }
       onSelectBin={[Function]}
+      selectedPopulation={null}
+      selectedSex={null}
       xRanges={[]}
       yRanges={[]}
     />
@@ -2569,8 +2541,8 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1" dataset has no unexected chang
             "asj",
           ]
         }
-        selectedPopulation=""
-        selectedSex=""
+        selectedPopulation={null}
+        selectedSex={null}
         setSelectedPopulation={[Function]}
         setSelectedSex={[Function]}
       />
@@ -2790,26 +2762,6 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1" dataset has no unexected chang
         topic="str-read-data"
       />
     </h2>
-    <ControlSection
-      style={
-        {
-          "marginBottom": "1em",
-        }
-      }
-    >
-      <ShortTandemRepeatPopulationOptions
-        id="STR1-genotype-distribution"
-        populations={
-          [
-            "asj",
-          ]
-        }
-        selectedPopulation=""
-        selectedSex=""
-        setSelectedPopulation={[Function]}
-        setSelectedSex={[Function]}
-      />
-    </ControlSection>
     <ShortTandemRepeatReadsContainer
       alleleSizeDistributionRepeatUnits={
         [
@@ -2817,13 +2769,16 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1" dataset has no unexected chang
         ]
       }
       datasetId="gnomad_r2_1"
-      filter={
-        {
-          "population": "",
-          "sex": "",
-        }
-      }
       maxRepeats={4}
+      populations={
+        [
+          "asj",
+        ]
+      }
+      selectedPopulation={null}
+      selectedSex={null}
+      setSelectedPopulation={[Function]}
+      setSelectedSex={[Function]}
       shortTandemRepeat={
         {
           "adjacent_repeats": [],
@@ -3396,18 +3351,18 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1_controls" dataset has no unexec
       alleleSizeDistribution={
         [
           {
-            "colorByValue": "",
+            "colorByValue": null,
             "frequency": 12,
             "repunit_count": 3,
           },
           {
-            "colorByValue": "",
+            "colorByValue": null,
             "frequency": 123,
             "repunit_count": 4,
           },
         ]
       }
-      colorBy=""
+      colorBy={null}
       maxRepeats={4}
       ranges={[]}
       repeatUnitLength={4}
@@ -3427,14 +3382,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1_controls" dataset has no unexec
             "asj",
           ]
         }
-        selectedPopulation=""
-        selectedSex=""
+        selectedPopulation={null}
+        selectedSex={null}
         setSelectedPopulation={[Function]}
         setSelectedSex={[Function]}
       />
       <ShortTandemRepeatColorBySelect
         id="STR1-color-by"
-        selectedColorBy=""
+        selectedColorBy={null}
         setSelectedColorBy={[Function]}
         setSelectedScaleType={[Function]}
       />
@@ -3536,6 +3491,8 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1_controls" dataset has no unexec
         ]
       }
       onSelectBin={[Function]}
+      selectedPopulation={null}
+      selectedSex={null}
       xRanges={[]}
       yRanges={[]}
     />
@@ -3553,8 +3510,8 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1_controls" dataset has no unexec
             "asj",
           ]
         }
-        selectedPopulation=""
-        selectedSex=""
+        selectedPopulation={null}
+        selectedSex={null}
         setSelectedPopulation={[Function]}
         setSelectedSex={[Function]}
       />
@@ -3774,26 +3731,6 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1_controls" dataset has no unexec
         topic="str-read-data"
       />
     </h2>
-    <ControlSection
-      style={
-        {
-          "marginBottom": "1em",
-        }
-      }
-    >
-      <ShortTandemRepeatPopulationOptions
-        id="STR1-genotype-distribution"
-        populations={
-          [
-            "asj",
-          ]
-        }
-        selectedPopulation=""
-        selectedSex=""
-        setSelectedPopulation={[Function]}
-        setSelectedSex={[Function]}
-      />
-    </ControlSection>
     <ShortTandemRepeatReadsContainer
       alleleSizeDistributionRepeatUnits={
         [
@@ -3801,13 +3738,16 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1_controls" dataset has no unexec
         ]
       }
       datasetId="gnomad_r2_1_controls"
-      filter={
-        {
-          "population": "",
-          "sex": "",
-        }
-      }
       maxRepeats={4}
+      populations={
+        [
+          "asj",
+        ]
+      }
+      selectedPopulation={null}
+      selectedSex={null}
+      setSelectedPopulation={[Function]}
+      setSelectedSex={[Function]}
       shortTandemRepeat={
         {
           "adjacent_repeats": [],
@@ -4380,18 +4320,18 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1_non_cancer" dataset has no unex
       alleleSizeDistribution={
         [
           {
-            "colorByValue": "",
+            "colorByValue": null,
             "frequency": 12,
             "repunit_count": 3,
           },
           {
-            "colorByValue": "",
+            "colorByValue": null,
             "frequency": 123,
             "repunit_count": 4,
           },
         ]
       }
-      colorBy=""
+      colorBy={null}
       maxRepeats={4}
       ranges={[]}
       repeatUnitLength={4}
@@ -4411,14 +4351,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1_non_cancer" dataset has no unex
             "asj",
           ]
         }
-        selectedPopulation=""
-        selectedSex=""
+        selectedPopulation={null}
+        selectedSex={null}
         setSelectedPopulation={[Function]}
         setSelectedSex={[Function]}
       />
       <ShortTandemRepeatColorBySelect
         id="STR1-color-by"
-        selectedColorBy=""
+        selectedColorBy={null}
         setSelectedColorBy={[Function]}
         setSelectedScaleType={[Function]}
       />
@@ -4520,6 +4460,8 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1_non_cancer" dataset has no unex
         ]
       }
       onSelectBin={[Function]}
+      selectedPopulation={null}
+      selectedSex={null}
       xRanges={[]}
       yRanges={[]}
     />
@@ -4537,8 +4479,8 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1_non_cancer" dataset has no unex
             "asj",
           ]
         }
-        selectedPopulation=""
-        selectedSex=""
+        selectedPopulation={null}
+        selectedSex={null}
         setSelectedPopulation={[Function]}
         setSelectedSex={[Function]}
       />
@@ -4758,26 +4700,6 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1_non_cancer" dataset has no unex
         topic="str-read-data"
       />
     </h2>
-    <ControlSection
-      style={
-        {
-          "marginBottom": "1em",
-        }
-      }
-    >
-      <ShortTandemRepeatPopulationOptions
-        id="STR1-genotype-distribution"
-        populations={
-          [
-            "asj",
-          ]
-        }
-        selectedPopulation=""
-        selectedSex=""
-        setSelectedPopulation={[Function]}
-        setSelectedSex={[Function]}
-      />
-    </ControlSection>
     <ShortTandemRepeatReadsContainer
       alleleSizeDistributionRepeatUnits={
         [
@@ -4785,13 +4707,16 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1_non_cancer" dataset has no unex
         ]
       }
       datasetId="gnomad_r2_1_non_cancer"
-      filter={
-        {
-          "population": "",
-          "sex": "",
-        }
-      }
       maxRepeats={4}
+      populations={
+        [
+          "asj",
+        ]
+      }
+      selectedPopulation={null}
+      selectedSex={null}
+      setSelectedPopulation={[Function]}
+      setSelectedSex={[Function]}
       shortTandemRepeat={
         {
           "adjacent_repeats": [],
@@ -5364,18 +5289,18 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1_non_neuro" dataset has no unexe
       alleleSizeDistribution={
         [
           {
-            "colorByValue": "",
+            "colorByValue": null,
             "frequency": 12,
             "repunit_count": 3,
           },
           {
-            "colorByValue": "",
+            "colorByValue": null,
             "frequency": 123,
             "repunit_count": 4,
           },
         ]
       }
-      colorBy=""
+      colorBy={null}
       maxRepeats={4}
       ranges={[]}
       repeatUnitLength={4}
@@ -5395,14 +5320,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1_non_neuro" dataset has no unexe
             "asj",
           ]
         }
-        selectedPopulation=""
-        selectedSex=""
+        selectedPopulation={null}
+        selectedSex={null}
         setSelectedPopulation={[Function]}
         setSelectedSex={[Function]}
       />
       <ShortTandemRepeatColorBySelect
         id="STR1-color-by"
-        selectedColorBy=""
+        selectedColorBy={null}
         setSelectedColorBy={[Function]}
         setSelectedScaleType={[Function]}
       />
@@ -5504,6 +5429,8 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1_non_neuro" dataset has no unexe
         ]
       }
       onSelectBin={[Function]}
+      selectedPopulation={null}
+      selectedSex={null}
       xRanges={[]}
       yRanges={[]}
     />
@@ -5521,8 +5448,8 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1_non_neuro" dataset has no unexe
             "asj",
           ]
         }
-        selectedPopulation=""
-        selectedSex=""
+        selectedPopulation={null}
+        selectedSex={null}
         setSelectedPopulation={[Function]}
         setSelectedSex={[Function]}
       />
@@ -5742,26 +5669,6 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1_non_neuro" dataset has no unexe
         topic="str-read-data"
       />
     </h2>
-    <ControlSection
-      style={
-        {
-          "marginBottom": "1em",
-        }
-      }
-    >
-      <ShortTandemRepeatPopulationOptions
-        id="STR1-genotype-distribution"
-        populations={
-          [
-            "asj",
-          ]
-        }
-        selectedPopulation=""
-        selectedSex=""
-        setSelectedPopulation={[Function]}
-        setSelectedSex={[Function]}
-      />
-    </ControlSection>
     <ShortTandemRepeatReadsContainer
       alleleSizeDistributionRepeatUnits={
         [
@@ -5769,13 +5676,16 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1_non_neuro" dataset has no unexe
         ]
       }
       datasetId="gnomad_r2_1_non_neuro"
-      filter={
-        {
-          "population": "",
-          "sex": "",
-        }
-      }
       maxRepeats={4}
+      populations={
+        [
+          "asj",
+        ]
+      }
+      selectedPopulation={null}
+      selectedSex={null}
+      setSelectedPopulation={[Function]}
+      setSelectedSex={[Function]}
       shortTandemRepeat={
         {
           "adjacent_repeats": [],
@@ -6348,18 +6258,18 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1_non_topmed" dataset has no unex
       alleleSizeDistribution={
         [
           {
-            "colorByValue": "",
+            "colorByValue": null,
             "frequency": 12,
             "repunit_count": 3,
           },
           {
-            "colorByValue": "",
+            "colorByValue": null,
             "frequency": 123,
             "repunit_count": 4,
           },
         ]
       }
-      colorBy=""
+      colorBy={null}
       maxRepeats={4}
       ranges={[]}
       repeatUnitLength={4}
@@ -6379,14 +6289,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1_non_topmed" dataset has no unex
             "asj",
           ]
         }
-        selectedPopulation=""
-        selectedSex=""
+        selectedPopulation={null}
+        selectedSex={null}
         setSelectedPopulation={[Function]}
         setSelectedSex={[Function]}
       />
       <ShortTandemRepeatColorBySelect
         id="STR1-color-by"
-        selectedColorBy=""
+        selectedColorBy={null}
         setSelectedColorBy={[Function]}
         setSelectedScaleType={[Function]}
       />
@@ -6488,6 +6398,8 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1_non_topmed" dataset has no unex
         ]
       }
       onSelectBin={[Function]}
+      selectedPopulation={null}
+      selectedSex={null}
       xRanges={[]}
       yRanges={[]}
     />
@@ -6505,8 +6417,8 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1_non_topmed" dataset has no unex
             "asj",
           ]
         }
-        selectedPopulation=""
-        selectedSex=""
+        selectedPopulation={null}
+        selectedSex={null}
         setSelectedPopulation={[Function]}
         setSelectedSex={[Function]}
       />
@@ -6726,26 +6638,6 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1_non_topmed" dataset has no unex
         topic="str-read-data"
       />
     </h2>
-    <ControlSection
-      style={
-        {
-          "marginBottom": "1em",
-        }
-      }
-    >
-      <ShortTandemRepeatPopulationOptions
-        id="STR1-genotype-distribution"
-        populations={
-          [
-            "asj",
-          ]
-        }
-        selectedPopulation=""
-        selectedSex=""
-        setSelectedPopulation={[Function]}
-        setSelectedSex={[Function]}
-      />
-    </ControlSection>
     <ShortTandemRepeatReadsContainer
       alleleSizeDistributionRepeatUnits={
         [
@@ -6753,13 +6645,16 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1_non_topmed" dataset has no unex
         ]
       }
       datasetId="gnomad_r2_1_non_topmed"
-      filter={
-        {
-          "population": "",
-          "sex": "",
-        }
-      }
       maxRepeats={4}
+      populations={
+        [
+          "asj",
+        ]
+      }
+      selectedPopulation={null}
+      selectedSex={null}
+      setSelectedPopulation={[Function]}
+      setSelectedSex={[Function]}
       shortTandemRepeat={
         {
           "adjacent_repeats": [],
@@ -7332,18 +7227,18 @@ exports[`ShortTandemRepeatPage with "gnomad_r3" dataset has no unexected changes
       alleleSizeDistribution={
         [
           {
-            "colorByValue": "",
+            "colorByValue": null,
             "frequency": 12,
             "repunit_count": 3,
           },
           {
-            "colorByValue": "",
+            "colorByValue": null,
             "frequency": 123,
             "repunit_count": 4,
           },
         ]
       }
-      colorBy=""
+      colorBy={null}
       maxRepeats={4}
       ranges={[]}
       repeatUnitLength={4}
@@ -7363,14 +7258,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r3" dataset has no unexected changes
             "asj",
           ]
         }
-        selectedPopulation=""
-        selectedSex=""
+        selectedPopulation={null}
+        selectedSex={null}
         setSelectedPopulation={[Function]}
         setSelectedSex={[Function]}
       />
       <ShortTandemRepeatColorBySelect
         id="STR1-color-by"
-        selectedColorBy=""
+        selectedColorBy={null}
         setSelectedColorBy={[Function]}
         setSelectedScaleType={[Function]}
       />
@@ -7472,6 +7367,8 @@ exports[`ShortTandemRepeatPage with "gnomad_r3" dataset has no unexected changes
         ]
       }
       onSelectBin={[Function]}
+      selectedPopulation={null}
+      selectedSex={null}
       xRanges={[]}
       yRanges={[]}
     />
@@ -7489,8 +7386,8 @@ exports[`ShortTandemRepeatPage with "gnomad_r3" dataset has no unexected changes
             "asj",
           ]
         }
-        selectedPopulation=""
-        selectedSex=""
+        selectedPopulation={null}
+        selectedSex={null}
         setSelectedPopulation={[Function]}
         setSelectedSex={[Function]}
       />
@@ -7710,26 +7607,6 @@ exports[`ShortTandemRepeatPage with "gnomad_r3" dataset has no unexected changes
         topic="str-read-data"
       />
     </h2>
-    <ControlSection
-      style={
-        {
-          "marginBottom": "1em",
-        }
-      }
-    >
-      <ShortTandemRepeatPopulationOptions
-        id="STR1-genotype-distribution"
-        populations={
-          [
-            "asj",
-          ]
-        }
-        selectedPopulation=""
-        selectedSex=""
-        setSelectedPopulation={[Function]}
-        setSelectedSex={[Function]}
-      />
-    </ControlSection>
     <ShortTandemRepeatReadsContainer
       alleleSizeDistributionRepeatUnits={
         [
@@ -7737,13 +7614,16 @@ exports[`ShortTandemRepeatPage with "gnomad_r3" dataset has no unexected changes
         ]
       }
       datasetId="gnomad_r3"
-      filter={
-        {
-          "population": "",
-          "sex": "",
-        }
-      }
       maxRepeats={4}
+      populations={
+        [
+          "asj",
+        ]
+      }
+      selectedPopulation={null}
+      selectedSex={null}
+      setSelectedPopulation={[Function]}
+      setSelectedSex={[Function]}
       shortTandemRepeat={
         {
           "adjacent_repeats": [],
@@ -8316,18 +8196,18 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_controls_and_biobanks" dataset ha
       alleleSizeDistribution={
         [
           {
-            "colorByValue": "",
+            "colorByValue": null,
             "frequency": 12,
             "repunit_count": 3,
           },
           {
-            "colorByValue": "",
+            "colorByValue": null,
             "frequency": 123,
             "repunit_count": 4,
           },
         ]
       }
-      colorBy=""
+      colorBy={null}
       maxRepeats={4}
       ranges={[]}
       repeatUnitLength={4}
@@ -8347,14 +8227,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_controls_and_biobanks" dataset ha
             "asj",
           ]
         }
-        selectedPopulation=""
-        selectedSex=""
+        selectedPopulation={null}
+        selectedSex={null}
         setSelectedPopulation={[Function]}
         setSelectedSex={[Function]}
       />
       <ShortTandemRepeatColorBySelect
         id="STR1-color-by"
-        selectedColorBy=""
+        selectedColorBy={null}
         setSelectedColorBy={[Function]}
         setSelectedScaleType={[Function]}
       />
@@ -8456,6 +8336,8 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_controls_and_biobanks" dataset ha
         ]
       }
       onSelectBin={[Function]}
+      selectedPopulation={null}
+      selectedSex={null}
       xRanges={[]}
       yRanges={[]}
     />
@@ -8473,8 +8355,8 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_controls_and_biobanks" dataset ha
             "asj",
           ]
         }
-        selectedPopulation=""
-        selectedSex=""
+        selectedPopulation={null}
+        selectedSex={null}
         setSelectedPopulation={[Function]}
         setSelectedSex={[Function]}
       />
@@ -8694,26 +8576,6 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_controls_and_biobanks" dataset ha
         topic="str-read-data"
       />
     </h2>
-    <ControlSection
-      style={
-        {
-          "marginBottom": "1em",
-        }
-      }
-    >
-      <ShortTandemRepeatPopulationOptions
-        id="STR1-genotype-distribution"
-        populations={
-          [
-            "asj",
-          ]
-        }
-        selectedPopulation=""
-        selectedSex=""
-        setSelectedPopulation={[Function]}
-        setSelectedSex={[Function]}
-      />
-    </ControlSection>
     <ShortTandemRepeatReadsContainer
       alleleSizeDistributionRepeatUnits={
         [
@@ -8721,13 +8583,16 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_controls_and_biobanks" dataset ha
         ]
       }
       datasetId="gnomad_r3_controls_and_biobanks"
-      filter={
-        {
-          "population": "",
-          "sex": "",
-        }
-      }
       maxRepeats={4}
+      populations={
+        [
+          "asj",
+        ]
+      }
+      selectedPopulation={null}
+      selectedSex={null}
+      setSelectedPopulation={[Function]}
+      setSelectedSex={[Function]}
       shortTandemRepeat={
         {
           "adjacent_repeats": [],
@@ -9300,18 +9165,18 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_non_cancer" dataset has no unexec
       alleleSizeDistribution={
         [
           {
-            "colorByValue": "",
+            "colorByValue": null,
             "frequency": 12,
             "repunit_count": 3,
           },
           {
-            "colorByValue": "",
+            "colorByValue": null,
             "frequency": 123,
             "repunit_count": 4,
           },
         ]
       }
-      colorBy=""
+      colorBy={null}
       maxRepeats={4}
       ranges={[]}
       repeatUnitLength={4}
@@ -9331,14 +9196,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_non_cancer" dataset has no unexec
             "asj",
           ]
         }
-        selectedPopulation=""
-        selectedSex=""
+        selectedPopulation={null}
+        selectedSex={null}
         setSelectedPopulation={[Function]}
         setSelectedSex={[Function]}
       />
       <ShortTandemRepeatColorBySelect
         id="STR1-color-by"
-        selectedColorBy=""
+        selectedColorBy={null}
         setSelectedColorBy={[Function]}
         setSelectedScaleType={[Function]}
       />
@@ -9440,6 +9305,8 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_non_cancer" dataset has no unexec
         ]
       }
       onSelectBin={[Function]}
+      selectedPopulation={null}
+      selectedSex={null}
       xRanges={[]}
       yRanges={[]}
     />
@@ -9457,8 +9324,8 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_non_cancer" dataset has no unexec
             "asj",
           ]
         }
-        selectedPopulation=""
-        selectedSex=""
+        selectedPopulation={null}
+        selectedSex={null}
         setSelectedPopulation={[Function]}
         setSelectedSex={[Function]}
       />
@@ -9678,26 +9545,6 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_non_cancer" dataset has no unexec
         topic="str-read-data"
       />
     </h2>
-    <ControlSection
-      style={
-        {
-          "marginBottom": "1em",
-        }
-      }
-    >
-      <ShortTandemRepeatPopulationOptions
-        id="STR1-genotype-distribution"
-        populations={
-          [
-            "asj",
-          ]
-        }
-        selectedPopulation=""
-        selectedSex=""
-        setSelectedPopulation={[Function]}
-        setSelectedSex={[Function]}
-      />
-    </ControlSection>
     <ShortTandemRepeatReadsContainer
       alleleSizeDistributionRepeatUnits={
         [
@@ -9705,13 +9552,16 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_non_cancer" dataset has no unexec
         ]
       }
       datasetId="gnomad_r3_non_cancer"
-      filter={
-        {
-          "population": "",
-          "sex": "",
-        }
-      }
       maxRepeats={4}
+      populations={
+        [
+          "asj",
+        ]
+      }
+      selectedPopulation={null}
+      selectedSex={null}
+      setSelectedPopulation={[Function]}
+      setSelectedSex={[Function]}
       shortTandemRepeat={
         {
           "adjacent_repeats": [],
@@ -10284,18 +10134,18 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_non_neuro" dataset has no unexect
       alleleSizeDistribution={
         [
           {
-            "colorByValue": "",
+            "colorByValue": null,
             "frequency": 12,
             "repunit_count": 3,
           },
           {
-            "colorByValue": "",
+            "colorByValue": null,
             "frequency": 123,
             "repunit_count": 4,
           },
         ]
       }
-      colorBy=""
+      colorBy={null}
       maxRepeats={4}
       ranges={[]}
       repeatUnitLength={4}
@@ -10315,14 +10165,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_non_neuro" dataset has no unexect
             "asj",
           ]
         }
-        selectedPopulation=""
-        selectedSex=""
+        selectedPopulation={null}
+        selectedSex={null}
         setSelectedPopulation={[Function]}
         setSelectedSex={[Function]}
       />
       <ShortTandemRepeatColorBySelect
         id="STR1-color-by"
-        selectedColorBy=""
+        selectedColorBy={null}
         setSelectedColorBy={[Function]}
         setSelectedScaleType={[Function]}
       />
@@ -10424,6 +10274,8 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_non_neuro" dataset has no unexect
         ]
       }
       onSelectBin={[Function]}
+      selectedPopulation={null}
+      selectedSex={null}
       xRanges={[]}
       yRanges={[]}
     />
@@ -10441,8 +10293,8 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_non_neuro" dataset has no unexect
             "asj",
           ]
         }
-        selectedPopulation=""
-        selectedSex=""
+        selectedPopulation={null}
+        selectedSex={null}
         setSelectedPopulation={[Function]}
         setSelectedSex={[Function]}
       />
@@ -10662,26 +10514,6 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_non_neuro" dataset has no unexect
         topic="str-read-data"
       />
     </h2>
-    <ControlSection
-      style={
-        {
-          "marginBottom": "1em",
-        }
-      }
-    >
-      <ShortTandemRepeatPopulationOptions
-        id="STR1-genotype-distribution"
-        populations={
-          [
-            "asj",
-          ]
-        }
-        selectedPopulation=""
-        selectedSex=""
-        setSelectedPopulation={[Function]}
-        setSelectedSex={[Function]}
-      />
-    </ControlSection>
     <ShortTandemRepeatReadsContainer
       alleleSizeDistributionRepeatUnits={
         [
@@ -10689,13 +10521,16 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_non_neuro" dataset has no unexect
         ]
       }
       datasetId="gnomad_r3_non_neuro"
-      filter={
-        {
-          "population": "",
-          "sex": "",
-        }
-      }
       maxRepeats={4}
+      populations={
+        [
+          "asj",
+        ]
+      }
+      selectedPopulation={null}
+      selectedSex={null}
+      setSelectedPopulation={[Function]}
+      setSelectedSex={[Function]}
       shortTandemRepeat={
         {
           "adjacent_repeats": [],
@@ -11268,18 +11103,18 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_non_topmed" dataset has no unexec
       alleleSizeDistribution={
         [
           {
-            "colorByValue": "",
+            "colorByValue": null,
             "frequency": 12,
             "repunit_count": 3,
           },
           {
-            "colorByValue": "",
+            "colorByValue": null,
             "frequency": 123,
             "repunit_count": 4,
           },
         ]
       }
-      colorBy=""
+      colorBy={null}
       maxRepeats={4}
       ranges={[]}
       repeatUnitLength={4}
@@ -11299,14 +11134,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_non_topmed" dataset has no unexec
             "asj",
           ]
         }
-        selectedPopulation=""
-        selectedSex=""
+        selectedPopulation={null}
+        selectedSex={null}
         setSelectedPopulation={[Function]}
         setSelectedSex={[Function]}
       />
       <ShortTandemRepeatColorBySelect
         id="STR1-color-by"
-        selectedColorBy=""
+        selectedColorBy={null}
         setSelectedColorBy={[Function]}
         setSelectedScaleType={[Function]}
       />
@@ -11408,6 +11243,8 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_non_topmed" dataset has no unexec
         ]
       }
       onSelectBin={[Function]}
+      selectedPopulation={null}
+      selectedSex={null}
       xRanges={[]}
       yRanges={[]}
     />
@@ -11425,8 +11262,8 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_non_topmed" dataset has no unexec
             "asj",
           ]
         }
-        selectedPopulation=""
-        selectedSex=""
+        selectedPopulation={null}
+        selectedSex={null}
         setSelectedPopulation={[Function]}
         setSelectedSex={[Function]}
       />
@@ -11646,26 +11483,6 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_non_topmed" dataset has no unexec
         topic="str-read-data"
       />
     </h2>
-    <ControlSection
-      style={
-        {
-          "marginBottom": "1em",
-        }
-      }
-    >
-      <ShortTandemRepeatPopulationOptions
-        id="STR1-genotype-distribution"
-        populations={
-          [
-            "asj",
-          ]
-        }
-        selectedPopulation=""
-        selectedSex=""
-        setSelectedPopulation={[Function]}
-        setSelectedSex={[Function]}
-      />
-    </ControlSection>
     <ShortTandemRepeatReadsContainer
       alleleSizeDistributionRepeatUnits={
         [
@@ -11673,13 +11490,16 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_non_topmed" dataset has no unexec
         ]
       }
       datasetId="gnomad_r3_non_topmed"
-      filter={
-        {
-          "population": "",
-          "sex": "",
-        }
-      }
       maxRepeats={4}
+      populations={
+        [
+          "asj",
+        ]
+      }
+      selectedPopulation={null}
+      selectedSex={null}
+      setSelectedPopulation={[Function]}
+      setSelectedSex={[Function]}
       shortTandemRepeat={
         {
           "adjacent_repeats": [],
@@ -12252,18 +12072,18 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_non_v2" dataset has no unexected 
       alleleSizeDistribution={
         [
           {
-            "colorByValue": "",
+            "colorByValue": null,
             "frequency": 12,
             "repunit_count": 3,
           },
           {
-            "colorByValue": "",
+            "colorByValue": null,
             "frequency": 123,
             "repunit_count": 4,
           },
         ]
       }
-      colorBy=""
+      colorBy={null}
       maxRepeats={4}
       ranges={[]}
       repeatUnitLength={4}
@@ -12283,14 +12103,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_non_v2" dataset has no unexected 
             "asj",
           ]
         }
-        selectedPopulation=""
-        selectedSex=""
+        selectedPopulation={null}
+        selectedSex={null}
         setSelectedPopulation={[Function]}
         setSelectedSex={[Function]}
       />
       <ShortTandemRepeatColorBySelect
         id="STR1-color-by"
-        selectedColorBy=""
+        selectedColorBy={null}
         setSelectedColorBy={[Function]}
         setSelectedScaleType={[Function]}
       />
@@ -12392,6 +12212,8 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_non_v2" dataset has no unexected 
         ]
       }
       onSelectBin={[Function]}
+      selectedPopulation={null}
+      selectedSex={null}
       xRanges={[]}
       yRanges={[]}
     />
@@ -12409,8 +12231,8 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_non_v2" dataset has no unexected 
             "asj",
           ]
         }
-        selectedPopulation=""
-        selectedSex=""
+        selectedPopulation={null}
+        selectedSex={null}
         setSelectedPopulation={[Function]}
         setSelectedSex={[Function]}
       />
@@ -12630,26 +12452,6 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_non_v2" dataset has no unexected 
         topic="str-read-data"
       />
     </h2>
-    <ControlSection
-      style={
-        {
-          "marginBottom": "1em",
-        }
-      }
-    >
-      <ShortTandemRepeatPopulationOptions
-        id="STR1-genotype-distribution"
-        populations={
-          [
-            "asj",
-          ]
-        }
-        selectedPopulation=""
-        selectedSex=""
-        setSelectedPopulation={[Function]}
-        setSelectedSex={[Function]}
-      />
-    </ControlSection>
     <ShortTandemRepeatReadsContainer
       alleleSizeDistributionRepeatUnits={
         [
@@ -12657,13 +12459,16 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_non_v2" dataset has no unexected 
         ]
       }
       datasetId="gnomad_r3_non_v2"
-      filter={
-        {
-          "population": "",
-          "sex": "",
-        }
-      }
       maxRepeats={4}
+      populations={
+        [
+          "asj",
+        ]
+      }
+      selectedPopulation={null}
+      selectedSex={null}
+      setSelectedPopulation={[Function]}
+      setSelectedSex={[Function]}
       shortTandemRepeat={
         {
           "adjacent_repeats": [],
@@ -13236,18 +13041,18 @@ exports[`ShortTandemRepeatPage with "gnomad_r4" dataset has no unexected changes
       alleleSizeDistribution={
         [
           {
-            "colorByValue": "",
+            "colorByValue": null,
             "frequency": 12,
             "repunit_count": 3,
           },
           {
-            "colorByValue": "",
+            "colorByValue": null,
             "frequency": 123,
             "repunit_count": 4,
           },
         ]
       }
-      colorBy=""
+      colorBy={null}
       maxRepeats={4}
       ranges={[]}
       repeatUnitLength={4}
@@ -13267,14 +13072,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r4" dataset has no unexected changes
             "asj",
           ]
         }
-        selectedPopulation=""
-        selectedSex=""
+        selectedPopulation={null}
+        selectedSex={null}
         setSelectedPopulation={[Function]}
         setSelectedSex={[Function]}
       />
       <ShortTandemRepeatColorBySelect
         id="STR1-color-by"
-        selectedColorBy=""
+        selectedColorBy={null}
         setSelectedColorBy={[Function]}
         setSelectedScaleType={[Function]}
       />
@@ -13376,6 +13181,8 @@ exports[`ShortTandemRepeatPage with "gnomad_r4" dataset has no unexected changes
         ]
       }
       onSelectBin={[Function]}
+      selectedPopulation={null}
+      selectedSex={null}
       xRanges={[]}
       yRanges={[]}
     />
@@ -13393,8 +13200,8 @@ exports[`ShortTandemRepeatPage with "gnomad_r4" dataset has no unexected changes
             "asj",
           ]
         }
-        selectedPopulation=""
-        selectedSex=""
+        selectedPopulation={null}
+        selectedSex={null}
         setSelectedPopulation={[Function]}
         setSelectedSex={[Function]}
       />
@@ -13614,26 +13421,6 @@ exports[`ShortTandemRepeatPage with "gnomad_r4" dataset has no unexected changes
         topic="str-read-data"
       />
     </h2>
-    <ControlSection
-      style={
-        {
-          "marginBottom": "1em",
-        }
-      }
-    >
-      <ShortTandemRepeatPopulationOptions
-        id="STR1-genotype-distribution"
-        populations={
-          [
-            "asj",
-          ]
-        }
-        selectedPopulation=""
-        selectedSex=""
-        setSelectedPopulation={[Function]}
-        setSelectedSex={[Function]}
-      />
-    </ControlSection>
     <ShortTandemRepeatReadsContainer
       alleleSizeDistributionRepeatUnits={
         [
@@ -13641,13 +13428,16 @@ exports[`ShortTandemRepeatPage with "gnomad_r4" dataset has no unexected changes
         ]
       }
       datasetId="gnomad_r4"
-      filter={
-        {
-          "population": "",
-          "sex": "",
-        }
-      }
       maxRepeats={4}
+      populations={
+        [
+          "asj",
+        ]
+      }
+      selectedPopulation={null}
+      selectedSex={null}
+      setSelectedPopulation={[Function]}
+      setSelectedSex={[Function]}
       shortTandemRepeat={
         {
           "adjacent_repeats": [],
@@ -14220,18 +14010,18 @@ exports[`ShortTandemRepeatPage with "gnomad_r4_non_ukb" dataset has no unexected
       alleleSizeDistribution={
         [
           {
-            "colorByValue": "",
+            "colorByValue": null,
             "frequency": 12,
             "repunit_count": 3,
           },
           {
-            "colorByValue": "",
+            "colorByValue": null,
             "frequency": 123,
             "repunit_count": 4,
           },
         ]
       }
-      colorBy=""
+      colorBy={null}
       maxRepeats={4}
       ranges={[]}
       repeatUnitLength={4}
@@ -14251,14 +14041,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r4_non_ukb" dataset has no unexected
             "asj",
           ]
         }
-        selectedPopulation=""
-        selectedSex=""
+        selectedPopulation={null}
+        selectedSex={null}
         setSelectedPopulation={[Function]}
         setSelectedSex={[Function]}
       />
       <ShortTandemRepeatColorBySelect
         id="STR1-color-by"
-        selectedColorBy=""
+        selectedColorBy={null}
         setSelectedColorBy={[Function]}
         setSelectedScaleType={[Function]}
       />
@@ -14360,6 +14150,8 @@ exports[`ShortTandemRepeatPage with "gnomad_r4_non_ukb" dataset has no unexected
         ]
       }
       onSelectBin={[Function]}
+      selectedPopulation={null}
+      selectedSex={null}
       xRanges={[]}
       yRanges={[]}
     />
@@ -14377,8 +14169,8 @@ exports[`ShortTandemRepeatPage with "gnomad_r4_non_ukb" dataset has no unexected
             "asj",
           ]
         }
-        selectedPopulation=""
-        selectedSex=""
+        selectedPopulation={null}
+        selectedSex={null}
         setSelectedPopulation={[Function]}
         setSelectedSex={[Function]}
       />
@@ -14598,26 +14390,6 @@ exports[`ShortTandemRepeatPage with "gnomad_r4_non_ukb" dataset has no unexected
         topic="str-read-data"
       />
     </h2>
-    <ControlSection
-      style={
-        {
-          "marginBottom": "1em",
-        }
-      }
-    >
-      <ShortTandemRepeatPopulationOptions
-        id="STR1-genotype-distribution"
-        populations={
-          [
-            "asj",
-          ]
-        }
-        selectedPopulation=""
-        selectedSex=""
-        setSelectedPopulation={[Function]}
-        setSelectedSex={[Function]}
-      />
-    </ControlSection>
     <ShortTandemRepeatReadsContainer
       alleleSizeDistributionRepeatUnits={
         [
@@ -14625,13 +14397,16 @@ exports[`ShortTandemRepeatPage with "gnomad_r4_non_ukb" dataset has no unexected
         ]
       }
       datasetId="gnomad_r4_non_ukb"
-      filter={
-        {
-          "population": "",
-          "sex": "",
-        }
-      }
       maxRepeats={4}
+      populations={
+        [
+          "asj",
+        ]
+      }
+      selectedPopulation={null}
+      selectedSex={null}
+      setSelectedPopulation={[Function]}
+      setSelectedSex={[Function]}
       shortTandemRepeat={
         {
           "adjacent_repeats": [],
@@ -15204,18 +14979,18 @@ exports[`ShortTandemRepeatPage with "gnomad_sv_r2_1" dataset has no unexected ch
       alleleSizeDistribution={
         [
           {
-            "colorByValue": "",
+            "colorByValue": null,
             "frequency": 12,
             "repunit_count": 3,
           },
           {
-            "colorByValue": "",
+            "colorByValue": null,
             "frequency": 123,
             "repunit_count": 4,
           },
         ]
       }
-      colorBy=""
+      colorBy={null}
       maxRepeats={4}
       ranges={[]}
       repeatUnitLength={4}
@@ -15235,14 +15010,14 @@ exports[`ShortTandemRepeatPage with "gnomad_sv_r2_1" dataset has no unexected ch
             "asj",
           ]
         }
-        selectedPopulation=""
-        selectedSex=""
+        selectedPopulation={null}
+        selectedSex={null}
         setSelectedPopulation={[Function]}
         setSelectedSex={[Function]}
       />
       <ShortTandemRepeatColorBySelect
         id="STR1-color-by"
-        selectedColorBy=""
+        selectedColorBy={null}
         setSelectedColorBy={[Function]}
         setSelectedScaleType={[Function]}
       />
@@ -15344,6 +15119,8 @@ exports[`ShortTandemRepeatPage with "gnomad_sv_r2_1" dataset has no unexected ch
         ]
       }
       onSelectBin={[Function]}
+      selectedPopulation={null}
+      selectedSex={null}
       xRanges={[]}
       yRanges={[]}
     />
@@ -15361,8 +15138,8 @@ exports[`ShortTandemRepeatPage with "gnomad_sv_r2_1" dataset has no unexected ch
             "asj",
           ]
         }
-        selectedPopulation=""
-        selectedSex=""
+        selectedPopulation={null}
+        selectedSex={null}
         setSelectedPopulation={[Function]}
         setSelectedSex={[Function]}
       />
@@ -15582,26 +15359,6 @@ exports[`ShortTandemRepeatPage with "gnomad_sv_r2_1" dataset has no unexected ch
         topic="str-read-data"
       />
     </h2>
-    <ControlSection
-      style={
-        {
-          "marginBottom": "1em",
-        }
-      }
-    >
-      <ShortTandemRepeatPopulationOptions
-        id="STR1-genotype-distribution"
-        populations={
-          [
-            "asj",
-          ]
-        }
-        selectedPopulation=""
-        selectedSex=""
-        setSelectedPopulation={[Function]}
-        setSelectedSex={[Function]}
-      />
-    </ControlSection>
     <ShortTandemRepeatReadsContainer
       alleleSizeDistributionRepeatUnits={
         [
@@ -15609,13 +15366,16 @@ exports[`ShortTandemRepeatPage with "gnomad_sv_r2_1" dataset has no unexected ch
         ]
       }
       datasetId="gnomad_sv_r2_1"
-      filter={
-        {
-          "population": "",
-          "sex": "",
-        }
-      }
       maxRepeats={4}
+      populations={
+        [
+          "asj",
+        ]
+      }
+      selectedPopulation={null}
+      selectedSex={null}
+      setSelectedPopulation={[Function]}
+      setSelectedSex={[Function]}
       shortTandemRepeat={
         {
           "adjacent_repeats": [],
@@ -16188,18 +15948,18 @@ exports[`ShortTandemRepeatPage with "gnomad_sv_r2_1_controls" dataset has no une
       alleleSizeDistribution={
         [
           {
-            "colorByValue": "",
+            "colorByValue": null,
             "frequency": 12,
             "repunit_count": 3,
           },
           {
-            "colorByValue": "",
+            "colorByValue": null,
             "frequency": 123,
             "repunit_count": 4,
           },
         ]
       }
-      colorBy=""
+      colorBy={null}
       maxRepeats={4}
       ranges={[]}
       repeatUnitLength={4}
@@ -16219,14 +15979,14 @@ exports[`ShortTandemRepeatPage with "gnomad_sv_r2_1_controls" dataset has no une
             "asj",
           ]
         }
-        selectedPopulation=""
-        selectedSex=""
+        selectedPopulation={null}
+        selectedSex={null}
         setSelectedPopulation={[Function]}
         setSelectedSex={[Function]}
       />
       <ShortTandemRepeatColorBySelect
         id="STR1-color-by"
-        selectedColorBy=""
+        selectedColorBy={null}
         setSelectedColorBy={[Function]}
         setSelectedScaleType={[Function]}
       />
@@ -16328,6 +16088,8 @@ exports[`ShortTandemRepeatPage with "gnomad_sv_r2_1_controls" dataset has no une
         ]
       }
       onSelectBin={[Function]}
+      selectedPopulation={null}
+      selectedSex={null}
       xRanges={[]}
       yRanges={[]}
     />
@@ -16345,8 +16107,8 @@ exports[`ShortTandemRepeatPage with "gnomad_sv_r2_1_controls" dataset has no une
             "asj",
           ]
         }
-        selectedPopulation=""
-        selectedSex=""
+        selectedPopulation={null}
+        selectedSex={null}
         setSelectedPopulation={[Function]}
         setSelectedSex={[Function]}
       />
@@ -16566,26 +16328,6 @@ exports[`ShortTandemRepeatPage with "gnomad_sv_r2_1_controls" dataset has no une
         topic="str-read-data"
       />
     </h2>
-    <ControlSection
-      style={
-        {
-          "marginBottom": "1em",
-        }
-      }
-    >
-      <ShortTandemRepeatPopulationOptions
-        id="STR1-genotype-distribution"
-        populations={
-          [
-            "asj",
-          ]
-        }
-        selectedPopulation=""
-        selectedSex=""
-        setSelectedPopulation={[Function]}
-        setSelectedSex={[Function]}
-      />
-    </ControlSection>
     <ShortTandemRepeatReadsContainer
       alleleSizeDistributionRepeatUnits={
         [
@@ -16593,13 +16335,16 @@ exports[`ShortTandemRepeatPage with "gnomad_sv_r2_1_controls" dataset has no une
         ]
       }
       datasetId="gnomad_sv_r2_1_controls"
-      filter={
-        {
-          "population": "",
-          "sex": "",
-        }
-      }
       maxRepeats={4}
+      populations={
+        [
+          "asj",
+        ]
+      }
+      selectedPopulation={null}
+      selectedSex={null}
+      setSelectedPopulation={[Function]}
+      setSelectedSex={[Function]}
       shortTandemRepeat={
         {
           "adjacent_repeats": [],
@@ -17172,18 +16917,18 @@ exports[`ShortTandemRepeatPage with "gnomad_sv_r2_1_non_neuro" dataset has no un
       alleleSizeDistribution={
         [
           {
-            "colorByValue": "",
+            "colorByValue": null,
             "frequency": 12,
             "repunit_count": 3,
           },
           {
-            "colorByValue": "",
+            "colorByValue": null,
             "frequency": 123,
             "repunit_count": 4,
           },
         ]
       }
-      colorBy=""
+      colorBy={null}
       maxRepeats={4}
       ranges={[]}
       repeatUnitLength={4}
@@ -17203,14 +16948,14 @@ exports[`ShortTandemRepeatPage with "gnomad_sv_r2_1_non_neuro" dataset has no un
             "asj",
           ]
         }
-        selectedPopulation=""
-        selectedSex=""
+        selectedPopulation={null}
+        selectedSex={null}
         setSelectedPopulation={[Function]}
         setSelectedSex={[Function]}
       />
       <ShortTandemRepeatColorBySelect
         id="STR1-color-by"
-        selectedColorBy=""
+        selectedColorBy={null}
         setSelectedColorBy={[Function]}
         setSelectedScaleType={[Function]}
       />
@@ -17312,6 +17057,8 @@ exports[`ShortTandemRepeatPage with "gnomad_sv_r2_1_non_neuro" dataset has no un
         ]
       }
       onSelectBin={[Function]}
+      selectedPopulation={null}
+      selectedSex={null}
       xRanges={[]}
       yRanges={[]}
     />
@@ -17329,8 +17076,8 @@ exports[`ShortTandemRepeatPage with "gnomad_sv_r2_1_non_neuro" dataset has no un
             "asj",
           ]
         }
-        selectedPopulation=""
-        selectedSex=""
+        selectedPopulation={null}
+        selectedSex={null}
         setSelectedPopulation={[Function]}
         setSelectedSex={[Function]}
       />
@@ -17550,26 +17297,6 @@ exports[`ShortTandemRepeatPage with "gnomad_sv_r2_1_non_neuro" dataset has no un
         topic="str-read-data"
       />
     </h2>
-    <ControlSection
-      style={
-        {
-          "marginBottom": "1em",
-        }
-      }
-    >
-      <ShortTandemRepeatPopulationOptions
-        id="STR1-genotype-distribution"
-        populations={
-          [
-            "asj",
-          ]
-        }
-        selectedPopulation=""
-        selectedSex=""
-        setSelectedPopulation={[Function]}
-        setSelectedSex={[Function]}
-      />
-    </ControlSection>
     <ShortTandemRepeatReadsContainer
       alleleSizeDistributionRepeatUnits={
         [
@@ -17577,13 +17304,16 @@ exports[`ShortTandemRepeatPage with "gnomad_sv_r2_1_non_neuro" dataset has no un
         ]
       }
       datasetId="gnomad_sv_r2_1_non_neuro"
-      filter={
-        {
-          "population": "",
-          "sex": "",
-        }
-      }
       maxRepeats={4}
+      populations={
+        [
+          "asj",
+        ]
+      }
+      selectedPopulation={null}
+      selectedSex={null}
+      setSelectedPopulation={[Function]}
+      setSelectedSex={[Function]}
       shortTandemRepeat={
         {
           "adjacent_repeats": [],
@@ -18156,18 +17886,18 @@ exports[`ShortTandemRepeatPage with "gnomad_sv_r4" dataset has no unexected chan
       alleleSizeDistribution={
         [
           {
-            "colorByValue": "",
+            "colorByValue": null,
             "frequency": 12,
             "repunit_count": 3,
           },
           {
-            "colorByValue": "",
+            "colorByValue": null,
             "frequency": 123,
             "repunit_count": 4,
           },
         ]
       }
-      colorBy=""
+      colorBy={null}
       maxRepeats={4}
       ranges={[]}
       repeatUnitLength={4}
@@ -18187,14 +17917,14 @@ exports[`ShortTandemRepeatPage with "gnomad_sv_r4" dataset has no unexected chan
             "asj",
           ]
         }
-        selectedPopulation=""
-        selectedSex=""
+        selectedPopulation={null}
+        selectedSex={null}
         setSelectedPopulation={[Function]}
         setSelectedSex={[Function]}
       />
       <ShortTandemRepeatColorBySelect
         id="STR1-color-by"
-        selectedColorBy=""
+        selectedColorBy={null}
         setSelectedColorBy={[Function]}
         setSelectedScaleType={[Function]}
       />
@@ -18296,6 +18026,8 @@ exports[`ShortTandemRepeatPage with "gnomad_sv_r4" dataset has no unexected chan
         ]
       }
       onSelectBin={[Function]}
+      selectedPopulation={null}
+      selectedSex={null}
       xRanges={[]}
       yRanges={[]}
     />
@@ -18313,8 +18045,8 @@ exports[`ShortTandemRepeatPage with "gnomad_sv_r4" dataset has no unexected chan
             "asj",
           ]
         }
-        selectedPopulation=""
-        selectedSex=""
+        selectedPopulation={null}
+        selectedSex={null}
         setSelectedPopulation={[Function]}
         setSelectedSex={[Function]}
       />
@@ -18534,26 +18266,6 @@ exports[`ShortTandemRepeatPage with "gnomad_sv_r4" dataset has no unexected chan
         topic="str-read-data"
       />
     </h2>
-    <ControlSection
-      style={
-        {
-          "marginBottom": "1em",
-        }
-      }
-    >
-      <ShortTandemRepeatPopulationOptions
-        id="STR1-genotype-distribution"
-        populations={
-          [
-            "asj",
-          ]
-        }
-        selectedPopulation=""
-        selectedSex=""
-        setSelectedPopulation={[Function]}
-        setSelectedSex={[Function]}
-      />
-    </ControlSection>
     <ShortTandemRepeatReadsContainer
       alleleSizeDistributionRepeatUnits={
         [
@@ -18561,13 +18273,16 @@ exports[`ShortTandemRepeatPage with "gnomad_sv_r4" dataset has no unexected chan
         ]
       }
       datasetId="gnomad_sv_r4"
-      filter={
-        {
-          "population": "",
-          "sex": "",
-        }
-      }
       maxRepeats={4}
+      populations={
+        [
+          "asj",
+        ]
+      }
+      selectedPopulation={null}
+      selectedSex={null}
+      setSelectedPopulation={[Function]}
+      setSelectedSex={[Function]}
       shortTandemRepeat={
         {
           "adjacent_repeats": [],

--- a/browser/src/ShortTandemRepeatPage/shortTandemRepeatHelpers.ts
+++ b/browser/src/ShortTandemRepeatPage/shortTandemRepeatHelpers.ts
@@ -4,28 +4,30 @@ import {
   GenotypeDistributionCohort,
   GenotypeDistributionItem,
   ShortTandemRepeatAdjacentRepeat,
+  Sex,
 } from './ShortTandemRepeatPage'
 
 import {
   ColorBy,
-  Sex,
   ColorByValue,
   AlleleSizeDistributionItem,
 } from './ShortTandemRepeatAlleleSizeDistributionPlot'
 
+import { PopulationId } from '@gnomad/dataset-metadata/gnomadPopulations'
+
 type AlleleSizeDistributionParams = {
-  selectedPopulation: string | ''
-  selectedSex: Sex | ''
-  selectedColorBy: ColorBy | ''
-  selectedRepeatUnit: string
+  selectedPopulation: PopulationId | null
+  selectedSex: Sex | null
+  selectedColorBy: ColorBy | null
+  selectedRepeatUnit: string | null
 }
 
 const addCohortToAlleleSizeDistribution = (
   cohort: AlleleSizeDistributionCohort,
-  colorBy: ColorBy | '',
+  colorBy: ColorBy | null,
   distribution: Record<string, AlleleSizeDistributionItem>
 ): Record<string, AlleleSizeDistributionItem> => {
-  let colorByValue: ColorByValue = ''
+  let colorByValue: ColorByValue | null = null
   if (colorBy === 'quality_description') {
     colorByValue = cohort.quality_description
   } else if (colorBy === 'q_score') {
@@ -70,21 +72,22 @@ export const getSelectedAlleleSizeDistribution = (
   }: AlleleSizeDistributionParams
 ): AlleleSizeDistributionItem[] => {
   const matchingRepunits: Set<string> =
+    selectedRepeatUnit !== null &&
     selectedRepeatUnit.startsWith('classification') &&
     !isAdjacentRepeat(shortTandemRepeatOrAdjacentRepeat)
       ? repunitsWithClassification(shortTandemRepeatOrAdjacentRepeat, selectedRepeatUnit.slice(15))
-      : new Set([selectedRepeatUnit])
+      : new Set([selectedRepeatUnit!])
 
   const itemsByRepunitCount: Record<number, AlleleSizeDistributionItem> =
     shortTandemRepeatOrAdjacentRepeat.allele_size_distribution.reduce((acc, cohort) => {
-      if (selectedPopulation !== '' && cohort.ancestry_group !== selectedPopulation) {
+      if (selectedPopulation !== null && cohort.ancestry_group !== selectedPopulation) {
         return acc
       }
-      if (selectedSex !== '' && cohort.sex !== selectedSex) {
+      if (selectedSex !== null && cohort.sex) {
         return acc
       }
 
-      if (selectedRepeatUnit !== '' && !matchingRepunits.has(cohort.repunit)) {
+      if (selectedRepeatUnit !== null && !matchingRepunits.has(cohort.repunit)) {
         return acc
       }
       return addCohortToAlleleSizeDistribution(cohort, selectedColorBy, acc)
@@ -117,21 +120,21 @@ export const getSelectedGenotypeDistribution = (
     selectedPopulation,
     selectedSex,
   }: {
-    selectedRepeatUnits: string[] | ''
-    selectedPopulation: string | ''
-    selectedSex: Sex | ''
+    selectedRepeatUnits: string[] | null
+    selectedPopulation: string | null
+    selectedSex: Sex | null
   }
 ): GenotypeDistributionItem[] => {
   const itemsByRepunitCounts: Record<string, GenotypeDistributionItem> =
     shortTandemRepeatOrAdjacentRepeat.genotype_distribution.reduce((acc, cohort) => {
-      if (selectedPopulation !== '' && cohort.ancestry_group !== selectedPopulation) {
+      if (selectedPopulation !== null && cohort.ancestry_group !== selectedPopulation) {
         return acc
       }
-      if (selectedSex !== '' && cohort.sex !== selectedSex) {
+      if (selectedSex !== null && cohort.sex !== selectedSex) {
         return acc
       }
       if (
-        selectedRepeatUnits !== '' &&
+        selectedRepeatUnits !== null &&
         (cohort.short_allele_repunit !== selectedRepeatUnits[0] ||
           cohort.long_allele_repunit !== selectedRepeatUnits[1])
       ) {
@@ -144,9 +147,9 @@ export const getSelectedGenotypeDistribution = (
 
 export const getGenotypeDistributionPlotAxisLabels = (
   shortTandemRepeatOrAdjacentRepeat: ShortTandemRepeat | ShortTandemRepeatAdjacentRepeat,
-  { selectedRepeatUnits }: { selectedRepeatUnits: string[] | '' }
+  { selectedRepeatUnits }: { selectedRepeatUnits: string[] | null }
 ) => {
-  if (selectedRepeatUnits !== '') {
+  if (selectedRepeatUnits !== null) {
     if (selectedRepeatUnits[0] === selectedRepeatUnits[1]) {
       return genotypeRepunitPairs(shortTandemRepeatOrAdjacentRepeat).length === 1
         ? ['longer allele', 'shorter allele']


### PR DESCRIPTION
This begins with some refactoring, and goes on to make two user-facing changes:

* The min/max repeats fields for reads are now text inputs that only reload the reads when they lose focus, or when the user hits "Enter".
* When using the "color by" option on the allele size distribution plot, the order of each individual stack follows the order in the legend.