### PR TITLE
fix(reads): proxy Preview Reads requests after internal rewrite

### DIFF
--- a/deploy/dockerfiles/reads/reads.nginx.conf
+++ b/deploy/dockerfiles/reads/reads.nginx.conf
@@ -77,8 +77,8 @@ server {
   add_header Pragma "no-cache";
 
   # Rewrite /preview-reads/* to /reads/* internally
-  location ~* ^/preview-reads(/.*)$ {
-    rewrite ^/preview-reads(/.*)$ /reads$1 break;
+  location ~* ^/preview-reads(/.*)?$ {
+    rewrite ^/preview-reads(/.*)?$ /reads$1? break;
     proxy_pass http://127.0.0.1:8000;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   }


### PR DESCRIPTION
Continuation of #1802.

The previous update successfully rewrote the `/preview-reads` requests, but needs proxy directives to complete the routing.

This PR adds `proxy_pass` and `proxy_set_header` to the `/preview-reads` location block to ensure requests are correctly proxied to the app after the URI is rewritten.
