### PR TITLE
feat: update gnomAD TR data to the July 2026 release (reads db mounted via GCS Fuse)

### DIFF
--- a/browser/src/DataPage/GnomadV3Downloads.tsx
+++ b/browser/src/DataPage/GnomadV3Downloads.tsx
@@ -318,6 +318,34 @@ const GnomadV3Downloads = () => (
         </ExternalLink>
         .
       </p>
+      <b>Update (July 2026)</b>: [
+      <a href="https://gnomad.broadinstitute.org/news/2026-07-str-data-update/">changelog entry</a>]
+      <FileList>
+        <ListItem>
+          {/* The column schema did not change in this release, so this release reuses the
+              March 2025 README rather than publishing an identical new one. */}
+          <DownloadLinks
+            label="README"
+            loggingLabel="v3.1.3 genotype TSV README"
+            path="/release/3.1.3/tsv/README__2025_03_17.txt"
+          />
+        </ListItem>
+        <ListItem>
+          <DownloadLinks
+            label="Genotypes (TSV)"
+            loggingLabel="v3.1.3 genotypes TSV (7-20-2026 update)"
+            path="/release/3.1.3/tsv/gnomAD_STR_genotypes__2026_07_20.tsv.gz"
+          />
+        </ListItem>
+        <ListItem>
+          <DownloadLinks
+            label="Distributions (JSON)"
+            loggingLabel="v3.1.3 distributions JSON (7-20-2026 update)"
+            path="/release/3.1.3/json/gnomAD_STR_distributions__2026_07_20.json.gz"
+          />
+        </ListItem>
+      </FileList>
+      <br />
       <b>Update (March 2025)</b>: [
       <a href="https://gnomad.broadinstitute.org/news/2025-03-known-disease-associated-tandem-repeat-pages/">
         changelog entry

--- a/browser/src/DataPage/__snapshots__/DataPage.spec.tsx.snap
+++ b/browser/src/DataPage/__snapshots__/DataPage.spec.tsx.snap
@@ -11627,6 +11627,120 @@ exports[`Data Page has no unexpected changes 1`] = `
         .
       </p>
       <b>
+        Update (July 2026)
+      </b>
+      : [
+      <a
+        href="https://gnomad.broadinstitute.org/news/2026-07-str-data-update/"
+      >
+        changelog entry
+      </a>
+      ]
+      <ul
+        className="c20 c21"
+      >
+        <li
+          className="c22"
+        >
+          <span>
+            README
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download README from Google"
+              className="c8"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.3/tsv/README__2025_03_17.txt"
+              onClick={[Function]}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download README from Amazon"
+              className="c8"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.3/tsv/README__2025_03_17.txt"
+              onClick={[Function]}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+          </span>
+        </li>
+        <li
+          className="c22"
+        >
+          <span>
+            Genotypes (TSV)
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download Genotypes (TSV) from Google"
+              className="c8"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.3/tsv/gnomAD_STR_genotypes__2026_07_20.tsv.gz"
+              onClick={[Function]}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download Genotypes (TSV) from Amazon"
+              className="c8"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.3/tsv/gnomAD_STR_genotypes__2026_07_20.tsv.gz"
+              onClick={[Function]}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+          </span>
+        </li>
+        <li
+          className="c22"
+        >
+          <span>
+            Distributions (JSON)
+          </span>
+          <br />
+          <span>
+            Download from
+             
+            <a
+              aria-label="Download Distributions (JSON) from Google"
+              className="c8"
+              href="https://storage.googleapis.com/gcp-public-data--gnomad/release/3.1.3/json/gnomAD_STR_distributions__2026_07_20.json.gz"
+              onClick={[Function]}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Google
+            </a>
+             / 
+            <a
+              aria-label="Download Distributions (JSON) from Amazon"
+              className="c8"
+              href="https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.3/json/gnomAD_STR_distributions__2026_07_20.json.gz"
+              onClick={[Function]}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Amazon
+            </a>
+          </span>
+        </li>
+      </ul>
+      <br />
+      <b>
         Update (March 2025)
       </b>
       : [

--- a/browser/src/ShortTandemRepeatsPage/ShortTandemRepeatsPage.tsx
+++ b/browser/src/ShortTandemRepeatsPage/ShortTandemRepeatsPage.tsx
@@ -162,7 +162,7 @@ const ShortTandemRepeatsPage = ({ shortTandemRepeats }: ShortTandemRepeatsPagePr
   return (
     <>
       <p>
-        For more information about Tandem Repeats in gnomAD, see our{' '}
+        STR data version: 2026-07-20. For more information about Tandem Repeats in gnomAD, see our{' '}
         <a href="https://gnomad.broadinstitute.org/news/2022-01-the-addition-of-short-tandem-repeat-calls-to-gnomad/">
           blog post
         </a>{' '}

--- a/browser/src/ShortTandemRepeatsPage/__snapshots__/ShortTandemRepeatsPage.spec.tsx.snap
+++ b/browser/src/ShortTandemRepeatsPage/__snapshots__/ShortTandemRepeatsPage.spec.tsx.snap
@@ -247,7 +247,7 @@ exports[`ShortTandemRepeatsPage has no unexpected changes 1`] = `
           </div>
         </div>
         <p>
-          For more information about Tandem Repeats in gnomAD, see our
+          STR data version: 2026-07-20. For more information about Tandem Repeats in gnomAD, see our
            
           <a
             href="https://gnomad.broadinstitute.org/news/2022-01-the-addition-of-short-tandem-repeat-calls-to-gnomad/"
@@ -929,7 +929,7 @@ exports[`ShortTandemRepeatsPage has no unexpected changes 1`] = `
         </div>
       </div>
       <p>
-        For more information about Tandem Repeats in gnomAD, see our
+        STR data version: 2026-07-20. For more information about Tandem Repeats in gnomAD, see our
          
         <a
           href="https://gnomad.broadinstitute.org/news/2022-01-the-addition-of-short-tandem-repeat-calls-to-gnomad/"

--- a/data-pipeline/src/data_pipeline/pipelines/gnomad_v3_short_tandem_repeats.py
+++ b/data-pipeline/src/data_pipeline/pipelines/gnomad_v3_short_tandem_repeats.py
@@ -1,3 +1,5 @@
+import os
+
 from data_pipeline.pipeline import Pipeline, run_pipeline
 
 from data_pipeline.datasets.gnomad_v3.gnomad_v3_short_tandem_repeats import prepare_gnomad_v3_short_tandem_repeats
@@ -10,7 +12,12 @@ pipeline.add_task(
     prepare_gnomad_v3_short_tandem_repeats,
     "/gnomad_v4/gnomad_v4_short_tandem_repeats.ht",
     {
-        "path": "gs://gnomad-browser-data-pipeline/inputs/secondary-analyses/strs/2025_03_17/gnomAD_STR_distributions__gnomad-v2__2025_03_17.json"
+        # Override with a local path for local dev (avoids GCS auth), e.g.
+        #   STR_DISTRIBUTIONS_JSON=/path/to/gnomAD_STR_distributions__gnomad-v2__2026_07_20.json.gz
+        "path": os.environ.get(
+            "STR_DISTRIBUTIONS_JSON",
+            "gs://gnomad-browser/STRs/gnomAD_STR_distributions__gnomad-v2__2026_07_20.json.gz",
+        )
     },
 )
 

--- a/reads/src/datasets.js
+++ b/reads/src/datasets.js
@@ -39,18 +39,14 @@ const variantDatasets = {
   },
 }
 
-const SHORT_TANDEM_REPEAT_READS_DB_PATH =
-  '/readviz/datasets/gnomad_r4_short_tandem_repeats/str_reads_2026_07_20.db'
+const SHORT_TANDEM_REPEAT_DATA = {
+  dbPath: '/readviz/datasets/gnomad_r4_short_tandem_repeats/str_reads_2026_07_20.db',
+  publicPath: 'https://storage.googleapis.com/gnomad-str-public/release_2024_07/readviz_v2',
+}
 
 const shortTandemRepeatDatasets = {
-  gnomad_r3: {
-    dbPath: SHORT_TANDEM_REPEAT_READS_DB_PATH,
-    publicPath: 'https://storage.googleapis.com/gnomad-str-public/release_2024_07/readviz_v2',
-  },
-  gnomad_r4: {
-    dbPath: SHORT_TANDEM_REPEAT_READS_DB_PATH,
-    publicPath: 'https://storage.googleapis.com/gnomad-str-public/release_2024_07/readviz_v2',
-  },
+  gnomad_r3: SHORT_TANDEM_REPEAT_DATA,
+  gnomad_r4: SHORT_TANDEM_REPEAT_DATA,
 }
 
 module.exports = { variantDatasets, shortTandemRepeatDatasets }

--- a/reads/src/datasets.js
+++ b/reads/src/datasets.js
@@ -39,11 +39,8 @@ const variantDatasets = {
   },
 }
 
-// Names the release explicitly rather than reusing the previous release's str_reads.db, so that
-// the new DB is added alongside the old one on the /readviz disk instead of overwriting it. That
-// keeps the previous release servable and makes rolling back a code revert rather than a data copy.
-const SHORT_TANDEM_REPEAT_READS_DB_PATH =
-  '/readviz/datasets/gnomad_r4_short_tandem_repeats/str_reads_2026_07_20.db'
+// mounted via GCS Fuse
+const SHORT_TANDEM_REPEAT_READS_DB_PATH = 'str_reads_2026_07_20.db'
 
 const shortTandemRepeatDatasets = {
   gnomad_r3: {

--- a/reads/src/datasets.js
+++ b/reads/src/datasets.js
@@ -40,7 +40,8 @@ const variantDatasets = {
 }
 
 // mounted via GCS Fuse
-const SHORT_TANDEM_REPEAT_READS_DB_PATH = 'str_reads_2026_07_20.db'
+const SHORT_TANDEM_REPEAT_READS_DB_PATH =
+  '/readviz/datasets/gnomad_r4_short_tandem_repeats/str_reads_2026_07_20.db'
 
 const shortTandemRepeatDatasets = {
   gnomad_r3: {

--- a/reads/src/datasets.js
+++ b/reads/src/datasets.js
@@ -39,7 +39,6 @@ const variantDatasets = {
   },
 }
 
-// mounted via GCS Fuse
 const SHORT_TANDEM_REPEAT_READS_DB_PATH =
   '/readviz/datasets/gnomad_r4_short_tandem_repeats/str_reads_2026_07_20.db'
 

--- a/reads/src/datasets.js
+++ b/reads/src/datasets.js
@@ -39,13 +39,19 @@ const variantDatasets = {
   },
 }
 
+// Names the release explicitly rather than reusing the previous release's str_reads.db, so that
+// the new DB is added alongside the old one on the /readviz disk instead of overwriting it. That
+// keeps the previous release servable and makes rolling back a code revert rather than a data copy.
+const SHORT_TANDEM_REPEAT_READS_DB_PATH =
+  '/readviz/datasets/gnomad_r4_short_tandem_repeats/str_reads_2026_07_20.db'
+
 const shortTandemRepeatDatasets = {
   gnomad_r3: {
-    dbPath: '/readviz/datasets/gnomad_r4_short_tandem_repeats/str_reads.db',
+    dbPath: SHORT_TANDEM_REPEAT_READS_DB_PATH,
     publicPath: 'https://storage.googleapis.com/gnomad-str-public/release_2024_07/readviz_v2',
   },
   gnomad_r4: {
-    dbPath: '/readviz/datasets/gnomad_r4_short_tandem_repeats/str_reads.db',
+    dbPath: SHORT_TANDEM_REPEAT_READS_DB_PATH,
     publicPath: 'https://storage.googleapis.com/gnomad-str-public/release_2024_07/readviz_v2',
   },
 }

--- a/reads/src/resolveShortTandemRepeatReads.js
+++ b/reads/src/resolveShortTandemRepeatReads.js
@@ -3,6 +3,12 @@ const sqlite3 = require('sqlite3')
 
 const { UserVisibleError } = require('./errors')
 
+// Map a locus id to a non-default readviz image folder under publicPath. Needed while a locus's
+// images live in a coordinate-named folder rather than the live <locusId>/ folder (EP400's
+// 548-definition images are staged under EP400__12-132062548-132062611/ so they do not overwrite
+// the wide-definition images still in EP400/). Delete the entry once EP400/ holds those images.
+const READVIZ_FOLDER_BY_LOCUS = { EP400: 'EP400__12-132062548-132062611' }
+
 const buildWhere = ({ id, filter }) => {
   const params = {
     ':id': id,
@@ -222,7 +228,7 @@ const resolveShortTandemRepeatReads = async (
       sex: row.sex,
       age: row.age,
       pcr_protocol: row.pcr_protocol,
-      path: `${publicPath}/${id}/${row.filename}`,
+      path: `${publicPath}/${READVIZ_FOLDER_BY_LOCUS[id] || id}/${row.filename}`,
       quality_description: row.quality_description,
       q_score: row.q,
     }


### PR DESCRIPTION
Points the browser and data pipeline at the July 2026 (`2026_07_20`) tandem repeat release. Changelog entry: https://gnomad.broadinstitute.org/news/2026-07-str-data-update/

This is an alternative to #1920. The reads service keeps opening the tandem repeat readviz SQLite DB as a file on the container filesystem — the DB is expected to be mounted, via GCS Fuse, rather than downloaded — so none of #1920's fetch-and-cache machinery is here. #1920 contains these same changes plus that refactor; merge one and close the other.

## Downloads page

`browser/src/DataPage/GnomadV3Downloads.tsx` — adds an "Update (July 2026)" section above the March 2025 one, linking the new genotypes TSV and distributions JSON.

- The README link intentionally points at the existing `README__2025_03_17.txt`: the column schema is unchanged from the March 2025 release (same 22 columns, same order), so no new README was produced. Its `loggingLabel` deliberately omits a July date so it does not imply a new document.
- The new entries carry distinct `loggingLabel`s so their download counts are separable from the 2025 and 2022 releases.

## TR overview page

`browser/src/ShortTandemRepeatsPage/ShortTandemRepeatsPage.tsx` — notes the data version (`2026-07-20`) in the intro paragraph.

## Data pipeline

`pipelines/gnomad_v3_short_tandem_repeats.py` — the default input is now the release's distributions JSON, overridable with `STR_DISTRIBUTIONS_JSON` (useful for local runs against a local file, which avoids GCS auth). Note this changes the input convention from a copy under `gs://gnomad-browser-data-pipeline/inputs/secondary-analyses/strs/` to the browser bucket's gzipped JSON — happy to move the file instead if the old convention is preferred.

## EP400 readviz folder override

`reads/src/resolveShortTandemRepeatReads.js` — EP400's images for the narrowed 548-611 locus definition live in `EP400__12-132062548-132062611/`, while `EP400/` still holds the wider-definition images (verified: genuinely different files, 63,718 vs 32,281 bytes). Without the override the Read Data panel would show images that disagree with the histograms. The entry should be deleted once `EP400/` is restaged with the 548-definition images, which cannot happen until the new Elasticsearch index is live, since the currently deployed reads DB resolves EP400 through the default `<locusId>/` path.

## Data dependencies

- `reads/src/datasets.js` now opens `/readviz/datasets/gnomad_r4_short_tandem_repeats/str_reads_2026_07_20.db`, to be mounted via GCS Fuse. The mount is not set up yet and the exact bucket and deployment wiring are still TBD. Until the DB is present at that path, this image serves variant reads normally but fails tandem repeat queries.
- Naming the file after the release (rather than reusing `str_reads.db`) keeps the March 2025 DB intact, so the previous release stays servable and a rollback is a code revert rather than a data copy.
- The download links 404 until the genotypes TSV and distributions JSON are published to `gs://gcp-public-data--gnomad/release/3.1.3/{tsv,json}/` **and** the AWS `gnomad-public-us-east-1` mirror, since the page renders a Google and an Amazon link for each file.
- The new Elasticsearch index already exists in production alongside the current one; the alias still points at `gnomad_v3_short_tandem_repeats-2025-03-17--19-04`, so nothing in this PR changes what the API serves.

## Checks

Run locally against the changed files: `eslint`, `prettier --check`, `ruff format --check data-pipeline`, `ruff check data-pipeline` (ruff 0.15.18, the version pinned in `uv.lock`) — all clean.

The browser and data-pipeline files here are byte-identical to the corresponding files in #1920, where the full suite (`pnpm jest`, 74 suites / 2059 tests / 1144 snapshots, plus `pnpm typecheck`) passes in CI. I did not re-run jest or tsc locally for this branch: it was built in a git worktree whose `node_modules` was shared rather than installed, and duplicate module resolution makes both of those fail on unmodified files. CI on this PR runs them properly.