### PR TITLE
feat(frontend): update policies page wording

### DIFF
--- a/browser/src/PoliciesPage.tsx
+++ b/browser/src/PoliciesPage.tsx
@@ -54,7 +54,7 @@ export default () => (
         <a href={privacyPolicy} target="_blank" rel="noreferrer">
           here
         </a>
-        . It is currently undergoing legal review and is not yet final.
+        .
       </p>
     </PrivacyPolicyWrapper>
 

--- a/browser/src/__snapshots__/PoliciesPage.spec.tsx.snap
+++ b/browser/src/__snapshots__/PoliciesPage.spec.tsx.snap
@@ -223,7 +223,7 @@ There is no need to include us as authors on your manuscript, unless we contribu
       >
         here
       </a>
-      . It is currently undergoing legal review and is not yet final.
+      .
     </p>
   </div>
   <br />


### PR DESCRIPTION
Per:

> I was just meeting with Heidi and she requested we remove the phrase "It is currently undergoing legal review and is not yet final." from the privacy policy section on the [policies page](https://gnomad.broadinstitute.org/policies)

Updates the text on the policies page to remove the "It is currently undergoing legal review and is not yet final." sentence.
