### PR TITLE
Move v4 lai download to v3 section

### DIFF
--- a/browser/src/DataPage/GnomadV3Downloads.tsx
+++ b/browser/src/DataPage/GnomadV3Downloads.tsx
@@ -295,20 +295,35 @@ const GnomadV3Downloads = () => (
     <DownloadsSection>
       <SectionTitle id="v3-local-ancestry">Local ancestry</SectionTitle>
       <p>
-        For more information about these files, see our blog post on{' '}
+        For more information about these files, see our blog posts on local ancestry inference for{' '}
         {/* @ts-expect-error TS(2786) FIXME: 'ExternalLink' cannot be used as a JSX component. */}
         <ExternalLink href="https://gnomad.broadinstitute.org/news/2021-12-local-ancestry-inference-for-latino-admixed-american-samples-in-gnomad/">
-          local ancestry inference for Latino/Admixed American samples in gnomAD
+          Admixed American
         </ExternalLink>
-        .
+        and
+        {/* @ts-expect-error TS(2786) FIXME: 'ExternalLink' cannot be used as a JSX component. */}
+        <ExternalLink href="https://gnomad.broadinstitute.org/news/2024-10-local-ancestry-inference-for-african-african-american-samples-in-gnomad/">
+          African/African American
+        </ExternalLink>
+        samples in gnomAD.
       </p>
 
       <FileList>
         {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
         <ListItem>
           <DownloadLinks
-            label="Sites VCF"
+            label="Admixed American Sites VCF"
             path="/release/3.1/local_ancestry/genomes/gnomad.genomes.v3.1.local_ancestry.amr.vcf.bgz"
+          />
+        </ListItem>
+      </FileList>
+
+      <FileList>
+        {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+        <ListItem>
+          <DownloadLinks
+            label=" African/African American Sites VCF"
+            path="/release/4.1/local_ancestry/genomes/gnomad.genomes.v4.1.local_ancestry.afr.vcf.bgz"
           />
         </ListItem>
       </FileList>

--- a/browser/src/DataPage/GnomadV4Downloads.tsx
+++ b/browser/src/DataPage/GnomadV4Downloads.tsx
@@ -377,20 +377,6 @@ const GnomadV4Downloads = () => {
       </DownloadsSection>
 
       <DownloadsSection>
-        <SectionTitle id="v4-local-ancestry">Local ancestry</SectionTitle>
-        <FileList>
-          {/* @ts-expect-error TS(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
-          <ListItem>
-            <DownloadLinks
-              label="Sites VCF"
-              path="/release/4.1/local_ancestry/genomes/gnomad.genomes.v4.1.local_ancestry.afr.vcf.bgz"
-              includeAzure={false}
-            />
-          </ListItem>
-        </FileList>
-      </DownloadsSection>
-
-      <DownloadsSection>
         <SectionTitle id="v4-constraint">Constraint</SectionTitle>
         <p>
           For information on constraint, see our <Link to="/help/constraint">help text</Link>

--- a/browser/src/DataPage/__snapshots__/DataPage.spec.tsx.snap
+++ b/browser/src/DataPage/__snapshots__/DataPage.spec.tsx.snap
@@ -7888,70 +7888,6 @@ exports[`Data Page has no unexpected changes 1`] = `
           <a
             aria-hidden="true"
             className="c8 c9"
-            href="#v4-local-ancestry"
-            id="v4-local-ancestry"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Local ancestry
-        </h2>
-      </span>
-      <ul
-        className="c19"
-      >
-        <li
-          className="c20"
-        >
-          <span>
-            Sites VCF
-          </span>
-          <br />
-          <span>
-            Download from
-             
-            <a
-              aria-label="Download Sites VCF from Google"
-              className="c11"
-              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/local_ancestry/genomes/gnomad.genomes.v4.1.local_ancestry.afr.vcf.bgz"
-              onClick={[Function]}
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Google
-            </a>
-             / 
-            <a
-              aria-label="Download Sites VCF from Amazon"
-              className="c11"
-              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/local_ancestry/genomes/gnomad.genomes.v4.1.local_ancestry.afr.vcf.bgz"
-              onClick={[Function]}
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Amazon
-            </a>
-          </span>
-        </li>
-      </ul>
-    </section>
-    <section
-      className="c15"
-    >
-      <span
-        className="c6"
-      >
-        <h2
-          className="c16"
-        >
-          <a
-            aria-hidden="true"
-            className="c8 c9"
             href="#v4-constraint"
             id="v4-constraint"
           >
@@ -14236,7 +14172,7 @@ exports[`Data Page has no unexpected changes 1`] = `
         </h2>
       </span>
       <p>
-        For more information about these files, see our blog post on
+        For more information about these files, see our blog posts on local ancestry inference for
          
         <a
           className="c11"
@@ -14244,9 +14180,18 @@ exports[`Data Page has no unexpected changes 1`] = `
           rel="noopener noreferrer"
           target="_blank"
         >
-          local ancestry inference for Latino/Admixed American samples in gnomAD
+          Admixed American
         </a>
-        .
+        and
+        <a
+          className="c11"
+          href="https://gnomad.broadinstitute.org/news/2024-10-local-ancestry-inference-for-african-african-american-samples-in-gnomad/"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          African/African American
+        </a>
+        samples in gnomAD.
       </p>
       <ul
         className="c19"
@@ -14255,14 +14200,14 @@ exports[`Data Page has no unexpected changes 1`] = `
           className="c20"
         >
           <span>
-            Sites VCF
+            Admixed American Sites VCF
           </span>
           <br />
           <span>
             Download from
              
             <a
-              aria-label="Download Sites VCF from Google"
+              aria-label="Download Admixed American Sites VCF from Google"
               className="c11"
               href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1/local_ancestry/genomes/gnomad.genomes.v3.1.local_ancestry.amr.vcf.bgz"
               onClick={[Function]}
@@ -14273,7 +14218,7 @@ exports[`Data Page has no unexpected changes 1`] = `
             </a>
              / 
             <a
-              aria-label="Download Sites VCF from Amazon"
+              aria-label="Download Admixed American Sites VCF from Amazon"
               className="c11"
               href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1/local_ancestry/genomes/gnomad.genomes.v3.1.local_ancestry.amr.vcf.bgz"
               onClick={[Function]}
@@ -14284,9 +14229,57 @@ exports[`Data Page has no unexpected changes 1`] = `
             </a>
              / 
             <a
-              aria-label="Download Sites VCF from Microsoft"
+              aria-label="Download Admixed American Sites VCF from Microsoft"
               className="c11"
               href="https://datasetgnomad.blob.core.windows.net/dataset/release/3.1/local_ancestry/genomes/gnomad.genomes.v3.1.local_ancestry.amr.vcf.bgz"
+              onClick={[Function]}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Microsoft
+            </a>
+          </span>
+        </li>
+      </ul>
+      <ul
+        className="c19"
+      >
+        <li
+          className="c20"
+        >
+          <span>
+             African/African American Sites VCF
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download  African/African American Sites VCF from Google"
+              className="c11"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/local_ancestry/genomes/gnomad.genomes.v4.1.local_ancestry.afr.vcf.bgz"
+              onClick={[Function]}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download  African/African American Sites VCF from Amazon"
+              className="c11"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.1/local_ancestry/genomes/gnomad.genomes.v4.1.local_ancestry.afr.vcf.bgz"
+              onClick={[Function]}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+             / 
+            <a
+              aria-label="Download  African/African American Sites VCF from Microsoft"
+              className="c11"
+              href="https://datasetgnomad.blob.core.windows.net/dataset/release/4.1/local_ancestry/genomes/gnomad.genomes.v4.1.local_ancestry.afr.vcf.bgz"
               onClick={[Function]}
               rel="noopener noreferrer"
               target="_blank"


### PR DESCRIPTION
Resolves #1703

Corresponding blog post PR that fixes a link to point to v3: https://github.com/broadinstitute/gnomad-blog/pull/190

---

![Screenshot 2025-05-05 at 14 34 51](https://github.com/user-attachments/assets/c89d3bcc-f4a1-40dd-921a-4ba774901f8d)
