### PR TITLE
FIx data page typo

### DIFF
--- a/browser/src/DataPage/GnomadV3Downloads.tsx
+++ b/browser/src/DataPage/GnomadV3Downloads.tsx
@@ -299,12 +299,12 @@ const GnomadV3Downloads = () => (
         {/* @ts-expect-error TS(2786) FIXME: 'ExternalLink' cannot be used as a JSX component. */}
         <ExternalLink href="https://gnomad.broadinstitute.org/news/2021-12-local-ancestry-inference-for-latino-admixed-american-samples-in-gnomad/">
           Admixed American
-        </ExternalLink>
-        and
+        </ExternalLink>{' '}
+        and{' '}
         {/* @ts-expect-error TS(2786) FIXME: 'ExternalLink' cannot be used as a JSX component. */}
         <ExternalLink href="https://gnomad.broadinstitute.org/news/2024-10-local-ancestry-inference-for-african-african-american-samples-in-gnomad/">
           African/African American
-        </ExternalLink>
+        </ExternalLink>{' '}
         samples in gnomAD.
       </p>
 

--- a/browser/src/DataPage/__snapshots__/DataPage.spec.tsx.snap
+++ b/browser/src/DataPage/__snapshots__/DataPage.spec.tsx.snap
@@ -14269,7 +14269,9 @@ exports[`Data Page has no unexpected changes 1`] = `
         >
           Admixed American
         </a>
+         
         and
+         
         <a
           className="c11"
           href="https://gnomad.broadinstitute.org/news/2024-10-local-ancestry-inference-for-african-african-american-samples-in-gnomad/"
@@ -14278,6 +14280,7 @@ exports[`Data Page has no unexpected changes 1`] = `
         >
           African/African American
         </a>
+         
         samples in gnomAD.
       </p>
       <ul


### PR DESCRIPTION
Tiny PR

Spaces got stripped away by accident, this adds some `{' '}` back in to have correct spacing.