### PR TITLE
Use ES alias again for v3 LAI

### DIFF
--- a/graphql-api/src/queries/local-ancestry-queries.ts
+++ b/graphql-api/src/queries/local-ancestry-queries.ts
@@ -2,7 +2,7 @@ import { DATASET_LABELS } from '../datasets'
 import { UserVisibleError } from '../errors'
 
 const LOCAL_ANCESTRY_INDICES = {
-  gnomad_r3: 'gnomad_v3_local_ancestry-2024-10-11--20-51',
+  gnomad_r3: 'gnomad_v3_local_ancestry',
 }
 
 export const fetchLocalAncestryPopulationsByVariant = async (


### PR DESCRIPTION
Re: 
- [`8ad4d02` (#1638)](https://github.com/broadinstitute/gnomad-browser/pull/1638/commits/8ad4d02703acb44d7084ef612a2b663ce4df78b3)
- https://github.com/broadinstitute/gnomad-browser/commit/f656414349754acdd4189c07bb5f822d19392803

Use ES alias again. The alias has been updated in prod already, so cutting this over is safe to do at any point.

```
alias                                index                                                  filter routing.index routing.search is_write_index
.fleet-policies                      .fleet-policies-7                                      -      -             -              -
...
...
...
gnomad_v3_local_ancestry             gnomad_v3_local_ancestry-2024-10-11--20-51             -      -             -              -
...
...
...
```

---

Sample variant from the blog post: https://gnomad.broadinstitute.org/variant/22-36265860-A-G?dataset=gnomad_r4