### PR TITLE
Handle edge case in memory logging

### DIFF
--- a/graphql-api/src/app.ts
+++ b/graphql-api/src/app.ts
@@ -53,6 +53,7 @@ app.use(function requestLogMiddleware(request: any, response: any, next: any) {
     }
 
     logger.info({
+      memory: { before: memoryBefore, after: memoryAfter, delta: memoryDelta },
       httpRequest: {
         requestMethod: request.method,
         requestUrl: `${request.protocol}://${request.hostname}${
@@ -70,7 +71,6 @@ app.use(function requestLogMiddleware(request: any, response: any, next: any) {
                 (response.startAt[1] - request.startAt[1]) * 1e-9
               ).toFixed(3)}s`
             : undefined,
-        memory: { before: memoryBefore, after: memoryAfter, delta: memoryDelta },
         protocol: `HTTP/${request.httpVersionMajor}.${request.httpVersionMinor}`,
       },
       graphqlRequest: request.graphqlParams

--- a/graphql-api/src/app.ts
+++ b/graphql-api/src/app.ts
@@ -34,7 +34,7 @@ app.get('/health/ready', (_request: any, response: any) => {
 // Log requests
 // Add logging here to avoid logging health checks
 app.use(function requestLogMiddleware(request: any, response: any, next: any) {
-  let memoryBefore: any
+  let memoryBefore: NodeJS.MemoryUsage | undefined
   request.startAt = process.hrtime()
   response.startAt = undefined
   onHeaders(response, () => {
@@ -44,7 +44,7 @@ app.use(function requestLogMiddleware(request: any, response: any, next: any) {
 
   onFinished(response, () => {
     const memoryAfter = process.memoryUsage()
-    const memoryDelta: NodeJS.MemoryUsage = {
+    const memoryDelta: NodeJS.MemoryUsage | undefined = memoryBefore && {
       rss: memoryAfter.rss - memoryBefore.rss,
       heapTotal: memoryAfter.heapTotal - memoryBefore.heapTotal,
       heapUsed: memoryAfter.heapUsed - memoryBefore.heapUsed,


### PR DESCRIPTION
There's occasional errors in the log now from `memoryBefore` not always getting set, fixed here.