### PR TITLE
chore: `black` -> `ruff format`

### DIFF
--- a/.github/workflows/data-pipeline-ci.yml
+++ b/.github/workflows/data-pipeline-ci.yml
@@ -32,7 +32,7 @@ jobs:
           pip install wheel
           pip install -r data-pipeline/requirements.txt
       - name: Check formatting
-        run: black --check data-pipeline/src/data_pipeline
+        run: ruff format --check data-pipeline/src/data_pipeline
       - name: Run Ruff
         run: ruff check data-pipeline/src/data_pipeline
       - name: Run Pyright

--- a/.github/workflows/deploy-scripts-ci.yml
+++ b/.github/workflows/deploy-scripts-ci.yml
@@ -33,6 +33,6 @@ jobs:
           pip install -r requirements-dev.txt
           pip install -r deploy/deployctl/requirements.txt
       - name: Check formatting
-        run: black --check deploy/deployctl
+        run: ruff format --check deploy/deployctl
       - name: Run Pylint
         run: pylint --disable=fixme deploy/deployctl

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,11 +7,10 @@ repos:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
-  - repo: https://github.com/psf/black
-    rev: 24.3.0 # This should be kept in sync with the version in requirements-dev.txt
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.17 # This should be kept in sync with the version in requirements-dev.txt
     hooks:
-      - id: black
-        language_version: python3
+      - id: ruff-format
         types: [python]
   - repo: local
     hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,10 +82,10 @@ See [data-pipeline/README.md](./data-pipeline/README.md).
 
 ## Conventions
 
-All code should formatted using either [Prettier](https://prettier.io/) for JavaScript or [Black](https://black.readthedocs.io/) for Python. To run these formatters, use:
+All code should formatted using either [Prettier](https://prettier.io/) for JavaScript or [Ruff](https://docs.astral.sh/ruff/formatter/) for Python. To run these formatters, use:
 
 - Prettier: `pnpm format`
-- Black: `black .`
+- Ruff: `ruff format .`
 
 If pre-commit hooks are installed, formatters will be automatically run on each commit.
 

--- a/data-pipeline/check.sh
+++ b/data-pipeline/check.sh
@@ -7,13 +7,13 @@ find . -name "*.pyc" -exec rm -f {} +
 echo "┏━━━ Running pyright ━━━━━━━━━━━━━━━━━━━"
 pyright
 
-echo "┏━━━ Running black ━━━━━━━━━━━━━━━━━━━"
-black src/data_pipeline
-black tests
+echo "┏━━━ Running ruff format ━━━━━━━━━━━━━━━━━━━"
+ruff format src/data_pipeline
+ruff format tests
 
 echo "┏━━━ Running ruff ━━━━━━━━━━━━━━━━━━━"
-ruff src/data_pipeline --fix
-ruff tests --fix
+ruff check src/data_pipeline --fix
+ruff check tests --fix
 
 echo "┏━━━ Running pytest ━━━━━━━━━━━━━━━━━━━"
 if [[ "$1" == "--mock-data" ]]; then

--- a/data-pipeline/pyproject.toml
+++ b/data-pipeline/pyproject.toml
@@ -1,8 +1,6 @@
-[tool.black]
-line-length = 120
-
 [tool.ruff]
 line-length = 120
+target-version = "py39"
 
 [tool.pyright]
 include = [

--- a/data-pipeline/requirements.txt
+++ b/data-pipeline/requirements.txt
@@ -6,5 +6,4 @@ attrs
 cattrs
 pytest
 ruff
-black
 pyright

--- a/data-pipeline/src/data_pipeline/data_types/pext.py
+++ b/data-pipeline/src/data_pipeline/data_types/pext.py
@@ -99,7 +99,7 @@ def prepare_base_level_pext(base_level_pext_path):
         **{
             renamed: hl.if_else(hl.is_missing(ds[original]) | hl.is_nan(ds[original]), hl.float(0), ds[original])
             for original, renamed in TISSUE_NAME_MAP.items()
-        }
+        },
     )
 
     ds = ds.order_by(ds.gene_id, hl.asc(ds.pos)).drop("locus")

--- a/data-pipeline/src/data_pipeline/data_types/variant/variant_id.py
+++ b/data-pipeline/src/data_pipeline/data_types/variant/variant_id.py
@@ -69,26 +69,28 @@ def compressed_variant_id(locus: hl.expr.LocusExpression, alleles: hl.expr.Array
     return hl.rbind(
         hl.len(alleles[0]),
         hl.len(alleles[1]),
-        lambda ref_len, alt_len: hl.case()
-        .when(
-            ref_len > alt_len,
-            normalized_contig(locus.contig)
-            + "-"
-            + hl.str(locus.position)
-            + "d"
-            + hl.str(ref_len - alt_len)
-            + "-"
-            + alleles[1],
-        )
-        .when(
-            ref_len < alt_len,
-            normalized_contig(locus.contig)
-            + "-"
-            + hl.str(locus.position)
-            + "i"
-            + hl.str(alt_len - ref_len)
-            + "-"
-            + _encode_allele(alleles[1]),
-        )
-        .default(variant_id(locus, alleles)),
+        lambda ref_len, alt_len: (
+            hl.case()
+            .when(
+                ref_len > alt_len,
+                normalized_contig(locus.contig)
+                + "-"
+                + hl.str(locus.position)
+                + "d"
+                + hl.str(ref_len - alt_len)
+                + "-"
+                + alleles[1],
+            )
+            .when(
+                ref_len < alt_len,
+                normalized_contig(locus.contig)
+                + "-"
+                + hl.str(locus.position)
+                + "i"
+                + hl.str(alt_len - ref_len)
+                + "-"
+                + _encode_allele(alleles[1]),
+            )
+            .default(variant_id(locus, alleles))
+        ),
     )

--- a/data-pipeline/src/data_pipeline/datasets/clinvar.py
+++ b/data-pipeline/src/data_pipeline/datasets/clinvar.py
@@ -152,7 +152,7 @@ def _parse_variant(variant_element, tqdm_pbar=None):
                 variant["locations"] = {}
                 allele_element = variant_element.findall("./ClassifiedRecord/SimpleAllele")
                 if tqdm_pbar is not None:
-                    tqdm_pbar.set_postfix_str(f'Skipped AlleleID: {allele_element[0].attrib["AlleleID"]} (Chr: Un)')
+                    tqdm_pbar.set_postfix_str(f"Skipped AlleleID: {allele_element[0].attrib['AlleleID']} (Chr: Un)")
                 break
 
             variant["locations"][element.attrib["Assembly"]] = {
@@ -203,9 +203,7 @@ def parse_clinvar_xml_to_tsv(
 
         open_function = gzip.open if str(input_xml_path).endswith(".gz") else open
         with open_function(input_xml_path, "r") as xml_file:
-
             with open(input_xml_path, "rb") as raw_xml_file:
-
                 # make tqdm bar progress based of bytes processed
                 with tqdm.wrapattr(
                     raw_xml_file, "read", total=file_size, mininterval=5, unit="B", unit_scale=True

--- a/data-pipeline/src/data_pipeline/datasets/exac/exac_variants.py
+++ b/data-pipeline/src/data_pipeline/datasets/exac/exac_variants.py
@@ -335,11 +335,13 @@ def import_exac_vcf(path):
     ds = ds.annotate(
         info=ds.info.annotate(
             CSQ=ds.info.CSQ.map(
-                lambda s: s.replace("%3A", ":")
-                .replace("%3B", ";")
-                .replace("%3D", "=")
-                .replace("%25", "%")
-                .replace("%2C", ",")
+                lambda s: (
+                    s.replace("%3A", ":")
+                    .replace("%3B", ";")
+                    .replace("%3D", "=")
+                    .replace("%25", "%")
+                    .replace("%2C", ",")
+                )
             )
         )
     )

--- a/data-pipeline/src/data_pipeline/datasets/gnomad_sv_v3.py
+++ b/data-pipeline/src/data_pipeline/datasets/gnomad_sv_v3.py
@@ -214,9 +214,7 @@ def import_svs_from_vcfs(vcf_path):
         freq=ds.freq.annotate(
             hemizygote_count=hl.or_missing(
                 ds.type != "MCNV",
-                hl.if_else(
-                    ((ds.chrom == "X") | (ds.chrom == "Y")) & (ds.par == False), ds.info.N_HEMIALT_XY, 0
-                ),  # noqa: E712
+                hl.if_else(((ds.chrom == "X") | (ds.chrom == "Y")) & (ds.par == False), ds.info.N_HEMIALT_XY, 0),  # noqa: E712
             ),
             populations=hl.if_else(
                 ds.type != "MCNV",

--- a/data-pipeline/src/data_pipeline/datasets/gnomad_v2/gnomad_v2_mnvs.py
+++ b/data-pipeline/src/data_pipeline/datasets/gnomad_v2/gnomad_v2_mnvs.py
@@ -503,9 +503,11 @@ def prepare_gnomad_v2_mnvs(mnvs_path, three_bp_mnvs_path):
                 "n_individuals",
                 "other_constituent_snvs",
                 changes_amino_acids=hl.bind(
-                    lambda mnv_consequences, related_mnv_consequences: mnv_consequences.key_set()
-                    .union(related_mnv_consequences.key_set())
-                    .any(lambda gene_id: mnv_consequences.get(gene_id) != related_mnv_consequences.get(gene_id)),
+                    lambda mnv_consequences, related_mnv_consequences: (
+                        mnv_consequences.key_set()
+                        .union(related_mnv_consequences.key_set())
+                        .any(lambda gene_id: mnv_consequences.get(gene_id) != related_mnv_consequences.get(gene_id))
+                    ),
                     hl.dict(mnvs.consequences.map(lambda c: (c.gene_id, c.amino_acids.lower()))),
                     hl.dict(related_mnv.consequences.map(lambda c: (c.gene_id, c.amino_acids.lower()))),
                 ),

--- a/data-pipeline/src/data_pipeline/datasets/gnomad_v3/gnomad_v3_variants.py
+++ b/data-pipeline/src/data_pipeline/datasets/gnomad_v3/gnomad_v3_variants.py
@@ -50,8 +50,7 @@ def prepare_gnomad_v3_variants(path):
     variants_by_locus = variants_by_locus.annotate(
         variant_ids=hl.struct(
             **{
-                subset
-                or "all": variants_by_locus.variants.filter(subset_filter(subset or "all")).map(
+                subset or "all": variants_by_locus.variants.filter(subset_filter(subset or "all")).map(
                     lambda variant: variant.variant_id
                 )
                 for subset in subsets
@@ -88,8 +87,7 @@ def prepare_gnomad_v3_variants(path):
         genome=hl.struct(
             freq=hl.struct(
                 **{
-                    subset
-                    or "all": hl.struct(
+                    subset or "all": hl.struct(
                         ac=freq(ds, subset=subset).AC,
                         ac_raw=freq(ds, subset=subset, raw=True).AC,
                         an=freq(ds, subset=subset).AN,
@@ -130,8 +128,7 @@ def prepare_gnomad_v3_variants(path):
         genome=ds.genome.annotate(
             freq=ds.genome.freq.annotate(
                 **{
-                    subset
-                    or "all": ds.genome.freq[subset or "all"].annotate(
+                    subset or "all": ds.genome.freq[subset or "all"].annotate(
                         populations=hl.if_else(
                             ds.genome.freq[subset or "all"].ac_raw == 0,
                             hl.empty_array(ds.genome.freq[subset or "all"].populations.dtype.element_type),

--- a/data-pipeline/src/data_pipeline/datasets/gnomad_v4/gnomad_v4_variants.py
+++ b/data-pipeline/src/data_pipeline/datasets/gnomad_v4/gnomad_v4_variants.py
@@ -51,8 +51,7 @@ def prepare_gnomad_v4_variants_helper(input_path: str, exomes_or_genomes: str):
     variants_by_locus = variants_by_locus.annotate(
         variant_ids=hl.struct(
             **{
-                subset
-                or "all": variants_by_locus.variants.filter(subset_filter(subset or "all")).map(
+                subset or "all": variants_by_locus.variants.filter(subset_filter(subset or "all")).map(
                     lambda variant: variant.variant_id
                 )
                 for subset in subsets
@@ -91,8 +90,7 @@ def prepare_gnomad_v4_variants_helper(input_path: str, exomes_or_genomes: str):
         gnomad=hl.struct(
             freq=hl.struct(
                 **{
-                    subset
-                    or "all": hl.struct(
+                    subset or "all": hl.struct(
                         ac=freq(ds, subset=subset).AC,
                         ac_raw=freq(ds, subset=subset, raw=True).AC,
                         an=freq(ds, subset=subset).AN,
@@ -133,8 +131,7 @@ def prepare_gnomad_v4_variants_helper(input_path: str, exomes_or_genomes: str):
         gnomad=ds.gnomad.annotate(
             freq=ds.gnomad.freq.annotate(
                 **{
-                    subset
-                    or "all": ds.gnomad.freq[subset or "all"].annotate(
+                    subset or "all": ds.gnomad.freq[subset or "all"].annotate(
                         ancestry_groups=hl.if_else(
                             ds.gnomad.freq[subset or "all"].ac_raw == 0,
                             hl.empty_array(ds.gnomad.freq[subset or "all"].ancestry_groups.dtype.element_type),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,6 @@
-[tool.black]
-line-length = 120
-
 [tool.ruff]
 line-length = 120
+target-version = "py39"
 
 [tool.pylint.basic]
 # ds: frequently used name for a variable containing a Hail table

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,2 @@
-black==24.3.0  # This should be kept in sync with the version in .pre-commit-config.yaml
+ruff==0.15.17  # This should be kept in sync with the version in .pre-commit-config.yaml
 pylint==2.7.1


### PR DESCRIPTION
- Replaces `black` with `ruff format`
- Reasoning: it's faster, reduces number of dependencies, under active development.