### PR TITLE
Improve `fetchAllSearchResults` performance

### DIFF
--- a/graphql-api/src/queries/helpers/elasticsearch-helpers.ts
+++ b/graphql-api/src/queries/helpers/elasticsearch-helpers.ts
@@ -6,7 +6,7 @@
  * @return {Object[]} Combined list of hits from all responses
  */
 export const fetchAllSearchResults = async (client: any, searchParams: any) => {
-  let allResults: any = []
+  const allResults: any = []
   const responseQueue = []
 
   const size = searchParams.size || 1000
@@ -22,7 +22,7 @@ export const fetchAllSearchResults = async (client: any, searchParams: any) => {
 
   while (responseQueue.length) {
     const response = responseQueue.shift()
-    allResults = allResults.concat(response.body.hits.hits)
+    allResults.push(...response.body.hits.hits)
 
     if (allResults.length === response.body.hits.total.value) {
       // eslint-disable-next-line no-await-in-loop


### PR DESCRIPTION
This one liner *should* make this helper more efficient due to reduced heap allocations and subsequent garbage collection
- `concat` allocates new heap memory for the result of combining two or more arrays. In this case the intermediate arrays should be GC'd at some point, but on large regions, we may be accumulating lots of intermediate sized arrays to then immediately just flag for GC
- `push` modifies an array in place, and will double the size in memory of the existing array as needed

As discussed in standup, this almost certainly won't fix things in a major way, as there are likely other bigger performance issues, and we do quite a bit of massaging of the resultant data in the API right after this anyways. However, this helper is used in every bulk variant query, and we might as well do this easy optimization imo on the chance it makes some slight difference.

On large regions, new arrays for 80% of variants, then 85% of variants, then 90%, etc, could get costly on the heap I'd imagine.

I don't see a particular reason why this helper should be using `concat` over `push` here? But I could be missing something.