### PR TITLE
Allow null in rest of constraint fields

### DIFF
--- a/browser/src/ConstraintTable/ExacConstraintTable.tsx
+++ b/browser/src/ConstraintTable/ExacConstraintTable.tsx
@@ -10,7 +10,7 @@ export type ExacConstraint = {
   syn_z: number | null
   exp_mis: number | null
   obs_mis: number | null
-  mis_z: number
+  mis_z: number | null
   exp_lof: number | null
   obs_lof: number | null
   pLI: number
@@ -54,7 +54,7 @@ const ExacConstraintTable = ({ constraint }: Props) => (
           {renderRoundedNumber(constraint.mis_z, {
             precision: 2,
             tooltipPrecision: 3,
-            highlightColor: constraint.mis_z > 3.09 ? '#ff9300' : null,
+            highlightColor: constraint.mis_z && constraint.mis_z > 3.09 ? '#ff9300' : null,
           })}
         </td>
       </tr>

--- a/browser/src/ConstraintTable/GnomadConstraintTable.tsx
+++ b/browser/src/ConstraintTable/GnomadConstraintTable.tsx
@@ -145,15 +145,15 @@ export type GnomadConstraint = {
   oe_lof: number | null
   oe_lof_lower: number | null
   oe_lof_upper: number | null
-  oe_mis: number
+  oe_mis: number | null
   oe_mis_lower: number | null
   oe_mis_upper: number | null
   oe_syn: number | null
   oe_syn_lower: number | null
   oe_syn_upper: number | null
   lof_z: number | null
-  mis_z: number
-  syn_z: number
+  mis_z: number | null
+  syn_z: number | null
   pLI: number | null
   flags: string[] | null
 }
@@ -216,7 +216,7 @@ const GnomadConstraintTable = ({ constraint }: GnomadConstraintTableProps) => {
               {renderRoundedNumber(constraint.syn_z, {
                 precision: 2,
                 tooltipPrecision: 3,
-                highlightColor: constraint.syn_z > 3.71 ? '#ff2600' : null,
+                highlightColor: constraint.syn_z && constraint.syn_z > 3.71 ? '#ff2600' : null,
               })}
               <br />
               {/* @ts-expect-error TS(2554) FIXME: Expected 3 arguments, but got 2. */}
@@ -234,7 +234,7 @@ const GnomadConstraintTable = ({ constraint }: GnomadConstraintTableProps) => {
               {renderRoundedNumber(constraint.mis_z, {
                 precision: 2,
                 tooltipPrecision: 3,
-                highlightColor: constraint.mis_z > 3.09 ? '#ff9300' : null,
+                highlightColor: constraint.mis_z && constraint.mis_z > 3.09 ? '#ff9300' : null,
               })}
               <br />
               {/* @ts-expect-error TS(2554) FIXME: Expected 3 arguments, but got 2. */}

--- a/browser/src/RegionalMissenseConstraintTrack.tsx
+++ b/browser/src/RegionalMissenseConstraintTrack.tsx
@@ -22,7 +22,7 @@ export type RegionalMissenseConstraintRegion = {
   aa_stop: string | null
   obs_mis: number | null
   exp_mis: number | null
-  obs_exp: number
+  obs_exp: number | null
   chisq_diff_null: number | undefined
   p_value: number
   z_score: number | null
@@ -43,20 +43,23 @@ function regionColor(region: RegionalMissenseConstraintRegion) {
     return region.z_score > 3.09 ? colorScale.middle : colorScale.not_significant
   }
 
-  let color
-  if (region.obs_exp > 0.8) {
-    color = colorScale.greatest
-  } else if (region.obs_exp > 0.6) {
-    color = colorScale.greater
-  } else if (region.obs_exp > 0.4) {
-    color = colorScale.middle
-  } else if (region.obs_exp > 0.2) {
-    color = colorScale.less
-  } else {
-    color = colorScale.least
+  if (region.obs_exp && region.p_value <= 0.001) {
+    if (region.obs_exp > 0.8) {
+      return colorScale.greatest
+    }
+    if (region.obs_exp > 0.6) {
+      return colorScale.greater
+    }
+    if (region.obs_exp > 0.4) {
+      return colorScale.middle
+    }
+    if (region.obs_exp > 0.2) {
+      return colorScale.less
+    }
+    return colorScale.least
   }
 
-  return region.p_value > 0.001 ? colorScale.not_significant : color
+  return colorScale.not_significant
 }
 
 const Legend = () => {
@@ -166,7 +169,8 @@ export type RegionalMissenseConstraint = {
   regions: RegionalMissenseConstraintRegion[]
 }
 
-const formattedOE = (region: RegionalMissenseConstraintRegion) => region.obs_exp.toFixed(2)
+const formattedOE = (region: RegionalMissenseConstraintRegion) =>
+  region.obs_exp ? region.obs_exp.toFixed(2) : ''
 
 type Props = {
   regionalMissenseConstraint: RegionalMissenseConstraint | null

--- a/graphql-api/src/graphql/types/constraint/exac-constraint.graphql
+++ b/graphql-api/src/graphql/types/constraint/exac-constraint.graphql
@@ -12,7 +12,7 @@ type ExacConstraint {
   mu_lof: Float
 
   syn_z: Float
-  mis_z: Float!
+  mis_z: Float
   lof_z: Float
 
   pli: Float

--- a/graphql-api/src/graphql/types/constraint/gnomad-constraint.graphql
+++ b/graphql-api/src/graphql/types/constraint/gnomad-constraint.graphql
@@ -11,7 +11,7 @@ type GnomadConstraint {
   oe_lof_lower: Float
   oe_lof_upper: Float
 
-  oe_mis: Float!
+  oe_mis: Float
   oe_mis_lower: Float
   oe_mis_upper: Float
 
@@ -20,8 +20,8 @@ type GnomadConstraint {
   oe_syn_upper: Float
 
   lof_z: Float
-  mis_z: Float!
-  syn_z: Float!
+  mis_z: Float
+  syn_z: Float
 
   pli: Float
   flags: [String!]


### PR DESCRIPTION
We're getting errors in production due to null values in some records for these fields. Changed to handle nulls gracefully.