### PR TITLE
Resolve variant vep consequence per context discrepancy

### DIFF
--- a/graphql-api/src/queries/variant-datasets/shared/transcriptConsequence.ts
+++ b/graphql-api/src/queries/variant-datasets/shared/transcriptConsequence.ts
@@ -4,7 +4,10 @@ export const getConsequenceForContext = (context: any) => {
       return (variant: any) =>
         (variant.transcript_consequences || []).find((csq: any) => csq.gene_id === context.geneId)
     case 'region':
-      return (variant: any) => (variant.transcript_consequences || [])[0]
+      return (variant: any) =>
+        (variant.transcript_consequences || []).filter((csq: any) =>
+          csq.gene_id.startsWith('ENSG')
+        )[0]
     case 'transcript':
       return (variant: any) =>
         (variant.transcript_consequences || []).find(


### PR DESCRIPTION
Resolves #1723

Adds a filter to the `getConsequence` helper for the Region context to filter Transcript Consequences in the same way that the Gene page already does. This makes the reporting of VEP consequences consistent across the various page contexts.

--- 

Brief background, see the issue for more complete context:

Based on context (Gene vs Region vs Variant), differing filters are applied to the Transcript Consequences field in the API. This results in reporting of different consequences based on which page a user is viewing.

In the case of APEH, there are two variants that are reported as having only intronic consequences on both the Gene and individual Variant pages, but are reported as having coding consequences (Synonymous and Missense) on the Region page.