### PR TITLE
Update banner, publications

### DIFF
--- a/browser/src/App.tsx
+++ b/browser/src/App.tsx
@@ -72,12 +72,12 @@ const Banner = styled.div`
 
 const BANNER_CONTENT = (
   <>
-    Join the gnomAD team for a{' '}
-    <ExternalLink href="https://us02web.zoom.us/meeting/register/lqWS2j97QDG2AMUmm3Jkyw#/registration">
-      talk on May 11, 4-5PM ET
+    Missed our recent talk on common misconceptions about gnomAD?{' '}
+    <ExternalLink href="https://docs.google.com/document/d/1HbD2HjdOUVZCf_0-zgEQyjNkTmKUGeGOh_VYTHTv490/edit?tab=t.0#heading=h.t8hwrqi0tmmw">
+      Watch the recording
     </ExternalLink>{' '}
-    addressing common misconceptions about the resource — what it is, what metadata are available,
-    and the types of studies it includes.
+    covering what the resource is, what metadata are available, and the types of studies it
+    includes.
   </>
 )
 

--- a/browser/src/PublicationsPage.tsx
+++ b/browser/src/PublicationsPage.tsx
@@ -88,10 +88,31 @@ export default () => (
       There is no need to include us as authors on your manuscript, unless we contributed specific
       advice or analysis for your work.
     </p>
+    <br />
     <p>
-      Current flagship paper (<b>v3</b>):
+      Current flagship paper (<b>v4</b> Preprint):
       <List>
         <PaperCitation
+          authorList="Guez, J.*, Goodrich, J. K.*, Moldovan, M. A., Chao, K. R., Kar, P., Panchal, R., Wilson, M. W., Laricchia, K. M., Rohlicek, G., Biba, D., Marten, D., He, Q., Darnowsky, P. W., Grant, R., Weisburd, B., Baxter, S. M., Nadeau, J., Lu, W., Jahl, S., Parsa, S., Lamane, A., DiTroia, S., Fu, J., Zhao, X., Alarmani, E., Tolonen, C., Novod, S., Bryant, S., Stevens, C., Chapman, S. B., Cusick, C., Vittal, C., Gauthier, L. D., Goldstein, J. I., Goldstein, D., King, D., Poterba, T., Tiao, G., gnomAD Project Consortium, Tranchero, M., Lotter, W., MacArthur, D. G., Brand, H., Seplyarskiy, V., Koch, E., Talkowski, M. E., Solomonson, M., Neale, B. M., O'Donnell-Luria, A., Finucane, H. K., Sunyaev, S. R., Daly, M. J., Rehm, H. L., Samocha, K. E.†, Karczewski, K. J.†"
+          title="Integrating 730,947 exome sequences with clinical literature improves gene discovery."
+          journal="medRxiv [Preprint]"
+          issue="Mar 25"
+          year="2026"
+          doiLink="https://doi.org/10.64898/2026.03.23.26349081"
+          citationDownloadLink="https://www.medrxiv.org/highwire/citation/1182884/reference-manager"
+          pmid="41929314"
+          pmcid="PMC13042128"
+        />
+        * contributed equally
+        <br />† contributed equally
+      </List>
+    </p>{' '}
+    <br />
+    <p>
+      Previous flagship papers:
+      <List>
+        <PaperCitation
+          prefix="v3"
           authorList="Chen, S.*, Francioli, L. C.*, Goodrich, J. K., Collins, R. L., Kanai, M., Wang, Q.,
               Alföldi, J., Watts, N. A., Vittal, C., Gauthier, L. D., Poterba, T., Wilson, M. W.,
               Tarasova, Y., Phu, W., Grant, R., Yohannes, M. T., Koenig, Z., Farjoun, Y., Banks, E.,
@@ -112,9 +133,6 @@ export default () => (
         * contributed equally
         <br />† contributed equally
       </List>
-    </p>{' '}
-    <p>
-      Previous flagship papers:
       <List>
         <PaperCitation
           prefix="v2"
@@ -150,6 +168,7 @@ export default () => (
         * contributed equally
       </List>
     </p>
+    <br />
     <p>
       Remaining publications:
       <List>

--- a/browser/src/StatsPage/StatsPage.tsx
+++ b/browser/src/StatsPage/StatsPage.tsx
@@ -370,7 +370,7 @@ const StatsPage = () => {
                 height={400}
                 formatTooltip={DiversityBarGraphTooltip}
                 xLabel=""
-                yLabel="Number of samples"
+                yLabel="Number of variants"
                 displayNumbers={false}
               />
             </DiversityBarGraph>

--- a/browser/src/StatsPage/__snapshots__/StatsPage.spec.tsx.snap
+++ b/browser/src/StatsPage/__snapshots__/StatsPage.spec.tsx.snap
@@ -6951,7 +6951,7 @@ exports[`Stats Page has no unexpected changes 1`] = `
                             dy="0em"
                             x={-180}
                           >
-                            Number of samples
+                            Number of variants
                           </tspan>
                         </text>
                       </svg>

--- a/browser/src/__snapshots__/PublicationsPage.spec.tsx.snap
+++ b/browser/src/__snapshots__/PublicationsPage.spec.tsx.snap
@@ -112,12 +112,13 @@ exports[`Publications Page has no unexpected changes 1`] = `
   <p>
     There is no need to include us as authors on your manuscript, unless we contributed specific advice or analysis for your work.
   </p>
+  <br />
   <p>
     Current flagship paper (
     <b>
-      v3
+      v4
     </b>
-    ):
+     Preprint):
     <ul
       className="c5"
     >
@@ -127,6 +128,69 @@ exports[`Publications Page has no unexpected changes 1`] = `
         <cite
           className="c7"
         >
+          Guez, J.*, Goodrich, J. K.*, Moldovan, M. A., Chao, K. R., Kar, P., Panchal, R., Wilson, M. W., Laricchia, K. M., Rohlicek, G., Biba, D., Marten, D., He, Q., Darnowsky, P. W., Grant, R., Weisburd, B., Baxter, S. M., Nadeau, J., Lu, W., Jahl, S., Parsa, S., Lamane, A., DiTroia, S., Fu, J., Zhao, X., Alarmani, E., Tolonen, C., Novod, S., Bryant, S., Stevens, C., Chapman, S. B., Cusick, C., Vittal, C., Gauthier, L. D., Goldstein, J. I., Goldstein, D., King, D., Poterba, T., Tiao, G., gnomAD Project Consortium, Tranchero, M., Lotter, W., MacArthur, D. G., Brand, H., Seplyarskiy, V., Koch, E., Talkowski, M. E., Solomonson, M., Neale, B. M., O'Donnell-Luria, A., Finucane, H. K., Sunyaev, S. R., Daly, M. J., Rehm, H. L., Samocha, K. E.†, Karczewski, K. J.†
+           
+           
+          Integrating 730,947 exome sequences with clinical literature improves gene discovery.
+           
+          <em>
+            medRxiv [Preprint]
+          </em>
+          . Mar 25,  (2026).
+          <span>
+            <a
+              className="c4"
+              href="https://doi.org/10.64898/2026.03.23.26349081"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+               
+              https://doi.org/10.64898/2026.03.23.26349081
+            </a>
+             
+          </span>
+          PMID: 
+          41929314
+          <span>
+             PMCID: 
+            PMC13042128
+          </span>
+          <div>
+            <a
+              className="c4"
+              href="https://www.medrxiv.org/highwire/citation/1182884/reference-manager"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Download citation
+            </a>
+             
+          </div>
+        </cite>
+      </li>
+      * contributed equally
+      <br />
+      † contributed equally
+    </ul>
+  </p>
+   
+  <br />
+  <p>
+    Previous flagship papers:
+    <ul
+      className="c5"
+    >
+      <li
+        className="c6"
+      >
+        <cite
+          className="c7"
+        >
+          <b>
+            v3
+          </b>
+          :
+           
           Chen, S.*, Francioli, L. C.*, Goodrich, J. K., Collins, R. L., Kanai, M., Wang, Q., Alföldi, J., Watts, N. A., Vittal, C., Gauthier, L. D., Poterba, T., Wilson, M. W., Tarasova, Y., Phu, W., Grant, R., Yohannes, M. T., Koenig, Z., Farjoun, Y., Banks, E., Donnelly, S., Gabriel, S., Gupta, N., Ferriera, S., Tolonen, C., Novod, S., Bergelson, L., Roazen, D., Ruano-Rubio, V., Covarrubias, M., Llanwarne, C., Petrillo, N., Wade, G., Jeandet, T., Munshi, R., Tibbetts, K., Genome Aggregation Database (gnomAD) Consortium, O’Donnell-Luria, A., Solomonson, M., Seed, C., Martin, A. R., Talkowski, M. E., Rehm, H. L., Daly, M. J., Tiao, G., Neale, B. M.†, MacArthur, D. G.† & Karczewski, K. J.
            
            
@@ -167,10 +231,6 @@ exports[`Publications Page has no unexpected changes 1`] = `
       <br />
       † contributed equally
     </ul>
-  </p>
-   
-  <p>
-    Previous flagship papers:
     <ul
       className="c5"
     >
@@ -271,6 +331,7 @@ exports[`Publications Page has no unexpected changes 1`] = `
       * contributed equally
     </ul>
   </p>
+  <br />
   <p>
     Remaining publications:
     <ul


### PR DESCRIPTION
Resolves #1877,
Resolves #1868,
Resolves #1784 

- changes banner to advertise upcoming talk to instead point to recorded talk
- update publication page to have v4 preprint as flagship paper, move v3 paper to 'previous flagship papers'
