### PR TITLE
Add CMRG warning to specific genes

### DIFF
--- a/browser/src/GenePage/GeneFlags.spec.tsx
+++ b/browser/src/GenePage/GeneFlags.spec.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import { describe, expect, test } from '@jest/globals'
+import renderer from 'react-test-renderer'
+
+import GeneFlags from './GeneFlags'
+import geneFactory from '../__factories__/Gene'
+
+describe('GeneFlags', () => {
+  test('does not render any flags with basic gene', () => {
+    const testGene = geneFactory.build()
+
+    const tree = renderer.create(<GeneFlags gene={testGene} />)
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  test('renders chip flag if present on gene', () => {
+    const testGene = geneFactory.build({ flags: ['chip'] })
+
+    const tree = renderer.create(<GeneFlags gene={testGene} />)
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  test('renders CMRG flag if one of 3 relevant genes', () => {
+    const testGene = geneFactory.build({ symbol: 'CRYAA', reference_genome: 'GRCh38' })
+
+    const tree = renderer.create(<GeneFlags gene={testGene} />)
+
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/browser/src/GenePage/GeneFlags.tsx
+++ b/browser/src/GenePage/GeneFlags.tsx
@@ -2,15 +2,39 @@ import React from 'react'
 
 import { Badge, ExternalLink } from '@gnomad/ui'
 
+import { ReferenceGenome } from '@gnomad/dataset-metadata/metadata'
+
 type Props = {
   gene: {
     flags: string[]
+    symbol: string
+    reference_genome: ReferenceGenome
   }
 }
 
+const allOfUsCMRGGenes = ['CBS', 'KCNE1', 'CRYAA']
+
 const GeneFlags = ({ gene }: Props) => {
+  const shouldDisplayCMRGWarning =
+    gene.reference_genome === 'GRCh38' && allOfUsCMRGGenes.includes(gene.symbol)
+
   return (
     <>
+      {shouldDisplayCMRGWarning && (
+        <p>
+          <Badge level="warning">Warning</Badge> Variant calls in this gene may be missing or
+          unreliable due to{' '}
+          <ExternalLink href="https://www.nature.com/articles/s41587-021-01158-1">
+            false duplications in the GRCh38 reference
+          </ExternalLink>
+          . We will be working on integrating data from the All of Us challenging medically relevant
+          genes (
+          <ExternalLink href="https://support.researchallofus.org/hc/en-us/articles/29475228181908-How-the-All-of-Us-Genomic-data-are-organized#01JQ7ES9YM8KS6PZBF03C8J399">
+            CMRG
+          </ExternalLink>
+          ) callset to remedy this issue in the future.
+        </p>
+      )}
       {gene.flags.includes('chip') && (
         <p>
           <Badge level="warning">Note</Badge> Analysis of allele balance and age data indicates that

--- a/browser/src/GenePage/GenePage.tsx
+++ b/browser/src/GenePage/GenePage.tsx
@@ -115,6 +115,7 @@ export type GeneMetadata = {
   gene_id: string
   gene_version: string
   symbol: string
+  reference_genome: ReferenceGenome
   mane_select_transcript: {
     ensembl_id: string
     ensembl_version: string
@@ -152,6 +153,7 @@ export type Pext = {
 export type Gene = GeneMetadata & {
   reference_genome: ReferenceGenome
   name: string | null
+  symbol: string
   chrom: string
   strand: Strand
   start: number

--- a/browser/src/GenePage/__snapshots__/GeneFlags.spec.tsx.snap
+++ b/browser/src/GenePage/__snapshots__/GeneFlags.spec.tsx.snap
@@ -1,0 +1,88 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`GeneFlags does not render any flags with basic gene 1`] = `null`;
+
+exports[`GeneFlags renders CMRG flag if one of 3 relevant genes 1`] = `
+<p>
+  <span
+    className="Badge__BadgeWrapper-sc-j4izdp-1 gRPPXC"
+  >
+    Warning
+  </span>
+   Variant calls in this gene may be missing or unreliable due to
+   
+  <a
+    className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 kswbwW"
+    href="https://www.nature.com/articles/s41587-021-01158-1"
+    rel="noopener noreferrer"
+    target="_blank"
+  >
+    false duplications in the GRCh38 reference
+  </a>
+  . We will be working on integrating data from the All of Us challenging medically relevant genes (
+  <a
+    className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 kswbwW"
+    href="https://support.researchallofus.org/hc/en-us/articles/29475228181908-How-the-All-of-Us-Genomic-data-are-organized#01JQ7ES9YM8KS6PZBF03C8J399"
+    rel="noopener noreferrer"
+    target="_blank"
+  >
+    CMRG
+  </a>
+  ) callset to remedy this issue in the future.
+</p>
+`;
+
+exports[`GeneFlags renders chip flag if present on gene 1`] = `
+<p>
+  <span
+    className="Badge__BadgeWrapper-sc-j4izdp-1 gRPPXC"
+  >
+    Note
+  </span>
+   Analysis of allele balance and age data indicates that this gene shows evidence of
+   
+  <a
+    className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 kswbwW"
+    href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC8050831/"
+    rel="noopener noreferrer"
+    target="_blank"
+  >
+    clonal hematopoiesis of indeterminate potential (CHIP)
+  </a>
+  . The potential presence of somatic variants should be taken into account when interpreting the penetrance, pathogenicity, and frequency of assumed germline variants. For more information, see pages 37-40 of
+   
+  <a
+    className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 kswbwW"
+    href="https://static-content.springer.com/esm/art%3A10.1038%2Fs41586-020-2308-7/MediaObjects/41586_2020_2308_MOESM1_ESM.pdf"
+    rel="noopener noreferrer"
+    target="_blank"
+  >
+    supplementary information
+  </a>
+   
+  for 
+  <a
+    className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 kswbwW"
+    href="https://doi.org/10.1038/s41586-020-2308-7"
+    rel="noopener noreferrer"
+    target="_blank"
+  >
+    <em>
+      The mutational constraint spectrum quantified from variation in 141,456 humans
+    </em>
+  </a>
+   
+  and 
+  <a
+    className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 kswbwW"
+    href="https://pubmed.ncbi.nlm.nih.gov/28229513/"
+    rel="noopener noreferrer"
+    target="_blank"
+  >
+    <em>
+      Pathogenic ASXL1 somatic variants in reference databases complicate germline variant interpretation for Bohring-Opitz Syndrome
+    </em>
+  </a>
+  .
+</p>
+`;

--- a/browser/src/__factories__/Gene.ts
+++ b/browser/src/__factories__/Gene.ts
@@ -55,6 +55,7 @@ const geneFactory = Factory.define<Gene>(({ params, associations }) => {
     gene_id,
     gene_version,
     symbol,
+    reference_genome,
     canonical_transcript_id,
     flags,
     mane_select_transcript,

--- a/browser/src/__factories__/GeneMetadata.ts
+++ b/browser/src/__factories__/GeneMetadata.ts
@@ -5,6 +5,7 @@ const geneMetadataFactory = Factory.define<GeneMetadata>(() => ({
   gene_id: 'dummy_gene',
   gene_version: '5.6.7.8',
   symbol: 'FAKEGENE',
+  reference_genome: 'GRCh38',
   canonical_transcript_id: 'some-transcript',
   flags: [],
   mane_select_transcript: null,


### PR DESCRIPTION
Resolves #1762 

Warning is added for: CBS, KCNE1, and CRYAA, on any dataset on GRCh38.

---

![Screenshot 2025-07-16 at 12 27 59](https://github.com/user-attachments/assets/c6e6e5fb-3938-44a0-b26a-57f10cdfa05c)
