### PR TITLE
Fix variant count y-axis label

### DIFF
--- a/browser/src/StatsPage/StatsPage.tsx
+++ b/browser/src/StatsPage/StatsPage.tsx
@@ -370,7 +370,7 @@ const StatsPage = () => {
                 height={400}
                 formatTooltip={DiversityBarGraphTooltip}
                 xLabel=""
-                yLabel="Number of samples"
+                yLabel="Number of variants"
                 displayNumbers={false}
               />
             </DiversityBarGraph>

--- a/browser/src/StatsPage/__snapshots__/StatsPage.spec.tsx.snap
+++ b/browser/src/StatsPage/__snapshots__/StatsPage.spec.tsx.snap
@@ -6951,7 +6951,7 @@ exports[`Stats Page has no unexpected changes 1`] = `
                             dy="0em"
                             x={-180}
                           >
-                            Number of samples
+                            Number of variants
                           </tspan>
                         </text>
                       </svg>


### PR DESCRIPTION
Fixes #1784

## Summary
- Updates the y-axis label on the non-synonymous coding variant count chart from `Number of samples` to `Number of variants`.
- Updates the matching StatsPage Jest snapshot.
- Leaves chart data and rendering logic unchanged.

## Validation
- `corepack pnpm@8.14.3 install --frozen-lockfile` - passed; local Node v22.22.0 emitted the repository engine warning for `^18.17.1`.
- `corepack pnpm@8.14.3 jest --selectProjects browser --runTestsByPath browser/src/StatsPage/StatsPage.spec.tsx -u` - passed; 1 test passed and 1 snapshot updated.
- `corepack pnpm@8.14.3 eslint browser/src/StatsPage/StatsPage.tsx` - passed.
- `corepack pnpm@8.14.3 stylelint 'browser/src/StatsPage/StatsPage.tsx'` - passed with existing Browserslist/stylelint deprecation warnings.
- `corepack pnpm@8.14.3 ts-node ./browser/build/buildHelp.ts && corepack pnpm@8.14.3 exec tsc --noEmit` - passed.
- `corepack pnpm@8.14.3 jest --selectProjects browser` - passed; 67 suites, 1765 tests, and 1144 snapshots.
- `corepack pnpm@8.14.3 --dir browser build` - passed; webpack reported existing asset/entrypoint size and Browserslist warnings.
- `git diff --check` - passed.

## Notes
- Local validation used pinned pnpm 8.14.3 because pnpm 10 rejected the current lockfile format.
- A serial browser Jest attempt with `--runInBand` hit unrelated timeouts, so the CI-shaped browser project command above was used for full browser Jest validation.
