### PR TITLE
feat: incorporate handlers for sigterm and sigkill in app.ts teardown.

### DIFF
--- a/graphql-api/src/app.ts
+++ b/graphql-api/src/app.ts
@@ -12,16 +12,6 @@ import { requestStore } from './request-context'
 import { closeCache } from './cache'
 import { loadWhitelist } from './whitelist'
 
-process.on('uncaughtException', (error) => {
-  logger.error(error)
-  process.exit(1)
-})
-
-process.on('unhandledRejection', (error) => {
-  logger.error(error)
-  process.exit(1)
-})
-
 const app = express()
 app.use(compression())
 app.use(cors())
@@ -123,11 +113,14 @@ app.use('/api/',
   })
 )
 
+// On shutdown (SIGTERM/SIGINT) or fatal error (uncaughtException/unhandledRejection), stop accepting
+// requests, drain connections, and close ES/cache clients before exiting. A 10-second timeout forces
+// exit if graceful teardown stalls.
 const server = app.listen(config.PORT, () => {
   logger.info({ event: 'serverStart', port: config.PORT })
 })
 
-const shutdown = (signal: string) => {
+const shutdown = (signal: string, exitCode = 0) => {
   logger.info({ event: 'shutdown', signal })
 
   const forceExit = setTimeout(() => {
@@ -143,9 +136,17 @@ const shutdown = (signal: string) => {
       logger.error(err)
     }
     clearTimeout(forceExit)
-    process.exit(0)
+    process.exit(exitCode)
   })
 }
 
 process.on('SIGTERM', () => shutdown('SIGTERM'))
 process.on('SIGINT', () => shutdown('SIGINT'))
+process.on('uncaughtException', (error) => {
+  logger.error(error)
+  shutdown('uncaughtException', 1)
+})
+process.on('unhandledRejection', (error) => {
+  logger.error(error)
+  shutdown('unhandledRejection', 1)
+})

--- a/graphql-api/src/app.ts
+++ b/graphql-api/src/app.ts
@@ -5,10 +5,11 @@ import express from 'express'
 import onFinished from 'on-finished'
 import { performance } from 'perf_hooks'
 import config from './config'
-import { client as esClient } from './elasticsearch'
+import { client as esClient, closeClient as closeEsClient } from './elasticsearch'
 import graphQLApi from './graphql/graphql-api'
 import logger from './logger'
 import { requestStore } from './request-context'
+import { closeCache } from './cache'
 import { loadWhitelist } from './whitelist'
 
 process.on('uncaughtException', (error) => {
@@ -122,4 +123,29 @@ app.use('/api/',
   })
 )
 
-app.listen(config.PORT)
+const server = app.listen(config.PORT, () => {
+  logger.info({ event: 'serverStart', port: config.PORT })
+})
+
+const shutdown = (signal: string) => {
+  logger.info({ event: 'shutdown', signal })
+
+  const forceExit = setTimeout(() => {
+    logger.error({ event: 'shutdownTimeout' })
+    process.exit(1)
+  }, 10_000)
+  forceExit.unref()
+
+  server.close(async () => {
+    try {
+      await Promise.all([closeEsClient(), closeCache()])
+    } catch (err) {
+      logger.error(err)
+    }
+    clearTimeout(forceExit)
+    process.exit(0)
+  })
+}
+
+process.on('SIGTERM', () => shutdown('SIGTERM'))
+process.on('SIGINT', () => shutdown('SIGINT'))

--- a/graphql-api/src/cache.ts
+++ b/graphql-api/src/cache.ts
@@ -21,9 +21,10 @@ let fetchCacheValue = () => Promise.resolve(null)
 let setCacheValue = () => Promise.resolve()
 let setCacheExpiration = () => Promise.resolve()
 
+let readCacheDb: Redis | undefined
+let writeCacheDb: Redis | undefined
+
 if (config.REDIS_HOST) {
-  let readCacheDb
-  let writeCacheDb
   if (config.REDIS_USE_SENTINEL) {
     readCacheDb = new Redis({
       sentinels: [{ host: config.REDIS_HOST, port: config.REDIS_PORT }],
@@ -77,6 +78,12 @@ if (config.REDIS_HOST) {
   )
 } else {
   logger.warn('No redis configured for caching')
+}
+
+export const closeCache = async () => {
+  if (config.REDIS_HOST) {
+    await Promise.all([readCacheDb?.quit(), writeCacheDb?.quit()])
+  }
 }
 
 export const withCache = (

--- a/graphql-api/src/elasticsearch.ts
+++ b/graphql-api/src/elasticsearch.ts
@@ -177,3 +177,5 @@ const limitedElastic = {
 }
 
 export { limitedElastic as client }
+
+export const closeClient = () => elastic.close()


### PR DESCRIPTION
Polishes some POC I wrote a few weeks ago to clean up the teardown, which was required to generate profiles.  