### PR TITLE
Introduce catchNotFound ES helper

### DIFF
--- a/graphql-api/src/elasticsearch.ts
+++ b/graphql-api/src/elasticsearch.ts
@@ -37,6 +37,13 @@ esLimiter.on('error', (error: any) => {
   logger.error(error)
 })
 
+export const catchNotFound = (err: any) => {
+  if (err?.meta?.body?.found === false) {
+    return null
+  }
+  throw err
+}
+
 const scheduleElasticsearchRequest = (fn: any) => {
   return new Promise((resolve, reject) => {
     let canceled = false

--- a/graphql-api/src/queries/clinvar-variant-queries.ts
+++ b/graphql-api/src/queries/clinvar-variant-queries.ts
@@ -2,6 +2,7 @@ import { omit, throttle } from 'lodash'
 
 import { withCache } from '../cache'
 import logger from '../logger'
+import { catchNotFound } from '../elasticsearch'
 
 import { fetchAllSearchResults, fetchIndexMetadata } from './helpers/elasticsearch-helpers'
 import { mergeOverlappingRegions } from './helpers/region-helpers'
@@ -119,12 +120,7 @@ export const fetchClinvarVariantByClinvarVariationId = async (
 
     return response.body._source.value
   } catch (err) {
-    // meta will not be present if the request times out in the queue before reaching ES
-    // @ts-expect-error TS(2571) FIXME: Object is of type 'unknown'.
-    if (err.meta && err.meta.body.found === false) {
-      return null
-    }
-    throw err
+    return catchNotFound(err)
   }
 }
 

--- a/graphql-api/src/queries/gene-queries.ts
+++ b/graphql-api/src/queries/gene-queries.ts
@@ -1,6 +1,7 @@
 import { withCache } from '../cache'
 
 import { fetchAllSearchResults } from './helpers/elasticsearch-helpers'
+import { catchNotFound } from '../elasticsearch'
 
 const GENE_INDICES = {
   GRCh37: 'genes_grch37',
@@ -18,12 +19,7 @@ const _fetchGeneById = async (esClient: any, geneId: any, referenceGenome: any) 
 
     return response.body._source.value
   } catch (err) {
-    // meta will not be present if the request times out in the queue before reaching ES
-    // @ts-expect-error TS(2571) FIXME: Object is of type 'unknown'.
-    if (err.meta && err.meta.body && err.meta.body.found === false) {
-      return null
-    }
-    throw err
+    return catchNotFound(err)
   }
 }
 

--- a/graphql-api/src/queries/multi-nucleotide-variant-queries.ts
+++ b/graphql-api/src/queries/multi-nucleotide-variant-queries.ts
@@ -1,5 +1,6 @@
 import { DATASET_LABELS } from '../datasets'
 import { UserVisibleError } from '../errors'
+import { catchNotFound } from '../elasticsearch'
 
 type DatasetId = keyof typeof DATASET_LABELS
 
@@ -35,11 +36,6 @@ export const fetchMultiNuceotideVariantById = async (
       genome: variant.genome.ac !== undefined ? variant.genome : null,
     }
   } catch (err) {
-    // meta will not be present if the request times out in the queue before reaching ES
-    // @ts-expect-error TS(2571) FIXME: Object is of type 'unknown'.
-    if (err.meta && err.meta.body.found === false) {
-      return null
-    }
-    throw err
+    return catchNotFound(err)
   }
 }

--- a/graphql-api/src/queries/short-tandem-repeat-queries.ts
+++ b/graphql-api/src/queries/short-tandem-repeat-queries.ts
@@ -1,6 +1,7 @@
 import { DATASET_LABELS } from '../datasets'
 import { UserVisibleError } from '../errors'
 import { fetchAllSearchResults } from './helpers/elasticsearch-helpers'
+import { catchNotFound } from '../elasticsearch'
 
 const SHORT_TANDEM_REPEAT_INDICES = {
   gnomad_r3: 'gnomad_v3_short_tandem_repeats-2025-03-17--19-04',
@@ -68,12 +69,7 @@ export const fetchShortTandemRepeatById = async (
 
     return response.body._source.value
   } catch (err) {
-    // meta will not be present if the request times out in the queue before reaching ES
-    // @ts-expect-error TS(2571) FIXME: Object is of type 'unknown'.
-    if (err.meta && err.meta.body.found === false) {
-      return null
-    }
-    throw err
+    return catchNotFound(err)
   }
 }
 

--- a/graphql-api/src/queries/transcript-queries.ts
+++ b/graphql-api/src/queries/transcript-queries.ts
@@ -1,3 +1,5 @@
+import { catchNotFound } from '../elasticsearch'
+
 const TRANSCRIPT_INDICES = {
   GRCh37: 'transcripts_grch37',
   GRCh38: 'transcripts_grch38',
@@ -14,11 +16,6 @@ export const fetchTranscriptById = async (es: any, transcriptId: any, referenceG
 
     return response.body._source.value
   } catch (err) {
-    // meta will not be present if the request times out in the queue before reaching ES
-    // @ts-expect-error TS(2571) FIXME: Object is of type 'unknown'.
-    if (err.meta && err.meta.body.found === false) {
-      return null
-    }
-    throw err
+    return catchNotFound(err)
   }
 }


### PR DESCRIPTION
Some transcript queries have been catching errors with `meta` but not `meta.body` set. Here we add a helper that handles that case properly, and also allows us to DRY up some copypasta in the API.