### PR TITLE
fix(graphql-api): reject ES request when it times out in the queue

### DIFF
--- a/graphql-api/src/elasticsearch.ts
+++ b/graphql-api/src/elasticsearch.ts
@@ -51,7 +51,13 @@ const scheduleElasticsearchRequest = (fn: any, operation: string) => {
   const queuedAt = performance.now()
   let canceled = false
 
-  // If task sits in the queue for more than 30s, cancel it and notify the user.
+  // If the task sits in the queue for more than 30s, cancel it and notify the user.
+  // The timer rejects the returned promise directly (via the Promise.race below) so a
+  // request backed up in the queue fails at the timeout instead of waiting to be dequeued.
+  let rejectQueue!: (reason?: any) => void
+  const queueTimeout = new Promise<never>((_resolve, reject) => {
+    rejectQueue = reject
+  })
   const timeout = setTimeout(() => {
     canceled = true
 
@@ -61,9 +67,11 @@ const scheduleElasticsearchRequest = (fn: any, operation: string) => {
       operation,
       queueMs: performance.now() - queuedAt,
     })
+
+    rejectQueue(new UserVisibleError('Request timed out'))
   }, config.ELASTICSEARCH_QUEUE_TIMEOUT)
 
-  return esLimiter
+  const scheduled = esLimiter
     .schedule(() => {
       const startedAt = performance.now()
 
@@ -124,6 +132,8 @@ const scheduleElasticsearchRequest = (fn: any, operation: string) => {
         throw err
       }
     )
+
+  return Promise.race([scheduled, queueTimeout])
 }
 
 // This wraps the ES methods used by the API and sends them through the rate limiter


### PR DESCRIPTION
### What
Restores the queue-timeout behavior that #1911 unintentionally dropped, while keeping all of that PR's new structured logging.

### Background
#1911 replaced the `new Promise((resolve, reject) => …)` wrapper around `esLimiter.schedule()` with a directly-returned promise chain — a sound cleanup, since `schedule()` already returns a promise. But the old code relied on that wrapper's `reject` in two places, and only one survived the refactor:
- **"dropped by Bottleneck"** → correctly re-homed to `throw new UserVisibleError('Service overloaded')` inside the chain's rejection handler. ✅
- **queue timeout** → the `setTimeout` callback fires on its own tick, outside the chain, so there's no longer a `reject` to call. It now only logs, and the job resolves `undefined` when eventually dequeued. ❌

### Impact
When a request sits in the ES queue past `ELASTICSEARCH_QUEUE_TIMEOUT` (30s in prod):
1. **Wrong error:** `scheduleElasticsearchRequest` resolves `undefined`. The `search`/`scroll`/`count` wrappers then read `response.body` on `undefined` → `TypeError`, which is *not* a `UserVisibleError`, so the client gets the generic `"An unknown error occurred"` (and it's logged as a server error) instead of `"Request timed out"`.
2. **Wrong timing:** the failure no longer happens at the 30s mark — it's deferred until the job is finally dequeued, which under the exact heavy-load conditions the timeout exists to guard against can be much later.

### Fix
Race the scheduled work against a timer promise that rejects with `UserVisibleError('Request timed out')`. This puts the rejection back on the timer (so it fires at the timeout), keeps `canceled` short-circuiting the actual ES call, and preserves every `esRequest*` log added in #1911.

<details>
<summary><b>Repro / proof (run against the repo's real Bottleneck 2.19.5)</b></summary>

A minimal harness that runs the OLD, NEW (#1911 as-is), and FIXED versions of `scheduleElasticsearchRequest` verbatim, with a 200ms stand-in for the 30s queue timeout and `maxConcurrent: 1`. Job A hogs the single slot for 1000ms so Job B is forced to wait in the queue past the timeout.

```js
const Bottleneck = require('bottleneck')
const QUEUE_TIMEOUT = 200 // stand-in for config.ELASTICSEARCH_QUEUE_TIMEOUT (30s in prod)

class UserVisibleError extends Error {
  constructor(...args) { super(...args); this.name = 'UserVisibleError'; this.extensions = { isUserVisible: true } }
}
const logger = { warn: (m) => console.log('   [warn]', typeof m === 'string' ? m : JSON.stringify(m)), info: () => {}, error: () => {} }
const makeLimiter = () => new Bottleneck({ maxConcurrent: 1, highWater: 10, strategy: Bottleneck.strategy.OVERFLOW })

// --- OLD (base branch): wraps esLimiter in new Promise(resolve, reject) ---
function scheduleOld(esLimiter, fn) {
  return new Promise((resolve, reject) => {
    let canceled = false
    const timeout = setTimeout(() => {
      canceled = true
      logger.warn('Elasticsearch request timed out in queue')
      reject(new UserVisibleError('Request timed out'))
    }, QUEUE_TIMEOUT)
    esLimiter
      .schedule(() => { clearTimeout(timeout); if (canceled) return Promise.resolve(undefined); return fn() })
      .then(resolve, (err) => {
        if (err.message === 'This job has been dropped by Bottleneck') {
          clearTimeout(timeout); reject(new UserVisibleError('Service overloaded'))
        }
        reject(err)
      })
  })
}

// --- NEW (PR #1911, as-is): returns esLimiter chain directly; timer only logs ---
function scheduleNew(esLimiter, fn, operation) {
  let canceled = false
  const timeout = setTimeout(() => {
    canceled = true
    logger.warn({ event: 'esRequestQueueTimeout', operation }) // NB: no reject / no throw
  }, QUEUE_TIMEOUT)
  return esLimiter
    .schedule(() => { clearTimeout(timeout); if (canceled) return Promise.resolve(undefined); return fn() })
    .then((r) => r, (err) => {
      clearTimeout(timeout)
      if (err?.message === 'This job has been dropped by Bottleneck') throw new UserVisibleError('Service overloaded')
      throw err
    })
}

// --- FIXED: keeps #1911's logging, but the timer rejects the returned promise (via Promise.race) ---
function scheduleFixed(esLimiter, fn, operation) {
  let canceled = false
  let rejectQueue
  const queueTimeout = new Promise((_resolve, reject) => { rejectQueue = reject })
  const timeout = setTimeout(() => {
    canceled = true
    logger.warn({ event: 'esRequestQueueTimeout', operation })
    rejectQueue(new UserVisibleError('Request timed out'))
  }, QUEUE_TIMEOUT)
  const scheduled = esLimiter
    .schedule(() => { clearTimeout(timeout); if (canceled) return Promise.resolve(undefined); return fn() })
    .then((r) => r, (err) => {
      clearTimeout(timeout)
      if (err?.message === 'This job has been dropped by Bottleneck') throw new UserVisibleError('Service overloaded')
      throw err
    })
  return Promise.race([scheduled, queueTimeout])
}

// Mirrors the limitedElastic.search wrapper, which immediately reads response.body
function searchWrapper(schedule, esLimiter) {
  const fakeEsCall = () => new Promise((r) => setTimeout(() => r({ body: { timed_out: false, _shards: { successful: 1, total: 1 } } }), 5))
  return schedule(esLimiter, fakeEsCall, 'search').then((response) => {
    if (response.body.timed_out) throw new Error('Elasticsearch search timed out')
    return response
  })
}

async function runScenario(label, schedule) {
  console.log(`\n=== ${label} ===`)
  const esLimiter = makeLimiter()
  const t0 = Date.now()
  schedule(esLimiter, () => new Promise((r) => setTimeout(r, 1000)), 'hog').catch(() => {}) // Job A hogs the slot
  let outcome
  try { await searchWrapper(schedule, esLimiter); outcome = 'RESOLVED (no error thrown)' }
  catch (err) {
    const kind = err instanceof UserVisibleError ? 'UserVisibleError' : err.constructor.name
    outcome = `THREW ${kind}: "${err.message}"`
  }
  console.log(`   Job B settled after ~${Date.now() - t0}ms -> ${outcome}`)
}

;(async () => {
  await runScenario('OLD (base branch)', scheduleOld)
  await runScenario('NEW (PR #1911, as-is)', scheduleNew)
  await runScenario('FIXED (Promise.race)', scheduleFixed)
})()

/* ----------------------------- OUTPUT -----------------------------
=== OLD (base branch) ===
   [warn] Elasticsearch request timed out in queue
   Job B settled after ~202ms -> THREW UserVisibleError: "Request timed out"

=== NEW (PR #1911, as-is) ===
   [warn] {"event":"esRequestQueueTimeout","operation":"search"}
   Job B settled after ~1009ms -> THREW TypeError: "Cannot read properties of undefined (reading 'body')"

=== FIXED (Promise.race) ===
   [warn] {"event":"esRequestQueueTimeout","operation":"search"}
   Job B settled after ~201ms -> THREW UserVisibleError: "Request timed out"
------------------------------------------------------------------- */
```

**Takeaways:**
- **OLD** fails fast at ~200ms with the friendly `UserVisibleError`.
- **NEW (#1911)** fails at ~1009ms — only when the job is dequeued — and with a bare `TypeError` (→ generic "unknown error" to the user).
- **FIXED** matches OLD (~200ms, `UserVisibleError`) while keeping the new `esRequestQueueTimeout` structured log.

Happy path and drop path were also exercised: a fast, uncontended request resolves normally with no false timeout and no unhandled rejection.

</details>

### The actual change to `scheduleElasticsearchRequest`
```diff
-  // If task sits in the queue for more than 30s, cancel it and notify the user.
+  // If the task sits in the queue for more than 30s, cancel it and notify the user.
+  // The timer rejects the returned promise directly (via the Promise.race below) so a
+  // request backed up in the queue fails at the timeout instead of waiting to be dequeued.
+  let rejectQueue!: (reason?: any) => void
+  const queueTimeout = new Promise<never>((_resolve, reject) => {
+    rejectQueue = reject
+  })
   const timeout = setTimeout(() => {
     canceled = true
     logger.warn({
       requestId: ctx?.requestId,
       event: 'esRequestQueueTimeout',
       operation,
       queueMs: performance.now() - queuedAt,
     })
+    rejectQueue(new UserVisibleError('Request timed out'))
   }, config.ELASTICSEARCH_QUEUE_TIMEOUT)

-  return esLimiter
+  const scheduled = esLimiter
     .schedule(() => {
       /* …unchanged: clearTimeout, canceled short-circuit, esRequestStart/End/Error logging… */
     })
     .then(
       (result: any) => result,
       (err: any) => {
         /* …unchanged: esRequestDropped → UserVisibleError('Service overloaded')… */
       }
     )
+
+  return Promise.race([scheduled, queueTimeout])
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
