### PR TITLE
Update browser HT help to include new VRS fields

### DIFF
--- a/browser/help/topics/v4-browser-hts.md
+++ b/browser/help/topics/v4-browser-hts.md
@@ -150,6 +150,8 @@ Row fields:
     - `start`: The start position of the Allele.
     - `end`: The end position of the Allele.
     - `state`: A VRS Sequence Expression that corresponds to the nucleotide or amino acid sequence of the Allele.
+    - `length`: The number of residues in the expressed sequence.
+    - `repeat_subunit_length`: The number of residues in the repeat subunit.
   - `alt`: Struct containing information about the alternate allele. Contains the same fields as `ref` above.
 
 #### gnomAD v4.1. browser gene models Hail Table annotations


### PR DESCRIPTION
Updating the browser HT help page to include the new fields. Definition source: https://vrs.ga4gh.org/en/stable/concepts/SequenceExpression/ReferenceLengthExpression.html 