### PR TITLE
perf: remove lodash `omit` calls

### DIFF
--- a/graphql-api/src/queries/clinvar-variant-queries.ts
+++ b/graphql-api/src/queries/clinvar-variant-queries.ts
@@ -1,4 +1,4 @@
-import { omit, throttle } from 'lodash'
+import { throttle } from 'lodash'
 
 import { withCache } from '../cache'
 import logger from '../logger'
@@ -151,8 +151,11 @@ const shapeVariantSummary = (context: any) => {
   return (variant: any) => {
     const transcriptConsequence = getConsequence(variant) || {}
 
+    // Destructure to drop fields we don't want to cache (cheaper than lodash.omit, which deep-clones)
+    const { transcript_consequences: _tc, ...variantRest } = variant
+
     return {
-      ...omit(variant, 'transcript_consequences'), // Omit full transcript consequences list to avoid caching it
+      ...variantRest, // Omit full transcript consequences list to avoid caching it
       transcript_consequence: transcriptConsequence,
     }
   }

--- a/graphql-api/src/queries/clinvar-variant-queries.ts
+++ b/graphql-api/src/queries/clinvar-variant-queries.ts
@@ -151,7 +151,8 @@ const shapeVariantSummary = (context: any) => {
   return (variant: any) => {
     const transcriptConsequence = getConsequence(variant) || {}
 
-    // Destructure to drop fields we don't want to cache (cheaper than lodash.omit, which deep-clones)
+    // Destructure to drop fields we don't want to cache. Cheaper than lodash.omit, which adds
+    // per-call overhead (path parsing, copying every key then deleting the omitted ones).
     const { transcript_consequences: _tc, ...variantRest } = variant
 
     return {

--- a/graphql-api/src/queries/mitochondrial-variant-datasets/gnomad-v3-mitochondrial-variant-queries.ts
+++ b/graphql-api/src/queries/mitochondrial-variant-datasets/gnomad-v3-mitochondrial-variant-queries.ts
@@ -1,4 +1,3 @@
-import { omit } from 'lodash'
 import { isRsId } from '@gnomad/identifiers'
 import { fetchAllSearchResults } from '../helpers/elasticsearch-helpers'
 import { mergeOverlappingRegions } from '../helpers/region-helpers'
@@ -80,8 +79,16 @@ const shapeMitochondrialVariantSummary = (context: any) => {
     const { variantFlags } = getFlagsForContext(context, variant)
     const flags = variantFlags.filter((f: any) => f !== 'nc_transcript')
 
+    // Destructure to drop fields we don't want to cache (cheaper than lodash.omit, which deep-clones)
+    const {
+      transcript_consequences: _tc,
+      locus: _locus,
+      alleles: _alleles,
+      ...variantRest
+    } = variant
+
     return {
-      ...omit(variant, 'transcript_consequences', 'locus', 'alleles'), // Omit full transcript consequences list to avoid caching it
+      ...variantRest, // Omit full transcript consequences list to avoid caching it
       reference_genome: 'GRCh38',
       chrom: variant.locus.contig.slice(3), // Remove "chr" prefix
       pos: variant.locus.position,

--- a/graphql-api/src/queries/mitochondrial-variant-datasets/gnomad-v3-mitochondrial-variant-queries.ts
+++ b/graphql-api/src/queries/mitochondrial-variant-datasets/gnomad-v3-mitochondrial-variant-queries.ts
@@ -79,7 +79,8 @@ const shapeMitochondrialVariantSummary = (context: any) => {
     const { variantFlags } = getFlagsForContext(context, variant)
     const flags = variantFlags.filter((f: any) => f !== 'nc_transcript')
 
-    // Destructure to drop fields we don't want to cache (cheaper than lodash.omit, which deep-clones)
+    // Destructure to drop fields we don't want to cache. Cheaper than lodash.omit, which adds
+    // per-call overhead (path parsing, copying every key then deleting the omitted ones).
     const {
       transcript_consequences: _tc,
       locus: _locus,

--- a/graphql-api/src/queries/variant-datasets/gnomad-v2-variant-queries.ts
+++ b/graphql-api/src/queries/variant-datasets/gnomad-v2-variant-queries.ts
@@ -1,5 +1,3 @@
-import { omit } from 'lodash'
-
 import { isRsId } from '@gnomad/identifiers'
 
 import { UserVisibleError } from '../../errors'
@@ -176,12 +174,17 @@ const shapeVariantSummary = (exomeSubset: any, genomeSubset: any, context: any) 
       genomeFilters.push('AC0')
     }
 
+    // Destructure to drop fields we don't want to cache (cheaper than lodash.omit, which deep-clones)
+    const { transcript_consequences: _tc, ...variantRest } = variant
+    const { freq: _exomeFreq, ...exomeRest } = variant.exome
+    const { freq: _genomeFreq, ...genomeRest } = variant.genome
+
     return {
-      ...omit(variant, 'transcript_consequences'), // Omit full transcript consequences list to avoid caching it
+      ...variantRest, // Omit full transcript consequences list to avoid caching it
       reference_genome: 'GRCh37',
       exome: variant.exome.freq[exomeSubset].ac_raw
         ? {
-            ...omit(variant.exome, 'freq'), // Omit freq field to avoid caching extra copy of frequency information
+            ...exomeRest, // Omit freq field to avoid caching extra copy of frequency information
             ...variant.exome.freq[exomeSubset],
             populations: variant.exome.freq[exomeSubset].populations.filter(
               (pop: any) => !(pop.id.includes('_') || pop.id === 'XX' || pop.id === 'XY')
@@ -192,7 +195,7 @@ const shapeVariantSummary = (exomeSubset: any, genomeSubset: any, context: any) 
         : null,
       genome: variant.genome.freq[genomeSubset].ac_raw
         ? {
-            ...omit(variant.genome, 'freq'), // Omit freq field to avoid caching extra copy of frequency information
+            ...genomeRest, // Omit freq field to avoid caching extra copy of frequency information
             ...variant.genome.freq[genomeSubset],
             populations: variant.genome.freq[genomeSubset].populations.filter(
               (pop: any) => !(pop.id.includes('_') || pop.id === 'XX' || pop.id === 'XY')

--- a/graphql-api/src/queries/variant-datasets/gnomad-v2-variant-queries.ts
+++ b/graphql-api/src/queries/variant-datasets/gnomad-v2-variant-queries.ts
@@ -174,7 +174,8 @@ const shapeVariantSummary = (exomeSubset: any, genomeSubset: any, context: any) 
       genomeFilters.push('AC0')
     }
 
-    // Destructure to drop fields we don't want to cache (cheaper than lodash.omit, which deep-clones)
+    // Destructure to drop fields we don't want to cache. Cheaper than lodash.omit, which adds
+    // per-call overhead (path parsing, copying every key then deleting the omitted ones).
     const { transcript_consequences: _tc, ...variantRest } = variant
     const { freq: _exomeFreq, ...exomeRest } = variant.exome
     const { freq: _genomeFreq, ...genomeRest } = variant.genome

--- a/graphql-api/src/queries/variant-datasets/gnomad-v3-variant-queries.ts
+++ b/graphql-api/src/queries/variant-datasets/gnomad-v3-variant-queries.ts
@@ -207,7 +207,8 @@ const shapeVariantSummary = (subset: any, context: any) => {
       filters.push('AC0')
     }
 
-    // Destructure to drop fields we don't want to cache (cheaper than lodash.omit, which deep-clones)
+    // Destructure to drop fields we don't want to cache. Cheaper than lodash.omit, which adds
+    // per-call overhead (path parsing, copying every key then deleting the omitted ones).
     const {
       transcript_consequences: _tc,
       locus: _locus,

--- a/graphql-api/src/queries/variant-datasets/gnomad-v3-variant-queries.ts
+++ b/graphql-api/src/queries/variant-datasets/gnomad-v3-variant-queries.ts
@@ -1,5 +1,3 @@
-import { omit } from 'lodash'
-
 import { isRsId } from '@gnomad/identifiers'
 
 import { UserVisibleError } from '../../errors'
@@ -209,8 +207,17 @@ const shapeVariantSummary = (subset: any, context: any) => {
       filters.push('AC0')
     }
 
+    // Destructure to drop fields we don't want to cache (cheaper than lodash.omit, which deep-clones)
+    const {
+      transcript_consequences: _tc,
+      locus: _locus,
+      alleles: _alleles,
+      ...variantRest
+    } = variant
+    const { freq: _genomeFreq, ...genomeRest } = variant.genome
+
     return {
-      ...omit(variant, 'transcript_consequences', 'locus', 'alleles'), // Omit full transcript consequences list to avoid caching it
+      ...variantRest, // Omit full transcript consequences list to avoid caching it
       reference_genome: 'GRCh38',
       chrom: variant.locus.contig.slice(3), // Remove "chr" prefix
       pos: variant.locus.position,
@@ -218,7 +225,7 @@ const shapeVariantSummary = (subset: any, context: any) => {
       alt: variant.alleles[1],
       exome: null,
       genome: {
-        ...omit(variant.genome, 'freq'), // Omit freq field to avoid caching extra copy of frequency information
+        ...genomeRest, // Omit freq field to avoid caching extra copy of frequency information
         ...variant.genome.freq[subset],
         populations: variant.genome.freq[subset].populations.filter(
           (pop: any) => !(pop.id.includes('_') || pop.id === 'XX' || pop.id === 'XY')

--- a/graphql-api/src/queries/variant-datasets/gnomad-v4-variant-queries.ts
+++ b/graphql-api/src/queries/variant-datasets/gnomad-v4-variant-queries.ts
@@ -323,7 +323,8 @@ const shapeVariantSummary = (subset: Subset, context: any) => {
 
     const inSilicoPredictorsList = createInSilicoPredictorsList(variant)
 
-    // Destructure to drop fields we don't want to cache (cheaper than lodash.omit, which deep-clones)
+    // Destructure to drop fields we don't want to cache. Cheaper than lodash.omit, which adds
+    // per-call overhead (path parsing, copying every key then deleting the omitted ones).
     const {
       transcript_consequences: _tc,
       locus: _locus,

--- a/graphql-api/src/queries/variant-datasets/gnomad-v4-variant-queries.ts
+++ b/graphql-api/src/queries/variant-datasets/gnomad-v4-variant-queries.ts
@@ -1,5 +1,3 @@
-import { omit } from 'lodash'
-
 import { isRsId } from '@gnomad/identifiers'
 
 import { UserVisibleError } from '../../errors'
@@ -325,8 +323,22 @@ const shapeVariantSummary = (subset: Subset, context: any) => {
 
     const inSilicoPredictorsList = createInSilicoPredictorsList(variant)
 
+    // Destructure to drop fields we don't want to cache (cheaper than lodash.omit, which deep-clones)
+    const {
+      transcript_consequences: _tc,
+      locus: _locus,
+      alleles: _alleles,
+      ...variantRest
+    } = variant
+    const { freq: _exomeFreq, ...exomeRest } = variant.exome
+    const { ancestry_groups: _exomeAncestryGroups, ...exomeFreqRest } = variant.exome.freq[subset]
+    const { freq: _genomeFreq, ...genomeRest } = variant.genome
+    const { ancestry_groups: _genomeAncestryGroups, ...genomeFreqRest } = subsetGenomeFreq
+    const { freq: _jointFreq, ...jointRest } = variant.joint
+    const { ancestry_groups: _jointAncestryGroups, ...jointFreqRest } = subsetJointFreq
+
     return {
-      ...omit(variant, 'transcript_consequences', 'locus', 'alleles'), // Omit full transcript consequences list to avoid caching it
+      ...variantRest, // Omit full transcript consequences list to avoid caching it
       reference_genome: 'GRCh38',
       chrom: variant.locus.contig.slice(3), // Remove "chr" prefix
       pos: variant.locus.position,
@@ -334,8 +346,8 @@ const shapeVariantSummary = (subset: Subset, context: any) => {
       alt: variant.alleles[1],
       exome: hasExomeVariant
         ? {
-            ...omit(variant.exome, 'freq'), // Omit freq field to avoid caching extra copy of frequency information
-            ...omit(variant.exome.freq[subset], 'ancestry_groups'),
+            ...exomeRest, // Omit freq field to avoid caching extra copy of frequency information
+            ...exomeFreqRest,
             populations: variant.exome.freq[subset].ancestry_groups.filter(
               (pop: any) => !(pop.id.includes('_') || pop.id === 'XX' || pop.id === 'XY')
             ),
@@ -346,8 +358,8 @@ const shapeVariantSummary = (subset: Subset, context: any) => {
         : null,
       genome: hasGenomeVariant
         ? {
-            ...omit(variant.genome, 'freq'), // Omit freq field to avoid caching extra copy of frequency information
-            ...omit(subsetGenomeFreq, 'ancestry_groups'),
+            ...genomeRest, // Omit freq field to avoid caching extra copy of frequency information
+            ...genomeFreqRest,
             populations: variant.genome.freq.all.ancestry_groups.filter(
               (pop: any) => !(pop.id.includes('_') || pop.id === 'XX' || pop.id === 'XY')
             ),
@@ -356,8 +368,8 @@ const shapeVariantSummary = (subset: Subset, context: any) => {
         : null,
       joint: hasJointVariant
         ? {
-            ...omit(variant.joint, 'freq'),
-            ...omit(variant.joint.freq[subset], 'ancestry_groups'),
+            ...jointRest,
+            ...jointFreqRest,
             populations: variant.joint.freq[subset].ancestry_groups.filter(
               (pop: any) => !(pop.id.includes('_') || pop.id === 'XX' || pop.id === 'XY')
             ),


### PR DESCRIPTION
Some thoughts:
- JS object allocation is _expensive_!  Avoiding `lodash` is a strategy I've seen in the past:
- `omit` does not `clone`, but does several things:
```
1. flatRest arg packaging + baseFlatten
2. castPath/isKey per key (twice — once in step 1, once in baseUnset)
3. getAllKeysIn → prototype-chain walk
4. copyObject copying all N top-level keys (not just the kept ones)
5. delete on the few omitted keys

```
- Wrote a brief performance harness w/ 100k variants, which attempts to mimic the pattern.  `Isolated` tests the `omit` option in isolation, `Realistic` includes mimicked  `getFlagsForContext`, `createInSilicoPredictorsList`, `stripPops` etc.

```
┌───────────────┬───────────────┬──────────────┬──────────────────────┐
│  Measurement  │     omit      │ destructure  │        delta         │
├───────────────┼───────────────┼──────────────┼──────────────────────┤
│ (1) Isolated  │ 10.675 µs/var │ 1.517 µs/var │ 7.04× · 916 ms saved │
├───────────────┼───────────────┼──────────────┼──────────────────────┤
│ (2) Realistic │ 10.988 µs/var │ 1.613 µs/var │ 6.81× · 938 ms saved │
└───────────────┴───────────────┴──────────────┴──────────────────────┘
```
- A [relevant blog post](https://williaminfante.medium.com/replacing-lodash-omit-using-object-restructuring-and-the-spread-syntax-d7af1607a390) I found.

The performance impact in the harness is obviously a severe over estimate of the actual performance gain, as most of the latency exists in elastic & elsewhere, but I think this is an easy win.
