### PR TITLE
Allow certain constraint fields to be null

### DIFF
--- a/browser/src/ConstraintTable/ExacConstraintTable.tsx
+++ b/browser/src/ConstraintTable/ExacConstraintTable.tsx
@@ -7,7 +7,7 @@ import { renderRoundedNumber } from './constraintMetrics'
 export type ExacConstraint = {
   exp_syn: number | null
   obs_syn: number | null
-  syn_z: number
+  syn_z: number | null
   exp_mis: number | null
   obs_mis: number | null
   mis_z: number
@@ -41,7 +41,7 @@ const ExacConstraintTable = ({ constraint }: Props) => (
           {renderRoundedNumber(constraint.syn_z, {
             precision: 2,
             tooltipPrecision: 3,
-            highlightColor: constraint.syn_z > 3.71 ? '#ff2600' : null,
+            highlightColor: constraint.syn_z && constraint.syn_z > 3.71 ? '#ff2600' : null,
           })}
         </td>
       </tr>

--- a/browser/src/ConstraintTable/GnomadConstraintTable.tsx
+++ b/browser/src/ConstraintTable/GnomadConstraintTable.tsx
@@ -137,7 +137,7 @@ const CONSTRAINT_FLAG_DESCRIPTIONS = {
 
 export type GnomadConstraint = {
   exp_lof: number | null
-  exp_mis: number
+  exp_mis: number | null
   exp_syn: number | null
   obs_lof: number | null
   obs_mis: number | null

--- a/browser/src/RegionalMissenseConstraintTrack.tsx
+++ b/browser/src/RegionalMissenseConstraintTrack.tsx
@@ -21,7 +21,7 @@ export type RegionalMissenseConstraintRegion = {
   aa_start: string | null
   aa_stop: string | null
   obs_mis: number | null
-  exp_mis: number
+  exp_mis: number | null
   obs_exp: number
   chisq_diff_null: number | undefined
   p_value: number
@@ -98,7 +98,7 @@ const Legend = () => {
   )
 }
 
-const renderNumber = (number: number | undefined) => {
+const renderNumber = (number: number | null | undefined) => {
   return number === undefined || number === null ? '-' : number.toPrecision(4)
 }
 

--- a/graphql-api/src/graphql/types/constraint/exac-constraint.graphql
+++ b/graphql-api/src/graphql/types/constraint/exac-constraint.graphql
@@ -11,7 +11,7 @@ type ExacConstraint {
   mu_mis: Float
   mu_lof: Float
 
-  syn_z: Float!
+  syn_z: Float
   mis_z: Float!
   lof_z: Float
 

--- a/graphql-api/src/graphql/types/constraint/gnomad-constraint.graphql
+++ b/graphql-api/src/graphql/types/constraint/gnomad-constraint.graphql
@@ -1,6 +1,6 @@
 type GnomadConstraint {
   exp_lof: Float
-  exp_mis: Float!
+  exp_mis: Float
   exp_syn: Float
 
   obs_lof: Int


### PR DESCRIPTION
Logs showed errors caused by missing GnomadConstraint.exp_mis and ExacConstraint.syn_z. Checking against the original Hail tables, confirmed that there are genes with missing values for these. Adjusted GraphQL schema and frontend code to allow for this.