### PR TITLE
Build and use patched gene, variant, and transcript data for RNU4ATAC

### DIFF
--- a/browser/src/GenePage/GeneFlags.spec.tsx
+++ b/browser/src/GenePage/GeneFlags.spec.tsx
@@ -29,4 +29,12 @@ describe('GeneFlags', () => {
 
     expect(tree).toMatchSnapshot()
   })
+
+  test('renders VEP 115 warning for RNU4ATAC', () => {
+    const testGene = geneFactory.build({ symbol: 'RNU4ATAC', reference_genome: 'GRCh38' })
+
+    const tree = renderer.create(<GeneFlags gene={testGene} />)
+
+    expect(tree).toMatchSnapshot()
+  })
 })

--- a/browser/src/GenePage/GeneFlags.tsx
+++ b/browser/src/GenePage/GeneFlags.tsx
@@ -13,10 +13,14 @@ type Props = {
 }
 
 const allOfUsCMRGGenes = ['CBS', 'KCNE1', 'CRYAA']
+const vep115Genes = ['RNU4ATAC']
 
 const GeneFlags = ({ gene }: Props) => {
   const shouldDisplayCMRGWarning =
     gene.reference_genome === 'GRCh38' && allOfUsCMRGGenes.includes(gene.symbol)
+
+  const shouldDisplayVEP115Warning =
+    gene.reference_genome === 'GRCh38' && vep115Genes.includes(gene.symbol)
 
   return (
     <>
@@ -33,6 +37,14 @@ const GeneFlags = ({ gene }: Props) => {
             CMRG
           </ExternalLink>
           ) callset to remedy this issue in the future.
+        </p>
+      )}
+      {shouldDisplayVEP115Warning && (
+        <p>
+          <Badge level="warning">Warning</Badge> MANE Select and variant consequence information in
+          this gene were annotated using Ensembl VEP version 115 (GENCODE v49). For more
+          information, see our{' '}
+          <ExternalLink href="https://gnomad.broadinstitute.org/help/vep">help page</ExternalLink>.
         </p>
       )}
       {gene.flags.includes('chip') && (

--- a/browser/src/GenePage/GeneInfo.tsx
+++ b/browser/src/GenePage/GeneInfo.tsx
@@ -8,39 +8,40 @@ import Link from '../Link'
 import GeneReferences from './GeneReferences'
 
 type ManeSelectTranscriptIdProps = {
-  gene: {
-    mane_select_transcript: {
-      ensembl_id: string
-      ensembl_version: string
-      refseq_id: string
-      refseq_version: string
-    }
-    transcripts: {
-      transcript_id: string
-      transcript_version: string
-    }[]
+  mane_select_transcript: {
+    ensembl_id: string
+    ensembl_version: string
+    refseq_id: string
+    refseq_version: string
   }
+  transcripts: {
+    transcript_id: string
+    transcript_version: string
+  }[]
 }
 
-const ManeSelectTranscriptId = ({ gene }: ManeSelectTranscriptIdProps) => {
-  const gencodeVersionOfManeSelectTranscript = gene.transcripts.find(
-    (transcript: any) => transcript.transcript_id === gene.mane_select_transcript.ensembl_id
+const ManeSelectTranscriptId = ({
+  mane_select_transcript,
+  transcripts,
+}: ManeSelectTranscriptIdProps) => {
+  const gencodeVersionOfManeSelectTranscript = transcripts.find(
+    (transcript) => transcript.transcript_id === mane_select_transcript.ensembl_id
   )
   const shouldLinkToTranscriptPage =
     gencodeVersionOfManeSelectTranscript &&
     gencodeVersionOfManeSelectTranscript.transcript_version ===
-      gene.mane_select_transcript.ensembl_version
+      mane_select_transcript.ensembl_version
 
   return (
     <React.Fragment>
       {shouldLinkToTranscriptPage ? (
-        <Link to={`/transcript/${gene.mane_select_transcript.ensembl_id}`}>
-          {gene.mane_select_transcript.ensembl_id}.{gene.mane_select_transcript.ensembl_version}
+        <Link to={`/transcript/${mane_select_transcript.ensembl_id}`}>
+          {mane_select_transcript.ensembl_id}.{mane_select_transcript.ensembl_version}
         </Link>
       ) : (
-        `${gene.mane_select_transcript.ensembl_id}.${gene.mane_select_transcript.ensembl_version}`
+        `${mane_select_transcript.ensembl_id}.${mane_select_transcript.ensembl_version}`
       )}{' '}
-      / {gene.mane_select_transcript.refseq_id}.{gene.mane_select_transcript.refseq_version}
+      / {mane_select_transcript.refseq_id}.{mane_select_transcript.refseq_version}
     </React.Fragment>
   )
 }
@@ -109,8 +110,14 @@ const GeneInfo = ({ gene }: GeneInfoProps) => {
             </React.Fragment>
           }
         >
-          {/* @ts-expect-error TS(2322) FIXME: Type '{ gene_id: string; gene_version: string; sym... Remove this comment to see the full error message */}
-          {gene.mane_select_transcript ? <ManeSelectTranscriptId gene={gene} /> : 'Not available'}
+          {gene.mane_select_transcript ? (
+            <ManeSelectTranscriptId
+              mane_select_transcript={gene.mane_select_transcript}
+              transcripts={gene.transcripts}
+            />
+          ) : (
+            'Not available'
+          )}
         </AttributeListItem>
       )}
 

--- a/browser/src/GenePage/GeneInfo.tsx
+++ b/browser/src/GenePage/GeneInfo.tsx
@@ -23,12 +23,12 @@ type ManeSelectTranscriptIdProps = {
 }
 
 const ManeSelectTranscriptId = ({ gene }: ManeSelectTranscriptIdProps) => {
-  const gencodeVersionOfManeSelectTransript = gene.transcripts.find(
+  const gencodeVersionOfManeSelectTranscript = gene.transcripts.find(
     (transcript: any) => transcript.transcript_id === gene.mane_select_transcript.ensembl_id
   )
   const shouldLinkToTranscriptPage =
-    gencodeVersionOfManeSelectTransript &&
-    gencodeVersionOfManeSelectTransript.transcript_version ===
+    gencodeVersionOfManeSelectTranscript &&
+    gencodeVersionOfManeSelectTranscript.transcript_version ===
       gene.mane_select_transcript.ensembl_version
 
   return (

--- a/browser/src/GenePage/__snapshots__/GeneFlags.spec.tsx.snap
+++ b/browser/src/GenePage/__snapshots__/GeneFlags.spec.tsx.snap
@@ -32,6 +32,27 @@ exports[`GeneFlags renders CMRG flag if one of 3 relevant genes 1`] = `
 </p>
 `;
 
+exports[`GeneFlags renders VEP 115 warning for RNU4ATAC 1`] = `
+<p>
+  <span
+    className="Badge__BadgeWrapper-sc-j4izdp-1 gRPPXC"
+  >
+    Warning
+  </span>
+   MANE Select and variant consequence information in this gene were annotated using Ensembl VEP version 115 (GENCODE v49). For more information, see our
+   
+  <a
+    className="Link-sc-14lgydv-0 Link__ExternalLink-sc-14lgydv-1 kswbwW"
+    href="https://gnomad.broadinstitute.org/help/vep"
+    rel="noopener noreferrer"
+    target="_blank"
+  >
+    help page
+  </a>
+  .
+</p>
+`;
+
 exports[`GeneFlags renders chip flag if present on gene 1`] = `
 <p>
   <span

--- a/data-pipeline/src/data_pipeline/data_types/gene.py
+++ b/data-pipeline/src/data_pipeline/data_types/gene.py
@@ -117,6 +117,66 @@ def reject_par_y_genes(genes_path=None):
     return genes
 
 
+def patch_rnu4atac(genes_path=None):
+    gene_symbol = "RNU4ATAC"
+
+    genes = hl.read_table(genes_path)
+    genes = genes.filter(genes.symbol == gene_symbol)
+
+    correct_start = 121530880
+    correct_stop = 121531009
+    correct_start_locus = hl.locus(contig="chr2", pos=correct_start, reference_genome="GRCh38")
+    correct_stop_locus = hl.locus(contig="chr2", pos=correct_stop, reference_genome="GRCh38")
+    correct_xstart = x_position(correct_start_locus)
+    correct_xstop = x_position(correct_stop_locus)
+
+    correct_interval = hl.interval(correct_start_locus, correct_stop_locus, includes_start=True, includes_end=True)
+
+    correct_exon = hl.struct(
+        feature_type="exon", start=correct_start, stop=correct_stop, xstart=correct_xstart, xstop=correct_xstop
+    )
+
+    incorrect_transcript = genes.take(1)[0].transcripts[0]
+    correct_transcript = hl.struct(
+        interval=correct_interval,
+        transcript_version="2",
+        gene_version="2",
+        start=correct_start,
+        stop=correct_stop,
+        xstart=correct_xstart,
+        xstop=correct_xstop,
+        exons=hl.array([correct_exon]),
+        transcript_id=incorrect_transcript.transcript_id,
+        gene_id=incorrect_transcript.gene_id,
+        chrom=incorrect_transcript.chrom,
+        strand=incorrect_transcript.strand,
+        reference_genome=incorrect_transcript.reference_genome,
+        gtex_tissue_expression=incorrect_transcript.gtex_tissue_expression,
+        refseq_id="NR_023343",
+        refseq_version="3",
+    )
+
+    correct_mane_select_transcript = hl.struct(
+        matched_gene_version="2",
+        ensembl_id="ENST00000580972",
+        ensembl_version="2",
+        refseq_id="NR_023343",
+        refseq_version="3",
+    )
+
+    genes = genes.annotate(
+        gene_version=2,
+        start=correct_start,
+        stop=correct_stop,
+        xstart=correct_xstart,
+        xstop=correct_xstop,
+        exons=[correct_exon],
+        transcripts=[correct_transcript],
+        mane_select_transcript=correct_mane_select_transcript,
+    )
+    return genes
+
+
 ###############################################
 # Transcripts                                 #
 ###############################################

--- a/data-pipeline/src/data_pipeline/data_types/variant/patch_rnu4atac_variants.py
+++ b/data-pipeline/src/data_pipeline/data_types/variant/patch_rnu4atac_variants.py
@@ -1,0 +1,48 @@
+import hail as hl
+
+from data_pipeline.data_types.variant.transcript_consequence.annotate_transcript_consequences import (
+    annotate_transcript_consequences_in_table,
+)
+
+
+def patch_rnu4atac_variants(vepped_path=None, freq_path=None, transcripts_data={}):
+    veps = hl.read_table(vepped_path)
+    freqs = hl.read_table(freq_path)
+    # Drop all consequences except for gene RNU4ATAC and transcript ENST00000580972
+    veps = veps.filter(veps.vep.transcript_consequences.any(lambda tc: tc.gene_symbol == "RNU4ATAC"))
+    veps = veps.annotate(
+        vep=veps.vep.annotate(
+            transcript_consequences=veps.vep.transcript_consequences.filter(
+                lambda tc: tc.transcript_id == "ENST00000580972"
+            )
+        )
+    )
+    veps = veps.filter(veps.vep.transcript_consequences.length() > 0)
+    veps = annotate_transcript_consequences_in_table(veps, transcripts_data=transcripts_data)
+
+    # We filter the data again here because annotate_transcript_consequences_in_table removes consequences with unimportant consequences terms
+    veps = veps.filter(veps.transcript_consequences.length() > 0)
+    veps = veps.annotate(
+        transcript_consequences=veps.transcript_consequences.map(
+            lambda tc: tc.annotate(
+                transcript_version="2",
+                gene_version="2",
+                is_mane_select=False,
+                is_mane_select_version=False,
+                refseq_id=hl.null(hl.tstr),
+                refseq_version=hl.null(hl.tstr),
+            )
+        )
+    )
+    veps = veps.annotate(
+        transcript_consequences=veps.transcript_consequences.map(
+            lambda tc: tc.drop("polyphen_prediction", "sift_prediction")
+        )
+    )
+
+    freqs = freqs.drop("transcript_consequences")
+    veps = veps.join(freqs)
+
+    # Include just consequences and index fields
+    veps = veps.select(veps.variant_id, veps.rsids, veps.caid, veps.vrs, veps.transcript_consequences)
+    return veps

--- a/data-pipeline/src/data_pipeline/pipelines/export_to_elasticsearch.py
+++ b/data-pipeline/src/data_pipeline/pipelines/export_to_elasticsearch.py
@@ -42,6 +42,8 @@ from data_pipeline.pipelines.gnomad_v4_cnvs import pipeline as gnomad_v4_cnvs_pi
 from data_pipeline.pipelines.gnomad_v4_lof_curation_results import pipeline as gnomad_v4_lof_curation_results_pipeline
 
 from data_pipeline.pipelines.gene_patches import pipeline as gnomad_v4_gene_patches
+from data_pipeline.pipelines.transcript_patches import pipeline as gnomad_v4_transcript_patches
+
 
 logger = logging.getLogger("gnomad_data_pipeline")
 
@@ -114,6 +116,17 @@ DATASETS_CONFIG = {
         "get_table": lambda: hl.read_table(genes_pipeline.get_output("transcripts_grch38").get_output_path()),
         "args": {
             "index": "transcripts_grch38",
+            "index_fields": ["transcript_id"],
+            "id_field": "transcript_id",
+            "block_size": 1_000,
+        },
+    },
+    "transcripts_grch38_patched": {
+        "get_table": lambda: hl.read_table(
+            gnomad_v4_transcript_patches.get_output("transcripts_grch38_patched").get_output_path()
+        ),
+        "args": {
+            "index": "transcripts_grch38_patched",
             "index_fields": ["transcript_id"],
             "id_field": "transcript_id",
             "block_size": 1_000,

--- a/data-pipeline/src/data_pipeline/pipelines/export_to_elasticsearch.py
+++ b/data-pipeline/src/data_pipeline/pipelines/export_to_elasticsearch.py
@@ -143,6 +143,30 @@ DATASETS_CONFIG = {
             "block_size": 1_000,
         },
     },
+    "gnomad_v4_variant_patches": {
+        "get_table": lambda: subset_table(
+            add_variant_document_id(
+                hl.read_table(
+                    "gs://gnomad-browser-data-pipeline/phil-scratch/output/gnomad_v4/gnomad_v4_variants_patched.ht"
+                )
+            )
+        ),
+        "args": {
+            "index": "gnomad_v4_variants_patches",
+            "index_fields": [
+                "document_id",
+                "variant_id",
+                "rsids",
+                "caid",
+                "locus",
+                "transcript_consequences.gene_id",
+                "transcript_consequences.transcript_id",
+                "vrs.alt.allele_id",
+            ],
+            "id_field": "document_id",
+            "block_size": 1_000,
+        },
+    },
     "gnomad_v4_exome_coverage": {
         "get_table": lambda: subset_table(
             hl.read_table(gnomad_v4_coverage_pipeline.get_output("exome_coverage").get_output_path())

--- a/data-pipeline/src/data_pipeline/pipelines/export_to_elasticsearch.py
+++ b/data-pipeline/src/data_pipeline/pipelines/export_to_elasticsearch.py
@@ -41,6 +41,7 @@ from data_pipeline.pipelines.gnomad_v4_coverage import pipeline as gnomad_v4_cov
 from data_pipeline.pipelines.gnomad_v4_cnvs import pipeline as gnomad_v4_cnvs_pipeline
 from data_pipeline.pipelines.gnomad_v4_lof_curation_results import pipeline as gnomad_v4_lof_curation_results_pipeline
 
+from data_pipeline.pipelines.gene_patches import pipeline as gnomad_v4_gene_patches
 
 logger = logging.getLogger("gnomad_data_pipeline")
 
@@ -83,6 +84,15 @@ DATASETS_CONFIG = {
         "get_table": lambda: hl.read_table(genes_pipeline.get_output("genes_grch38").get_output_path()),
         "args": {
             "index": "genes_grch38",
+            "index_fields": ["gene_id", "symbol_upper_case", "search_terms", "xstart", "xstop"],
+            "id_field": "gene_id",
+            "block_size": 200,
+        },
+    },
+    "gene_patches": {
+        "get_table": lambda: hl.read_table(gnomad_v4_gene_patches.get_output("gene_patches").get_output_path()),
+        "args": {
+            "index": "genes_grch38_patches",
             "index_fields": ["gene_id", "symbol_upper_case", "search_terms", "xstart", "xstop"],
             "id_field": "gene_id",
             "block_size": 200,

--- a/data-pipeline/src/data_pipeline/pipelines/gene_patches.py
+++ b/data-pipeline/src/data_pipeline/pipelines/gene_patches.py
@@ -1,0 +1,19 @@
+import hail as hl
+
+from data_pipeline.pipeline import Pipeline, run_pipeline
+
+from data_pipeline.data_types.gene import patch_rnu4atac
+
+pipeline = Pipeline()
+
+pipeline.add_task(
+    "patch_rnu4atac_grch38",
+    patch_rnu4atac,
+    "/genes/genes_grch38_patched.ht",
+    {"genes_path": "gs://gnomad-v4-data-pipeline/output/genes/genes_grch38_annotated_6.ht"},
+)
+
+pipeline.set_outputs({"gene_patches": "patch_rnu4atac_grch38"})
+
+if __name__ == "__main__":
+    run_pipeline(pipeline)

--- a/data-pipeline/src/data_pipeline/pipelines/gene_patches.py
+++ b/data-pipeline/src/data_pipeline/pipelines/gene_patches.py
@@ -1,5 +1,3 @@
-import hail as hl
-
 from data_pipeline.pipeline import Pipeline, run_pipeline
 
 from data_pipeline.data_types.gene import patch_rnu4atac

--- a/data-pipeline/src/data_pipeline/pipelines/transcript_patches.py
+++ b/data-pipeline/src/data_pipeline/pipelines/transcript_patches.py
@@ -1,0 +1,28 @@
+from data_pipeline.pipeline import Pipeline, run_pipeline
+
+from data_pipeline.data_types.transcript import extract_transcripts
+from data_pipeline.helpers import annotate_table
+
+pipeline = Pipeline()
+
+pipeline.add_task(
+    "extract_patched_transcripts",
+    extract_transcripts,
+    "/transcripts/transcripts_grch38_patched_base.ht",
+    {"genes_path": "gs://gnomad-browser-data-pipeline/phil-scratch/output/genes/genes_grch38_patched.ht"},
+)
+
+pipeline.add_task(
+    "annotate_patched_transcripts",
+    annotate_table,
+    "/transcripts/transcripts_grch38_annotated_1.ht",
+    {
+        "table_path": pipeline.get_task("extract_patched_transcripts"),
+        "gnomad_constraint": "gs://gnomad-v4-data-pipeline/output/constraint/gnomad_v4_constraint.ht",
+    },
+)
+
+pipeline.set_outputs({"transcripts_grch38_patched": "annotate_patched_transcripts"})
+
+if __name__ == "__main__":
+    run_pipeline(pipeline)

--- a/data-pipeline/src/data_pipeline/pipelines/variant_patches.py
+++ b/data-pipeline/src/data_pipeline/pipelines/variant_patches.py
@@ -1,0 +1,20 @@
+from data_pipeline.pipeline import Pipeline, run_pipeline
+
+from data_pipeline.data_types.variant.patch_rnu4atac_variants import patch_rnu4atac_variants
+
+pipeline = Pipeline()
+
+pipeline.add_task(
+    "patch_rnu4atac_variants",
+    patch_rnu4atac_variants,
+    "/gnomad_v4/gnomad_v4_variants_patched.ht",
+    {
+        "vepped_path": "gs://gnomad-v4-data-pipeline/inputs/secondary-analyses/gnomad_v4.1.RNU4ATAC.vep115.ht",
+        "freq_path": "gs://gnomad-v4-data-pipeline/output/gnomad_v4/gnomad_v4_variants_annotated_4.ht",
+    },
+)
+
+pipeline.set_outputs({"variant_patches": "patch_rnu4atac_variants"})
+
+if __name__ == "__main__":
+    run_pipeline(pipeline)

--- a/graphql-api/src/elasticsearch.ts
+++ b/graphql-api/src/elasticsearch.ts
@@ -82,8 +82,8 @@ const scheduleElasticsearchRequest = (fn: any) => {
 const limitedElastic = {
   indices: elastic.indices,
   clearScroll: elastic.clearScroll.bind(elastic),
-  search: (...args: Parameters<typeof elastic.search>) =>
-    scheduleElasticsearchRequest(() => elastic.search(...args)).then((response) => {
+  search: (args: elasticsearch.RequestParams.Search<any>) =>
+    scheduleElasticsearchRequest(() => elastic.search(args)).then((response) => {
       // @ts-expect-error TS(2571) FIXME: Object is of type 'unknown'.
       if (response.body.timed_out) {
         throw new Error('Elasticsearch search timed out')
@@ -95,8 +95,8 @@ const limitedElastic = {
       }
       return response
     }),
-  scroll: (...args: Parameters<typeof elastic.scroll>) =>
-    scheduleElasticsearchRequest(() => elastic.scroll(...args)).then((response) => {
+  scroll: (args: { scroll: string; scrollId?: string }) =>
+    scheduleElasticsearchRequest(() => elastic.scroll(args)).then((response) => {
       // @ts-expect-error TS(2571) FIXME: Object is of type 'unknown'.
       if (response.body.timed_out) {
         throw new Error('Elasticsearch scroll timed out')
@@ -117,10 +117,22 @@ const limitedElastic = {
       }
       return response
     }),
-  get: (...args: Parameters<typeof elastic.get>) =>
-    scheduleElasticsearchRequest(() => elastic.get(...args)),
+  get: (args: { index: string; type: '_doc'; id: string }) =>
+    scheduleElasticsearchRequest(() => elastic.get(args)),
   mget: (...args: Parameters<typeof elastic.mget>) =>
     scheduleElasticsearchRequest(() => elastic.mget(...args)),
+}
+
+export type LimitedElasticClient = typeof limitedElastic
+
+export type GetResponse = {
+  body: { _source: { value: Record<string, any> } }
+}
+
+export type SearchHit = { _id: string; _source: any }
+
+export type SearchResponse = {
+  body: { hits: { total: { value: number }; hits: SearchHit[] }; _scroll_id?: string }
 }
 
 export { limitedElastic as client }

--- a/graphql-api/src/queries/gene-queries.ts
+++ b/graphql-api/src/queries/gene-queries.ts
@@ -1,43 +1,69 @@
+import elasticsearch from '@elastic/elasticsearch'
 import { withCache } from '../cache'
 
 import { fetchAllSearchResults } from './helpers/elasticsearch-helpers'
 
-const GENE_INDICES = {
-  GRCh37: 'genes_grch37',
-  GRCh38: 'genes_grch38',
+import { ReferenceGenome } from '@gnomad/dataset-metadata/metadata'
+import { LimitedElasticClient, GetResponse, SearchResponse, SearchHit } from '../elasticsearch'
+
+type GeneIndex = 'genes_grch37' | 'genes_grch38' | 'genes_grch38_patches-2025-10-23--19-35'
+
+type GeneSearchRegion = { reference_genome: ReferenceGenome; xstart: number; xstop: number }
+
+const GENE_INDICES: Record<ReferenceGenome, GeneIndex[]> = {
+  // Order matters here: later indices take precedence over earlier
+  GRCh37: ['genes_grch37'],
+  GRCh38: ['genes_grch38', 'genes_grch38_patches-2025-10-23--19-35'],
 }
 
-const _fetchGeneById = async (esClient: any, geneId: any, referenceGenome: any) => {
-  try {
-    const response = await esClient.get({
-      // @ts-expect-error TS(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-      index: GENE_INDICES[referenceGenome],
-      type: '_doc',
-      id: geneId,
-    })
-
-    return response.body._source.value
-  } catch (err) {
-    // meta will not be present if the request times out in the queue before reaching ES
-    // @ts-expect-error TS(2571) FIXME: Object is of type 'unknown'.
-    if (err.meta && err.meta.body && err.meta.body.found === false) {
-      return null
+const _fetchGeneById = async (
+  esClient: LimitedElasticClient,
+  geneId: string,
+  referenceGenome: ReferenceGenome
+) => {
+  const indices = GENE_INDICES[referenceGenome]
+  const requests = indices.map(
+    (index) =>
+      esClient
+        .get({
+          index,
+          type: '_doc',
+          id: geneId,
+        })
+        .catch((err) => {
+          // meta will not be present if the request times out in the queue before reaching ES
+          if (err.meta && err.meta.body && err.meta.body.found === false) {
+            return null
+          }
+          throw err
+        }) as Promise<GetResponse | null>
+  )
+  return Promise.all(requests).then(
+    (responses) => {
+      const responsesWithValue = responses.filter((response) => response !== null)
+      return responsesWithValue.length > 0
+        ? responsesWithValue[responsesWithValue.length - 1]!.body._source.value
+        : null
+    },
+    (err) => {
+      throw err
     }
-    throw err
-  }
+  )
 }
 
 export const fetchGeneById = withCache(
   _fetchGeneById,
-  (_: any, geneId: any, referenceGenome: any) => `gene:${geneId}:${referenceGenome}`,
+  (_: any, geneId: string, referenceGenome: ReferenceGenome) => `gene:${geneId}:${referenceGenome}`,
   { expiration: 86400 }
 )
 
-export const fetchGeneBySymbol = async (esClient: any, geneSymbol: any, referenceGenome: any) => {
-  const response = await esClient.search({
-    // @ts-expect-error TS(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-    index: GENE_INDICES[referenceGenome],
-    type: '_doc',
+export const fetchGeneBySymbol = async (
+  esClient: LimitedElasticClient,
+  geneSymbol: string,
+  referenceGenome: ReferenceGenome
+) => {
+  const indices = GENE_INDICES[referenceGenome]
+  const responses = await searchMultipleIndices(esClient, indices, {
     body: {
       query: {
         bool: {
@@ -48,20 +74,22 @@ export const fetchGeneBySymbol = async (esClient: any, geneSymbol: any, referenc
     size: 1,
   })
 
-  if (response.body.hits.total.value === 0) {
+  const responsesWithValue = responses.filter((response) => response.body.hits.total.value > 0)
+  if (responsesWithValue.length === 0) {
     return null
   }
 
-  return response.body.hits.hits[0]._source.value
+  return responsesWithValue[responsesWithValue.length - 1].body.hits.hits[0]._source.value
 }
 
-export const fetchGenesByRegion = async (esClient: any, region: any) => {
-  const { reference_genome: referenceGenome, xstart, xstop } = region
+export const fetchGenesByRegion = async (
+  esClient: LimitedElasticClient,
+  region: GeneSearchRegion
+) => {
+  const { reference_genome, xstart, xstop } = region
+  const indices = GENE_INDICES[reference_genome]
 
-  const hits = await fetchAllSearchResults(esClient, {
-    // @ts-expect-error TS(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-    index: GENE_INDICES[referenceGenome],
-    type: '_doc',
+  const hits = await fetchAllSearchResultsFromMultipleIndices(esClient, indices, {
     size: 200,
     _source: [
       'value.exons',
@@ -98,28 +126,91 @@ export const fetchGenesByRegion = async (esClient: any, region: any) => {
     },
   })
 
-  return hits.map((hit: any) => hit._source.value)
+  const mergedHits = mergeHitsById(hits.flat())
+  return mergedHits.map((hit) => hit._source.value)
 }
 
-export const fetchGenesMatchingText = async (esClient: any, query: any, referenceGenome: any) => {
+const fetchAllSearchResultsFromMultipleIndices = async (
+  esClient: LimitedElasticClient,
+  indices: string[],
+  searchParams: elasticsearch.RequestParams.Search<any>
+) => {
+  const requests = indices.map((index) =>
+    fetchAllSearchResults(esClient, {
+      index,
+      type: '_doc',
+      ...searchParams,
+    })
+  )
+  return Promise.all(requests)
+}
+
+const searchMultipleIndices = async (
+  esClient: LimitedElasticClient,
+  indices: string[],
+  searchParams: elasticsearch.RequestParams.Search<any>
+): Promise<SearchResponse[]> => {
+  const requests = indices.map(
+    (index) =>
+      esClient.search({
+        index,
+        type: '_doc',
+        ...searchParams,
+      }) as Promise<SearchResponse>
+  )
+
+  return Promise.all(requests)
+}
+
+const mergeHitsById = (hits: SearchHit[]): SearchHit[] => {
+  const ids: string[] = []
+  const idsToHits: Record<string, any> = {}
+  hits.forEach((hit) => {
+    if (idsToHits[hit._id] === undefined) {
+      ids.push(hit._id)
+    }
+    idsToHits[hit._id] = hit
+  })
+  return ids.map((id) => idsToHits[id])
+}
+
+const mergeResponsesById = (responses: SearchResponse[]) => {
+  const ids: string[] = []
+  const idsToDocs: Record<string, any> = {}
+  responses.forEach((response) =>
+    response.body.hits.hits.forEach((hit) => {
+      if (idsToDocs[hit._id] === undefined) {
+        ids.push(hit._id)
+      }
+      idsToDocs[hit._id] = hit._source
+    })
+  )
+
+  return ids.map((id) => idsToDocs[id])
+}
+
+export const fetchGenesMatchingText = async (
+  esClient: LimitedElasticClient,
+  query: string,
+  referenceGenome: ReferenceGenome
+) => {
   const upperCaseQuery = query.toUpperCase()
 
   // Ensembl ID
   if (/^ENSG\d{11}$/.test(upperCaseQuery)) {
     const gene = await _fetchGeneById(esClient, upperCaseQuery, referenceGenome)
-    return [
-      {
-        ensembl_id: gene.gene_id,
-        symbol: gene.symbol,
-      },
-    ]
+    return (
+      gene && [
+        {
+          ensembl_id: gene.gene_id,
+          symbol: gene.symbol,
+        },
+      ]
+    )
   }
 
   // Symbol
-  const response = await esClient.search({
-    // @ts-expect-error TS(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-    index: GENE_INDICES[referenceGenome],
-    type: '_doc',
+  const responses = await searchMultipleIndices(esClient, GENE_INDICES[referenceGenome], {
     _source: ['gene_id', 'value.gene_version', 'value.symbol'],
     body: {
       query: {
@@ -134,15 +225,16 @@ export const fetchGenesMatchingText = async (esClient: any, query: any, referenc
     size: 5,
   })
 
-  if (response.body.hits.total.value === 0) {
+  const responsesWithValue = responses.filter((response) => response.body.hits.total.value !== 0)
+  if (responsesWithValue.length === 0) {
     return []
   }
 
-  return response.body.hits.hits
-    .map((hit: any) => hit._source)
-    .map((doc: any) => ({
-      ensembl_id: doc.gene_id,
-      ensembl_version: doc.value.gene_version,
-      symbol: doc.value.symbol,
-    }))
+  const mergedDocs = mergeResponsesById(responsesWithValue)
+
+  return mergedDocs.map((doc) => ({
+    ensembl_id: doc.gene_id,
+    ensembl_version: doc.value.gene_version,
+    symbol: doc.value.symbol,
+  }))
 }

--- a/graphql-api/src/queries/gene-queries.ts
+++ b/graphql-api/src/queries/gene-queries.ts
@@ -1,7 +1,10 @@
 import elasticsearch from '@elastic/elasticsearch'
 import { withCache } from '../cache'
 
-import { fetchAllSearchResultsFromMultipleIndices } from './helpers/elasticsearch-helpers'
+import {
+  fetchAllSearchResultsFromMultipleIndices,
+  getFromMultipleIndices,
+} from './helpers/elasticsearch-helpers'
 
 import { ReferenceGenome } from '@gnomad/dataset-metadata/metadata'
 import { LimitedElasticClient, GetResponse, SearchResponse, SearchHit } from '../elasticsearch'
@@ -38,17 +41,7 @@ const _fetchGeneById = async (
           throw err
         }) as Promise<GetResponse | null>
   )
-  return Promise.all(requests).then(
-    (responses) => {
-      const responsesWithValue = responses.filter((response) => response !== null)
-      return responsesWithValue.length > 0
-        ? responsesWithValue[responsesWithValue.length - 1]!.body._source.value
-        : null
-    },
-    (err) => {
-      throw err
-    }
-  )
+  return getFromMultipleIndices(requests)
 }
 
 export const fetchGeneById = withCache(

--- a/graphql-api/src/queries/gene-queries.ts
+++ b/graphql-api/src/queries/gene-queries.ts
@@ -1,7 +1,7 @@
 import elasticsearch from '@elastic/elasticsearch'
 import { withCache } from '../cache'
 
-import { fetchAllSearchResults } from './helpers/elasticsearch-helpers'
+import { fetchAllSearchResultsFromMultipleIndices } from './helpers/elasticsearch-helpers'
 
 import { ReferenceGenome } from '@gnomad/dataset-metadata/metadata'
 import { LimitedElasticClient, GetResponse, SearchResponse, SearchHit } from '../elasticsearch'
@@ -128,21 +128,6 @@ export const fetchGenesByRegion = async (
 
   const mergedHits = mergeHitsById(hits.flat())
   return mergedHits.map((hit) => hit._source.value)
-}
-
-const fetchAllSearchResultsFromMultipleIndices = async (
-  esClient: LimitedElasticClient,
-  indices: string[],
-  searchParams: elasticsearch.RequestParams.Search<any>
-) => {
-  const requests = indices.map((index) =>
-    fetchAllSearchResults(esClient, {
-      index,
-      type: '_doc',
-      ...searchParams,
-    })
-  )
-  return Promise.all(requests)
 }
 
 const searchMultipleIndices = async (

--- a/graphql-api/src/queries/helpers/elasticsearch-helpers.ts
+++ b/graphql-api/src/queries/helpers/elasticsearch-helpers.ts
@@ -1,3 +1,4 @@
+import elasticsearch from '@elastic/elasticsearch'
 import { LimitedElasticClient, SearchResponse, SearchHit } from '../../elasticsearch'
 
 /**
@@ -41,6 +42,21 @@ export const fetchAllSearchResults = async (client: LimitedElasticClient, search
   }
 
   return allResults
+}
+
+export const fetchAllSearchResultsFromMultipleIndices = async (
+  esClient: LimitedElasticClient,
+  indices: string[],
+  searchParams: elasticsearch.RequestParams.Search<any>
+) => {
+  const requests = indices.map((index) =>
+    fetchAllSearchResults(esClient, {
+      index,
+      type: '_doc',
+      ...searchParams,
+    })
+  )
+  return Promise.all(requests)
 }
 
 // Retrieve index metadata set by data pipeline

--- a/graphql-api/src/queries/helpers/elasticsearch-helpers.ts
+++ b/graphql-api/src/queries/helpers/elasticsearch-helpers.ts
@@ -1,5 +1,5 @@
 import elasticsearch from '@elastic/elasticsearch'
-import { LimitedElasticClient, SearchResponse, SearchHit } from '../../elasticsearch'
+import { LimitedElasticClient, SearchResponse, SearchHit, GetResponse } from '../../elasticsearch'
 
 /**
  * Search and then scroll to retrieve all pages of search results.
@@ -69,3 +69,16 @@ export const fetchIndexMetadata = async (esClient: any, index: any) => {
   // eslint-disable-next-line no-underscore-dangle
   return Object.values(response.body)[0].mappings._meta
 }
+
+export const getFromMultipleIndices = (requests: Promise<GetResponse | null>[]) =>
+  Promise.all(requests).then(
+    (responses) => {
+      const responsesWithValue = responses.filter((response) => response !== null)
+      return responsesWithValue.length > 0
+        ? responsesWithValue[responsesWithValue.length - 1]!.body._source.value
+        : null
+    },
+    (err) => {
+      throw err
+    }
+  )

--- a/graphql-api/src/queries/transcript-queries.ts
+++ b/graphql-api/src/queries/transcript-queries.ts
@@ -1,24 +1,39 @@
-const TRANSCRIPT_INDICES = {
-  GRCh37: 'transcripts_grch37',
-  GRCh38: 'transcripts_grch38',
+import { ReferenceGenome } from '@gnomad/dataset-metadata/metadata'
+import { GetResponse, LimitedElasticClient } from '../elasticsearch'
+import { getFromMultipleIndices } from './helpers/elasticsearch-helpers'
+
+type TranscriptIndex =
+  | 'transcripts_grch37'
+  | 'transcripts_grch38'
+  | 'transcripts_grch38_patched-2025-10-23--19-36'
+
+const TRANSCRIPT_INDICES: Record<ReferenceGenome, TranscriptIndex[]> = {
+  GRCh37: ['transcripts_grch37'],
+  GRCh38: ['transcripts_grch38', 'transcripts_grch38_patched-2025-10-23--19-36'],
 }
 
-export const fetchTranscriptById = async (es: any, transcriptId: any, referenceGenome: any) => {
-  try {
-    const response = await es.get({
-      // @ts-expect-error TS(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-      index: TRANSCRIPT_INDICES[referenceGenome],
-      type: '_doc',
-      id: transcriptId,
-    })
+export const fetchTranscriptById = async (
+  esClient: LimitedElasticClient,
+  transcriptId: string,
+  referenceGenome: ReferenceGenome
+) => {
+  const indices = TRANSCRIPT_INDICES[referenceGenome]
+  const requests = indices.map(
+    (index) =>
+      esClient
+        .get({
+          index,
+          type: '_doc',
+          id: transcriptId,
+        })
+        .catch((err) => {
+          // meta will not be present if the request times out in the queue before reaching ES
+          if (err.meta && err.meta.body.found === false) {
+            return null
+          }
+          throw err
+        }) as Promise<GetResponse | null>
+  )
 
-    return response.body._source.value
-  } catch (err) {
-    // meta will not be present if the request times out in the queue before reaching ES
-    // @ts-expect-error TS(2571) FIXME: Object is of type 'unknown'.
-    if (err.meta && err.meta.body.found === false) {
-      return null
-    }
-    throw err
-  }
+  return getFromMultipleIndices(requests)
 }


### PR DESCRIPTION
This adds indices and API changes to allow us to correct the incorrect data related to gene RNU4ATAC without having to rebuild every index. I've tried to write the API changes in terms of helpers that we can re-use in the future, on the theory that this is probably not the last error in the data we'll ever find.