### PR TITLE
Update Federated page group name

### DIFF
--- a/browser/src/FederationPage.tsx
+++ b/browser/src/FederationPage.tsx
@@ -81,8 +81,7 @@ const datasets: Dataset[] = [
   {
     country: 'China',
     samples: '10,000',
-    source:
-      'Advanced Institute of Information Technology-Juno Genomics joint Center for Mendelian Genomics (AIIT-Juno CMG)',
+    source: 'Advanced Institute for Information Technology',
     lead: 'Xiao Li',
   },
   {

--- a/browser/src/__snapshots__/FederationPage.spec.tsx.snap
+++ b/browser/src/__snapshots__/FederationPage.spec.tsx.snap
@@ -366,7 +366,7 @@ exports[`Federation Page has no unexpected changes 1`] = `
             10,000
           </td>
           <td>
-            Advanced Institute of Information Technology-Juno Genomics joint Center for Mendelian Genomics (AIIT-Juno CMG)
+            Advanced Institute for Information Technology
           </td>
           <td>
             Xiao Li


### PR DESCRIPTION
From Slack request, updates 'source' for gnomAD China to "Advanced Institute for Information Technology".

Smol content one liner.