### PR TITLE
Re-route Reads Preview requests

### DIFF
--- a/deploy/dockerfiles/reads/reads.nginx.conf
+++ b/deploy/dockerfiles/reads/reads.nginx.conf
@@ -76,6 +76,11 @@ server {
   expires -1y;
   add_header Pragma "no-cache";
 
+  # Rewrite /preview-reads/* to /reads/* internally
+  location ~* ^/preview-reads(/.*)$ {
+    rewrite ^/preview-reads(/.*)$ /reads$1 break;
+  }
+
   # Return not found by default for all paths
   location / {
     return 404;


### PR DESCRIPTION
We have Ingress rules to route `/reads` and `/preview-reads` requests to different Kubernetes resources.

But once those requests arrive at the actual backends, they're expected to follow the `/reads` pattern because of the existing Nginx config that is deployed to both `reads` and `preview-reads`. As a result, current requests to `/preview-reads` result in a 404 error.

This PR updates the Nginx config to listen for requests at `/preview-reads`, and then rewrite those requests to `/reads`.
