### PR TITLE
Use v4.1.1 constraint data

### DIFF
--- a/browser/src/ConstraintTable/ConstraintTable.tsx
+++ b/browser/src/ConstraintTable/ConstraintTable.tsx
@@ -126,7 +126,10 @@ const ConstraintTable = ({ datasetId, geneOrTranscript }: Props) => {
       {['controls', 'non_neuro', 'non_cancer', 'non_topmed'].some((subset) =>
         datasetId.includes(subset)
       ) && <p>Constraint is based on the full gnomAD dataset, not the selected subset.</p>}
-      <GnomadConstraintTable constraint={gnomadConstraint!} />
+      <GnomadConstraintTable
+        geneFlags={isGene(geneOrTranscript) ? (geneOrTranscript as Gene).flags : []}
+        constraint={gnomadConstraint!}
+      />
       {isGene(geneOrTranscript) && (
         <p style={{ marginBottom: 0 }}>
           Constraint metrics based on {transcriptDescription} transcript (

--- a/browser/src/ConstraintTable/GnomadConstraintTable.tsx
+++ b/browser/src/ConstraintTable/GnomadConstraintTable.tsx
@@ -296,16 +296,11 @@ const GnomadConstraintTable = ({ geneFlags, constraint }: GnomadConstraintTableP
           {geneFlags
             .filter((flag) => flag in GENE_LEVEL_CONSTRAINT_FLAG_DESCRIPTIONS)
             .map((flag) => {
-              let flagDescription
-              if (flag in GENE_LEVEL_CONSTRAINT_FLAG_DESCRIPTIONS) {
-                flagDescription = GENE_LEVEL_CONSTRAINT_FLAG_DESCRIPTIONS[flag]
-              } else {
-                flagDescription = (
-                  <span>
-                    Gene constraint flag: <code>{flag}</code>
-                  </span>
-                )
-              }
+              const flagDescription = GENE_LEVEL_CONSTRAINT_FLAG_DESCRIPTIONS[flag] || (
+                <span>
+                  Gene constraint flag: <code>{flag}</code>
+                </span>
+              )
               return (
                 <p key={flag} style={{ maxWidth: '460px' }}>
                   <Badge level="info">Note</Badge> {flagDescription}

--- a/browser/src/ConstraintTable/GnomadConstraintTable.tsx
+++ b/browser/src/ConstraintTable/GnomadConstraintTable.tsx
@@ -135,6 +135,11 @@ const CONSTRAINT_FLAG_DESCRIPTIONS = {
   outlier_syn: 'More or fewer synonymous variants than expected',
 }
 
+const GENE_LEVEL_CONSTRAINT_FLAG_DESCRIPTIONS: Record<string, string> = {
+  low_exome_coverage: 'Low coverage gene',
+  low_exome_mapping_quality: 'Low mappability gene',
+}
+
 export type GnomadConstraint = {
   exp_lof: number | null
   exp_mis: number | null
@@ -165,10 +170,11 @@ type OEMetricField =
   | `oe_${ConstraintFieldWithOEMetrics}_upper`
 
 type GnomadConstraintTableProps = {
+  geneFlags: string[]
   constraint: GnomadConstraint
 }
 
-const GnomadConstraintTable = ({ constraint }: GnomadConstraintTableProps) => {
+const GnomadConstraintTable = ({ geneFlags, constraint }: GnomadConstraintTableProps) => {
   let lofHighlightColor = null
   if (constraint.oe_lof_upper !== null) {
     if (constraint.oe_lof_upper < 0.33) {
@@ -282,6 +288,30 @@ const GnomadConstraintTable = ({ constraint }: GnomadConstraintTableProps) => {
               More information on constraint flags.
             </Link>
           </p>
+        </React.Fragment>
+      )}
+
+      {geneFlags.length > 0 && (
+        <React.Fragment>
+          {geneFlags
+            .filter((flag) => flag in GENE_LEVEL_CONSTRAINT_FLAG_DESCRIPTIONS)
+            .map((flag) => {
+              let flagDescription
+              if (flag in GENE_LEVEL_CONSTRAINT_FLAG_DESCRIPTIONS) {
+                flagDescription = GENE_LEVEL_CONSTRAINT_FLAG_DESCRIPTIONS[flag]
+              } else {
+                flagDescription = (
+                  <span>
+                    Gene constraint flag: <code>{flag}</code>
+                  </span>
+                )
+              }
+              return (
+                <p key={flag} style={{ maxWidth: '460px' }}>
+                  <Badge level="info">Note</Badge> {flagDescription}
+                </p>
+              )
+            })}
         </React.Fragment>
       )}
     </div>

--- a/browser/src/ErrorBoundary.tsx
+++ b/browser/src/ErrorBoundary.tsx
@@ -88,8 +88,7 @@ ${error.stack}
                 <ExternalLink href={forumURL}>a topic on our forum</ExternalLink>
               </li>
             </ul>
-            Then
-            <StyledLink href="/">reload the browser</StyledLink>.
+            Then <StyledLink href="/">reload the browser</StyledLink>.
             <br />
             <br />
             <br />

--- a/browser/src/GenePage/GeneInfo.tsx
+++ b/browser/src/GenePage/GeneInfo.tsx
@@ -6,6 +6,7 @@ import InlineList from '../InlineList'
 import Link from '../Link'
 
 import GeneReferences from './GeneReferences'
+import { Badge } from '@gnomad/ui'
 
 type ManeSelectTranscriptIdProps = {
   gene: {
@@ -66,7 +67,15 @@ type GeneInfoProps = {
       transcript_id: string
       transcript_version: string
     }[]
+    flags: string[]
   }
+}
+
+const GENE_FLAGS_TO_RENDER: Record<string, string> = {
+  low_exome_coverage:
+    'This gene is not well covered in the gnomAD v4.1.1 exomes. Allele frequency estimates in the exomes and gene constraint metrics may not be reliable.',
+  low_exome_mapping_quality:
+    'This gene has poor read mapping statistics in the gnomAD v4.1.1 exomes. Allele frequency estimates in the exomes and gene constraint metrics may not be reliable.',
 }
 
 const GeneInfo = ({ gene }: GeneInfoProps) => {
@@ -152,6 +161,16 @@ const GeneInfo = ({ gene }: GeneInfoProps) => {
       <AttributeListItem label="External resources">
         <GeneReferences gene={gene} />
       </AttributeListItem>
+
+      {gene.flags
+        .filter((flag) => flag in GENE_FLAGS_TO_RENDER)
+        .map((flag) => {
+          return (
+            <p>
+              <Badge level="warning">Warning</Badge> {GENE_FLAGS_TO_RENDER[flag]}
+            </p>
+          )
+        })}
     </AttributeList>
   )
 }

--- a/browser/src/GenePage/GeneTranscriptsTrack.tsx
+++ b/browser/src/GenePage/GeneTranscriptsTrack.tsx
@@ -62,9 +62,13 @@ const GeneTranscriptsTrack = ({
       (transcript) => transcript.transcript_id === preferredTranscriptId
     )
     preferredTranscript!.gtex_tissue_expression.forEach((tissue) => {
+      if (ALL_GTEX_TISSUES[tissue.tissue as GtexTissueName]?.fullName === undefined) {
+        return
+      }
+
       gtexTissues[tissue.tissue as GtexTissueName] = {
-        fullName: ALL_GTEX_TISSUES[tissue.tissue as GtexTissueName].fullName || tissue.tissue,
-        color: ALL_GTEX_TISSUES[tissue.tissue as GtexTissueName].color || '#888888',
+        fullName: ALL_GTEX_TISSUES[tissue.tissue as GtexTissueName]?.fullName || tissue.tissue,
+        color: ALL_GTEX_TISSUES[tissue.tissue as GtexTissueName]?.color || '#888888',
         value: tissue.value,
       }
     })
@@ -151,17 +155,19 @@ const GeneTranscriptsTrack = ({
                   return null
                 }
 
+                const displayedGtexTissues = transcript.gtex_tissue_expression.filter(
+                  (tissueExpression) =>
+                    ALL_GTEX_TISSUES[tissueExpression.tissue as GtexTissueName]?.fullName ===
+                    undefined
+                )
+
                 const meanExpression = mean(
-                  transcript.gtex_tissue_expression.map(
-                    (tissueExpression) => tissueExpression.value
-                  )
+                  displayedGtexTissues.map((tissueExpression) => tissueExpression.value)
                 )!
                 const maxExpression = max(
-                  transcript.gtex_tissue_expression.map(
-                    (tissueExpression) => tissueExpression.value
-                  )
+                  displayedGtexTissues.map((tissueExpression) => tissueExpression.value)
                 )!
-                const tissueMostExpressedIn = transcript.gtex_tissue_expression.find(
+                const tissueMostExpressedIn = displayedGtexTissues.find(
                   (tissue) => tissue.value === maxExpression
                 )!.tissue
 
@@ -179,7 +185,8 @@ const GeneTranscriptsTrack = ({
                       tooltip={`Mean expression across all tissues = ${meanExpression.toFixed(
                         2
                       )} TPM\nMost expressed in ${
-                        gtexTissues[tissueMostExpressedIn as GtexTissueName]!.fullName
+                        gtexTissues[tissueMostExpressedIn as GtexTissueName]?.fullName ||
+                        tissueMostExpressedIn
                       } (${maxExpression.toFixed(2)} TPM)`}
                     >
                       <rect

--- a/browser/src/GenePage/GeneTranscriptsTrack.tsx
+++ b/browser/src/GenePage/GeneTranscriptsTrack.tsx
@@ -157,7 +157,7 @@ const GeneTranscriptsTrack = ({
 
                 const displayedGtexTissues = transcript.gtex_tissue_expression.filter(
                   (tissueExpression) =>
-                    ALL_GTEX_TISSUES[tissueExpression.tissue as GtexTissueName]?.fullName ===
+                    ALL_GTEX_TISSUES[tissueExpression.tissue as GtexTissueName]?.fullName !==
                     undefined
                 )
 

--- a/browser/src/GenePage/TissueExpressionTrack.tsx
+++ b/browser/src/GenePage/TissueExpressionTrack.tsx
@@ -8,7 +8,13 @@ import { Track } from '@gnomad/region-viewer'
 import { RegionsPlot } from '@gnomad/track-regions'
 import { Badge, Button, Modal, SearchInput, Select, TooltipAnchor } from '@gnomad/ui'
 
-import { ALL_GTEX_TISSUES, GtexTissueName, GtexTissues } from '../gtex'
+import {
+  ALL_GTEX_TISSUES,
+  GtexTissueName,
+  GtexTissues,
+  V2_GTEX_TISSUES,
+  V4_GTEX_TISSUES,
+} from '../gtex'
 import InfoButton from '../help/InfoButton'
 
 import { logButtonClick } from '../analytics'
@@ -373,11 +379,12 @@ const TissueExpressionTrack = ({
     'alphabetical'
   )
 
+  const gtex_version_tissues = topLevelDataset === 'v4' ? V4_GTEX_TISSUES : V2_GTEX_TISSUES
   const gtexTissues: Partial<Record<GtexTissueName, GtexTissueDetail>> = {}
   transcripts
     .find((transcript) => transcript.transcript_id === preferredTranscriptId)
     ?.gtex_tissue_expression.forEach((tissue) => {
-      if (ALL_GTEX_TISSUES[tissue.tissue as GtexTissueName]?.fullName === undefined) {
+      if (gtex_version_tissues[tissue.tissue as GtexTissueName]?.fullName === undefined) {
         return
       }
 

--- a/browser/src/GenePage/TissueExpressionTrack.tsx
+++ b/browser/src/GenePage/TissueExpressionTrack.tsx
@@ -377,9 +377,13 @@ const TissueExpressionTrack = ({
   transcripts
     .find((transcript) => transcript.transcript_id === preferredTranscriptId)
     ?.gtex_tissue_expression.forEach((tissue) => {
+      if (ALL_GTEX_TISSUES[tissue.tissue as GtexTissueName]?.fullName === undefined) {
+        return
+      }
+
       gtexTissues[tissue.tissue as GtexTissueName] = {
-        fullName: ALL_GTEX_TISSUES[tissue.tissue as GtexTissueName].fullName || tissue.tissue,
-        color: ALL_GTEX_TISSUES[tissue.tissue as GtexTissueName].color || '#888888',
+        fullName: ALL_GTEX_TISSUES[tissue.tissue as GtexTissueName]?.fullName || tissue.tissue,
+        color: ALL_GTEX_TISSUES[tissue.tissue as GtexTissueName]?.color || '#888888',
         value: tissue.value,
       }
     })
@@ -438,26 +442,29 @@ const TissueExpressionTrack = ({
     Object.values(expressionByTissue).map((v) => v.meanTranscriptExpressionInTissue)
   )!
 
+  const safeFullName = (t: [string, GtexTissueDetail]) => {
+    return ALL_GTEX_TISSUES[t[0] as GtexTissueName]?.fullName || t[0]
+  }
+
   const tissues =
     sortTissuesBy === 'mean-expression'
       ? Object.entries(gtexTissues)
+          .filter((t) => ALL_GTEX_TISSUES[t[0] as GtexTissueName]?.fullName !== undefined)
           .sort((t1, t2) => {
+            const t1FullName = safeFullName(t1)
+            const t2FullName = safeFullName(t2)
             const t1Expression = expressionByTissue[t1[0]].meanTranscriptExpressionInTissue
             const t2Expression = expressionByTissue[t2[0]].meanTranscriptExpressionInTissue
+
             if (t1Expression === t2Expression) {
-              return ALL_GTEX_TISSUES[t1[0] as GtexTissueName].fullName.localeCompare(
-                ALL_GTEX_TISSUES[t2[0] as GtexTissueName].fullName
-              )
+              return t1FullName.localeCompare(t2FullName)
             }
             return t2Expression - t1Expression
           })
-          .map((t: any) => t[0])
+          .map((t) => t[0])
       : Object.entries(gtexTissues)
-          .sort((t1, t2) =>
-            ALL_GTEX_TISSUES[t1[0] as GtexTissueName].fullName.localeCompare(
-              ALL_GTEX_TISSUES[t2[0] as GtexTissueName].fullName
-            )
-          )
+          .filter((t) => ALL_GTEX_TISSUES[t[0] as GtexTissueName]?.fullName !== undefined)
+          .sort((t1, t2) => safeFullName(t1).localeCompare(safeFullName(t2)))
           .map((t) => t[0])
 
   const isExpressed = expressionRegions.some((region: any) => region.mean !== 0)

--- a/browser/src/gtex.ts
+++ b/browser/src/gtex.ts
@@ -235,6 +235,16 @@ export type TissueDetail = {
 
 export type GtexTissues = Record<GtexTissueName, TissueDetail>
 
+export const V2_GTEX_TISSUES: Partial<Record<GtexTissueName, TissueDetail>> = {
+  ...SHARED_GTEX_TISSUES,
+  ...V2_SPECIFIC_GTEX_TISSUES,
+}
+
+export const V4_GTEX_TISSUES: Partial<Record<GtexTissueName, TissueDetail>> = {
+  ...SHARED_GTEX_TISSUES,
+  ...V4_SPECIFIC_GTEX_TISSUES,
+}
+
 export const ALL_GTEX_TISSUES: GtexTissues = {
   ...SHARED_GTEX_TISSUES,
   ...V2_SPECIFIC_GTEX_TISSUES,

--- a/data-pipeline/src/data_pipeline/data_types/gene.py
+++ b/data-pipeline/src/data_pipeline/data_types/gene.py
@@ -164,6 +164,24 @@ def collect_transcript_exons(transcript_exons):
     return exons
 
 
+def annotate_gene_models_with_low_coverage_flag(genes_path, low_coverage_tsv_path):
+    low_coverage_flag_name = "v4_low_coverage_trancript"
+
+    genes_ht = hl.read_table(genes_path)
+    tsv_ht = hl.import_table(low_coverage_tsv_path)
+    tsv_ht = tsv_ht.key_by("transcript_id")
+
+    genes_ht = genes_ht.annotate(
+        flags=hl.if_else(
+            hl.is_defined(tsv_ht[genes_ht.canonical_transcript_id]),
+            hl.or_else(genes_ht.flags, hl.empty_set(hl.tstr)).add(low_coverage_flag_name),
+            genes_ht.flags,
+        )
+    )
+
+    return genes_ht
+
+
 ###############################################
 # Main                                        #
 ###############################################

--- a/data-pipeline/src/data_pipeline/datasets/gnomad_v4/gnomad_v4_constraint.py
+++ b/data-pipeline/src/data_pipeline/datasets/gnomad_v4/gnomad_v4_constraint.py
@@ -36,6 +36,8 @@ def prepare_gnomad_v4_constraint(path):
         # Other
         pli=ds.lof.pLI,
         flags=ds.constraint_flags,
+        # to be raised into top level `flags` field on annotation
+        gene_flags=ds.gene_flags,
     )
 
     ds = ds.filter(ds.transcript.contains("ENST"))

--- a/data-pipeline/src/data_pipeline/pipelines/genes.py
+++ b/data-pipeline/src/data_pipeline/pipelines/genes.py
@@ -32,7 +32,7 @@ from data_pipeline.pipelines.variant_cooccurrence_counts import (
     prepare_heterozygous_variant_cooccurrence_counts,
     prepare_homozygous_variant_cooccurrence_counts,
 )
-from data_pipeline.data_types.gene import reject_par_y_genes
+from data_pipeline.data_types.gene import reject_par_y_genes, annotate_gene_models_with_low_coverage_flag
 
 from data_pipeline.datasets.gnomad_v4.gnomad_v4_constraint import (
     prepare_gnomad_v4_constraint,
@@ -492,11 +492,21 @@ pipeline.add_task(
 )
 
 pipeline.add_task(
+    "annotate_grch38_genes_step_7",
+    annotate_gene_models_with_low_coverage_flag,
+    f"/{genes_subdir}/genes_grch38_annotated_7.ht",
+    {
+        "genes_path": pipeline.get_task("annotate_grch38_genes_step_6"),
+        "low_coverage_tsv_path": "gs://gnomad-v4-data-pipeline/inputs/v4.1.1/gnomad.v4.1.low_coverage_transcripts.tsv",
+    },
+)
+
+pipeline.add_task(
     "remove_grch38_genes_constraint_for_release",
     remove_gnomad_v4_constraint,
-    f"/{genes_subdir}/genes_grch38_annotate_5_removed_constraint",
+    f"/{genes_subdir}/genes_grch38_annotate_7_removed_constraint",
     {
-        "genes_path": pipeline.get_task("annotate_grch38_genes_step_5"),
+        "genes_path": pipeline.get_task("annotate_grch38_genes_step_7"),
     },
 )
 
@@ -563,7 +573,7 @@ pipeline.add_task(
 pipeline.set_outputs(
     {
         "genes_grch37": "annotate_grch37_genes_step_5",
-        "genes_grch38": "annotate_grch38_genes_step_6",
+        "genes_grch38": "annotate_grch38_genes_step_7",
         "base_transcripts_grch37": "extract_grch37_transcripts",
         "base_transcripts_grch38": "extract_grch38_transcripts",
         "transcripts_grch37": "annotate_grch37_transcripts",

--- a/data-pipeline/src/data_pipeline/pipelines/genes.py
+++ b/data-pipeline/src/data_pipeline/pipelines/genes.py
@@ -41,9 +41,9 @@ from data_pipeline.datasets.gnomad_v4.gnomad_v4_constraint import (
 
 pipeline = Pipeline()
 
-external_sources_subdir = "external_sources"
-genes_subdir = "genes"
-constraint_subdir = "constraint"
+external_sources_subdir = "external_sources/v4.1.1_demo"
+genes_subdir = "genes/v4.1.1_demo"
+constraint_subdir = "constraint/v4.1.1_demo"
 
 
 ###############################################
@@ -298,7 +298,8 @@ pipeline.add_task(
     "prepare_gnomad_v4_constraint",
     prepare_gnomad_v4_constraint,
     f"/{constraint_subdir}/gnomad_v4_constraint.ht",
-    {"path": "gs://gcp-public-data--gnomad/release/4.1/constraint/gnomad.v4.1.constraint_metrics.ht"},
+    # TK: TODO: change this to the public 'gcp-public-data--gnomad/...' path when released
+    {"path": "gs://gnomad-v4-data-pipeline/inputs/v4.1.1/constraint/gnomad.v4.1.1.constraint_metrics.ht"},
 )
 
 pipeline.add_task(

--- a/data-pipeline/src/data_pipeline/pipelines/genes.py
+++ b/data-pipeline/src/data_pipeline/pipelines/genes.py
@@ -452,15 +452,29 @@ pipeline.add_task(
 )
 
 
-def annotate_with_constraint(genes_path, constraint_path):
+def annotate_v4_with_constraint(genes_path, constraint_path):
     genes = hl.read_table(genes_path)
     constraint = hl.read_table(constraint_path)
-    return genes.annotate(gnomad_constraint=constraint[genes.preferred_transcript_id])
+
+    constraint_match = constraint[genes.preferred_transcript_id]
+
+    genes = genes.annotate(
+        gnomad_constraint=constraint_match.drop("gene_flags"),
+        flags=hl.if_else(
+            hl.is_defined(constraint_match.gene_flags),
+            hl.or_else(genes.flags, hl.empty_set(hl.tstr)).union(
+                hl.or_else(constraint_match.gene_flags, hl.empty_set(hl.tstr))
+            ),
+            genes.flags,
+        ),
+    )
+
+    return genes
 
 
 pipeline.add_task(
     "annotate_grch38_genes_step_5",
-    annotate_with_constraint,
+    annotate_v4_with_constraint,
     f"/{genes_subdir}/genes_grch38_annotated_5.ht",
     {
         "genes_path": pipeline.get_task("annotate_grch38_genes_step_4"),

--- a/graphql-api/src/queries/gene-queries.ts
+++ b/graphql-api/src/queries/gene-queries.ts
@@ -5,7 +5,8 @@ import { catchNotFound } from '../elasticsearch'
 
 const GENE_INDICES = {
   GRCh37: 'genes_grch37',
-  GRCh38: 'genes_grch38',
+  // GRCh38: 'genes_grch38',
+  GRCh38: 'genes_grch38-2026-02-25--22-06',
 }
 
 const _fetchGeneById = async (esClient: any, geneId: any, referenceGenome: any) => {


### PR DESCRIPTION
Resolves:
- https://github.com/broadinstitute/gnomad-browser-team/issues/109
- https://github.com/broadinstitute/gnomad-browser-team/issues/110


- Modifies the gtex/transcript components to handle additional tissues from the Gtex release not defined in our data.

- Slightly modifies the genes pipeline to handle the new format for v4.1.1 constraint, pulling the gene level flags contained in that file into the top level `flags` field on a Gene. 

- Modifies the frontend to render the new flags on the Gene summary, and below the constraint table.

This currently uses a non alias'd index to grab the new constraint data, with new flags, from the production ES db. Once this gets approved, we can run restore the alias, and run the pipeline without the staging 4.1.1 bucket.

---

### PCSK9
- ![Screenshot 2026-02-26 at 06 35 07](https://github.com/user-attachments/assets/2aa5fe7f-49e5-4ce8-9892-a11906ca118a)

### AMY1B
- ![Screenshot 2026-02-26 at 06 38 54](https://github.com/user-attachments/assets/e490b2df-6ad0-4d0e-af3f-cef1b51997c6)

### CBS
- ![Screenshot 2026-02-26 at 06 39 24](https://github.com/user-attachments/assets/893f9194-f136-48cf-a802-0ce6ad0258d1)