### PR TITLE
feat: update gnomAD TR data to the July 2026 release and fetch the reads db from GCS

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -72,7 +72,7 @@ module.exports = {
   overrides: [
     {
       // Set environment for tests
-      files: ['**/*spec.ts', '**/*test.ts', 'tests/**/*.ts'],
+      files: ['**/*spec.ts', '**/*spec.js', '**/*test.ts', 'tests/**/*.ts'],
       env: {
         jest: true,
       },

--- a/browser/src/DataPage/GnomadV3Downloads.tsx
+++ b/browser/src/DataPage/GnomadV3Downloads.tsx
@@ -323,6 +323,13 @@ const GnomadV3Downloads = () => (
       <FileList>
         <ListItem>
           <DownloadLinks
+            label="README"
+            loggingLabel="v3.1.3 genotype TSV README (7-20-2026 update)"
+            path="/release/3.1.3/tsv/README__2025_03_17.txt"
+          />
+        </ListItem>
+        <ListItem>
+          <DownloadLinks
             label="Genotypes (TSV)"
             path="/release/3.1.3/tsv/gnomAD_STR_genotypes__2026_07_20.tsv.gz"
           />

--- a/browser/src/DataPage/GnomadV3Downloads.tsx
+++ b/browser/src/DataPage/GnomadV3Downloads.tsx
@@ -322,21 +322,25 @@ const GnomadV3Downloads = () => (
       <a href="https://gnomad.broadinstitute.org/news/2026-07-str-data-update/">changelog entry</a>]
       <FileList>
         <ListItem>
+          {/* The column schema did not change in this release, so this release reuses the
+              March 2025 README rather than publishing an identical new one. */}
           <DownloadLinks
             label="README"
-            loggingLabel="v3.1.3 genotype TSV README (7-20-2026 update)"
+            loggingLabel="v3.1.3 genotype TSV README"
             path="/release/3.1.3/tsv/README__2025_03_17.txt"
           />
         </ListItem>
         <ListItem>
           <DownloadLinks
             label="Genotypes (TSV)"
+            loggingLabel="v3.1.3 genotypes TSV (7-20-2026 update)"
             path="/release/3.1.3/tsv/gnomAD_STR_genotypes__2026_07_20.tsv.gz"
           />
         </ListItem>
         <ListItem>
           <DownloadLinks
             label="Distributions (JSON)"
+            loggingLabel="v3.1.3 distributions JSON (7-20-2026 update)"
             path="/release/3.1.3/json/gnomAD_STR_distributions__2026_07_20.json.gz"
           />
         </ListItem>

--- a/browser/src/DataPage/GnomadV3Downloads.tsx
+++ b/browser/src/DataPage/GnomadV3Downloads.tsx
@@ -318,6 +318,23 @@ const GnomadV3Downloads = () => (
         </ExternalLink>
         .
       </p>
+      <b>Update (July 2026)</b>: [
+      <a href="https://gnomad.broadinstitute.org/news/2026-07-str-data-update/">changelog entry</a>]
+      <FileList>
+        <ListItem>
+          <DownloadLinks
+            label="Genotypes (TSV)"
+            path="/release/3.1.3/tsv/gnomAD_STR_genotypes__2026_07_20.tsv.gz"
+          />
+        </ListItem>
+        <ListItem>
+          <DownloadLinks
+            label="Distributions (JSON)"
+            path="/release/3.1.3/json/gnomAD_STR_distributions__2026_07_20.json.gz"
+          />
+        </ListItem>
+      </FileList>
+      <br />
       <b>Update (March 2025)</b>: [
       <a href="https://gnomad.broadinstitute.org/news/2025-03-known-disease-associated-tandem-repeat-pages/">
         changelog entry

--- a/browser/src/DataPage/__snapshots__/DataPage.spec.tsx.snap
+++ b/browser/src/DataPage/__snapshots__/DataPage.spec.tsx.snap
@@ -11627,6 +11627,87 @@ exports[`Data Page has no unexpected changes 1`] = `
         .
       </p>
       <b>
+        Update (July 2026)
+      </b>
+      : [
+      <a
+        href="https://gnomad.broadinstitute.org/news/2026-07-str-data-update/"
+      >
+        changelog entry
+      </a>
+      ]
+      <ul
+        className="c20 c21"
+      >
+        <li
+          className="c22"
+        >
+          <span>
+            Genotypes (TSV)
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download Genotypes (TSV) from Google"
+              className="c8"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.3/tsv/gnomAD_STR_genotypes__2026_07_20.tsv.gz"
+              onClick={[Function]}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download Genotypes (TSV) from Amazon"
+              className="c8"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.3/tsv/gnomAD_STR_genotypes__2026_07_20.tsv.gz"
+              onClick={[Function]}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+          </span>
+        </li>
+        <li
+          className="c22"
+        >
+          <span>
+            Distributions (JSON)
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download Distributions (JSON) from Google"
+              className="c8"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.3/json/gnomAD_STR_distributions__2026_07_20.json.gz"
+              onClick={[Function]}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download Distributions (JSON) from Amazon"
+              className="c8"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.3/json/gnomAD_STR_distributions__2026_07_20.json.gz"
+              onClick={[Function]}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+          </span>
+        </li>
+      </ul>
+      <br />
+      <b>
         Update (March 2025)
       </b>
       : [

--- a/browser/src/DataPage/__snapshots__/DataPage.spec.tsx.snap
+++ b/browser/src/DataPage/__snapshots__/DataPage.spec.tsx.snap
@@ -11643,6 +11643,39 @@ exports[`Data Page has no unexpected changes 1`] = `
           className="c22"
         >
           <span>
+            README
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download README from Google"
+              className="c8"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.3/tsv/README__2025_03_17.txt"
+              onClick={[Function]}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download README from Amazon"
+              className="c8"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.3/tsv/README__2025_03_17.txt"
+              onClick={[Function]}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+          </span>
+        </li>
+        <li
+          className="c22"
+        >
+          <span>
             Genotypes (TSV)
           </span>
           <br />

--- a/browser/src/ShortTandemRepeatsPage/ShortTandemRepeatsPage.tsx
+++ b/browser/src/ShortTandemRepeatsPage/ShortTandemRepeatsPage.tsx
@@ -162,7 +162,7 @@ const ShortTandemRepeatsPage = ({ shortTandemRepeats }: ShortTandemRepeatsPagePr
   return (
     <>
       <p>
-        For more information about Tandem Repeats in gnomAD, see our{' '}
+        STR data version: 2026-07-20. For more information about Tandem Repeats in gnomAD, see our{' '}
         <a href="https://gnomad.broadinstitute.org/news/2022-01-the-addition-of-short-tandem-repeat-calls-to-gnomad/">
           blog post
         </a>{' '}

--- a/browser/src/ShortTandemRepeatsPage/__snapshots__/ShortTandemRepeatsPage.spec.tsx.snap
+++ b/browser/src/ShortTandemRepeatsPage/__snapshots__/ShortTandemRepeatsPage.spec.tsx.snap
@@ -247,7 +247,7 @@ exports[`ShortTandemRepeatsPage has no unexpected changes 1`] = `
           </div>
         </div>
         <p>
-          For more information about Tandem Repeats in gnomAD, see our
+          STR data version: 2026-07-20. For more information about Tandem Repeats in gnomAD, see our
            
           <a
             href="https://gnomad.broadinstitute.org/news/2022-01-the-addition-of-short-tandem-repeat-calls-to-gnomad/"
@@ -929,7 +929,7 @@ exports[`ShortTandemRepeatsPage has no unexpected changes 1`] = `
         </div>
       </div>
       <p>
-        For more information about Tandem Repeats in gnomAD, see our
+        STR data version: 2026-07-20. For more information about Tandem Repeats in gnomAD, see our
          
         <a
           href="https://gnomad.broadinstitute.org/news/2022-01-the-addition-of-short-tandem-repeat-calls-to-gnomad/"

--- a/data-pipeline/src/data_pipeline/helpers/elasticsearch_export.py
+++ b/data-pipeline/src/data_pipeline/helpers/elasticsearch_export.py
@@ -103,6 +103,7 @@ def export_table_to_elasticsearch(
     id_field=None,
     index_fields=None,
     num_shards=1,
+    index_suffix=None,
 ):
     export_time = datetime.datetime.utcnow()
 
@@ -141,7 +142,9 @@ def export_table_to_elasticsearch(
     es_client = elasticsearch.Elasticsearch(host, port=9200, http_auth=auth)
     cluster_name = es_client.cluster.health()["cluster_name"]
 
-    index = f"{index}-{export_time.strftime('%Y-%m-%d--%H-%M')}"
+    # Defaults to the export timestamp. Callers can pass index_suffix to name the index after the
+    # data release instead (eg. "2026_07_20"), which keeps the index name stable across reloads.
+    index = f"{index}-{index_suffix or export_time.strftime('%Y-%m-%d--%H-%M')}"
 
     if es_client.indices.exists(index=index):
         es_client.indices.delete(index=index)

--- a/data-pipeline/src/data_pipeline/helpers/elasticsearch_export.py
+++ b/data-pipeline/src/data_pipeline/helpers/elasticsearch_export.py
@@ -103,7 +103,6 @@ def export_table_to_elasticsearch(
     id_field=None,
     index_fields=None,
     num_shards=1,
-    index_suffix=None,
 ):
     export_time = datetime.datetime.utcnow()
 
@@ -142,9 +141,7 @@ def export_table_to_elasticsearch(
     es_client = elasticsearch.Elasticsearch(host, port=9200, http_auth=auth)
     cluster_name = es_client.cluster.health()["cluster_name"]
 
-    # Defaults to the export timestamp. Callers can pass index_suffix to name the index after the
-    # data release instead (eg. "2026_07_20"), which keeps the index name stable across reloads.
-    index = f"{index}-{index_suffix or export_time.strftime('%Y-%m-%d--%H-%M')}"
+    index = f"{index}-{export_time.strftime('%Y-%m-%d--%H-%M')}"
 
     if es_client.indices.exists(index=index):
         es_client.indices.delete(index=index)

--- a/data-pipeline/src/data_pipeline/pipelines/gnomad_v3_short_tandem_repeats.py
+++ b/data-pipeline/src/data_pipeline/pipelines/gnomad_v3_short_tandem_repeats.py
@@ -1,3 +1,5 @@
+import os
+
 from data_pipeline.pipeline import Pipeline, run_pipeline
 
 from data_pipeline.datasets.gnomad_v3.gnomad_v3_short_tandem_repeats import prepare_gnomad_v3_short_tandem_repeats
@@ -10,7 +12,12 @@ pipeline.add_task(
     prepare_gnomad_v3_short_tandem_repeats,
     "/gnomad_v4/gnomad_v4_short_tandem_repeats.ht",
     {
-        "path": "gs://gnomad-browser-data-pipeline/inputs/secondary-analyses/strs/2025_03_17/gnomAD_STR_distributions__gnomad-v2__2025_03_17.json"
+        # Override with a local path for local dev (avoids GCS auth), e.g.
+        #   STR_DISTRIBUTIONS_JSON=/path/to/gnomAD_STR_distributions__gnomad-v2__2026_07_20.json.gz
+        "path": os.environ.get(
+            "STR_DISTRIBUTIONS_JSON",
+            "gs://gnomad-browser/STRs/gnomAD_STR_distributions__gnomad-v2__2026_07_20.json.gz",
+        )
     },
 )
 

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -32,6 +32,12 @@ module.exports = {
       testMatch: ['<rootDir>/dataset-metadata/**/*.spec.(js|jsx|ts|tsx)'],
       preset: 'ts-jest',
     },
+    {
+      // No ts-jest preset here: reads/ is plain CommonJS JavaScript.
+      displayName: 'reads',
+      testEnvironment: 'node',
+      testMatch: ['<rootDir>/reads/**/*.spec.(js|jsx|ts|tsx)'],
+    },
   ],
   roots: ['<rootDir>', '<rootDir>/tests'],
 }

--- a/reads/src/datasets.js
+++ b/reads/src/datasets.js
@@ -41,11 +41,15 @@ const variantDatasets = {
 
 const shortTandemRepeatDatasets = {
   gnomad_r3: {
-    dbPath: '/readviz/datasets/gnomad_r4_short_tandem_repeats/str_reads.db',
+    dbPath:
+      process.env.STR_READS_DB_PATH ||
+      '/readviz/datasets/gnomad_r4_short_tandem_repeats/str_reads.db',
     publicPath: 'https://storage.googleapis.com/gnomad-str-public/release_2024_07/readviz_v2',
   },
   gnomad_r4: {
-    dbPath: '/readviz/datasets/gnomad_r4_short_tandem_repeats/str_reads.db',
+    dbPath:
+      process.env.STR_READS_DB_PATH ||
+      '/readviz/datasets/gnomad_r4_short_tandem_repeats/str_reads.db',
     publicPath: 'https://storage.googleapis.com/gnomad-str-public/release_2024_07/readviz_v2',
   },
 }

--- a/reads/src/datasets.js
+++ b/reads/src/datasets.js
@@ -39,17 +39,24 @@ const variantDatasets = {
   },
 }
 
+// Downloaded to the container's writable filesystem at startup. Override with STR_READS_DB_URL so
+// that a data-only release does not require a code change.
+const SHORT_TANDEM_REPEAT_READS_DB_URL =
+  process.env.STR_READS_DB_URL ||
+  'https://storage.googleapis.com/gnomad-str-public/release_2026_07/reads_db/str_reads_2026_07_20.db'
+
+// Set STR_READS_DB_PATH to serve a DB already on disk and skip the download entirely (local dev).
+const SHORT_TANDEM_REPEAT_READS_DB_PATH = process.env.STR_READS_DB_PATH || null
+
 const shortTandemRepeatDatasets = {
   gnomad_r3: {
-    dbPath:
-      process.env.STR_READS_DB_PATH ||
-      '/readviz/datasets/gnomad_r4_short_tandem_repeats/str_reads.db',
+    dbPath: SHORT_TANDEM_REPEAT_READS_DB_PATH,
+    dbUrl: SHORT_TANDEM_REPEAT_READS_DB_URL,
     publicPath: 'https://storage.googleapis.com/gnomad-str-public/release_2024_07/readviz_v2',
   },
   gnomad_r4: {
-    dbPath:
-      process.env.STR_READS_DB_PATH ||
-      '/readviz/datasets/gnomad_r4_short_tandem_repeats/str_reads.db',
+    dbPath: SHORT_TANDEM_REPEAT_READS_DB_PATH,
+    dbUrl: SHORT_TANDEM_REPEAT_READS_DB_URL,
     publicPath: 'https://storage.googleapis.com/gnomad-str-public/release_2024_07/readviz_v2',
   },
 }

--- a/reads/src/resolveShortTandemRepeatReads.js
+++ b/reads/src/resolveShortTandemRepeatReads.js
@@ -1,7 +1,11 @@
-const sqlite = require('sqlite')
-const sqlite3 = require('sqlite3')
-
 const { UserVisibleError } = require('./errors')
+const { getShortTandemRepeatReadsDb } = require('./shortTandemRepeatReadsDb')
+
+// Map a locus id to a non-default readviz image folder under publicPath. Needed while a locus's
+// images live in a coordinate-named folder rather than the live <locusId>/ folder (EP400's
+// 548-definition images are staged under EP400__12-132062548-132062611/ so they do not overwrite
+// the wide-definition images still in EP400/). Delete the entry once EP400/ holds those images.
+const READVIZ_FOLDER_BY_LOCUS = { EP400: 'EP400__12-132062548-132062611' }
 
 const buildWhere = ({ id, filter }) => {
   const params = {
@@ -118,17 +122,13 @@ const buildWhere = ({ id, filter }) => {
   return { where, params }
 }
 
-const resolveShortTandemRepeatNumReads = async ({ dbPath }, { id, filter }) => {
+const resolveShortTandemRepeatNumReads = async (dataset, { id, filter }) => {
   const { where, params } = buildWhere({ id, filter })
 
   const query = `SELECT COUNT(*) AS \`num_reads\` FROM \`reads\` WHERE ${where}`
 
-  const db = await sqlite.open({
-    filename: dbPath,
-    driver: sqlite3.Database,
-  })
+  const db = await getShortTandemRepeatReadsDb(dataset)
   const result = await db.get(query, params)
-  await db.close()
 
   return result.num_reads
 }
@@ -136,7 +136,7 @@ const resolveShortTandemRepeatNumReads = async ({ dbPath }, { id, filter }) => {
 const MAX_READS_PER_REQUEST = 1_000
 
 const resolveShortTandemRepeatReads = async (
-  { dbPath, publicPath },
+  dataset,
   { id, filter },
   { limit = 10, offset = 0 }
 ) => {
@@ -179,12 +179,8 @@ const resolveShortTandemRepeatReads = async (
     ':offset': offset,
   })
 
-  const db = await sqlite.open({
-    filename: dbPath,
-    driver: sqlite3.Database,
-  })
+  const db = await getShortTandemRepeatReadsDb(dataset)
   const rows = await db.all(query, params)
-  await db.close()
 
   return rows.map((row) => {
     return {
@@ -222,7 +218,7 @@ const resolveShortTandemRepeatReads = async (
       sex: row.sex,
       age: row.age,
       pcr_protocol: row.pcr_protocol,
-      path: `${publicPath}/${id}/${row.filename}`,
+      path: `${dataset.publicPath}/${READVIZ_FOLDER_BY_LOCUS[id] || id}/${row.filename}`,
       quality_description: row.quality_description,
       q_score: row.q,
     }

--- a/reads/src/server.js
+++ b/reads/src/server.js
@@ -49,12 +49,17 @@ app.use(
   })
 )
 
-// Fetch and validate the tandem repeat reads DB before listening, so that the pod cannot pass its
-// readiness probe until it is actually able to serve read data.
+// Fetch and validate the tandem repeat reads DB before listening, so that the common case is a
+// warm process rather than a first request that waits on a ~170MB download. A failure here is
+// logged but not fatal: this service also serves variant reads from the /readviz disk, which have
+// no dependency on this DB, so taking the process down would be a much larger outage than the one
+// being reported. Tandem repeat queries retry the fetch and surface an error until it succeeds.
 const main = async () => {
   await Promise.all(
     Object.values(shortTandemRepeatDatasets).map((dataset) =>
-      ensureShortTandemRepeatReadsDb(dataset)
+      ensureShortTandemRepeatReadsDb(dataset).catch((error) => {
+        logger.error(error)
+      })
     )
   )
 

--- a/reads/src/server.js
+++ b/reads/src/server.js
@@ -1,9 +1,11 @@
 const express = require('express')
 const { graphqlHTTP } = require('express-graphql')
 
+const { shortTandemRepeatDatasets } = require('./datasets')
 const { formatError } = require('./errors')
 const logger = require('./logging')
 const schema = require('./schema')
+const { ensureShortTandemRepeatReadsDb } = require('./shortTandemRepeatReadsDb')
 
 // The behavior of Express' trust proxy setting varies based on the type of the argument.
 // Parse the environment variable string into the appropriate type.
@@ -47,6 +49,21 @@ app.use(
   })
 )
 
-app.listen(config.PORT, () => {
-  logger.info(`Listening on ${config.PORT}`)
+// Fetch and validate the tandem repeat reads DB before listening, so that the pod cannot pass its
+// readiness probe until it is actually able to serve read data.
+const main = async () => {
+  await Promise.all(
+    Object.values(shortTandemRepeatDatasets).map((dataset) =>
+      ensureShortTandemRepeatReadsDb(dataset)
+    )
+  )
+
+  app.listen(config.PORT, () => {
+    logger.info(`Listening on ${config.PORT}`)
+  })
+}
+
+main().catch((error) => {
+  logger.error(error)
+  process.exit(1)
 })

--- a/reads/src/shortTandemRepeatReadsDb.js
+++ b/reads/src/shortTandemRepeatReadsDb.js
@@ -1,0 +1,189 @@
+const crypto = require('crypto')
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+const { Readable } = require('stream')
+const { pipeline } = require('stream/promises')
+
+const sqlite = require('sqlite')
+const sqlite3 = require('sqlite3')
+
+const logger = require('./logging')
+
+// The tandem repeat reads DB is cached on the container's writable filesystem. It is deliberately
+// not written to /readviz, which is a read-only persistent disk.
+const CACHE_DIR = process.env.STR_READS_DB_CACHE_DIR || path.join(os.tmpdir(), 'gnomad-str-reads')
+
+const DOWNLOAD_ATTEMPTS = 3
+// Abort when the transfer makes no progress for this long, rather than capping its total duration:
+// the DB is ~170MB, so a total-duration cap fails on any link slower than size/cap regardless of
+// whether the transfer is healthy. Retrying a stalled download costs at most 3 * this + backoff,
+// which stays inside the rollout's 600s progress deadline.
+const DOWNLOAD_STALL_TIMEOUT_MS = 60_000
+// Backstop for a transfer that keeps trickling bytes without ever finishing.
+const DOWNLOAD_MAX_MS = 900_000
+
+// Derive the cache file name from the URL rather than using a fixed name, so that pointing
+// STR_READS_DB_URL at a new release can never be served from a stale cached file. The hash
+// disambiguates releases that reuse a basename; the basename is kept so logs stay readable.
+const cachePathForUrl = (dbUrl) => {
+  const digest = crypto.createHash('sha256').update(dbUrl).digest('hex').slice(0, 12)
+  return path.join(CACHE_DIR, `${digest}-${path.basename(new URL(dbUrl).pathname)}`)
+}
+
+const localDbPath = ({ dbPath, dbUrl }) => dbPath || cachePathForUrl(dbUrl)
+
+const fetchToFile = async (dbUrl, destPath) => {
+  const controller = new AbortController()
+  let stallTimer = null
+  const resetStallTimer = () => {
+    clearTimeout(stallTimer)
+    stallTimer = setTimeout(
+      () => controller.abort(new Error('Download stalled')),
+      DOWNLOAD_STALL_TIMEOUT_MS
+    )
+  }
+  const maxTimer = setTimeout(
+    () => controller.abort(new Error('Download exceeded its time limit')),
+    DOWNLOAD_MAX_MS
+  )
+  resetStallTimer()
+
+  try {
+    const response = await fetch(dbUrl, { signal: controller.signal })
+    if (!response.ok) {
+      const error = new Error(`Request for ${dbUrl} returned ${response.status}`)
+      error.isRetryable = response.status === 429 || response.status >= 500
+      throw error
+    }
+
+    // Written next to the destination so that the rename below is a same-filesystem atomic operation.
+    const tmpPath = `${destPath}.tmp-${process.pid}`
+    try {
+      const file = fs.createWriteStream(tmpPath)
+      const body = Readable.fromWeb(response.body)
+      body.on('data', resetStallTimer)
+      // Streamed, never buffered: the container has a 256Mi memory limit and the DB is ~170MB.
+      await pipeline(body, file)
+
+      // Content-Length describes the stored bytes, so it only matches what we wrote when the
+      // object is served with identity encoding. When the client decompresses a gzip-encoded
+      // response the two legitimately differ, and a response without Content-Length gives us
+      // nothing to compare against — skip the check in both cases rather than fail a good download.
+      const contentLength = response.headers.get('content-length')
+      if (contentLength !== null && !response.headers.get('content-encoding')) {
+        const expectedBytes = Number(contentLength)
+        if (expectedBytes !== file.bytesWritten) {
+          throw new Error(
+            `Expected ${expectedBytes} bytes from ${dbUrl}, but wrote ${file.bytesWritten}`
+          )
+        }
+      }
+
+      await fs.promises.rename(tmpPath, destPath)
+    } catch (error) {
+      await fs.promises.rm(tmpPath, { force: true })
+      throw error
+    }
+  } finally {
+    clearTimeout(stallTimer)
+    clearTimeout(maxTimer)
+  }
+}
+
+const verify = async (dbFilePath) => {
+  const db = await sqlite.open({
+    filename: dbFilePath,
+    driver: sqlite3.Database,
+    mode: sqlite3.OPEN_READONLY,
+  })
+  try {
+    const { quick_check: quickCheck } = await db.get('PRAGMA quick_check')
+    if (quickCheck !== 'ok') {
+      throw new Error(`PRAGMA quick_check on ${dbFilePath} returned "${quickCheck}"`)
+    }
+    // quick_check would happily pass an unrelated database, so confirm the expected table exists.
+    await db.get('SELECT 1 FROM `reads` LIMIT 1')
+  } finally {
+    await db.close()
+  }
+}
+
+const downloads = new Map()
+
+// Resolves once the DB is present on local disk and has passed its integrity checks. Memoized by
+// path so that the r3 and r4 dataset entries, which share a DB, download it exactly once.
+const ensureShortTandemRepeatReadsDb = (dataset) => {
+  const dbFilePath = localDbPath(dataset)
+
+  if (!downloads.has(dbFilePath)) {
+    downloads.set(
+      dbFilePath,
+      (async () => {
+        if (dataset.dbPath) {
+          await fs.promises.access(dataset.dbPath, fs.constants.R_OK)
+          logger.info(`Using tandem repeat reads DB at ${dataset.dbPath}`)
+        } else if (fs.existsSync(dbFilePath)) {
+          logger.info(`Reusing cached tandem repeat reads DB at ${dbFilePath}`)
+        } else {
+          await fs.promises.mkdir(path.dirname(dbFilePath), { recursive: true })
+
+          for (let attempt = 1; ; attempt += 1) {
+            try {
+              logger.info(`Downloading ${dataset.dbUrl} (attempt ${attempt})`)
+              // eslint-disable-next-line no-await-in-loop
+              await fetchToFile(dataset.dbUrl, dbFilePath)
+              break
+            } catch (error) {
+              // A 4xx other than 429 is a configuration error, so fail immediately rather than
+              // spending the whole retry budget on a URL that will never work.
+              if (attempt >= DOWNLOAD_ATTEMPTS || error.isRetryable === false) {
+                throw error
+              }
+              logger.warn(error)
+              // eslint-disable-next-line no-await-in-loop
+              await new Promise((resolve) => {
+                setTimeout(resolve, 2 ** attempt * 1000)
+              })
+            }
+          }
+        }
+
+        await verify(dbFilePath)
+        logger.info(`Tandem repeat reads DB ready at ${dbFilePath}`)
+
+        return dbFilePath
+      })()
+    )
+  }
+
+  return downloads.get(dbFilePath)
+}
+
+const connections = new Map()
+
+// One read-only handle per DB, opened on first use and kept for the life of the process. The
+// promise itself is memoized so that concurrent first requests share a single open() rather than
+// racing. OPEN_READONLY matters: the default mode would create an empty DB if the file were
+// missing, turning a startup failure into a confusing per-request "no such table: reads".
+const getShortTandemRepeatReadsDb = (dataset) => {
+  const dbFilePath = localDbPath(dataset)
+
+  if (!connections.has(dbFilePath)) {
+    connections.set(
+      dbFilePath,
+      sqlite.open({
+        filename: dbFilePath,
+        driver: sqlite3.Database,
+        mode: sqlite3.OPEN_READONLY,
+      })
+    )
+  }
+
+  return connections.get(dbFilePath)
+}
+
+module.exports = {
+  ensureShortTandemRepeatReadsDb,
+  getShortTandemRepeatReadsDb,
+}

--- a/reads/src/shortTandemRepeatReadsDb.js
+++ b/reads/src/shortTandemRepeatReadsDb.js
@@ -153,7 +153,12 @@ const ensureShortTandemRepeatReadsDb = (dataset) => {
         logger.info(`Tandem repeat reads DB ready at ${dbFilePath}`)
 
         return dbFilePath
-      })()
+      })().catch((error) => {
+        // Drop the memoized rejection so a later request can retry rather than replaying this
+        // failure for the life of the process.
+        downloads.delete(dbFilePath)
+        throw error
+      })
     )
   }
 
@@ -166,7 +171,13 @@ const connections = new Map()
 // promise itself is memoized so that concurrent first requests share a single open() rather than
 // racing. OPEN_READONLY matters: the default mode would create an empty DB if the file were
 // missing, turning a startup failure into a confusing per-request "no such table: reads".
-const getShortTandemRepeatReadsDb = (dataset) => {
+//
+// Awaiting ensure…() here rather than assuming startup completed means a query either waits for
+// the in-flight download or retries one that failed, and surfaces a real error if it still cannot
+// be satisfied — so the reads service can start serving variant reads before this DB is available.
+const getShortTandemRepeatReadsDb = async (dataset) => {
+  await ensureShortTandemRepeatReadsDb(dataset)
+
   const dbFilePath = localDbPath(dataset)
 
   if (!connections.has(dbFilePath)) {

--- a/reads/src/shortTandemRepeatReadsDb.js
+++ b/reads/src/shortTandemRepeatReadsDb.js
@@ -149,7 +149,19 @@ const ensureShortTandemRepeatReadsDb = (dataset) => {
           }
         }
 
-        await verify(dbFilePath)
+        try {
+          await verify(dbFilePath)
+        } catch (error) {
+          // Evict a cached file that does not verify. It is renamed into place before this check
+          // runs, so leaving it would send every later attempt down the "reuse cached" branch above
+          // and fail identically forever, even once the URL serves a good file. A caller-supplied
+          // dbPath is not ours to delete.
+          if (!dataset.dbPath) {
+            await fs.promises.rm(dbFilePath, { force: true })
+          }
+          throw error
+        }
+
         logger.info(`Tandem repeat reads DB ready at ${dbFilePath}`)
 
         return dbFilePath

--- a/reads/src/shortTandemRepeatReadsDb.spec.js
+++ b/reads/src/shortTandemRepeatReadsDb.spec.js
@@ -244,6 +244,26 @@ describe('verification', () => {
   })
 })
 
+describe('recovery', () => {
+  it('retries after a failure instead of replaying the rejection forever', async () => {
+    const { ensureShortTandemRepeatReadsDb } = loadModule()
+
+    const dbPath = path.join(fixtureDir, 'str_reads.db')
+    await writeFixtureDb(dbPath)
+    const contents = fs.readFileSync(dbPath)
+
+    let calls = 0
+    jest.spyOn(global, 'fetch').mockImplementation(() => {
+      calls += 1
+      return calls === 1 ? mockResponse('', { status: 404 }) : okResponse(contents)
+    })
+
+    const dataset = { dbUrl: 'https://example.com/db/str_reads.db' }
+    await expect(ensureShortTandemRepeatReadsDb(dataset)).rejects.toThrow(/returned 404/)
+    await expect(ensureShortTandemRepeatReadsDb(dataset)).resolves.toBeTruthy()
+  }, 20000)
+})
+
 describe('getShortTandemRepeatReadsDb', () => {
   it('returns the same handle for repeated calls and opens it read-only', async () => {
     const { ensureShortTandemRepeatReadsDb, getShortTandemRepeatReadsDb } = loadModule()

--- a/reads/src/shortTandemRepeatReadsDb.spec.js
+++ b/reads/src/shortTandemRepeatReadsDb.spec.js
@@ -1,0 +1,265 @@
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+const { Readable } = require('stream')
+
+const sqlite = require('sqlite')
+const sqlite3 = require('sqlite3')
+
+jest.mock('./logging', () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn() }))
+
+let cacheDir
+let fixtureDir
+
+// A response whose body streams `content` once, mimicking the parts of fetch's Response that
+// fetchToFile uses.
+const mockResponse = (content, { status = 200, headers = {} } = {}) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  headers: {
+    get: (name) => headers[name.toLowerCase()] ?? null,
+  },
+  body: Readable.toWeb(Readable.from([Buffer.from(content)])),
+})
+
+const okResponse = (content, extraHeaders = {}) =>
+  mockResponse(content, {
+    headers: { 'content-length': String(Buffer.byteLength(content)), ...extraHeaders },
+  })
+
+const writeFixtureDb = async (filePath, { withReadsTable = true } = {}) => {
+  const db = await sqlite.open({ filename: filePath, driver: sqlite3.Database })
+  if (withReadsTable) {
+    await db.exec('CREATE TABLE `reads` (`id` varchar(10), `filename` char(47))')
+    await db.exec("INSERT INTO `reads` VALUES ('EP400', 'abc.EP400.svg.gz')")
+  } else {
+    await db.exec('CREATE TABLE `other` (`id` varchar(10))')
+  }
+  await db.close()
+}
+
+// The module memoizes downloads and connections in module scope, so every test needs a fresh copy.
+const loadModule = () => {
+  let module
+  jest.isolateModules(() => {
+    // eslint-disable-next-line global-require
+    module = require('./shortTandemRepeatReadsDb')
+  })
+  return module
+}
+
+beforeEach(() => {
+  cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'str-reads-cache-'))
+  fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'str-reads-fixture-'))
+  process.env.STR_READS_DB_CACHE_DIR = cacheDir
+})
+
+afterEach(() => {
+  delete process.env.STR_READS_DB_CACHE_DIR
+  fs.rmSync(cacheDir, { recursive: true, force: true })
+  fs.rmSync(fixtureDir, { recursive: true, force: true })
+  jest.restoreAllMocks()
+})
+
+describe('cache path derivation', () => {
+  it('gives different URLs different local paths, so a new release is never served from cache', async () => {
+    const { ensureShortTandemRepeatReadsDb } = loadModule()
+
+    const dbPath = path.join(fixtureDir, 'str_reads.db')
+    await writeFixtureDb(dbPath)
+    const contents = fs.readFileSync(dbPath)
+
+    const fetchMock = jest.spyOn(global, 'fetch').mockImplementation(() => okResponse(contents))
+
+    await ensureShortTandemRepeatReadsDb({
+      dbUrl: 'https://example.com/db/str_reads_2026_07_20.db',
+    })
+    await ensureShortTandemRepeatReadsDb({
+      dbUrl: 'https://example.com/db/str_reads_2027_01_01.db',
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    const cached = fs.readdirSync(cacheDir).sort()
+    expect(cached).toHaveLength(2)
+    expect(cached[0]).toMatch(/^[0-9a-f]{12}-str_reads_20\d\d_\d\d_\d\d\.db$/)
+  })
+})
+
+describe('dbPath', () => {
+  it('serves a local file without fetching', async () => {
+    const { ensureShortTandemRepeatReadsDb } = loadModule()
+    const fetchMock = jest.spyOn(global, 'fetch')
+
+    const dbPath = path.join(fixtureDir, 'str_reads.db')
+    await writeFixtureDb(dbPath)
+
+    await expect(ensureShortTandemRepeatReadsDb({ dbPath })).resolves.toBe(dbPath)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects when the local file is missing', async () => {
+    const { ensureShortTandemRepeatReadsDb } = loadModule()
+
+    await expect(
+      ensureShortTandemRepeatReadsDb({ dbPath: path.join(fixtureDir, 'missing.db') })
+    ).rejects.toThrow(/ENOENT/)
+  })
+})
+
+describe('download', () => {
+  let contents
+
+  beforeEach(async () => {
+    const dbPath = path.join(fixtureDir, 'str_reads.db')
+    await writeFixtureDb(dbPath)
+    contents = fs.readFileSync(dbPath)
+  })
+
+  it('skips the download when the cached file is already present', async () => {
+    const { ensureShortTandemRepeatReadsDb } = loadModule()
+    const fetchMock = jest.spyOn(global, 'fetch').mockImplementation(() => okResponse(contents))
+
+    const dataset = { dbUrl: 'https://example.com/db/str_reads.db' }
+    await ensureShortTandemRepeatReadsDb(dataset)
+
+    const { ensureShortTandemRepeatReadsDb: ensureAgain } = loadModule()
+    await ensureAgain(dataset)
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('downloads once for two datasets that share a URL', async () => {
+    const { ensureShortTandemRepeatReadsDb } = loadModule()
+    const fetchMock = jest.spyOn(global, 'fetch').mockImplementation(() => okResponse(contents))
+
+    const dbUrl = 'https://example.com/db/str_reads.db'
+    await Promise.all([
+      ensureShortTandemRepeatReadsDb({ dbUrl }),
+      ensureShortTandemRepeatReadsDb({ dbUrl }),
+    ])
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  // A truncated transfer is treated as transient, so these two exhaust the retry budget
+  // (2s + 4s of backoff) before rejecting. Hence the extended timeouts.
+  it('leaves no partial file behind when the body errors mid-stream', async () => {
+    const { ensureShortTandemRepeatReadsDb } = loadModule()
+    const fetchMock = jest.spyOn(global, 'fetch').mockImplementation(() => ({
+      ok: true,
+      status: 200,
+      headers: { get: () => null },
+      body: Readable.toWeb(
+        Readable.from(
+          (function* body() {
+            yield contents.subarray(0, 100)
+            throw new Error('connection reset')
+          })()
+        )
+      ),
+    }))
+
+    await expect(
+      ensureShortTandemRepeatReadsDb({ dbUrl: 'https://example.com/db/str_reads.db' })
+    ).rejects.toThrow(/connection reset/)
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(fs.readdirSync(cacheDir)).toEqual([])
+  }, 20000)
+
+  it('rejects a truncated response whose length disagrees with Content-Length', async () => {
+    const { ensureShortTandemRepeatReadsDb } = loadModule()
+    const fetchMock = jest.spyOn(global, 'fetch').mockImplementation(() =>
+      mockResponse(contents, {
+        headers: { 'content-length': String(contents.length + 1000) },
+      })
+    )
+
+    await expect(
+      ensureShortTandemRepeatReadsDb({ dbUrl: 'https://example.com/db/str_reads.db' })
+    ).rejects.toThrow(/Expected \d+ bytes/)
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(fs.readdirSync(cacheDir)).toEqual([])
+  }, 20000)
+
+  it('skips the size check when the response is transcoded, since Content-Length is the stored size', async () => {
+    const { ensureShortTandemRepeatReadsDb } = loadModule()
+    jest.spyOn(global, 'fetch').mockImplementation(() =>
+      mockResponse(contents, {
+        headers: {
+          'content-length': String(Math.floor(contents.length / 30)),
+          'content-encoding': 'gzip',
+        },
+      })
+    )
+
+    await expect(
+      ensureShortTandemRepeatReadsDb({ dbUrl: 'https://example.com/db/str_reads.db' })
+    ).resolves.toBeTruthy()
+  })
+
+  it('retries a 503 and succeeds', async () => {
+    const { ensureShortTandemRepeatReadsDb } = loadModule()
+    let calls = 0
+    const fetchMock = jest.spyOn(global, 'fetch').mockImplementation(() => {
+      calls += 1
+      return calls === 1 ? mockResponse('', { status: 503 }) : okResponse(contents)
+    })
+
+    await expect(
+      ensureShortTandemRepeatReadsDb({ dbUrl: 'https://example.com/db/str_reads.db' })
+    ).resolves.toBeTruthy()
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  }, 20000)
+
+  it('does not retry a 404, which is a configuration error', async () => {
+    const { ensureShortTandemRepeatReadsDb } = loadModule()
+    const fetchMock = jest
+      .spyOn(global, 'fetch')
+      .mockImplementation(() => mockResponse('', { status: 404 }))
+
+    await expect(
+      ensureShortTandemRepeatReadsDb({ dbUrl: 'https://example.com/db/missing.db' })
+    ).rejects.toThrow(/returned 404/)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('verification', () => {
+  it('rejects a file that is not a SQLite database', async () => {
+    const { ensureShortTandemRepeatReadsDb } = loadModule()
+    jest.spyOn(global, 'fetch').mockImplementation(() => okResponse('this is not a database'))
+
+    await expect(
+      ensureShortTandemRepeatReadsDb({ dbUrl: 'https://example.com/db/str_reads.db' })
+    ).rejects.toThrow()
+  })
+
+  it('rejects a valid database that has no reads table', async () => {
+    const { ensureShortTandemRepeatReadsDb } = loadModule()
+
+    const dbPath = path.join(fixtureDir, 'other.db')
+    await writeFixtureDb(dbPath, { withReadsTable: false })
+
+    await expect(ensureShortTandemRepeatReadsDb({ dbPath })).rejects.toThrow(/no such table/)
+  })
+})
+
+describe('getShortTandemRepeatReadsDb', () => {
+  it('returns the same handle for repeated calls and opens it read-only', async () => {
+    const { ensureShortTandemRepeatReadsDb, getShortTandemRepeatReadsDb } = loadModule()
+
+    const dbPath = path.join(fixtureDir, 'str_reads.db')
+    await writeFixtureDb(dbPath)
+    await ensureShortTandemRepeatReadsDb({ dbPath })
+
+    const [first, second] = await Promise.all([
+      getShortTandemRepeatReadsDb({ dbPath }),
+      getShortTandemRepeatReadsDb({ dbPath }),
+    ])
+
+    expect(first).toBe(second)
+    await expect(first.exec("INSERT INTO `reads` VALUES ('X', 'x.svg.gz')")).rejects.toThrow(
+      /readonly/
+    )
+  })
+})

--- a/reads/src/shortTandemRepeatReadsDb.spec.js
+++ b/reads/src/shortTandemRepeatReadsDb.spec.js
@@ -245,6 +245,39 @@ describe('verification', () => {
 })
 
 describe('recovery', () => {
+  it('evicts a cached file that fails verification so the next attempt re-downloads', async () => {
+    const { ensureShortTandemRepeatReadsDb } = loadModule()
+
+    const dbPath = path.join(fixtureDir, 'str_reads.db')
+    await writeFixtureDb(dbPath)
+    const good = fs.readFileSync(dbPath)
+
+    let calls = 0
+    const fetchMock = jest.spyOn(global, 'fetch').mockImplementation(() => {
+      calls += 1
+      return calls === 1 ? okResponse('this is not a database') : okResponse(good)
+    })
+
+    const dataset = { dbUrl: 'https://example.com/db/str_reads.db' }
+    await expect(ensureShortTandemRepeatReadsDb(dataset)).rejects.toThrow()
+    // The bad file must be gone, or the "reuse cached" branch would replay this failure forever.
+    expect(fs.readdirSync(cacheDir)).toEqual([])
+
+    await expect(ensureShortTandemRepeatReadsDb(dataset)).resolves.toBeTruthy()
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(fs.readdirSync(cacheDir)).toHaveLength(1)
+  }, 20000)
+
+  it('does not delete a caller-supplied dbPath that fails verification', async () => {
+    const { ensureShortTandemRepeatReadsDb } = loadModule()
+
+    const dbPath = path.join(fixtureDir, 'not_a_db.db')
+    fs.writeFileSync(dbPath, 'this is not a database')
+
+    await expect(ensureShortTandemRepeatReadsDb({ dbPath })).rejects.toThrow()
+    expect(fs.existsSync(dbPath)).toBe(true)
+  })
+
   it('retries after a failure instead of replaying the rejection forever', async () => {
     const { ensureShortTandemRepeatReadsDb } = loadModule()
 


### PR DESCRIPTION
Two related changes for the July 2026 (`2026_07_20`) tandem repeat release. Changelog entry: https://gnomad.broadinstitute.org/news/2026-07-str-data-update/

## 1. Point the browser and pipeline at the new release

**Downloads page** (`browser/src/DataPage/GnomadV3Downloads.tsx`)
- Adds an "Update (July 2026)" section above the March 2025 one, linking the new genotypes TSV and distributions JSON.
- The README link intentionally points at the existing `README__2025_03_17.txt`: the column schema is unchanged from the March 2025 release (same 22 columns, same order), so no new README was produced. Its `loggingLabel` deliberately omits a July date so it does not imply a new document.
- The new entries carry distinct `loggingLabel`s so their download counts are separable from the 2025 and 2022 releases.

**TR overview page** (`browser/src/ShortTandemRepeatsPage/ShortTandemRepeatsPage.tsx`) — notes the data version (`2026-07-20`) in the intro paragraph.

**Data pipeline** — `pipelines/gnomad_v3_short_tandem_repeats.py`: default input is now the release's distributions JSON, overridable with `STR_DISTRIBUTIONS_JSON` (useful for local runs against a local file, which avoids GCS auth). Note this changes the input convention from a copy under `gs://gnomad-browser-data-pipeline/inputs/secondary-analyses/strs/` to the browser bucket's gzipped JSON — happy to move the file instead if the old convention is preferred.

## 2. Fetch the tandem repeat reads DB from GCS at startup

Previously the reads service opened `/readviz/datasets/gnomad_r4_short_tandem_repeats/str_reads.db` from a 6552 GB read-only persistent disk, so shipping a new ~170 MB DB meant snapshotting and cloning that disk. It now downloads the DB from a public GCS URL into the container's writable filesystem.

- **New module** `reads/src/shortTandemRepeatReadsDb.js` — download, verify, and hand out a memoized read-only handle.
  - Streamed with `pipeline()`, never buffered: the container has a 256Mi memory limit and the file is ~170 MB.
  - Downloads to a temp path and `rename()`s into place, so a partial transfer can never be opened.
  - The cache filename is derived from a hash of the URL, so pointing `STR_READS_DB_URL` at a new release is a cache miss by construction and can never serve the previous release's file.
  - Aborts on a 60s **stall** rather than capping total duration — a duration cap fails on any link slower than size/cap even when the transfer is healthy.
  - Verifies with `PRAGMA quick_check` plus a `SELECT 1 FROM reads` schema probe, since `quick_check` alone would pass an unrelated database.
  - Opens `OPEN_READONLY`. The default mode would silently create an empty DB if the file were missing, turning a startup failure into a confusing per-request `no such table: reads`.
- **`reads/src/server.js`** warms the DB before `listen()` so the common case is not a first request waiting on a download. A failure there is logged but not fatal: this service also serves variant reads off `/readviz`, which have no dependency on this DB, so exiting would cause a much larger outage than the one being reported.
- **`reads/src/resolveShortTandemRepeatReads.js`** uses one shared handle instead of opening and closing the DB on every request (it did so twice per page load). A query awaits the fetch, so it either waits on the in-flight download or retries a failed one.
- **`jest.config.ts`** gains a `reads` project. Without it, specs under `reads/` are silently never run. `.eslintrc.js` extends its jest-env override to `*spec.js` so those specs lint.

Also included: an `EP400` readviz folder override. EP400's images for the narrowed 548-611 locus definition live in `EP400__12-132062548-132062611/`, while `EP400/` still holds the wider-definition images (verified: genuinely different files, 63,718 vs 32,281 bytes). Without the override the Read Data panel would show images that disagree with the histograms. The entry should be deleted once `EP400/` is restaged.

## Data dependencies

- The reads DB is uploaded at `gs://gnomad-str-public/release_2026_07/reads_db/str_reads_2026_07_20.db` (public, identity-encoded, crc32c verified against the source file). Identity encoding matters: the size check is skipped for encoded responses.
- The download links 404 until the genotypes TSV and distributions JSON are published to `gs://gcp-public-data--gnomad/release/3.1.3/{tsv,json}/` **and** the AWS `gnomad-public-us-east-1` mirror, since the page renders a Google and an Amazon link for each file.
- The new Elasticsearch index already exists in production alongside the current one; the alias still points at `gnomad_v3_short_tandem_repeats-2025-03-17--19-04`, so nothing in this PR changes what the API serves.

## Checks

Run locally, matching the CI workflows:

- `pnpm eslint browser`, `pnpm eslint reads`, `pnpm stylelint`
- `pnpm ts-node ./browser/build/buildHelp.ts && pnpm typecheck`
- `pnpm jest` — 74 suites, 2059 tests, 1144 snapshots
- `ruff format --check data-pipeline` and `ruff check data-pipeline` with the version pinned in `uv.lock` (0.15.18)

Beyond the unit tests, the reads service was exercised end to end against the real 168 MB DB: a cold start downloads, verifies, and serves (`num_reads: 14035` for both EP400 and RAI1), the downloaded copy is byte-identical to the source, and with an unreachable DB URL the service still starts, still serves variant reads, and returns an error for tandem repeat queries.
