### PR TITLE
Add docs for playwright tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,6 +118,32 @@ pnpm jest
 
 To run only tests for one component, use `pnpm jest --projects browser` or `pnpm jest --projects graphql-api`.
 
+[Playwright](https://playwright.dev) is used for a set of minimal e2e tests as a sanity check before promoting off color deployments to production.
+
+To run the playwright tests, use:
+
+```
+GNOMAD_API_URL=<YOUR_URL>/api pnpm start:browser
+```
+
+e.g., to run the tests against a locally running development backend:
+
+```
+GNOMAD_API_URL=http://localhost:8010/api pnpm start:browser
+```
+
+To do it for the ingress associated with a new `green` deployment
+
+```
+GNOMAD_API_URL="http://$(kubectl get ingress gnomad-ingress-demo-green -o jsonpath='{.status.loadBalancer.ingress[0].ip}')/api" pnpm test:playwright
+```
+
+For blue:
+
+```
+GNOMAD_API_URL="http://$(kubectl get ingress gnomad-ingress-demo-blue -o jsonpath='{.status.loadBalancer.ingress[0].ip}')/api" pnpm test:playwright
+```
+
 ## Updating dependencies
 
 Images for the Docker Compose development environment need to be rebuilt after updating dependencies.

--- a/deploy/docs/Deployment.md
+++ b/deploy/docs/Deployment.md
@@ -302,6 +302,12 @@ The production gnomad browser uses a [blue/green deployment](https://martinfowle
 
      It typically takes ~5 minutes for the IP to resolve to the new deployment
 
+   - Run the minimal Playwright e2e tests against this deployment:
+
+     ```
+     GNOMAD_API_URL="http://$(kubectl get ingress gnomad-ingress-demo-<DEPLOYMENT_NAME> -o jsonpath='{.status.loadBalancer.ingress[0].ip}')/api" pnpm test:playwright
+     ```
+
    - Clean up the ingress when you no longer need it with:
 
      ```
@@ -325,7 +331,7 @@ The production gnomad browser uses a [blue/green deployment](https://martinfowle
     - It is typically useful to leave the old deployment up for a few days, as it makes a rollback very quick to perform. Once it is clear the new deployment is stable, the old deployment can safely be taken down.
 
       ```
-      ./deployctl deployments delete <old-deployment-name>
+      ./deployctl deployments delete <OLD_DEPLOYMENT_NAME>
       ```
 
 **Where:**

--- a/tests/e2e/RegionPage.playwright.spec.ts
+++ b/tests/e2e/RegionPage.playwright.spec.ts
@@ -14,7 +14,7 @@ test.describe('Region page', () => {
     test('region query', async () => {
       await expect(page.getByText('Loading region')).toHaveCount(0)
       await expect(
-        page.getByText('1-55050934-55053465ChangeDatasetgnomAD v4.1.0GRCh38gnomAD v4.1.0807,162')
+        page.getByText('1-55050934-55053465ChangeDatasetgnomAD v4.1.1GRCh38gnomAD v4.1.1807,162')
       ).toBeVisible({ timeout: 20_000 })
     })
 


### PR DESCRIPTION
I normally use these (admittedly very minimal) test when I'm doing a new gnomAD deployment to prod, but I realized they're not really mentioned anywhere.

Using a variable, its very easy to point them against a newly stood up `blue/green` deployment, to have them run against that before running `./deployctl production update ...`.

They don't do a whole lot, they really just make sure that the major portions of the big 4 pages render without crashing (no interaction, etc), but still, this is more than nothing and I like them for what they are.

Example output:
```
❯ GNOMAD_API_URL="http://$(kubectl get ingress gnomad-ingress-demo-green -o jsonpath='{.status.loadBalancer.ingress[0].ip}')/api" pnpm test:playwright

...
...


Running 13 tests using 1 worker

  ✓  1 [chromium] › GenePage.playwright.spec.ts:18:9 › Gene page › v4 › gene query (401ms)
  ✓  2 [chromium] › GenePage.playwright.spec.ts:26:9 › Gene page › v4 › coverage query (362ms)
  ✓  3 [chromium] › GenePage.playwright.spec.ts:36:9 › Gene page › v4 › variants query (414ms)
  ✓  4 [chromium] › RegionPage.playwright.spec.ts:14:9 › Region page › v4 › region query (383ms)
  ✓  5 [chromium] › RegionPage.playwright.spec.ts:21:9 › Region page › v4 › coverage query (121ms)
  ✓  6 [chromium] › RegionPage.playwright.spec.ts:30:9 › Region page › v4 › variants query (461ms)
  ✓  7 [chromium] › StructuralVariantRegionPage.playwright.spec.ts:15:9 › Structural variant region page › v4 › region query (388ms)
  ✓  8 [chromium] › StructuralVariantRegionPage.playwright.spec.ts:22:9 › Structural variant region page › v4 › coverage query (119ms)
  ✓  9 [chromium] › StructuralVariantRegionPage.playwright.spec.ts:31:9 › Structural variant region page › v4 › variants query (6ms)
  ✓  10 [chromium] › TranscriptPage.playwright.spec.ts:16:9 › Transcript page › v4 › transcript query (398ms)
  ✓  11 [chromium] › TranscriptPage.playwright.spec.ts:24:9 › Transcript page › v4 › coverage query (139ms)
  ✓  12 [chromium] › TranscriptPage.playwright.spec.ts:34:9 › Transcript page › v4 › variants query (558ms)
  ✓  13 [chromium] › VariantPage.playwright.spec.ts:4:7 › Variant page › v4 renders without crashes (928ms)

  13 passed (17.0s)

```