### PR TITLE
Minorly update '`./deployctl`'

### DIFF
--- a/deploy/deployctl/subcommands/browser_deployments.py
+++ b/deploy/deployctl/subcommands/browser_deployments.py
@@ -5,6 +5,7 @@ import os
 import string
 import sys
 import typing
+import time
 
 from deployctl.config import config
 from deployctl.shell import kubectl, get_most_recent_tag, image_exists, get_k8s_deployments
@@ -235,6 +236,22 @@ def apply_deployment(name: str) -> None:
 
 
 def delete_deployment(name: str, clean: bool = False) -> None:
+    try:
+        active_prod = get_current_browser_deployment()
+    except Exception as err:  # pylint: disable=broad-except
+        active_prod = None
+        sleep_time = 30
+        print(f"Warning: Could not determine active production deployment. Error: ({err})", file=sys.stderr)
+        print(
+            f"Sleeping for {sleep_time}s before proceeding with deletion. Cancel now with 'ctrl + c' unless you are SURE you want to proceed and delete deployment '{name}'."
+        )
+        time.sleep(sleep_time)
+
+    if active_prod and name == active_prod:
+        raise RuntimeError(
+            f"Warning: '{name}' is currently serving production. Quitting before deletion command is issued."
+        )
+
     deployment_directory = os.path.join(deployments_directory(), name)
 
     if os.path.exists(deployment_directory):

--- a/deploy/deployctl/subcommands/browser_deployments.py
+++ b/deploy/deployctl/subcommands/browser_deployments.py
@@ -8,6 +8,7 @@ import typing
 
 from deployctl.config import config
 from deployctl.shell import kubectl, get_most_recent_tag, image_exists, get_k8s_deployments
+from deployctl.subcommands.ingress_production import get_current_browser_deployment
 
 
 KUSTOMIZATION_TEMPLATE = """---
@@ -130,7 +131,7 @@ def deployments_directory() -> str:
 
 def print_pool_name(pool: str) -> str:
     if pool == "demo-pool":
-        return "(demo-pool)"
+        return " (demo-pool)"
     if pool == "main-pool":
         return ""
 
@@ -144,20 +145,29 @@ def determine_deployment_pool(path: str) -> str:
 
 
 def list_deployments() -> None:
+    active_prod = None
+    try:
+        active_prod = get_current_browser_deployment()
+    except Exception:  # pylint: disable=broad-except
+        pass
+
     print("Local configurations")
     print("====================")
     paths = reversed(sorted(glob.iglob(f"{deployments_directory()}/*/kustomization.yaml"), key=os.path.getmtime))
     for path in paths:
         name = os.path.basename(os.path.dirname(path))
         pool = determine_deployment_pool(path)
-        print(f"{name} {print_pool_name(pool)}")
+        print(f"{name}{print_pool_name(pool)}")
 
     print()
 
     print("Cluster deployments")
     print("===================")
     for deployment, pool in get_k8s_deployments("component=gnomad-browser"):
-        print(f"{deployment[len('gnomad-browser-'):]} {print_pool_name(pool)}")
+        name = deployment[len("gnomad-browser-") :]
+        pool_label = print_pool_name(pool)
+        prod_label = " (prod)" if name == active_prod else ""
+        print(f"{name}{pool_label}{prod_label}".strip())
 
     print()
 


### PR DESCRIPTION
Just adding some safeguards and more output to more easily see which deployment is prod. Typing '`./deployctl deployments delete <NAME>`' each time always gives me the heebie jeebies, even after triple checking '`... production describe`' to make sure I'm taking down the inactive green/blue

---

- have '`./deployctl`' show which deployment is prod when using `deployments list`
```
❯ ./deployctl deployments list
``` 

```
Local configurations
====================
green
blue

Cluster deployments
===================
v4-1-1 (demo-pool)
blue
green (prod)
```

- disallow '`./deployctl`' from deleting the deployment currently serving prod:
```
❯ ./deployctl deployments delete green
```

```
Error: Warning: 'green' is currently serving production. Quitting before deletion command is issued.
```
