### PR TITLE
Add description for low coverage and low MQ flags

### DIFF
--- a/browser/help/faq/technical-details/what-do-the-flags-on-the-browser-mean.md
+++ b/browser/help/faq/technical-details/what-do-the-flags-on-the-browser-mean.md
@@ -28,5 +28,5 @@ Flags that will appear in the variant table on gene/region pages:
 
 Flags that will appear at the top of gene/transcript pages:
 
-- Low exome coverage: Less than 10% of the coding base pairs in this gene are well-covered in the gnomAD exomes. Well-covered is defined here has having a median allele number percent (AN%; percent of total possible AN observed at site) greater than 90%
+- Low exome coverage: Less than 10% of the coding base pairs in this gene are well-covered in the gnomAD exomes. Well-covered is defined here as having a median allele number percent (AN%; percent of total possible AN observed at site) greater than 90%
 - Low exome mapping quality: The mean `AS_MQ` (allele-specific root mean square of the mapping quality of reads across all samples) value across this gene is less than 50

--- a/browser/help/faq/technical-details/what-do-the-flags-on-the-browser-mean.md
+++ b/browser/help/faq/technical-details/what-do-the-flags-on-the-browser-mean.md
@@ -27,5 +27,6 @@ Flags that will appear in the variant table on gene/region pages:
 - Common low heteroplasmy: Variant is present at an overall frequency of .001 across all samples with a heteroplasmy level > 0 and < 0.50 (mitochondrial variants only)
 
 Flags that will appear at the top of gene/transcript pages:
+
 - Low exome coverage: Less than 10% of the coding base pairs in this gene are well-covered in the gnomAD exomes. Well-covered is defined here has having a median allele number percent (AN%; percent of total possible AN observed at site) greater than 90%
 - Low exome mapping quality: The mean `AS_MQ` (allele-specific root mean square of the mapping quality of reads across all samples) value across this gene is less than 50

--- a/browser/help/faq/technical-details/what-do-the-flags-on-the-browser-mean.md
+++ b/browser/help/faq/technical-details/what-do-the-flags-on-the-browser-mean.md
@@ -25,3 +25,7 @@ Flags that will appear in the variant table on gene/region pages:
 - NC Transcript: Marked in a putative LoF category by VEP (essential splice, stop-gained, or frameshift) but appears on a non-protein-coding transcript
 - SEGDUP: Found in a region overlapping a segmental duplication (regions provided by GA4GH Benchmarking Team)
 - Common low heteroplasmy: Variant is present at an overall frequency of .001 across all samples with a heteroplasmy level > 0 and < 0.50 (mitochondrial variants only)
+
+Flags that will appear at the top of gene/transcript pages:
+- Low exome coverage: Less than 10% of the coding base pairs in this gene are well-covered in the gnomAD exomes. Well-covered is defined here has having a median allele number percent (AN%; percent of total possible AN observed at site) greater than 90%
+- Low exome mapping quality: The mean `AS_MQ` (allele-specific root mean square of the mapping quality of reads across all samples) value across this gene is less than 50

--- a/browser/src/help/__snapshots__/HelpPage.spec.tsx.snap
+++ b/browser/src/help/__snapshots__/HelpPage.spec.tsx.snap
@@ -9805,7 +9805,11 @@ Flags that will appear in the variant table on gene/region pages:
 - NC Transcript: Marked in a putative LoF category by VEP (essential splice, stop-gained, or frameshift) but appears on a non-protein-coding transcript
 - SEGDUP: Found in a region overlapping a segmental duplication (regions provided by GA4GH Benchmarking Team)
 - Common low heteroplasmy: Variant is present at an overall frequency of .001 across all samples with a heteroplasmy level > 0 and < 0.50 (mitochondrial variants only)
-",
+
+Flags that will appear at the top of gene/transcript pages:
+
+- Low exome coverage: Less than 10% of the coding base pairs in this gene are well-covered in the gnomAD exomes. Well-covered is defined here as having a median allele number percent (AN%; percent of total possible AN observed at site) greater than 90%
+- Low exome mapping quality: The mean \`AS_MQ\` (allele-specific root mean square of the mapping quality of reads across all samples) value across this gene is less than 50",
                       }
                     }
                     onClick={[Function]}


### PR DESCRIPTION
PR adds description for two new gene-level flags added as part of gnomAD v4.1.1:
- Low exome coverage
- Low exome mappability