### PR TITLE
Double check no cache pnpm jest

### DIFF
--- a/.github/workflows/browser-ci.yml
+++ b/.github/workflows/browser-ci.yml
@@ -30,7 +30,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '^18.17.1'
-          cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Run ESLint

--- a/.github/workflows/graphql-api-ci.yml
+++ b/.github/workflows/graphql-api-ci.yml
@@ -30,7 +30,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '^18.17.1'
-          cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Run ESLint


### PR DESCRIPTION
My local machine is failing CI (specifically in the SV graphql test due to type errors with `lodash` vs `lodash-es` and I'm trying to figure out what could possibly be different.