### PR TITLE
Re-enable linking to # on data page

### DIFF
--- a/browser/src/DataPage/DataPage.tsx
+++ b/browser/src/DataPage/DataPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import styled from 'styled-components'
 
 import { Badge, ExternalLink, PageHeading } from '@gnomad/ui'
@@ -52,6 +52,16 @@ const BottomSpacer = styled.div`
 const DataPage = () => {
   // Load stylesheet to make smooth scroll behavior active
   const _style = styles.html
+
+  useEffect(() => {
+    const hash = window.location.hash
+    if (hash !== '') {
+      const element = document.querySelector(`${hash}`)
+      if (element) {
+        element.scrollIntoView()
+      }
+    }
+  }, [])
 
   return (
     <InfoPage>


### PR DESCRIPTION
Resolves #1793

As best I can tell, changes in rendering of the DOM in react 18 broke the scroll to an anchor tag id behavior that let us link to a given section on the data page. Linking to a specific section is used extensively in blog posts, and elsewhere. 

This PR adds a tiny `useEffect` hook to the data page to snoop on the hash and scroll to it, to re-enable the behavior.