### PR TITLE
Add otel service name to API instrumentation

### DIFF
--- a/deploy/deployctl/subcommands/browser_deployments.py
+++ b/deploy/deployctl/subcommands/browser_deployments.py
@@ -58,6 +58,8 @@ patches:
                     value: 'gs://{cluster_name}-gene-cache/2024-04-24'
                   - name: OPENTELEMETRY_COLLECTOR_URL
                     value: http://opentelemetry-collector-{deployment_name}:4318
+                  - name: OPENTELEMETRY_SERVICE_NAME
+                    value: gnomad-api-{deployment_name}
 """
 
 DEMO_DEPLOYMENT_KUSTOMIZATION = """

--- a/graphql-api/src/config.ts
+++ b/graphql-api/src/config.ts
@@ -50,6 +50,7 @@ const config: Record<string, any> = {
 
   // OpenTelemetry collector endpoint
   OPENTELEMETRY_COLLECTOR_URL: env.OPENTELEMETRY_COLLECTOR_URL,
+  OPENTELEMETRY_SERVICE_NAME: env.OPENTELEMETRY_SERVICE_NAME,
 }
 
 const requiredConfig = ['ELASTICSEARCH_URL']

--- a/graphql-api/src/instrumentation.ts
+++ b/graphql-api/src/instrumentation.ts
@@ -17,6 +17,7 @@ if (config.OPENTELEMETRY_COLLECTOR_URL !== undefined) {
       }),
     }),
     instrumentations: [getNodeAutoInstrumentations()],
+    serviceName: config.OPENTELEMETRY_SERVICE_NAME,
   })
   sdk.start()
 }


### PR DESCRIPTION
This will help us differentiate traces from different deployments.

In this screenshot, the "unknown_service:node" service option refers to production, an unknown (because it's not named) service whose root process is named `node` (as in Node.js). "gnomad-api-otel-service-name" is the demo deployment for this branch.

<img width="1242" alt="Screenshot 2025-06-13 at 11 29 26 AM" src="https://github.com/user-attachments/assets/eb7156e1-9484-4658-87d2-358fe1afb081" />
