### PR TITLE
Use ES aliases in production again

### DIFF
--- a/deploy/docs/ElasticsearchConnection.md
+++ b/deploy/docs/ElasticsearchConnection.md
@@ -1,5 +1,7 @@
 # Connecting to Elasticsearch
 
+- If not at the Broad, VPN to the Broad's network
+
 - Forward local port to Elasticsearch service.
 
   ```
@@ -19,6 +21,28 @@
   ```
   curl -u "elastic:$ELASTICSEARCH_PASSWORD" http://localhost:9200/_cluster/health
   ```
+
+## Using the Kibana UI to connect to Elasticsearch
+
+- If not at the Broad, VPN to the Broad's network
+
+- Forward local port to Kibana service.
+
+  ```
+  kubectl port-forward service/gnomad-kb-http 5601:5601
+  ```
+
+- Navigate to `https://localhost:5601`
+
+  - Note the `https` in the URL, even when using localhost this is required
+
+  - Some browsers (e.g. Chromium based ones) warn about an unsecure connection, bypass this as it's our own service
+
+- Log in with the elastic username/password
+
+  - Username: `elastic`
+
+  - Password: obtained from the K8S secret: `ELASTICSEARCH_PASSWORD=$(./deployctl elasticsearch get-password)`
 
 ## Connecting to Elasticsearch from a Dataproc cluster
 

--- a/graphql-api/src/queries/gene-queries.ts
+++ b/graphql-api/src/queries/gene-queries.ts
@@ -5,7 +5,7 @@ import { catchNotFound } from '../elasticsearch'
 
 const GENE_INDICES = {
   GRCh37: 'genes_grch37',
-  GRCh38: 'genes_grch38-2026-03-25--21-10',
+  GRCh38: 'genes_grch38',
 }
 
 const _fetchGeneById = async (esClient: any, geneId: any, referenceGenome: any) => {

--- a/graphql-api/src/queries/short-tandem-repeat-queries.ts
+++ b/graphql-api/src/queries/short-tandem-repeat-queries.ts
@@ -4,8 +4,8 @@ import { fetchAllSearchResults } from './helpers/elasticsearch-helpers'
 import { catchNotFound } from '../elasticsearch'
 
 const SHORT_TANDEM_REPEAT_INDICES = {
-  gnomad_r3: 'gnomad_v3_short_tandem_repeats-2025-03-17--19-04',
-  gnomad_r4: 'gnomad_v3_short_tandem_repeats-2025-03-17--19-04',
+  gnomad_r3: 'gnomad_v3_short_tandem_repeats',
+  gnomad_r4: 'gnomad_v3_short_tandem_repeats',
 }
 
 const SUMMARY_FIELDS = [

--- a/graphql-api/src/queries/transcript-queries.ts
+++ b/graphql-api/src/queries/transcript-queries.ts
@@ -2,7 +2,7 @@ import { catchNotFound } from '../elasticsearch'
 
 const TRANSCRIPT_INDICES = {
   GRCh37: 'transcripts_grch37',
-  GRCh38: 'transcripts_grch38-2026-03-25--21-11',
+  GRCh38: 'transcripts_grch38',
 }
 
 export const fetchTranscriptById = async (es: any, transcriptId: any, referenceGenome: any) => {

--- a/graphql-api/src/queries/variant-datasets/gnomad-v4-variant-queries.ts
+++ b/graphql-api/src/queries/variant-datasets/gnomad-v4-variant-queries.ts
@@ -17,7 +17,7 @@ import { getFlagsForContext } from './shared/flags'
 import { getConsequenceForContext } from './shared/transcriptConsequence'
 import largeGenes from '../helpers/large-genes'
 
-const GNOMAD_V4_VARIANT_INDEX = 'gnomad_v4_variants-2026-03-25--21-20'
+const GNOMAD_V4_VARIANT_INDEX = 'gnomad_v4_variants'
 
 type Subset = 'all' | 'non_ukb'
 


### PR DESCRIPTION
Over time, and sometimes with demos that are long running, some queries against the ES db end up pointing to an index, rather than an alias, which we normally use.

This PR updates the queries that currently use indices to use aliases instead. It is accompanied by documentation that shows the aliases were updated to point to the same indices.

This is in prep to removing the old gnomAD v4 Variant indice, that is no longer in use, and is quite large (~1.7tb).


Relevant updated ES aliases:

```
curl -u "elastic:$ELASTICSEARCH_PASSWORD" "http://localhost:9200/_cat/aliases/*,-.*?pretty&v=true&s=index:asc"
alias                                index                                                  filter routing.index routing.search is_write_index
genes_grch38                         genes_grch38-2026-03-25--21-10                         -      -             -              -
gnomad_v3_short_tandem_repeats       gnomad_v3_short_tandem_repeats-2025-03-17--19-04       -      -             -              -
gnomad_v4_variants                   gnomad_v4_variants-2026-03-25--21-20                   -      -             -              -
transcripts_grch38                   transcripts_grch38-2026-03-25--21-11                   -      -             -              -
```

All ES aliases, as of this PR

```
curl -u "elastic:$ELASTICSEARCH_PASSWORD" "http://localhost:9200/_cat/aliases/*,-.*?pretty&v=true&s=index:asc"
alias                                index                                                  filter routing.index routing.search is_write_index
clinvar_grch37_variants              clinvar_grch37_variants-2026-05-06--21-49              -      -             -              -
clinvar_grch38_variants              clinvar_grch38_variants-2026-05-06--21-54              -      -             -              -
exac_exome_coverage                  exac_exome_coverage-2023-01-25--17-25                  -      -             -              -
exac_variants                        exac_variants-2023-01-25--17-21                        -      -             -              -
genes_grch37                         genes_grch37-2024-11-15--15-23                         -      -             -              -
genes_grch38                         genes_grch38-2026-03-25--21-10                         -      -             -              -
gnomad_structural_variants_v2        gnomad_structural_variants_v2-2023-01-24--20-26        -      -             -              -
gnomad_structural_variants_v3        gnomad_structural_variants_v3-2024-06-21--18-51        -      -             -              -
gnomad_v2_exome_coverage             gnomad_v2_exome_coverage-2023-01-25--14-16             -      -             -              -
gnomad_v2_genome_coverage            gnomad_v2_genome_coverage-2023-01-25--14-21            -      -             -              -
gnomad_v2_lof_curation_results       gnomad_v2_lof_curation_results-2024-06-17--19-35       -      -             -              -
gnomad_v2_mnvs                       gnomad_v2_mnvs-2023-01-25--17-05                       -      -             -              -
gnomad_v2_variant_cooccurrence       gnomad_v2_variant_cooccurrence-2023-01-25--17-06       -      -             -              -
gnomad_v2_variants                   gnomad_v2_variants-2023-01-24--20-27                   -      -             -              -
gnomad_v3_genome_coverage            gnomad_v3_genome_coverage-2023-01-24--18-50            -      -             -              -
gnomad_v3_genomic_constraint_regions gnomad_v3_genomic_constraint_regions-2023-02-01--20-17 -      -             -              -
gnomad_v3_local_ancestry             gnomad_v3_local_ancestry-2024-10-11--20-51             -      -             -              -
gnomad_v3_mitochondrial_coverage     gnomad_v3_mitochondrial_coverage-2023-02-01--20-19     -      -             -              -
gnomad_v3_mitochondrial_variants     gnomad_v3_mitochondrial_variants-2023-01-24--20-21     -      -             -              -
gnomad_v3_short_tandem_repeats       gnomad_v3_short_tandem_repeats-2025-03-17--19-04       -      -             -              -
gnomad_v3_variants                   gnomad_v3_variants-2023-01-23--18-17                   -      -             -              -
gnomad_v4_cnvs                       gnomad_v4_cnvs-2024-04-24--20-12                       -      -             -              -
gnomad_v4_exome_coverage             gnomad_v4_exome_coverage-2023-10-28--11-24             -      -             -              -
gnomad_v4_lof_curation_results       gnomad_v4_lof_curation_results-2025-09-29--21-33       -      -             -              -
gnomad_v4_variants                   gnomad_v4_variants-2026-03-25--21-20                   -      -             -              -
liftover                             liftover-2023-10-29--22-02                             -      -             -              -
transcripts_grch37                   transcripts_grch37-2023-10-30--13-03                   -      -             -              -
transcripts_grch38                   transcripts_grch38-2026-03-25--21-11                   -      -             -              -
```








This PR accompanies a clean up of older indices that were no longer in use.
