### PR TITLE
Update Reads NGINX config to allow for HTTP/2

### DIFF
--- a/deploy/dockerfiles/reads/reads-server.dockerfile
+++ b/deploy/dockerfiles/reads/reads-server.dockerfile
@@ -3,5 +3,6 @@ FROM --platform=linux/amd64 nginx:stable-alpine
 COPY deploy/dockerfiles/reads/reads.nginx.conf /etc/nginx/reads.nginx.conf.template
 
 CMD REAL_IP_CONFIG=$([ -z "${PROXY_IPS:-}" ] || echo "$PROXY_IPS" | awk 'BEGIN { RS="," } { print "set_real_ip_from " $1 ";" }') \
-  envsubst "\$REAL_IP_CONFIG" < /etc/nginx/reads.nginx.conf.template > /etc/nginx/conf.d/default.conf && \
+  HTTP2_CONFIG=$([ "${ENABLE_HTTP2:-false}" = "true" ] && echo "http2 on;") \
+  envsubst '$REAL_IP_CONFIG $HTTP2_CONFIG' < /etc/nginx/reads.nginx.conf.template > /etc/nginx/conf.d/default.conf && \
   nginx -g "daemon off;"

--- a/deploy/dockerfiles/reads/reads.nginx.conf
+++ b/deploy/dockerfiles/reads/reads.nginx.conf
@@ -18,7 +18,9 @@ log_format json_combined escape=json
 server {
   listen 80 default_server;
 
-  http2 on; # Enforces HTTP/2 cleartext (h2c) for Cloud Run traffic
+  # When enabled, enforces HTTP/2 cleartext (h2c)
+  # NOTE: HTTP/2 required for Cloud Run traffic w/request & response sizes larger than 32MiB
+  $HTTP2_CONFIG
 
   access_log /var/log/nginx/access.log json_combined;
 

--- a/deploy/dockerfiles/reads/reads.nginx.conf
+++ b/deploy/dockerfiles/reads/reads.nginx.conf
@@ -18,6 +18,8 @@ log_format json_combined escape=json
 server {
   listen 80 default_server;
 
+  http2 on; # Enforces HTTP/2 cleartext (h2c) for Cloud Run traffic
+
   access_log /var/log/nginx/access.log json_combined;
 
   # Use relative URLs for redirects


### PR DESCRIPTION
This PR is part of work for https://github.com/broadinstitute/gnomad-browser-team/issues/116.

We have an NGINX container for the Reads server, and it currently uses HTTP/1.1 by default. This config causes a problem for running Reads in GCP Cloud Run, because [Cloud Run service payloads are capped at 32MiB](https://docs.cloud.google.com/run/quotas#request_limits). Reads responses can be much larger than the cap.

Seeing that HTTP/2 request sizes are not limited in the docs, we hand-tested running Reads on Cloud Run with HTTP/2, and confirmed that responses are also not subject to the size cap.

This PR updates the Reads NGINX container config to allow using HTTP/2, so that we can then deploy the Reads service to prod using Cloud Run, making our new K8s-less infrastructure simpler and easier to manage.

Setting the ENABLE_HTTP2 env var at container run time will set the HTTP/2 config in NGINX to `on`. Using this mechanism keeps everything backwards-compatible in case other Browser deployments are not using HTTP/2.
