### PR TITLE
Update ClinVar docs

### DIFF
--- a/browser/help/topics/clinvar-hts.md
+++ b/browser/help/topics/clinvar-hts.md
@@ -5,13 +5,39 @@ title: 'ClinVar Hail Tables'
 
 ### Overview
 
-We release two data tables underlying the ClinVar data displayed in the gnomAD browser. On a bi-monthly basis, we process the ClinVar monthly VCV XML release into two Hail Tables, one for GRCh38 and one for GRCh37. These tables enable our users to more easily incorporate ClinVar data into external pipelines in a manner consistent with what they see in the browser.
+We release two data tables underlying the ClinVar data displayed in the gnomAD browser. At least once per quarter (though frequently on a monthly basis), we process the ClinVar monthly VCV XML release into two Hail Tables, one for GRCh38 and one for GRCh37. These tables enable our users to more easily incorporate ClinVar data into external pipelines in a manner consistent with what they see in the browser.
+
+We release both the most recently processed ClinVar XML VCV release, titled `gnomad_clinvar_grch<VERSION>_latest`, and releases dated with the ClinVar data release date, e.g. `gnomad_clinvar_grch38_2026-03-28_release.ht`.
 
 These tables are stored in a requester pays GCS bucket. As such, to access or download this data you must provide a billing project when accessing the data with `gsutil`, e.g.
 
+To copy the latest GRCh38 ClinVar Browser table:
+
 ```
-gsutil -u YOUR_PROJECT -m cp -r \
-  gs://gnomad-browser-clinvar/gnomad_clinvar_grch38.ht \
+gsutil -u <YOUR_PROJECT> -m cp -r \
+  gs://gnomad-browser-clinvar/grch38/gnomad_clinvar_grch38_latest.ht \
+  gs://YOUR-BUCKET/YOUR-OPTIONAL-NESTED-BUCKETS/gnomad_clinvar_grch38.ht
+```
+
+To see all releases for GRCh38
+
+```
+gsutil -u <YOUR_PROJECT> ls gs://gnomad-browser/clinvar/grch38/
+```
+
+To copy a specific ClinVar release date Browser Hail table:
+
+```
+gsutil -u <YOUR_PROJECT> -m cp -r \
+  gs://gnomad-browser-clinvar/grch38/gnomad_browser_clinvar_grch38_2026-03-28_release.ht \
+  gs://YOUR-BUCKET/YOUR-OPTIONAL-NESTED-BUCKETS/gnomad_clinvar_grch38.ht
+```
+
+To copy the latest GRCh37 ClinVar Browser table:
+
+```
+gsutil -u <YOUR_PROJECT> -m cp -r \
+  gs://gnomad-browser-clinvar/grch37/gnomad_clinvar_grch37_latest.ht \
   gs://YOUR-BUCKET/YOUR-OPTIONAL-NESTED-BUCKETS/gnomad_clinvar_grch38.ht
 ```
 

--- a/browser/help/topics/vep.md
+++ b/browser/help/topics/vep.md
@@ -23,6 +23,14 @@ These [regions](https://storage.googleapis.com/gcp-public-data--gnomad/intervals
 
 The segmental duplication regions we used are from the Global Alliance for Genomics and Health (GA4GH) Benchmarking Team and the Genome in a Bottle Consortium. Information on the source of these files can be found in [GA4GH's benchmarking-tools GitHub repository](https://github.com/ga4gh/benchmarking-tools/tree/d88448a68a79ed322837bc8eb4d5a096a710993d/resources/stratification-bed-files/SegmentalDuplications).
 
+### ClinVar
+
+The gnomAD Browser's ClinVar track is populated by short variants included in ClinVar's weekly [VCV](https://www.ncbi.nlm.nih.gov/clinvar/docs/variation_report/) release by parsing their XML files updated on their [FTP server](https://ftp.ncbi.nlm.nih.gov/pub/clinvar/xml/weekly_release/).
+
+This information is used to populate the standalone ClinVar variant track on the Gene/Transcript/Region pages, and in displaying ClinVar information for gnomAD variants in the browser in the variant table on the Gene/Transcript/Region pages, as well as on invididual Variant pages.
+
+The ClinVar data is updated at least once per quarter, though it is frequently updated on a monthly basis. The most recent, and previous, parsed and reshaped ClinVar data can be downloaded from the [Data Page](https://gnomad.broadinstitute.org/data). Downloads are seperated into [ClinVar GRCh38](https://gnomad.broadinstitute.org/data#v4-clinvar-grch38), for gnomAD v4; and [ClinVar GRCh37](https://gnomad.broadinstitute.org/data#v2-clinvar-grch37), for gnomAD v2.
+
 <br/><br/>
 
 <details>

--- a/browser/src/DataPage/GnomadV2Downloads.tsx
+++ b/browser/src/DataPage/GnomadV2Downloads.tsx
@@ -431,7 +431,8 @@ const GnomadV2Downloads = () => {
       <DownloadsSection>
         <SectionTitle id="v2-clinvar-grch37">ClinVar</SectionTitle>
         <p>
-          For more information about these files, see the{' '}
+          For more information about these files, including how to download a specific previous
+          version of the gnomAD browser ClinVar GRCh37 table, see the{' '}
           <Link to="/help/clinvar-hts">help text</Link>.
         </p>
 
@@ -439,8 +440,8 @@ const GnomadV2Downloads = () => {
           <ListItem>
             <GetUrlButtons
               gcsBucket="gnomad-browser-clinvar"
-              label="ClinVar GRCh37 Browser Hail Table"
-              path="/gnomad_clinvar_grch37.ht"
+              label="Latest ClinVar GRCh37 Browser Hail Table"
+              path="/grch37/gnomad_clinvar_grch37_latest.ht"
               includeAWS={false}
             />
           </ListItem>

--- a/browser/src/DataPage/GnomadV4Downloads.tsx
+++ b/browser/src/DataPage/GnomadV4Downloads.tsx
@@ -555,7 +555,8 @@ const GnomadV4Downloads = () => {
       <DownloadsSection>
         <SectionTitle id="v4-clinvar-grch38">ClinVar</SectionTitle>
         <p>
-          For more information about these files, see the{' '}
+          For more information about these files, including how to download a specific previous
+          version of the gnomAD browser ClinVar GRCh38 table, see the{' '}
           <Link to="/help/clinvar-hts">help text</Link>.
         </p>
 
@@ -563,8 +564,8 @@ const GnomadV4Downloads = () => {
           <ListItem>
             <GetUrlButtons
               gcsBucket="gnomad-browser-clinvar"
-              label="ClinVar GRCh38 Browser Hail Table"
-              path="/gnomad_clinvar_grch38.ht"
+              label="Latest ClinVar GRCh38 Browser Hail Table"
+              path="/grch38/gnomad_clinvar_grch38_latest.ht"
               includeAWS={false}
             />
           </ListItem>

--- a/browser/src/DataPage/__snapshots__/DataPage.spec.tsx.snap
+++ b/browser/src/DataPage/__snapshots__/DataPage.spec.tsx.snap
@@ -7192,7 +7192,7 @@ exports[`Data Page has no unexpected changes 1`] = `
         </h2>
       </span>
       <p>
-        For more information about these files, see the
+        For more information about these files, including how to download a specific previous version of the gnomAD browser ClinVar GRCh38 table, see the
          
         <a
           className="c8"
@@ -7210,13 +7210,13 @@ exports[`Data Page has no unexpected changes 1`] = `
           className="c22"
         >
           <span>
-            ClinVar GRCh38 Browser Hail Table
+            Latest ClinVar GRCh38 Browser Hail Table
           </span>
           <br />
           Show URL for
            
           <button
-            aria-label="Show Google URL for ClinVar GRCh38 Browser Hail Table"
+            aria-label="Show Google URL for Latest ClinVar GRCh38 Browser Hail Table"
             className="c23"
             onClick={[Function]}
             type="button"
@@ -21316,7 +21316,7 @@ exports[`Data Page has no unexpected changes 1`] = `
         </h2>
       </span>
       <p>
-        For more information about these files, see the
+        For more information about these files, including how to download a specific previous version of the gnomAD browser ClinVar GRCh37 table, see the
          
         <a
           className="c8"
@@ -21334,13 +21334,13 @@ exports[`Data Page has no unexpected changes 1`] = `
           className="c22"
         >
           <span>
-            ClinVar GRCh37 Browser Hail Table
+            Latest ClinVar GRCh37 Browser Hail Table
           </span>
           <br />
           Show URL for
            
           <button
-            aria-label="Show Google URL for ClinVar GRCh37 Browser Hail Table"
+            aria-label="Show Google URL for Latest ClinVar GRCh37 Browser Hail Table"
             className="c23"
             onClick={[Function]}
             type="button"

--- a/data-pipeline/src/data_pipeline/datasets/clinvar.py
+++ b/data-pipeline/src/data_pipeline/datasets/clinvar.py
@@ -17,7 +17,9 @@ from data_pipeline.data_types.locus import normalized_contig
 from data_pipeline.data_types.variant import variant_id
 
 
-CLINVAR_XML_URL = "https://ftp.ncbi.nlm.nih.gov/pub/clinvar/xml/ClinVarVCVRelease_00-latest.xml.gz"
+CLINVAR_XML_URL = (
+    "https://ftp.ncbi.nlm.nih.gov/pub/clinvar/xml/weekly_release/ClinVarVCVRelease_00-latest_weekly.xml.gz"
+)
 
 CLINVAR_GOLD_STARS = {
     None: 0,

--- a/deploy/docs/UpdateClinvarVariants.md
+++ b/deploy/docs/UpdateClinvarVariants.md
@@ -1,66 +1,130 @@
 # Updating ClinVar variants
 
+0. (Optional) Create a backup of the previous ClinVar release files:
+
+   Grab the release date, e.g. `2026-03-02` from Hail's globals. It's stored as a string in the part file.
+
+   ```
+   CLINVAR_PATH="gs://gnomad-v4-data-pipeline/output/clinvar/clinvar_grch38_annotated_2.ht"
+
+   OLD_CLINVAR_RELEASE_DATE=$(gsutil cat "${CLINVAR_PATH}/globals/parts/part-0" | strings | grep -oE '20[0-9]{2}-[0-9]{2}-[0-9]{2}')
+
+   CLINVAR_BACKUP_PATH="gs://gnomad-v4-data-pipeline/output/clinvar_backups/${OLD_CLINVAR_RELEASE_DATE}_clinvar_release_backup/"
+   ```
+
+   Back up just the final output of both the GRCh37, and GRCh38 pipelines
+
+   ```
+   gsutil -u exac-gnomad -m cp -r "gs://gnomad-v4-data-pipeline/output/clinvar/clinvar_grch37_annotated_2.ht" "$CLINVAR_BACKUP_PATH"
+   gsutil -u exac-gnomad -m cp -r "gs://gnomad-v4-data-pipeline/output/clinvar/clinvar_grch38_annotated_2.ht" "$CLINVAR_BACKUP_PATH"
+   ```
+
 1. Delete clinvar.xml from the data pipeline output bucket so that the data pipeline will download the latest version
 
    ```
-   gsutil rm gs://gnomad-browser-data-pipeline/output/external_sources/clinvar.xml.gz
+   gsutil -u exac-gnomad rm gs://gnomad-v4-data-pipeline/output/external_sources/clinvar.xml.gz
    ```
 
-2. Run data pipeline
+2. Run data pipelines
 
-   ClinVar pipelines use VEP and thus must be run on clusters with VEP installed and configured. To match gnomAD v2.1 (GRCh37) ClinVar variants should be annotated with VEP 85. To match gnomAD v4.0 (GRCh38) ClinVar variants should be annotated with VEP 101.
+   ClinVar pipelines use VEP and thus must be run on clusters with VEP installed and configured. To match gnomAD v2.1 (GRCh37) ClinVar variants should be annotated with VEP 85. To match gnomAD v4.1 (GRCh38) ClinVar variants should be annotated with VEP 105.
 
-   1. Start Dataproc cluster
+   The first step, in which the pipeline(s) parse the input ClinVar XML produces an intermediate Hail table that is used by both pipelines. Thus, to avoid duplicating work, it is best to wait for the first pipeline to finish this step, before starting the second pipeline.
 
-      GRCh37
+   1. GRCh37
 
-      ```
-      ./deployctl dataproc-cluster start vep85 \
-         --vep GRCh37 \
-         --num-secondary-workers 32
-      ```
-
-      GRCh38
+      Start cluster
 
       ```
-      ./deployctl dataproc-cluster start vep105 \
-         --init=gs://gcp-public-data--gnomad/resources/vep/v105/vep105-init.sh \
-         --metadata=VEP_CONFIG_PATH=/vep_data/vep-gcloud.json,VEP_CONFIG_URI=file:///vep_data/vep-gcloud.json,VEP_REPLICATE=us \
+      ./deployctl dataproc-cluster start clinvar-grch37-vep85 \
+         --init=gs://gnomad-v4-data-pipeline/output/clinvar/vep85/gnomad-browser-grch37-vep85-init.sh \
+         --metadata=VEP_CONFIG_PATH=/vep_data/vep-gcloud.json,VEP_CONFIG_URI=file:///vep_data/vep-gcloud.json \
          --master-machine-type n1-highmem-8 \
          --worker-machine-type n1-highmem-8 \
+         --master-boot-disk-type=pd-ssd \
+         --worker-boot-disk-type=pd-ssd \
+         --secondary-worker-boot-disk-type=pd-ssd \
          --worker-boot-disk-size=200 \
          --secondary-worker-boot-disk-size=200 \
          --num-secondary-workers 16
       ```
 
-   2. Run pipeline
-
-      GRCh37
+      Run pipeline
 
       ```
-      ./deployctl data-pipeline run --cluster vep85 clinvar_grch37
+      ./deployctl data-pipeline run --cluster clinvar-grch37-vep85 clinvar_grch37
       ```
 
-      GRCh38
+      Stop the cluster
 
       ```
-      ./deployctl data-pipeline run --cluster vep105 clinvar_grch38
+      ./deployctl dataproc-cluster stop clinvar-grch37-vep85
       ```
 
-      \*Note: The `vep105-init.sh` script is inconsistent about starting Docker. As a workaround, after starting the Dataproc Cluster, SSH into every individual node and run `sudo systemctl start docker`
+   2. GRCh38
+
+      Once the GRCh37 pipeline finishes the "parse_clinvar_xml" step, start this pipeline.
+
+      Start cluster
+
+      ```
+      ./deployctl dataproc-cluster start clinvar-grch38-vep105 \
+         --init=gs://gnomad-v4-data-pipeline/output/clinvar/gnomad-browser-grch38-vep105-init.sh \
+         --metadata=VEP_CONFIG_PATH=/vep_data/vep-gcloud.json,VEP_CONFIG_URI=file:///vep_data/vep-gcloud.json,VEP_REPLICATE=us \
+         --master-machine-type n1-highmem-8 \
+         --worker-machine-type n1-highmem-8 \
+         --master-boot-disk-type=pd-ssd \
+         --worker-boot-disk-type=pd-ssd \
+         --secondary-worker-boot-disk-type=pd-ssd \
+         --worker-boot-disk-size=200 \
+         --secondary-worker-boot-disk-size=200 \
+         --num-secondary-workers 16
+      ```
+
+      Run pipeline
+
+      ```
+      ./deployctl data-pipeline run --cluster clinvar-grch38-vep105 clinvar_grch38
+      ```
+
+      Stop the cluster
+
+      ```
+      ./deployctl dataproc-cluster stop clinvar-grch38-vep105
+      ```
 
 3. Load variants to Elasticsearch
 
-   GRCh37
+   Start dataproc cluster
 
    ```
-   ./deployctl elasticsearch load-datasets --dataproc-cluster vep85 clinvar_grch37_variants
+   ./deployctl dataproc-cluster start clinvar-es-load
    ```
 
-   GRCh38
+   VPN into the Broad, if you are not on site, using the Cisco Secure Client
+
+   Get the Elastic password to be used
 
    ```
-   ./deployctl elasticsearch load-datasets --dataproc-cluster vep105 clinvar_grch38_variants
+   ELASTICSEARCH_PASSWORD=$(./deployctl elasticsearch get-password)
+   ```
+
+   Load the GRCh37 ClinVar data to an ES index
+
+   ```
+   ./deployctl elasticsearch load-datasets --dataproc-cluster clinvar-es-load clinvar_grch37_variants
+   ```
+
+   Load the GRCh38 ClinVar data to an ES index
+
+   ```
+   ./deployctl elasticsearch load-datasets --dataproc-cluster clinvar-es-load clinvar_grch38_variants
+   ```
+
+   Stop the ES-load cluster
+
+   ```
+   ./deployctl dataproc-cluster stop clinvar-es-load
    ```
 
 4. [Update Elasticsearch index aliases](./ElasticsearchIndexAliases.md)
@@ -74,10 +138,16 @@
    Lookup the names of all the indices that exist
 
    ```
-   curl -u "elastic:$ELASTICSEARCH_PASSWORD" http://localhost:9200/_cat/indices
+   curl -u "elastic:$ELASTICSEARCH_PASSWORD" "http://localhost:9200/_cat/indices/*,-.*?pretty&v=true&s=index:asc"
    ```
 
-   Replace an older index associated with an alias with a newer one
+   For aliases
+
+   ```
+   curl -u "elastic:$ELASTICSEARCH_PASSWORD" "http://localhost:9200/_cat/aliases/*,-.*?pretty&v=true&s=index:asc"
+   ```
+
+   To replace a given alias's associated index, run a command like this:
 
    ```
    curl -u "elastic:$ELASTICSEARCH_PASSWORD" -XPOST http://localhost:9200/_aliases --header "Content-Type: application/json" --data @- <<EOF
@@ -90,15 +160,62 @@
    EOF
    ```
 
-5. [Clear Redis cache](./RedisCache.md)
+5. Clear gnomAD Browser caches
 
-   Start a shell in the Redis pod.
+   Clear both the Redis and Nginx caches gnomAD has to see the new data in production
 
-   Delete cache keys matching `clinvar_variants:*`.
+   1. Clear the [Redis cache](./RedisCache.md)
 
-   ```
-   redis-cli -n 1 --scan --pattern 'clinvar_variants:*' | xargs redis-cli -n 1 del
-   ```
+      Start a shell in the Redis pod.
+
+      ```
+      REDIS_POD=$(kubectl get pods --selector=name=redis -o=name)
+      kubectl exec -ti $REDIS_POD -- /bin/bash
+      ```
+
+      Delete cache keys matching `production:clinvar_variants:*`.
+
+      ```
+      redis-cli -n 1 --scan --pattern 'production:clinvar_variants:*' | xargs redis-cli -n 1 del
+      ```
+
+   2. (Optional) Clear Nginx cache
+
+      When creating a new deployment, this cache gets blown away. However, if you don't anticipate creating a new deployment soon, you can manually clear the Nginx cache to have production serve the new ClinVar data right away.
+
+      Get the deployment serving production
+
+      ```
+      ./deployctl production describe
+      ```
+
+      Check the pod name for that color
+
+      ```
+      kubectl get pods
+      ```
+
+      Exec into the current production gnomAD browser pod
+
+      ```
+      kubectl exec -it gnomad-browser-<POD_NAME> -- sh
+      ```
+
+      e.g. to exec into production when the color was `blue` once, the command was:
+
+      ```
+      kubectl exec -it gnomad-browser-blue-68fbcbc54f-5nxfj -- sh
+      ```
+
+      Cache data dirs are named with a single symbol hexidecimal character, e.g. `0`, `1`, ... `9`, `a`, `b`, ... `f`, and are stored in `/var/cache/nginx`
+
+      Manually delete the dirs 1 by 1 with `rm -rf <DIR>`
+
+      Or, remove all the cache dirs programatically
+
+      ```
+      rm -rf /var/cache/nginx/[0-9a-f]
+      ```
 
 6. Delete old Elasticsearch indices
 
@@ -108,9 +225,9 @@
    curl -u "elastic:$ELASTICSEARCH_PASSWORD" -XDELETE "http://localhost:9200/<index_name>-<previous_timestamp>"
    ```
 
-7. [Create an Elasticsearch snapshot](./ElasticsearchSnapshots.md)
+7. (Optional) [Create an Elasticsearch snapshot](./ElasticsearchSnapshots.md)
 
-   Create a snapshot with the current date
+   gnomAD Browser's ES instance is set to take snapshots on a monthly basis, if you want, you can create a snapshot with the current date right after loading the new ClinVar data, and setting the aliases
 
    ```
    curl -u "elastic:$ELASTICSEARCH_PASSWORD" -XPUT 'http://localhost:9200/_snapshot/backups/%3Csnapshot-%7Bnow%7BYYYY.MM.dd.HH.mm%7D%7D%3E'
@@ -118,20 +235,41 @@
 
 8. Update the public ClinVar buckets
 
-   We release these final hail tables in a requester pays bucket, `gs://gnomad-browser-clinvar`, use `gsutil rsync` to keep the files in sync.
+   We release these final hail tables into a requester pays GCS bucket: `gs://gnomad-browser-clinvar`. Copy the newly created final tables with `gsutil rsync` with the `-d` flag to keep the `_latest` hail table dir correctly sync'd
 
-   GRCh37
+   Grab the release date, e.g. `2026-03-02` from Hail's globals with `strings` and `grep` for use in releasing a file with a release date appended.
 
    ```
-   gsutil -u gnomadev -m rsync -r \
+   CLINVAR_PATH="gs://gnomad-v4-data-pipeline/output/clinvar/clinvar_grch37_annotated_2.ht"
+
+   NEW_CLINVAR_RELEASE_DATE=$(gsutil cat "${CLINVAR_PATH}/globals/parts/part-0" | strings | grep -oE '20[0-9]{2}-[0-9]{2}-[0-9]{2}')
+   echo $NEW_CLINVAR_RELEASE_DATE
+   ```
+
+   GRCh37 - overwrite the `..._latest.ht` table, create a date stamped table (`..._YYYY-MM-DD_release.ht`
+
+   ```
+   gsutil -u exac-gnomad -m rsync -d -r \
      gs://gnomad-v4-data-pipeline/output/clinvar/clinvar_grch37_annotated_2.ht/ \
-     gs://gnomad-browser-clinvar/gnomad_clinvar_grch37.ht
+     gs://gnomad-browser-clinvar/grch37/gnomad_browser_clinvar_grch37_latest.ht
    ```
 
-   GRCh38
+   ```
+   gsutil -u exac-gnomad -m rsync -d -r \
+     gs://gnomad-v4-data-pipeline/output/clinvar/clinvar_grch37_annotated_2.ht/ \
+     "gs://gnomad-browser-clinvar/grch37/gnomad_browser_clinvar_grch37_${NEW_CLINVAR_RELEASE_DATE}_release.ht"
+   ```
+
+   GRCh38 - overwrite the `..._latest.ht` table, create a date stamped table (`..._YYYY-MM-DD_release.ht`
 
    ```
-   gsutil -u gnomadev -m rsync -r \
+   gsutil -u exac-gnomad -m rsync -d -r \
      gs://gnomad-v4-data-pipeline/output/clinvar/clinvar_grch38_annotated_2.ht/ \
-     gs://gnomad-browser-clinvar/gnomad_clinvar_grch38.ht
+     gs://gnomad-browser-clinvar/grch38/gnomad_browser_clinvar_grch38_latest.ht
+   ```
+
+   ```
+   gsutil -u exac-gnomad -m rsync -d -r \
+     gs://gnomad-v4-data-pipeline/output/clinvar/clinvar_grch38_annotated_2.ht/ \
+     "gs://gnomad-browser-clinvar/grch38/gnomad_browser_clinvar_grch38_${NEW_CLINVAR_RELEASE_DATE}_release.ht"
    ```


### PR DESCRIPTION
Updates docs:
- Adds instructions for backup of ClinVar to public bucket
- Uses new custom init script to avoid needing us-central infra to run VEP85 on our GRCh37 ClinVar data

Resolves: #1778 
- Adds ClinVar cadence update to `vep` (gnomAD annotations help text)
- Changes wording on ClinVar HTs help text, clarify update cadence, note how to find old ClinVar releases
- Updates Data page link for new Data path for latest ClinVar files
- Adds note on Data page to check out dedicated help page to access older data

Related PR:
https://github.com/broadinstitute/gnomad-browser-team/pull/114
- The above PR describes the new `init.sh` scripts, and keeps a backup of those files in that repo