### PR TITLE
perf: a few more lightweight, risk-free JS optimizations

### DIFF
--- a/graphql-api/src/queries/coverage-queries.ts
+++ b/graphql-api/src/queries/coverage-queries.ts
@@ -171,23 +171,27 @@ export const _fetchCoverageForGene = async (esClient: any, datasetId: any, gene:
   // @ts-expect-error TS(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
   const genomeCoverageIndex = COVERAGE_INDICES[datasetId].genome
 
-  const exomeCoverage = exomeCoverageIndex
-    ? await fetchCoverage(esClient, {
+  const exomeCoveragePromise = exomeCoverageIndex
+    ? fetchCoverage(esClient, {
         index: exomeCoverageIndex,
         contig: gene.reference_genome === 'GRCh38' ? `chr${gene.chrom}` : gene.chrom,
         regions: mergedExons,
         bucketSize,
       })
     : []
-
-  const genomeCoverage = genomeCoverageIndex
-    ? await fetchCoverage(esClient, {
+  const genomeCoveragePromise = genomeCoverageIndex
+    ? fetchCoverage(esClient, {
         index: genomeCoverageIndex,
         contig: gene.reference_genome === 'GRCh38' ? `chr${gene.chrom}` : gene.chrom,
         regions: mergedExons,
         bucketSize,
       })
     : []
+
+  const [exomeCoverage, genomeCoverage] = await Promise.all([
+    exomeCoveragePromise,
+    genomeCoveragePromise,
+  ])
 
   return {
     exome: exomeCoverage,
@@ -223,8 +227,8 @@ const _fetchCoverageForTranscript = async (esClient: any, datasetId: any, transc
   // @ts-expect-error TS(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
   const genomeCoverageIndex = COVERAGE_INDICES[datasetId].genome
 
-  const exomeCoverage = exomeCoverageIndex
-    ? await fetchCoverage(esClient, {
+  const exomeCoveragePromise = exomeCoverageIndex
+    ? fetchCoverage(esClient, {
         index: exomeCoverageIndex,
         contig:
           transcript.reference_genome === 'GRCh38' ? `chr${transcript.chrom}` : transcript.chrom,
@@ -232,8 +236,7 @@ const _fetchCoverageForTranscript = async (esClient: any, datasetId: any, transc
         bucketSize,
       })
     : []
-
-  const genomeCoverage = genomeCoverageIndex
+  const genomeCoveragePromise = genomeCoverageIndex
     ? await fetchCoverage(esClient, {
         index: genomeCoverageIndex,
         contig:
@@ -242,6 +245,11 @@ const _fetchCoverageForTranscript = async (esClient: any, datasetId: any, transc
         bucketSize,
       })
     : []
+
+  const [exomeCoverage, genomeCoverage] = await Promise.all([
+    exomeCoveragePromise,
+    genomeCoveragePromise,
+  ])
 
   return {
     exome: exomeCoverage,

--- a/graphql-api/src/queries/variant-datasets/gnomad-v4-variant-queries.ts
+++ b/graphql-api/src/queries/variant-datasets/gnomad-v4-variant-queries.ts
@@ -18,6 +18,15 @@ import { getConsequenceForContext } from './shared/transcriptConsequence'
 import largeGenes from '../helpers/large-genes'
 
 const GNOMAD_V4_VARIANT_INDEX = 'gnomad_v4_variants'
+const IN_SILICO_PREDICTOR_IDS = [
+    'cadd',
+    'revel_max',
+    'spliceai_ds_max',
+    'pangolin_largest_ds',
+    'phylop',
+    'sift_max',
+    'polyphen_max',
+  ]
 
 type Subset = 'all' | 'non_ukb'
 
@@ -258,17 +267,7 @@ const fetchVariantById = async (esClient: any, variantId: any, subset: Subset) =
 // ================================================================================================
 
 const createInSilicoPredictorsList = (variant: any) => {
-  const inSilicoPredictorIds = [
-    'cadd',
-    'revel_max',
-    'spliceai_ds_max',
-    'pangolin_largest_ds',
-    'phylop',
-    'sift_max',
-    'polyphen_max',
-  ]
-
-  const inSilicoPredictorsList = inSilicoPredictorIds
+  const inSilicoPredictorsList = IN_SILICO_PREDICTOR_IDS
     .map((id) => {
       if (variant.in_silico_predictors[id] || variant.in_silico_predictors[id] === 0) {
         const name: string = id
@@ -555,16 +554,14 @@ const fetchVariantsByRegion = async (esClient: any, region: any, subset: Subset)
     ])
   )
 
-  const variantsWithLofCurations = variants.map((variant: any) => ({
-    ...variant,
-    lof_curation: variant.transcript_consequence
+  for (const variant of variants) {
+    variant.lof_curation = variant.transcript_consequence
       ? lofCurationsByVariantAndGene
           .get(variant.variant_id)
           ?.get(variant.transcript_consequence.gene_id)
-      : undefined,
-  }))
-
-  return variantsWithLofCurations
+      : undefined
+  }
+  return variants
 }
 
 // ================================================================================================

--- a/graphql-api/src/queries/variant-datasets/shared/flags.ts
+++ b/graphql-api/src/queries/variant-datasets/shared/flags.ts
@@ -5,6 +5,7 @@ const LOF_CONSEQUENCE_TERMS = new Set([
   'stop_gained',
   'frameshift_variant',
 ])
+const REGIONAL_FLAGS = ['par', 'segdup', 'lcr']
 
 const isLofOnNonCodingTranscript = (transcriptConsequence: any) =>
   LOF_CONSEQUENCE_TERMS.has(transcriptConsequence.major_consequence) && !transcriptConsequence.lof
@@ -132,7 +133,7 @@ export const getFlagsForContext = (context: any, variant: any) => {
   const baseExomeFlags = variant.exome?.flags || []
   const baseGenomeFlags = variant.genome?.flags || []
 
-  const regionalFlags = ['par', 'segdup', 'lcr'].filter(
+  const regionalFlags = REGIONAL_FLAGS.filter(
     (regionalFlag) =>
       baseExomeFlags.includes(regionalFlag) || baseGenomeFlags.includes(regionalFlag)
   )


### PR DESCRIPTION
- Lifts two constant arrays to the global scope, preventing object allocations on the `variants` hot path.
- Moves two sequential `awaits` into ` Promise.all`.
- Mutates an existing `variant` object rather than creating a new one.