### PR TITLE
feat(frontend): add copyable anchor links to age distribution sections

### DIFF
--- a/browser/src/AnchorLink.spec.tsx
+++ b/browser/src/AnchorLink.spec.tsx
@@ -1,0 +1,66 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals'
+import styled from 'styled-components'
+
+import { AnchoredSectionHeading, withAnchor } from './AnchorLink'
+
+const PlainHeading = withAnchor(styled.h2``)
+
+const writeText = jest.fn(() => Promise.resolve())
+
+const originalClipboard = navigator.clipboard
+
+const setClipboard = (value: any) => {
+  Object.defineProperty(navigator, 'clipboard', { value, configurable: true, writable: true })
+}
+
+describe('withAnchor', () => {
+  beforeEach(() => {
+    writeText.mockClear()
+    setClipboard({ writeText })
+    window.history.pushState({}, '', '/variant/1-55051215-G-GA?dataset=gnomad_r4')
+  })
+
+  afterEach(() => {
+    setClipboard(originalClipboard)
+  })
+
+  test('renders an anchor carrying the section id', () => {
+    const { container } = render(
+      <PlainHeading id="age-distribution">Age Distribution</PlainHeading>
+    )
+    const anchor = container.querySelector('#age-distribution')
+    expect(anchor).not.toBeNull()
+    expect(anchor!.getAttribute('href')).toBe('#age-distribution')
+  })
+
+  test('does not touch the clipboard by default', async () => {
+    const { container } = render(
+      <PlainHeading id="age-distribution">Age Distribution</PlainHeading>
+    )
+    await userEvent.click(container.querySelector('#age-distribution')!)
+    expect(writeText).not.toHaveBeenCalled()
+  })
+
+  test('AnchoredSectionHeading copies the full section URL on click', async () => {
+    const { container } = render(
+      <AnchoredSectionHeading id="age-distribution">Age Distribution</AnchoredSectionHeading>
+    )
+    await userEvent.click(container.querySelector('#age-distribution')!)
+    expect(writeText).toHaveBeenCalledWith(
+      'http://localhost/variant/1-55051215-G-GA?dataset=gnomad_r4#age-distribution'
+    )
+  })
+
+  test('does nothing when the Clipboard API is unavailable', async () => {
+    setClipboard(undefined)
+    const { container } = render(
+      <AnchoredSectionHeading id="age-distribution">Age Distribution</AnchoredSectionHeading>
+    )
+    await expect(
+      userEvent.click(container.querySelector('#age-distribution')!)
+    ).resolves.not.toThrow()
+  })
+})

--- a/browser/src/AnchorLink.spec.tsx
+++ b/browser/src/AnchorLink.spec.tsx
@@ -1,119 +1,124 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals'
 import styled from 'styled-components'
 
-import { AgeDistributionHeading, withAnchor } from './AnchorLink'
+import { SectionHeading, withAnchor } from './AnchorLink'
 import Notifications from './Notifications'
 
 const PlainHeading = withAnchor(styled.h2``)
-
 const writeText = jest.fn(() => Promise.resolve())
-
 const originalClipboard = navigator.clipboard
 
 const setClipboard = (value: any) => {
   Object.defineProperty(navigator, 'clipboard', { value, configurable: true, writable: true })
 }
 
-const renderAgeDistributionHeading = () =>
-  render(
-    <>
-      <Notifications />
-      <AgeDistributionHeading>Age Distribution</AgeDistributionHeading>
-    </>
+beforeEach(() => {
+  writeText.mockClear()
+  setClipboard({ writeText })
+  window.history.pushState({}, '', '/variant/1-55051215-G-GA?dataset=gnomad_r4')
+})
+
+afterEach(() => {
+  setClipboard(originalClipboard)
+})
+
+test('withAnchor keeps legacy anchor targets unchanged and does not touch the clipboard', async () => {
+  const { container } = render(<PlainHeading id="help-section">Help section</PlainHeading>)
+  const anchor = container.querySelector('#help-section')
+
+  expect(anchor?.tagName).toBe('A')
+  expect(anchor?.getAttribute('href')).toBe('#help-section')
+  expect(anchor?.getAttribute('aria-hidden')).toBe('true')
+
+  await userEvent.click(anchor!)
+  expect(writeText).not.toHaveBeenCalled()
+})
+
+test('SectionHeading renders its title and adornments and forwards h2 attributes', () => {
+  const { container } = render(
+    <SectionHeading id="ancestry" title="Genetic Ancestry" className="custom" data-test="heading">
+      <button type="button">More information</button>
+    </SectionHeading>
   )
+  const heading = screen.getByRole('heading', { level: 2 })
+  expect(heading.textContent).toBe('Genetic Ancestry More information')
+  expect(container.firstElementChild).toBe(heading)
+  expect(getComputedStyle(heading).position).toBe('relative')
+  expect(heading.classList.contains('custom')).toBe(true)
+  expect(heading.getAttribute('data-test')).toBe('heading')
+  expect(heading.hasAttribute('title')).toBe(false)
+  expect(within(heading).getByRole('button', { name: 'More information' })).toBeTruthy()
+  expect(within(heading).getByRole('link', { name: 'Copy link to Genetic Ancestry' })).toBeTruthy()
+})
 
-describe('withAnchor', () => {
-  beforeEach(() => {
-    writeText.mockClear()
-    setClipboard({ writeText })
-    window.history.pushState({}, '', '/variant/1-55051215-G-GA?dataset=gnomad_r4')
-  })
+describe.each([
+  ['age-distribution', 'Age Distribution'],
+  ['variant-effect-predictor', 'Ensembl Variant Effect Predictor'],
+])('SectionHeading #%s', (id, title) => {
+  const renderHeading = () => {
+    render(
+      <>
+        <Notifications />
+        <SectionHeading id={id} title={title} />
+      </>
+    )
+    return screen.getByRole('link', { name: `Copy link to ${title}` })
+  }
+  const expectedUrl = `http://localhost/variant/1-55051215-G-GA?dataset=gnomad_r4#${id}`
 
-  afterEach(() => {
-    setClipboard(originalClipboard)
-  })
-
-  test('keeps existing heading anchors unchanged and does not touch the clipboard', async () => {
-    const { container } = render(<PlainHeading id="help-section">Help section</PlainHeading>)
-    const anchor = container.querySelector('#help-section')
-
-    expect(anchor).not.toBeNull()
-    expect(anchor?.getAttribute('href')).toBe('#help-section')
-    expect(anchor?.getAttribute('aria-hidden')).toBe('true')
-
-    await userEvent.click(anchor!)
-    expect(writeText).not.toHaveBeenCalled()
-  })
-
-  test('renders the Age Distribution control as a named link with a practical target', () => {
-    renderAgeDistributionHeading()
-
-    const link = screen.getByRole('link', { name: 'Copy link to Age Distribution' })
-    expect(link.getAttribute('href')).toBe('#age-distribution')
-    expect(link.getAttribute('id')).toBe('age-distribution')
+  test('puts the unique target ID on h2 and provides a named native link with a practical target', () => {
+    const link = renderHeading()
+    const heading = screen.getByRole('heading', { level: 2 })
+    expect(heading.tagName).toBe('H2')
+    expect(heading.id).toBe(id)
+    expect(document.querySelectorAll(`[id="${id}"]`)).toHaveLength(1)
+    expect(link.getAttribute('href')).toBe(`#${id}`)
+    expect(link.hasAttribute('id')).toBe(false)
     expect(getComputedStyle(link).width).toBe('44px')
     expect(getComputedStyle(link).height).toBe('44px')
   })
 
-  test('focuses and activates the Age Distribution link from the keyboard', async () => {
-    renderAgeDistributionHeading()
-    const link = screen.getByRole('link', { name: 'Copy link to Age Distribution' })
-
+  test('focuses and activates the link from the keyboard', async () => {
+    const link = renderHeading()
     await userEvent.tab()
     expect(document.activeElement).toBe(link)
     expect(getComputedStyle(link).opacity).toBe('1')
     await userEvent.keyboard('{Enter}')
 
-    expect(writeText).toHaveBeenCalledWith(
-      'http://localhost/variant/1-55051215-G-GA?dataset=gnomad_r4#age-distribution'
-    )
-    expect(window.location.hash).toBe('#age-distribution')
+    expect(writeText).toHaveBeenCalledWith(expectedUrl)
+    expect(window.location.hash).toBe(`#${id}`)
     expect(screen.getByRole('status').textContent).toContain('Link copied')
   })
 
   test('preserves the full current URL when replacing its fragment', async () => {
     window.history.pushState({}, '', '/variant/1-55051215-G-GA?dataset=gnomad_r4#another-section')
-    renderAgeDistributionHeading()
-
-    await userEvent.click(screen.getByRole('link', { name: 'Copy link to Age Distribution' }))
-
-    expect(writeText).toHaveBeenCalledWith(
-      'http://localhost/variant/1-55051215-G-GA?dataset=gnomad_r4#age-distribution'
-    )
+    await userEvent.click(renderHeading())
+    expect(writeText).toHaveBeenCalledWith(expectedUrl)
+    expect(window.location.hash).toBe(`#${id}`)
   })
 
-  test('shows an announced error and still navigates when clipboard access is rejected', async () => {
-    writeText.mockRejectedValueOnce(new Error('Permission denied'))
-    renderAgeDistributionHeading()
+  test.each(['rejects', 'throws', 'is unavailable'])(
+    'announces an error and still navigates by keyboard when clipboard access %s',
+    async (failure) => {
+      if (failure === 'rejects') {
+        writeText.mockRejectedValueOnce(new Error('Permission denied'))
+      } else if (failure === 'throws') {
+        writeText.mockImplementationOnce(() => {
+          throw new Error('Clipboard failure')
+        })
+      } else {
+        setClipboard(undefined)
+      }
+      renderHeading()
+      await userEvent.tab()
+      await userEvent.keyboard('{Enter}')
 
-    await userEvent.click(screen.getByRole('link', { name: 'Copy link to Age Distribution' }))
-
-    expect(window.location.hash).toBe('#age-distribution')
-    expect(screen.getByRole('alert').textContent).toContain('Unable to copy link')
-  })
-
-  test('shows an announced error and still navigates when clipboard access throws', async () => {
-    writeText.mockImplementationOnce(() => {
-      throw new Error('Clipboard failure')
-    })
-    renderAgeDistributionHeading()
-
-    await userEvent.click(screen.getByRole('link', { name: 'Copy link to Age Distribution' }))
-
-    expect(window.location.hash).toBe('#age-distribution')
-    expect(screen.getByRole('alert').textContent).toContain('Unable to copy link')
-  })
-
-  test('shows an announced error and still navigates when the Clipboard API is unavailable', async () => {
-    setClipboard(undefined)
-    renderAgeDistributionHeading()
-
-    await userEvent.click(screen.getByRole('link', { name: 'Copy link to Age Distribution' }))
-
-    expect(window.location.hash).toBe('#age-distribution')
-    expect(screen.getByRole('alert').textContent).toContain('Unable to copy link')
-  })
+      expect(window.location.hash).toBe(`#${id}`)
+      expect(screen.getByRole('alert').textContent).toContain('Unable to copy link')
+      expect(screen.getByRole('status').textContent).toBe('')
+    }
+  )
 })

--- a/browser/src/AnchorLink.spec.tsx
+++ b/browser/src/AnchorLink.spec.tsx
@@ -1,10 +1,11 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals'
 import styled from 'styled-components'
 
-import { AnchoredSectionHeading, withAnchor } from './AnchorLink'
+import { AgeDistributionHeading, withAnchor } from './AnchorLink'
+import Notifications from './Notifications'
 
 const PlainHeading = withAnchor(styled.h2``)
 
@@ -15,6 +16,14 @@ const originalClipboard = navigator.clipboard
 const setClipboard = (value: any) => {
   Object.defineProperty(navigator, 'clipboard', { value, configurable: true, writable: true })
 }
+
+const renderAgeDistributionHeading = () =>
+  render(
+    <>
+      <Notifications />
+      <AgeDistributionHeading>Age Distribution</AgeDistributionHeading>
+    </>
+  )
 
 describe('withAnchor', () => {
   beforeEach(() => {
@@ -27,40 +36,84 @@ describe('withAnchor', () => {
     setClipboard(originalClipboard)
   })
 
-  test('renders an anchor carrying the section id', () => {
-    const { container } = render(
-      <PlainHeading id="age-distribution">Age Distribution</PlainHeading>
-    )
-    const anchor = container.querySelector('#age-distribution')
-    expect(anchor).not.toBeNull()
-    expect(anchor!.getAttribute('href')).toBe('#age-distribution')
-  })
+  test('keeps existing heading anchors unchanged and does not touch the clipboard', async () => {
+    const { container } = render(<PlainHeading id="help-section">Help section</PlainHeading>)
+    const anchor = container.querySelector('#help-section')
 
-  test('does not touch the clipboard by default', async () => {
-    const { container } = render(
-      <PlainHeading id="age-distribution">Age Distribution</PlainHeading>
-    )
-    await userEvent.click(container.querySelector('#age-distribution')!)
+    expect(anchor).not.toBeNull()
+    expect(anchor?.getAttribute('href')).toBe('#help-section')
+    expect(anchor?.getAttribute('aria-hidden')).toBe('true')
+
+    await userEvent.click(anchor!)
     expect(writeText).not.toHaveBeenCalled()
   })
 
-  test('AnchoredSectionHeading copies the full section URL on click', async () => {
-    const { container } = render(
-      <AnchoredSectionHeading id="age-distribution">Age Distribution</AnchoredSectionHeading>
+  test('renders the Age Distribution control as a named link with a practical target', () => {
+    renderAgeDistributionHeading()
+
+    const link = screen.getByRole('link', { name: 'Copy link to Age Distribution' })
+    expect(link.getAttribute('href')).toBe('#age-distribution')
+    expect(link.getAttribute('id')).toBe('age-distribution')
+    expect(getComputedStyle(link).width).toBe('44px')
+    expect(getComputedStyle(link).height).toBe('44px')
+  })
+
+  test('focuses and activates the Age Distribution link from the keyboard', async () => {
+    renderAgeDistributionHeading()
+    const link = screen.getByRole('link', { name: 'Copy link to Age Distribution' })
+
+    await userEvent.tab()
+    expect(document.activeElement).toBe(link)
+    expect(getComputedStyle(link).opacity).toBe('1')
+    await userEvent.keyboard('{Enter}')
+
+    expect(writeText).toHaveBeenCalledWith(
+      'http://localhost/variant/1-55051215-G-GA?dataset=gnomad_r4#age-distribution'
     )
-    await userEvent.click(container.querySelector('#age-distribution')!)
+    expect(window.location.hash).toBe('#age-distribution')
+    expect(screen.getByRole('status').textContent).toContain('Link copied')
+  })
+
+  test('preserves the full current URL when replacing its fragment', async () => {
+    window.history.pushState({}, '', '/variant/1-55051215-G-GA?dataset=gnomad_r4#another-section')
+    renderAgeDistributionHeading()
+
+    await userEvent.click(screen.getByRole('link', { name: 'Copy link to Age Distribution' }))
+
     expect(writeText).toHaveBeenCalledWith(
       'http://localhost/variant/1-55051215-G-GA?dataset=gnomad_r4#age-distribution'
     )
   })
 
-  test('does nothing when the Clipboard API is unavailable', async () => {
+  test('shows an announced error and still navigates when clipboard access is rejected', async () => {
+    writeText.mockRejectedValueOnce(new Error('Permission denied'))
+    renderAgeDistributionHeading()
+
+    await userEvent.click(screen.getByRole('link', { name: 'Copy link to Age Distribution' }))
+
+    expect(window.location.hash).toBe('#age-distribution')
+    expect(screen.getByRole('alert').textContent).toContain('Unable to copy link')
+  })
+
+  test('shows an announced error and still navigates when clipboard access throws', async () => {
+    writeText.mockImplementationOnce(() => {
+      throw new Error('Clipboard failure')
+    })
+    renderAgeDistributionHeading()
+
+    await userEvent.click(screen.getByRole('link', { name: 'Copy link to Age Distribution' }))
+
+    expect(window.location.hash).toBe('#age-distribution')
+    expect(screen.getByRole('alert').textContent).toContain('Unable to copy link')
+  })
+
+  test('shows an announced error and still navigates when the Clipboard API is unavailable', async () => {
     setClipboard(undefined)
-    const { container } = render(
-      <AnchoredSectionHeading id="age-distribution">Age Distribution</AnchoredSectionHeading>
-    )
-    await expect(
-      userEvent.click(container.querySelector('#age-distribution')!)
-    ).resolves.not.toThrow()
+    renderAgeDistributionHeading()
+
+    await userEvent.click(screen.getByRole('link', { name: 'Copy link to Age Distribution' }))
+
+    expect(window.location.hash).toBe('#age-distribution')
+    expect(screen.getByRole('alert').textContent).toContain('Unable to copy link')
   })
 })

--- a/browser/src/AnchorLink.tsx
+++ b/browser/src/AnchorLink.tsx
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import styled from 'styled-components'
 
+import { showNotification } from './Notifications'
+
 const AnchorLink = styled.a.attrs({ 'aria-hidden': 'true' })`
   position: absolute;
   transform: translate(-15px, calc(50% - 0.5em));
@@ -25,11 +27,39 @@ const AnchorWrapper = styled.span`
   }
 `
 
+// The link still navigates, so the address bar updates either way. Copying is a convenience on
+// top of that, and is skipped where the Clipboard API is unavailable.
+export const copyLinkToSection = (id: string) => {
+  if (!navigator.clipboard || !navigator.clipboard.writeText) {
+    return
+  }
+
+  const { origin, pathname, search } = window.location
+  navigator.clipboard.writeText(`${origin}${pathname}${search}#${id}`).then(
+    () => {
+      showNotification({ title: 'Link copied', status: 'success' })
+    },
+    () => {
+      showNotification({ title: 'Unable to copy link', status: 'error' })
+    }
+  )
+}
+
 export const withAnchor = (Component: any) => {
-  const ComposedComponent = ({ children, id, ...props }: any) => (
+  const ComposedComponent = ({ children, id, copyUrlOnClick, ...props }: any) => (
     <AnchorWrapper>
       <Component {...props}>
-        <AnchorLink href={`#${id}`} id={id}>
+        <AnchorLink
+          href={`#${id}`}
+          id={id}
+          onClick={
+            copyUrlOnClick
+              ? () => {
+                  copyLinkToSection(id)
+                }
+              : undefined
+          }
+        >
           <img src={LinkIcon} alt="" aria-hidden="true" height={12} width={12} />
         </AnchorLink>
         {children}
@@ -41,6 +71,16 @@ export const withAnchor = (Component: any) => {
   ComposedComponent.propTypes = {
     children: PropTypes.node.isRequired,
     id: PropTypes.string.isRequired,
+    copyUrlOnClick: PropTypes.bool,
+  }
+  ComposedComponent.defaultProps = {
+    copyUrlOnClick: false,
   }
   return ComposedComponent
 }
+
+const SectionHeadingWithAnchor = withAnchor(styled.h2``)
+
+export const AnchoredSectionHeading = (props: any) => (
+  <SectionHeadingWithAnchor {...props} copyUrlOnClick />
+)

--- a/browser/src/AnchorLink.tsx
+++ b/browser/src/AnchorLink.tsx
@@ -27,39 +27,11 @@ const AnchorWrapper = styled.span`
   }
 `
 
-// The link still navigates, so the address bar updates either way. Copying is a convenience on
-// top of that, and is skipped where the Clipboard API is unavailable.
-export const copyLinkToSection = (id: string) => {
-  if (!navigator.clipboard || !navigator.clipboard.writeText) {
-    return
-  }
-
-  const { origin, pathname, search } = window.location
-  navigator.clipboard.writeText(`${origin}${pathname}${search}#${id}`).then(
-    () => {
-      showNotification({ title: 'Link copied', status: 'success' })
-    },
-    () => {
-      showNotification({ title: 'Unable to copy link', status: 'error' })
-    }
-  )
-}
-
 export const withAnchor = (Component: any) => {
-  const ComposedComponent = ({ children, id, copyUrlOnClick, ...props }: any) => (
+  const ComposedComponent = ({ children, id, ...props }: any) => (
     <AnchorWrapper>
       <Component {...props}>
-        <AnchorLink
-          href={`#${id}`}
-          id={id}
-          onClick={
-            copyUrlOnClick
-              ? () => {
-                  copyLinkToSection(id)
-                }
-              : undefined
-          }
-        >
+        <AnchorLink href={`#${id}`} id={id}>
           <img src={LinkIcon} alt="" aria-hidden="true" height={12} width={12} />
         </AnchorLink>
         {children}
@@ -71,16 +43,87 @@ export const withAnchor = (Component: any) => {
   ComposedComponent.propTypes = {
     children: PropTypes.node.isRequired,
     id: PropTypes.string.isRequired,
-    copyUrlOnClick: PropTypes.bool,
-  }
-  ComposedComponent.defaultProps = {
-    copyUrlOnClick: false,
   }
   return ComposedComponent
 }
 
-const SectionHeadingWithAnchor = withAnchor(styled.h2``)
+const AGE_DISTRIBUTION_ID = 'age-distribution'
 
-export const AnchoredSectionHeading = (props: any) => (
-  <SectionHeadingWithAnchor {...props} copyUrlOnClick />
+const AgeDistributionLink = styled.a`
+  position: absolute;
+  top: 50%;
+  left: 0;
+  transform: translate(-29px, -50%);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  width: 44px;
+  height: 44px;
+  opacity: 0;
+  vertical-align: middle;
+
+  /* stylelint-disable selector-type-no-unknown */
+  :hover,
+  :focus,
+  :focus-visible,
+  ${AnchorWrapper}:hover &,
+  ${AnchorWrapper}:focus-within & {
+    opacity: 1;
+  }
+  /* stylelint-enable selector-type-no-unknown */
+
+  :focus,
+  :focus-visible {
+    outline: 2px solid currentColor;
+    outline-offset: -8px;
+  }
+
+  @media (hover: none) {
+    opacity: 1;
+  }
+
+  /* Without the centered page's outer gutter, reserve inline space for the full target. */
+  @media (max-width: 1230px) {
+    position: static;
+    transform: none;
+    display: inline-flex;
+  }
+`
+
+// Clipboard failures must not suppress the link's default fragment navigation.
+const copyAgeDistributionLink = async () => {
+  try {
+    const clipboard = navigator.clipboard
+    if (!clipboard || !clipboard.writeText) {
+      throw new Error('Clipboard API unavailable')
+    }
+
+    const sectionUrl = new URL(window.location.href)
+    sectionUrl.hash = AGE_DISTRIBUTION_ID
+    await clipboard.writeText(sectionUrl.toString())
+    showNotification({ title: 'Link copied', status: 'success' })
+  } catch {
+    showNotification({ title: 'Unable to copy link', status: 'error' })
+  }
+}
+
+type AgeDistributionHeadingProps = Omit<React.ComponentPropsWithoutRef<'h2'>, 'id'>
+
+export const AgeDistributionHeading = ({ children, ...props }: AgeDistributionHeadingProps) => (
+  <AnchorWrapper>
+    <h2 {...props}>
+      <AgeDistributionLink
+        href={`#${AGE_DISTRIBUTION_ID}`}
+        id={AGE_DISTRIBUTION_ID}
+        aria-label="Copy link to Age Distribution"
+        onClick={() => {
+          copyAgeDistributionLink()
+        }}
+      >
+        <img src={LinkIcon} alt="" aria-hidden="true" height={12} width={12} />
+      </AgeDistributionLink>
+      {children}
+    </h2>
+  </AnchorWrapper>
 )

--- a/browser/src/AnchorLink.tsx
+++ b/browser/src/AnchorLink.tsx
@@ -47,9 +47,11 @@ export const withAnchor = (Component: any) => {
   return ComposedComponent
 }
 
-const AGE_DISTRIBUTION_ID = 'age-distribution'
+const Heading = styled.h2`
+  position: relative;
+`
 
-const AgeDistributionLink = styled.a`
+const SectionLink = styled.a`
   position: absolute;
   top: 50%;
   left: 0;
@@ -67,8 +69,8 @@ const AgeDistributionLink = styled.a`
   :hover,
   :focus,
   :focus-visible,
-  ${AnchorWrapper}:hover &,
-  ${AnchorWrapper}:focus-within & {
+  ${Heading}:hover &,
+  ${Heading}:focus-within & {
     opacity: 1;
   }
   /* stylelint-enable selector-type-no-unknown */
@@ -92,7 +94,7 @@ const AgeDistributionLink = styled.a`
 `
 
 // Clipboard failures must not suppress the link's default fragment navigation.
-const copyAgeDistributionLink = async () => {
+const copySectionLink = async (id: string) => {
   try {
     const clipboard = navigator.clipboard
     if (!clipboard || !clipboard.writeText) {
@@ -100,7 +102,7 @@ const copyAgeDistributionLink = async () => {
     }
 
     const sectionUrl = new URL(window.location.href)
-    sectionUrl.hash = AGE_DISTRIBUTION_ID
+    sectionUrl.hash = id
     await clipboard.writeText(sectionUrl.toString())
     showNotification({ title: 'Link copied', status: 'success' })
   } catch {
@@ -108,22 +110,44 @@ const copyAgeDistributionLink = async () => {
   }
 }
 
-type AgeDistributionHeadingProps = Omit<React.ComponentPropsWithoutRef<'h2'>, 'id'>
+type SectionHeadingProps = Omit<
+  React.ComponentPropsWithoutRef<'h2'>,
+  'id' | 'title' | 'children'
+> & {
+  id: string
+  title: string
+  // The container must reserve a 44px left gutter for the full link target.
+  linkInGutter?: boolean
+  children?: React.ReactNode
+}
 
-export const AgeDistributionHeading = ({ children, ...props }: AgeDistributionHeadingProps) => (
-  <AnchorWrapper>
-    <h2 {...props}>
-      <AgeDistributionLink
-        href={`#${AGE_DISTRIBUTION_ID}`}
-        id={AGE_DISTRIBUTION_ID}
-        aria-label="Copy link to Age Distribution"
-        onClick={() => {
-          copyAgeDistributionLink()
-        }}
-      >
-        <img src={LinkIcon} alt="" aria-hidden="true" height={12} width={12} />
-      </AgeDistributionLink>
-      {children}
-    </h2>
-  </AnchorWrapper>
+export const SectionHeading = ({
+  id,
+  title,
+  linkInGutter = false,
+  children,
+  ...props
+}: SectionHeadingProps) => (
+  <Heading
+    {...props}
+    id={id}
+    style={linkInGutter ? { padding: '8px 0', ...props.style } : props.style}
+  >
+    <SectionLink
+      style={
+        linkInGutter
+          ? { position: 'absolute', transform: 'translate(-100%, -50%)', display: 'flex' }
+          : undefined
+      }
+      href={`#${id}`}
+      aria-label={`Copy link to ${title}`}
+      onClick={() => {
+        copySectionLink(id)
+      }}
+    >
+      <img src={LinkIcon} alt="" aria-hidden="true" height={12} width={12} />
+    </SectionLink>
+    {title}
+    {children && <> {children}</>}
+  </Heading>
 )

--- a/browser/src/App.spec.tsx
+++ b/browser/src/App.spec.tsx
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals'
+
+import { scrollToAnchorOrStartOfPage } from './App'
+
+describe('App hash scrolling', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+    jest.spyOn(window, 'scrollTo').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    document.body.replaceChildren()
+    jest.useRealTimers()
+    jest.restoreAllMocks()
+  })
+
+  test.each(['h2', 'a'])('scrolls to a %s target after the render tick', (tag) => {
+    scrollToAnchorOrStartOfPage({ hash: '#section' })
+    const target = document.createElement(tag)
+    target.id = 'section'
+    target.scrollIntoView = jest.fn()
+    document.body.appendChild(target)
+    expect(target.scrollIntoView).not.toHaveBeenCalled()
+
+    jest.runOnlyPendingTimers()
+    expect(target.scrollIntoView).toHaveBeenCalledTimes(1)
+    expect(window.scrollTo).not.toHaveBeenCalled()
+  })
+
+  test.each(['#missing', '#[', '#123 not a selector'])(
+    'safely falls back to the top for missing target %s',
+    (hash) => {
+      scrollToAnchorOrStartOfPage({ hash })
+      expect(window.scrollTo).not.toHaveBeenCalled()
+      expect(() => jest.runOnlyPendingTimers()).not.toThrow()
+      expect(window.scrollTo).toHaveBeenCalledWith(0, 0)
+    }
+  )
+
+  test('scrolls to the top immediately when there is no hash', () => {
+    scrollToAnchorOrStartOfPage({ hash: '' })
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 0)
+    expect(jest.getTimerCount()).toBe(0)
+  })
+})

--- a/browser/src/App.tsx
+++ b/browser/src/App.tsx
@@ -13,10 +13,10 @@ import { ExternalLink } from '@gnomad/ui'
 const NavBar = lazy(() => import('./NavBar'))
 const Routes = lazy(() => import('./Routes'))
 
-const scrollToAnchorOrStartOfPage = (location: any) => {
+export const scrollToAnchorOrStartOfPage = (location: any) => {
   if (location.hash) {
     setTimeout(() => {
-      const anchor = document.querySelector(`a${location.hash}`)
+      const anchor = document.getElementById(location.hash.slice(1))
       if (anchor) {
         anchor.scrollIntoView()
       } else {

--- a/browser/src/DataPage/DataPage.tsx
+++ b/browser/src/DataPage/DataPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import styled from 'styled-components'
 
 import { Badge, ExternalLink, PageHeading } from '@gnomad/ui'
@@ -7,6 +7,7 @@ import Link from '../Link'
 
 import DocumentTitle from '../DocumentTitle'
 import InfoPage from '../InfoPage'
+import useScrollToHash from '../useScrollToHash'
 
 import { SectionTitle, StyledParagraph, CodeBlock } from './downloadsPageStyles'
 
@@ -53,18 +54,10 @@ const DataPage = () => {
   // Load stylesheet to make smooth scroll behavior active
   const _style = styles.html
 
-  useEffect(() => {
-    const hash = window.location.hash
-    if (hash !== '') {
-      const element = document.querySelector(`${hash}`)
-      if (element) {
-        element.scrollIntoView()
-      }
-    }
-  }, [])
+  useScrollToHash()
 
   return (
-    <InfoPage>
+    <InfoPage $withSectionLinks>
       <DocumentTitle title="Data" />
       <PageHeading>Data</PageHeading>
 
@@ -89,9 +82,7 @@ const DataPage = () => {
           .
         </div>
         <div>
-          <SectionTitle id="summary" subject="datasets">
-            Summary
-          </SectionTitle>
+          <SectionTitle id="summary" $subject="datasets" title="Summary" />
           <StyledParagraph>
             gnomAD data is available for download through{' '}
             <ExternalLink href="https://cloud.google.com/public-datasets">

--- a/browser/src/DataPage/ExacDownloads.tsx
+++ b/browser/src/DataPage/ExacDownloads.tsx
@@ -40,23 +40,19 @@ const coverageFiles = [
 
 const ExacDownloads = () => (
   <>
-    <SectionTitle id="exac" subject="release">
-      ExAC Downloads
-    </SectionTitle>
+    <SectionTitle id="exac" $subject="release" title="ExAC Downloads" />
     <StyledParagraph>
       The ExAC data set contains data from 60,706 exomes, all mapped to the GRCh37/hg19 reference
       sequence.
     </StyledParagraph>
 
-    <SectionTitle id="exac-core-dataset" subject="datasets">
-      Core Dataset
-    </SectionTitle>
+    <SectionTitle id="exac-core-dataset" $subject="datasets" title="Core Dataset" />
     <StyledParagraph>
       gnomAD database and features created and maintained by the gnomAD production team.
     </StyledParagraph>
 
     <DownloadsSection>
-      <SectionTitle id="exac-variants">Variants</SectionTitle>
+      <SectionTitle id="exac-variants" title="Variants" />
       <h3>Exomes</h3>
       <FileList>
         <ListItem>
@@ -72,7 +68,7 @@ const ExacDownloads = () => (
     </DownloadsSection>
 
     <DownloadsSection>
-      <SectionTitle id="exac-coverage">Coverage</SectionTitle>
+      <SectionTitle id="exac-coverage" title="Coverage" />
       <FileList>
         {coverageFiles.map(({ chrom, md5, size }) => (
           <ListItem key={chrom}>
@@ -88,7 +84,7 @@ const ExacDownloads = () => (
     </DownloadsSection>
 
     <DownloadsSection>
-      <SectionTitle id="exac-constraint">Constraint</SectionTitle>
+      <SectionTitle id="exac-constraint" title="Constraint" />
       <FileList>
         <ListItem>
           <DownloadLinks
@@ -100,9 +96,7 @@ const ExacDownloads = () => (
     </DownloadsSection>
 
     <DownloadsSection>
-      <SectionTitle id="exac-regional-missense-constraint">
-        Regional Missense Constraint
-      </SectionTitle>
+      <SectionTitle id="exac-regional-missense-constraint" title="Regional Missense Constraint" />
       <FileList>
         <ListItem>
           <DownloadLinks
@@ -114,7 +108,7 @@ const ExacDownloads = () => (
     </DownloadsSection>
 
     <DownloadsSection>
-      <SectionTitle id="exac-resources">Resources</SectionTitle>
+      <SectionTitle id="exac-resources" title="Resources" />
       <FileList>
         <ListItem>
           <DownloadLinks
@@ -126,7 +120,7 @@ const ExacDownloads = () => (
     </DownloadsSection>
 
     <section>
-      <SectionTitle id="exac-other">Other</SectionTitle>
+      <SectionTitle id="exac-other" title="Other" />
       <FileList>
         <ListItem>
           <GetUrlButtons

--- a/browser/src/DataPage/GnomadV2Downloads.tsx
+++ b/browser/src/DataPage/GnomadV2Downloads.tsx
@@ -154,23 +154,19 @@ const LDFiles = () => {
 const GnomadV2Downloads = () => {
   return (
     <>
-      <SectionTitle id="v2" subject="release">
-        v2 Downloads
-      </SectionTitle>
+      <SectionTitle id="v2" $subject="release" title="v2 Downloads" />
       <StyledParagraph>
         The gnomAD v2.1.1 data set contains data from 125,748 exomes and 15,708 whole genomes, all
         mapped to the GRCh37/hg19 reference sequence.
       </StyledParagraph>
 
-      <SectionTitle id="v2-core-dataset" subject="datasets">
-        Core Dataset
-      </SectionTitle>
+      <SectionTitle id="v2-core-dataset" $subject="datasets" title="Core Dataset" />
       <StyledParagraph>
         gnomAD database and features created and maintained by the gnomAD production team.
       </StyledParagraph>
 
       <DownloadsSection>
-        <SectionTitle id="v2-variants">Variants</SectionTitle>
+        <SectionTitle id="v2-variants" title="Variants" />
         <p>
           <Badge level="info">Note</Badge> Find out what changed in the latest release in the{' '}
           <ExternalLink href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/README.txt">
@@ -260,7 +256,7 @@ const GnomadV2Downloads = () => {
       </DownloadsSection>
 
       <DownloadsSection>
-        <SectionTitle id="v2-browser-tables">Browser Tables</SectionTitle>
+        <SectionTitle id="v2-browser-tables" title="Browser Tables" />
 
         <p>
           For more information about these files, see our{' '}
@@ -282,7 +278,7 @@ const GnomadV2Downloads = () => {
       </DownloadsSection>
 
       <DownloadsSection>
-        <SectionTitle id="v2-coverage">Coverage</SectionTitle>
+        <SectionTitle id="v2-coverage" title="Coverage" />
         <FileList>
           <ListItem>
             <GetUrlButtons
@@ -316,7 +312,7 @@ const GnomadV2Downloads = () => {
       </DownloadsSection>
 
       <DownloadsSection>
-        <SectionTitle id="v2-structural-variants">Structural variants</SectionTitle>
+        <SectionTitle id="v2-structural-variants" title="Structural variants" />
         <p>
           For information on gnomAD structural variants, see{' '}
           <ExternalLink href="https://doi.org/10.1038/s41586-020-2287-8">
@@ -371,12 +367,12 @@ const GnomadV2Downloads = () => {
       </DownloadsSection>
 
       <DownloadsSection>
-        <SectionTitle id="v2-linkage-disequilibrium">Linkage disequilibrium</SectionTitle>
+        <SectionTitle id="v2-linkage-disequilibrium" title="Linkage disequilibrium" />
         <LDFiles />
       </DownloadsSection>
 
       <DownloadsSection>
-        <SectionTitle id="v2-ancestry-classification">Ancestry classification</SectionTitle>
+        <SectionTitle id="v2-ancestry-classification" title="Ancestry classification" />
         <p>
           For more information about these files, see our blog post on{' '}
           <ExternalLink href="https://gnomad.broadinstitute.org/news/2021-09-using-the-gnomad-ancestry-principal-components-analysis-loadings-and-random-forest-classifier-on-your-dataset/">
@@ -403,9 +399,7 @@ const GnomadV2Downloads = () => {
       </DownloadsSection>
 
       <DownloadsSection>
-        <SectionTitle id="v2-regional-missense-constraint">
-          Regional Missense Constraint
-        </SectionTitle>
+        <SectionTitle id="v2-regional-missense-constraint" title="Regional Missense Constraint" />
         <FileList>
           <ListItem>
             <GetUrlButtons
@@ -429,7 +423,7 @@ const GnomadV2Downloads = () => {
       </DownloadsSection>
 
       <DownloadsSection>
-        <SectionTitle id="v2-clinvar-grch37">ClinVar</SectionTitle>
+        <SectionTitle id="v2-clinvar-grch37" title="ClinVar" />
         <p>
           For more information about these files, including how to download a specific previous
           version of the gnomAD browser ClinVar GRCh37 table, see the{' '}
@@ -449,7 +443,7 @@ const GnomadV2Downloads = () => {
       </DownloadsSection>
 
       <DownloadsSection>
-        <SectionTitle id="v2-resources">Resources</SectionTitle>
+        <SectionTitle id="v2-resources" title="Resources" />
         <FileList>
           <ListItem>
             <DownloadLinks
@@ -484,16 +478,14 @@ const GnomadV2Downloads = () => {
         </FileList>
       </DownloadsSection>
 
-      <SectionTitle id="v2-secondary-analyses" subject="datasets">
-        Secondary Analyses
-      </SectionTitle>
+      <SectionTitle id="v2-secondary-analyses" $subject="datasets" title="Secondary Analyses" />
       <StyledParagraph>
         Additional research analyses created using the core gnomAD releases in collaboration with
         members of the gnomAD steering committee.
       </StyledParagraph>
 
       <DownloadsSection>
-        <SectionTitle id="v2-constraint">Constraint</SectionTitle>
+        <SectionTitle id="v2-constraint" title="Constraint" />
         <p>
           For information on constraint, see{' '}
           <ExternalLink href="https://doi.org/10.1038/s41586-020-2308-7">
@@ -536,9 +528,7 @@ const GnomadV2Downloads = () => {
       </DownloadsSection>
 
       <DownloadsSection>
-        <SectionTitle id="v2-multi-nucleotide-variants">
-          Multi-nucleotide variants (MNVs)
-        </SectionTitle>
+        <SectionTitle id="v2-multi-nucleotide-variants" title="Multi-nucleotide variants (MNVs)" />
         <p>
           For information on multi-nucleotide variants in gnomAD, see{' '}
           <ExternalLink href="https://doi.org/10.1038/s41467-019-12438-5">
@@ -588,7 +578,7 @@ const GnomadV2Downloads = () => {
       </DownloadsSection>
 
       <DownloadsSection>
-        <SectionTitle id="v2-pext">Proportion expressed across transcripts (pext)</SectionTitle>
+        <SectionTitle id="v2-pext" title="Proportion expressed across transcripts (pext)" />
         <p>
           For information on pext, see{' '}
           <ExternalLink href="https://doi.org/10.1038/s41586-020-2329-2">
@@ -625,7 +615,7 @@ const GnomadV2Downloads = () => {
       </DownloadsSection>
 
       <DownloadsSection>
-        <SectionTitle id="v2-variant-cooccurrence">Variant co-occurrence</SectionTitle>
+        <SectionTitle id="v2-variant-cooccurrence" title="Variant co-occurrence" />
         <FileList>
           <ListItem>
             <DownloadLinks
@@ -656,7 +646,7 @@ const GnomadV2Downloads = () => {
       </DownloadsSection>
 
       <DownloadsSection>
-        <SectionTitle id="v2-lof-curation-results">Loss-of-function curation results</SectionTitle>
+        <SectionTitle id="v2-lof-curation-results" title="Loss-of-function curation results" />
         <p>
           For information on loss-of-function curation results, see{' '}
           <ExternalLink href="https://doi.org/10.1038/s41586-020-2308-7">

--- a/browser/src/DataPage/GnomadV2LiftoverDownloads.tsx
+++ b/browser/src/DataPage/GnomadV2LiftoverDownloads.tsx
@@ -69,23 +69,19 @@ const liftoverGenomeChromosomeVcfs = [
 const Gnomadv2LiftoverDownloads = () => {
   return (
     <>
-      <SectionTitle id="v2-liftover" subject="release">
-        v2 Liftover Downloads
-      </SectionTitle>
+      <SectionTitle id="v2-liftover" $subject="release" title="v2 Liftover Downloads" />
       <StyledParagraph>
         The gnomAD v2.1.1 liftover data set contains data from 125,748 exomes and 15,708 whole
         genomes, lifted over from the GRCh37 to the GRCh38 reference sequence.
       </StyledParagraph>
 
-      <SectionTitle id="v2-liftover-core-dataset" subject="datasets">
-        Core Dataset
-      </SectionTitle>
+      <SectionTitle id="v2-liftover-core-dataset" $subject="datasets" title="Core Dataset" />
       <StyledParagraph>
         gnomAD database and features created and maintained by the gnomAD production team.
       </StyledParagraph>
 
       <DownloadsSection>
-        <SectionTitle id="v2-liftover-variants">Variants (GRCh38 liftover)</SectionTitle>
+        <SectionTitle id="v2-liftover-variants" title="Variants (GRCh38 liftover)" />
         <p>
           The variant dataset files below contain all subsets (non-neuro, non-cancer, controls-only,
           and non-TOPMed).
@@ -159,9 +155,10 @@ const Gnomadv2LiftoverDownloads = () => {
       </DownloadsSection>
 
       <DownloadsSection>
-        <SectionTitle id="v2-liftover-structural-variants">
-          Structural variants (GRCh38 liftover)
-        </SectionTitle>
+        <SectionTitle
+          id="v2-liftover-structural-variants"
+          title="Structural variants (GRCh38 liftover)"
+        />
         <p>
           <Badge level="info">Note</Badge> The lifted over structural variant dataset was created by
           dbVar and has not been assessed by the gnomAD production team.

--- a/browser/src/DataPage/GnomadV3Downloads.tsx
+++ b/browser/src/DataPage/GnomadV3Downloads.tsx
@@ -69,23 +69,19 @@ const hgdpAnd1kgChromosomeVcfs = [
 
 const GnomadV3Downloads = () => (
   <>
-    <SectionTitle id="v3" subject="release">
-      v3 Downloads
-    </SectionTitle>
+    <SectionTitle id="v3" $subject="release" title="v3 Downloads" />
     <StyledParagraph>
       The gnomAD v3.1.2 data set contains 76,156 whole genomes (and no exomes), all mapped to the
       GRCh38 reference sequence.
     </StyledParagraph>
 
-    <SectionTitle id="v3-core-dataset" subject="datasets">
-      Core Dataset
-    </SectionTitle>
+    <SectionTitle id="v3-core-dataset" $subject="datasets" title="Core Dataset" />
     <StyledParagraph>
       gnomAD database and features created and maintained by the gnomAD production team.
     </StyledParagraph>
 
     <DownloadsSection>
-      <SectionTitle id="v3-variants">Variants</SectionTitle>
+      <SectionTitle id="v3-variants" title="Variants" />
       <p>
         <Badge level="info">Note</Badge> Find out what changed in the latest release in the{' '}
         <ExternalLink href="https://gnomad.broadinstitute.org/news/2021-10-gnomad-v3-1-2-minor-release/">
@@ -121,7 +117,7 @@ const GnomadV3Downloads = () => (
     </DownloadsSection>
 
     <DownloadsSection>
-      <SectionTitle id="v3-coverage">Coverage</SectionTitle>
+      <SectionTitle id="v3-coverage" title="Coverage" />
       <FileList>
         <ListItem>
           <GetUrlButtons
@@ -141,7 +137,7 @@ const GnomadV3Downloads = () => (
     </DownloadsSection>
 
     <DownloadsSection>
-      <SectionTitle id="v3-hgdp-1kg">HGDP + 1KG callset</SectionTitle>
+      <SectionTitle id="v3-hgdp-1kg" title="HGDP + 1KG callset" />
       <p>
         These files contain individual genotypes for all samples in the HGDP and 1KG subsets. For
         more information, see the{' '}
@@ -202,7 +198,7 @@ const GnomadV3Downloads = () => (
     </DownloadsSection>
 
     <DownloadsSection>
-      <SectionTitle id="v3-mitochondrial-dna">Mitochondrial DNA (mtDNA)</SectionTitle>
+      <SectionTitle id="v3-mitochondrial-dna" title="Mitochondrial DNA (mtDNA)" />
       <p>
         For details about these files, see the{' '}
         <ExternalLink href="https://gnomad.broadinstitute.org/news/2020-11-gnomad-v3-1-mitochondrial-dna-variants/">
@@ -244,9 +240,7 @@ const GnomadV3Downloads = () => (
     </DownloadsSection>
 
     <DownloadsSection>
-      <SectionTitle id="v3-ancestry-classification">
-        Genetic ancestry group classification
-      </SectionTitle>
+      <SectionTitle id="v3-ancestry-classification" title="Genetic ancestry group classification" />
       <p>
         For more information about these files, see our blog post on{' '}
         <ExternalLink href="https://gnomad.broadinstitute.org/news/2021-09-using-the-gnomad-ancestry-principal-components-analysis-loadings-and-random-forest-classifier-on-your-dataset/">
@@ -273,7 +267,7 @@ const GnomadV3Downloads = () => (
     </DownloadsSection>
 
     <DownloadsSection>
-      <SectionTitle id="v3-local-ancestry">Local ancestry</SectionTitle>
+      <SectionTitle id="v3-local-ancestry" title="Local ancestry" />
       <p>
         For more information about these files, see our blog posts on local ancestry inference for{' '}
         <ExternalLink href="https://gnomad.broadinstitute.org/news/2021-12-local-ancestry-inference-for-latino-admixed-american-samples-in-gnomad/">
@@ -306,7 +300,7 @@ const GnomadV3Downloads = () => (
     </DownloadsSection>
 
     <DownloadsSection>
-      <SectionTitle id="v3-short-tandem-repeats">Short tandem repeats</SectionTitle>
+      <SectionTitle id="v3-short-tandem-repeats" title="Short tandem repeats" />
       <p>
         These files contain the data that underlies the{' '}
         <ExternalLink href="https://gnomad.broadinstitute.org/short-tandem-repeats?dataset=gnomad_r4">
@@ -397,16 +391,14 @@ const GnomadV3Downloads = () => (
       </FileList>
     </DownloadsSection>
 
-    <SectionTitle id="v3-secondary-analyses" subject="datasets">
-      Secondary Analyses
-    </SectionTitle>
+    <SectionTitle id="v3-secondary-analyses" $subject="datasets" title="Secondary Analyses" />
     <StyledParagraph>
       Additional research analyses created using the core gnomAD releases in collaboration with
       members of the gnomAD steering committee.
     </StyledParagraph>
 
     <DownloadsSection>
-      <SectionTitle id="v3-genomic-constraint">Genomic constraint</SectionTitle>
+      <SectionTitle id="v3-genomic-constraint" title="Genomic constraint" />
       <p>For more information about these files, see the README included in the download.</p>
       <FileList>
         <ListItem>
@@ -438,7 +430,7 @@ const GnomadV3Downloads = () => (
     </DownloadsSection>
 
     <DownloadsSection>
-      <SectionTitle id="v3-hgdp-1kg-tutorials">HGDP + 1KG tutorials</SectionTitle>
+      <SectionTitle id="v3-hgdp-1kg-tutorials" title="HGDP + 1KG tutorials" />
       <p>
         For more information about these files, see the{' '}
         <ExternalLink href="https://docs.google.com/document/d/16W0KyrpRGRKHaOwahxtogtepbHe181BoOrSpTQVSVHc/edit?usp=sharing">
@@ -666,7 +658,7 @@ const GnomadV3Downloads = () => (
     </DownloadsSection>
 
     <DownloadsSection>
-      <SectionTitle id="v3-mito-constraint">Mitochondrial constraint</SectionTitle>
+      <SectionTitle id="v3-mito-constraint" title="Mitochondrial constraint" />
       <p>
         For more information about mitochondrial constraint, see{' '}
         <ExternalLink href="https://doi.org/10.1038/s41586-024-08048-x">

--- a/browser/src/DataPage/GnomadV4Downloads.tsx
+++ b/browser/src/DataPage/GnomadV4Downloads.tsx
@@ -98,23 +98,19 @@ const jointChromosomeVcfs = [
 const GnomadV4Downloads = () => {
   return (
     <>
-      <SectionTitle id="v4" subject="release">
-        v4 Downloads
-      </SectionTitle>
+      <SectionTitle id="v4" $subject="release" title="v4 Downloads" />
       <StyledParagraph>
         The gnomAD v4.1.0 data set contains data from 730,947 exomes and 76,215 whole genomes, all
         mapped to the GRCh38 reference sequence.
       </StyledParagraph>
 
-      <SectionTitle id="v4-core-dataset" subject="datasets">
-        Core Dataset
-      </SectionTitle>
+      <SectionTitle id="v4-core-dataset" $subject="datasets" title="Core Dataset" />
       <StyledParagraph>
         gnomAD database and features created and maintained by the gnomAD production team.
       </StyledParagraph>
 
       <DownloadsSection>
-        <SectionTitle id="v4-variants">Variants</SectionTitle>
+        <SectionTitle id="v4-variants" title="Variants" />
         <p>
           For more information, read the{' '}
           <ExternalLink href="https://gnomad.broadinstitute.org/news/2023-11-gnomad-v4-0">
@@ -176,7 +172,7 @@ const GnomadV4Downloads = () => {
       </DownloadsSection>
 
       <DownloadsSection>
-        <SectionTitle id="v4-joint-freq-stats">Joint Frequency</SectionTitle>
+        <SectionTitle id="v4-joint-freq-stats" title="Joint Frequency" />
         <FileList>
           <ListItem>
             <GetUrlButtons
@@ -199,7 +195,7 @@ const GnomadV4Downloads = () => {
       </DownloadsSection>
 
       <DownloadsSection>
-        <SectionTitle id="v4-all-sites-allele-number">All sites allele numbers</SectionTitle>
+        <SectionTitle id="v4-all-sites-allele-number" title="All sites allele numbers" />
         <ColumnsWrapper>
           <Column>
             <h3>Exomes</h3>
@@ -246,7 +242,7 @@ const GnomadV4Downloads = () => {
       </DownloadsSection>
 
       <DownloadsSection>
-        <SectionTitle id="v4-browser-tables">Browser Tables</SectionTitle>
+        <SectionTitle id="v4-browser-tables" title="Browser Tables" />
 
         <p>
           For more information about these files, see our{' '}
@@ -290,7 +286,7 @@ const GnomadV4Downloads = () => {
       </DownloadsSection>
 
       <DownloadsSection>
-        <SectionTitle id="v4-coverage">Coverage</SectionTitle>
+        <SectionTitle id="v4-coverage" title="Coverage" />
         <FileList>
           <ListItem>
             <GetUrlButtons
@@ -310,9 +306,10 @@ const GnomadV4Downloads = () => {
       </DownloadsSection>
 
       <DownloadsSection>
-        <SectionTitle id="v4-genetic-ancestry-group-classification">
-          Genetic ancestry group classification
-        </SectionTitle>
+        <SectionTitle
+          id="v4-genetic-ancestry-group-classification"
+          title="Genetic ancestry group classification"
+        />
         <p>
           For more information about these files, see our blog post on{' '}
           <ExternalLink href="https://gnomad.broadinstitute.org/news/2021-09-using-the-gnomad-ancestry-principal-components-analysis-loadings-and-random-forest-classifier-on-your-dataset/">
@@ -344,7 +341,7 @@ const GnomadV4Downloads = () => {
       </DownloadsSection>
 
       <DownloadsSection>
-        <SectionTitle id="v4-constraint">Constraint</SectionTitle>
+        <SectionTitle id="v4-constraint" title="Constraint" />
         <p>
           For information on constraint, see our <Link to="/help/constraint">help text</Link>
         </p>
@@ -408,7 +405,7 @@ const GnomadV4Downloads = () => {
       </DownloadsSection>
 
       <DownloadsSection>
-        <SectionTitle id="v4-structural-variants">Structural variants</SectionTitle>
+        <SectionTitle id="v4-structural-variants" title="Structural variants" />
         <p>
           For information on structural variants, see our{' '}
           <Link to="/help/sv-overview">help text</Link>
@@ -452,7 +449,7 @@ const GnomadV4Downloads = () => {
       </DownloadsSection>
 
       <DownloadsSection>
-        <SectionTitle id="v4-copy-number-variants">Copy number variants</SectionTitle>
+        <SectionTitle id="v4-copy-number-variants" title="Copy number variants" />
         <p>
           For information on copy number variants, see our{' '}
           <Link to="/help/sv-overview">help text</Link>
@@ -486,7 +483,7 @@ const GnomadV4Downloads = () => {
       </DownloadsSection>
 
       <DownloadsSection>
-        <SectionTitle id="v4-pext">Proportion expressed across transcripts (pext)</SectionTitle>
+        <SectionTitle id="v4-pext" title="Proportion expressed across transcripts (pext)" />
         <p>
           For information on pext, see{' '}
           <ExternalLink href="https://doi.org/10.1038/s41586-020-2329-2">
@@ -523,7 +520,7 @@ const GnomadV4Downloads = () => {
       </DownloadsSection>
 
       <DownloadsSection>
-        <SectionTitle id="v4-de-novo">De novo variants (DNVs)</SectionTitle>
+        <SectionTitle id="v4-de-novo" title="De novo variants (DNVs)" />
         <p>
           For more information on DNVs, see the{' '}
           <ExternalLink href="https://gnomad.broadinstitute.org/news/2025-03-de-novo-variants-in-gnomad-v4-exomes">
@@ -553,7 +550,7 @@ const GnomadV4Downloads = () => {
       </DownloadsSection>
 
       <DownloadsSection>
-        <SectionTitle id="v4-clinvar-grch38">ClinVar</SectionTitle>
+        <SectionTitle id="v4-clinvar-grch38" title="ClinVar" />
         <p>
           For more information about these files, including how to download a specific previous
           version of the gnomAD browser ClinVar GRCh38 table, see the{' '}
@@ -573,7 +570,7 @@ const GnomadV4Downloads = () => {
       </DownloadsSection>
 
       <DownloadsSection>
-        <SectionTitle id="v4-resources">Resources</SectionTitle>
+        <SectionTitle id="v4-resources" title="Resources" />
         <FileList>
           <ListItem>
             <DownloadLinks
@@ -614,16 +611,14 @@ const GnomadV4Downloads = () => {
         </FileList>
       </DownloadsSection>
 
-      <SectionTitle id="v4-secondary-analyses" subject="datasets">
-        Secondary Analyses
-      </SectionTitle>
+      <SectionTitle id="v4-secondary-analyses" $subject="datasets" title="Secondary Analyses" />
       <StyledParagraph>
         Additional research analyses created using the core gnomAD releases in collaboration with
         members of the gnomAD steering committee.
       </StyledParagraph>
 
       <DownloadsSection>
-        <SectionTitle id="v4-lof-curation-results">Loss-of-function curation results</SectionTitle>
+        <SectionTitle id="v4-lof-curation-results" title="Loss-of-function curation results" />
         <p>
           For information on v4 loss-of-function curation results, see{' '}
           <ExternalLink href="https://doi.org/10.1038/s41586-020-2308-7">

--- a/browser/src/DataPage/GraphQLDocs.tsx
+++ b/browser/src/DataPage/GraphQLDocs.tsx
@@ -19,7 +19,7 @@ const GraphQLCodeBlock = styled(CodeBlock)`
 
 const GraphQLDocs = () => (
   <>
-    <SectionTitle id="api">gnomAD API</SectionTitle>
+    <SectionTitle id="api" title="gnomAD API" />
     <StyledParagraph>
       The gnomAD browser gets its data through a{' '}
       <ExternalLink href="https://graphql.org">GraphQL</ExternalLink> API which is open to the

--- a/browser/src/DataPage/TableOfContents.tsx
+++ b/browser/src/DataPage/TableOfContents.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 
 import useHeadsObserver from './downloadsHooks'
 
-const TableOfContents = styled.div`
+const TableOfContents = styled.nav`
   margin-left: 1rem;
 `
 
@@ -24,8 +24,14 @@ const TableOfContentsStyledItem = styled.div<{
   }
 `
 
+type ContentItem = {
+  link: string
+  indent: string
+  text: string
+}
+
 const DataPageTableOfContents = () => {
-  const [headings, setHeadings] = useState([])
+  const [headings, setHeadings] = useState<ContentItem[]>([])
   const { activeId } = useHeadsObserver()
   const [activeSection, setActiveSection] = useState('')
 
@@ -39,15 +45,12 @@ const DataPageTableOfContents = () => {
     return '3.5rem'
   }
 
-  // useEffect to dynamically grab all the section titles on first page load
   useEffect(() => {
-    const elements = Array.from(document.querySelectorAll('a[id]')).map((el) => ({
-      // @ts-expect-error
-      text: el.nextSibling.data,
+    const elements = Array.from(document.querySelectorAll('h2[id]')).map((el) => ({
+      text: el.textContent ?? '',
       link: el.id,
       indent: checkIndent(el.id),
     }))
-    // @ts-expect-error
     setHeadings(elements)
   }, [])
 
@@ -89,15 +92,9 @@ const DataPageTableOfContents = () => {
     )
   }
 
-  type ContentItem = {
-    link: string
-    indent: string
-    text: string
-  }
-
   return (
     <>
-      <TableOfContents>
+      <TableOfContents aria-label="Data sections">
         {/* Filter to only the sections that should show, then render the ToC */}
         {headings
           .filter((item: ContentItem) => filterSection(item.link))

--- a/browser/src/DataPage/__snapshots__/DataPage.spec.tsx.snap
+++ b/browser/src/DataPage/__snapshots__/DataPage.spec.tsx.snap
@@ -170,6 +170,7 @@ exports[`Data Page has no unexpected changes 1`] = `
 }
 
 .c1 {
+  padding-left: 44px;
   font-size: 16px;
 }
 
@@ -178,30 +179,44 @@ exports[`Data Page has no unexpected changes 1`] = `
   line-height: 1.4;
 }
 
-.c12 {
-  position: absolute;
-  transform: translate(-15px,calc(50% - 0.5em));
-  display: flex;
-  align-items: center;
-  width: 15px;
-  height: 1em;
-  visibility: hidden;
-  vertical-align: middle;
-}
-
-.c9 {
+.c10 {
   position: relative;
 }
 
-.c9 :hover .c11 {
-  visibility: visible;
+.c12 {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  transform: translate(-29px,-50%);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  width: 44px;
+  height: 44px;
+  opacity: 0;
+  vertical-align: middle;
+}
+
+.c12 :hover,
+.c12 :focus,
+.c12 :focus-visible,
+.c9:hover .c12,
+.c9:focus-within .c12 {
+  opacity: 1;
+}
+
+.c12 :focus,
+.c12 :focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: -8px;
 }
 
 .c21 li {
   line-height: 1.25;
 }
 
-.c10 {
+.c11 {
   font-size: 1.88rem;
 }
 
@@ -301,6 +316,20 @@ exports[`Data Page has no unexpected changes 1`] = `
   }
 }
 
+@media (hover:none) {
+  .c12 {
+    opacity: 1;
+  }
+}
+
+@media (max-width:1230px) {
+  .c12 {
+    position: static;
+    transform: none;
+    display: inline-flex;
+  }
+}
+
 @media (max-width:900px) {
   .c19 {
     flex-basis: 100%;
@@ -334,7 +363,8 @@ exports[`Data Page has no unexpected changes 1`] = `
   <div
     className="c4"
   >
-    <div
+    <nav
+      aria-label="Data sections"
       className="c5"
     />
   </div>
@@ -383,30 +413,38 @@ exports[`Data Page has no unexpected changes 1`] = `
       .
     </div>
     <div>
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c11"
+        id="summary"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
-        <h2
-          className="c10 "
-          subject="datasets"
+        <a
+          aria-label="Copy link to Summary"
+          className="c12"
+          href="#summary"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#summary"
-            id="summary"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Summary
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Summary
+      </h2>
       <p
         className="c13"
       >
@@ -621,59 +659,75 @@ exports[`Data Page has no unexpected changes 1`] = `
       </p>
     </div>
     <hr />
-    <span
-      className="c9"
+    <h2
+      className="c9 c10 c15"
+      id="v4"
+      style={
+        {
+          "padding": "8px 0",
+        }
+      }
     >
-      <h2
-        className="c15 "
-        subject="release"
+      <a
+        aria-label="Copy link to v4 Downloads"
+        className="c12"
+        href="#v4"
+        onClick={[Function]}
+        style={
+          {
+            "display": "flex",
+            "position": "absolute",
+            "transform": "translate(-100%, -50%)",
+          }
+        }
       >
-        <a
+        <img
+          alt=""
           aria-hidden="true"
-          className="c11 c12"
-          href="#v4"
-          id="v4"
-        >
-          <img
-            alt=""
-            aria-hidden="true"
-            height={12}
-            src="test-file-stub"
-            width={12}
-          />
-        </a>
-        v4 Downloads
-      </h2>
-    </span>
+          height={12}
+          src="test-file-stub"
+          width={12}
+        />
+      </a>
+      v4 Downloads
+    </h2>
     <p
       className="c13"
     >
       The gnomAD v4.1.0 data set contains data from 730,947 exomes and 76,215 whole genomes, all mapped to the GRCh38 reference sequence.
     </p>
-    <span
-      className="c9"
+    <h2
+      className="c9 c10 c11"
+      id="v4-core-dataset"
+      style={
+        {
+          "padding": "8px 0",
+        }
+      }
     >
-      <h2
-        className="c10 "
-        subject="datasets"
+      <a
+        aria-label="Copy link to Core Dataset"
+        className="c12"
+        href="#v4-core-dataset"
+        onClick={[Function]}
+        style={
+          {
+            "display": "flex",
+            "position": "absolute",
+            "transform": "translate(-100%, -50%)",
+          }
+        }
       >
-        <a
+        <img
+          alt=""
           aria-hidden="true"
-          className="c11 c12"
-          href="#v4-core-dataset"
-          id="v4-core-dataset"
-        >
-          <img
-            alt=""
-            aria-hidden="true"
-            height={12}
-            src="test-file-stub"
-            width={12}
-          />
-        </a>
-        Core Dataset
-      </h2>
-    </span>
+          height={12}
+          src="test-file-stub"
+          width={12}
+        />
+      </a>
+      Core Dataset
+    </h2>
     <p
       className="c13"
     >
@@ -682,29 +736,38 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v4-variants"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Variants"
+          className="c12"
+          href="#v4-variants"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v4-variants"
-            id="v4-variants"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Variants
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Variants
+      </h2>
       <p>
         For more information, read the
          
@@ -3933,29 +3996,38 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v4-joint-freq-stats"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Joint Frequency"
+          className="c12"
+          href="#v4-joint-freq-stats"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v4-joint-freq-stats"
-            id="v4-joint-freq-stats"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Joint Frequency
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Joint Frequency
+      </h2>
       <ul
         className="c20 c21"
       >
@@ -5551,29 +5623,38 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v4-all-sites-allele-number"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to All sites allele numbers"
+          className="c12"
+          href="#v4-all-sites-allele-number"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v4-all-sites-allele-number"
-            id="v4-all-sites-allele-number"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          All sites allele numbers
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        All sites allele numbers
+      </h2>
       <div
         className="c18"
       >
@@ -5736,29 +5817,38 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v4-browser-tables"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Browser Tables"
+          className="c12"
+          href="#v4-browser-tables"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v4-browser-tables"
-            id="v4-browser-tables"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Browser Tables
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Browser Tables
+      </h2>
       <p>
         For more information about these files, see our
          
@@ -5907,29 +5997,38 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v4-coverage"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Coverage"
+          className="c12"
+          href="#v4-coverage"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v4-coverage"
-            id="v4-coverage"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Coverage
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Coverage
+      </h2>
       <ul
         className="c20 c21"
       >
@@ -6004,29 +6103,38 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v4-genetic-ancestry-group-classification"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Genetic ancestry group classification"
+          className="c12"
+          href="#v4-genetic-ancestry-group-classification"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v4-genetic-ancestry-group-classification"
-            id="v4-genetic-ancestry-group-classification"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Genetic ancestry group classification
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Genetic ancestry group classification
+      </h2>
       <p>
         For more information about these files, see our blog post on
          
@@ -6141,29 +6249,38 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v4-constraint"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Constraint"
+          className="c12"
+          href="#v4-constraint"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v4-constraint"
-            id="v4-constraint"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Constraint
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Constraint
+      </h2>
       <p>
         For information on constraint, see our 
         <a
@@ -6461,29 +6578,38 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v4-structural-variants"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Structural variants"
+          className="c12"
+          href="#v4-structural-variants"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v4-structural-variants"
-            id="v4-structural-variants"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Structural variants
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Structural variants
+      </h2>
       <p>
         For information on structural variants, see our
          
@@ -6711,29 +6837,38 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v4-copy-number-variants"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Copy number variants"
+          className="c12"
+          href="#v4-copy-number-variants"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v4-copy-number-variants"
-            id="v4-copy-number-variants"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Copy number variants
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Copy number variants
+      </h2>
       <p>
         For information on copy number variants, see our
          
@@ -6870,29 +7005,38 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v4-pext"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Proportion expressed across transcripts (pext)"
+          className="c12"
+          href="#v4-pext"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v4-pext"
-            id="v4-pext"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Proportion expressed across transcripts (pext)
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Proportion expressed across transcripts (pext)
+      </h2>
       <p>
         For information on pext, see
          
@@ -7037,29 +7181,38 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v4-de-novo"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to De novo variants (DNVs)"
+          className="c12"
+          href="#v4-de-novo"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v4-de-novo"
-            id="v4-de-novo"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          De novo variants (DNVs)
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        De novo variants (DNVs)
+      </h2>
       <p>
         For more information on DNVs, see the
          
@@ -7168,29 +7321,38 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v4-clinvar-grch38"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to ClinVar"
+          className="c12"
+          href="#v4-clinvar-grch38"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v4-clinvar-grch38"
-            id="v4-clinvar-grch38"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          ClinVar
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        ClinVar
+      </h2>
       <p>
         For more information about these files, including how to download a specific previous version of the gnomAD browser ClinVar GRCh38 table, see the
          
@@ -7229,29 +7391,38 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v4-resources"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Resources"
+          className="c12"
+          href="#v4-resources"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v4-resources"
-            id="v4-resources"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Resources
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Resources
+      </h2>
       <ul
         className="c20 c21"
       >
@@ -7449,18 +7620,67 @@ exports[`Data Page has no unexpected changes 1`] = `
         </li>
       </ul>
     </section>
-    <span
-      className="c9"
+    <h2
+      className="c9 c10 c11"
+      id="v4-secondary-analyses"
+      style={
+        {
+          "padding": "8px 0",
+        }
+      }
+    >
+      <a
+        aria-label="Copy link to Secondary Analyses"
+        className="c12"
+        href="#v4-secondary-analyses"
+        onClick={[Function]}
+        style={
+          {
+            "display": "flex",
+            "position": "absolute",
+            "transform": "translate(-100%, -50%)",
+          }
+        }
+      >
+        <img
+          alt=""
+          aria-hidden="true"
+          height={12}
+          src="test-file-stub"
+          width={12}
+        />
+      </a>
+      Secondary Analyses
+    </h2>
+    <p
+      className="c13"
+    >
+      Additional research analyses created using the core gnomAD releases in collaboration with members of the gnomAD steering committee.
+    </p>
+    <section
+      className="c16"
     >
       <h2
-        className="c10 "
-        subject="datasets"
+        className="c9 c10 c17"
+        id="v4-lof-curation-results"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
-          aria-hidden="true"
-          className="c11 c12"
-          href="#v4-secondary-analyses"
-          id="v4-secondary-analyses"
+          aria-label="Copy link to Loss-of-function curation results"
+          className="c12"
+          href="#v4-lof-curation-results"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
           <img
             alt=""
@@ -7470,40 +7690,8 @@ exports[`Data Page has no unexpected changes 1`] = `
             width={12}
           />
         </a>
-        Secondary Analyses
+        Loss-of-function curation results
       </h2>
-    </span>
-    <p
-      className="c13"
-    >
-      Additional research analyses created using the core gnomAD releases in collaboration with members of the gnomAD steering committee.
-    </p>
-    <section
-      className="c16"
-    >
-      <span
-        className="c9"
-      >
-        <h2
-          className="c17 "
-        >
-          <a
-            aria-hidden="true"
-            className="c11 c12"
-            href="#v4-lof-curation-results"
-            id="v4-lof-curation-results"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Loss-of-function curation results
-        </h2>
-      </span>
       <p>
         For information on v4 loss-of-function curation results, see
          
@@ -7589,59 +7777,75 @@ exports[`Data Page has no unexpected changes 1`] = `
         </li>
       </ul>
     </section>
-    <span
-      className="c9"
+    <h2
+      className="c9 c10 c15"
+      id="v3"
+      style={
+        {
+          "padding": "8px 0",
+        }
+      }
     >
-      <h2
-        className="c15 "
-        subject="release"
+      <a
+        aria-label="Copy link to v3 Downloads"
+        className="c12"
+        href="#v3"
+        onClick={[Function]}
+        style={
+          {
+            "display": "flex",
+            "position": "absolute",
+            "transform": "translate(-100%, -50%)",
+          }
+        }
       >
-        <a
+        <img
+          alt=""
           aria-hidden="true"
-          className="c11 c12"
-          href="#v3"
-          id="v3"
-        >
-          <img
-            alt=""
-            aria-hidden="true"
-            height={12}
-            src="test-file-stub"
-            width={12}
-          />
-        </a>
-        v3 Downloads
-      </h2>
-    </span>
+          height={12}
+          src="test-file-stub"
+          width={12}
+        />
+      </a>
+      v3 Downloads
+    </h2>
     <p
       className="c13"
     >
       The gnomAD v3.1.2 data set contains 76,156 whole genomes (and no exomes), all mapped to the GRCh38 reference sequence.
     </p>
-    <span
-      className="c9"
+    <h2
+      className="c9 c10 c11"
+      id="v3-core-dataset"
+      style={
+        {
+          "padding": "8px 0",
+        }
+      }
     >
-      <h2
-        className="c10 "
-        subject="datasets"
+      <a
+        aria-label="Copy link to Core Dataset"
+        className="c12"
+        href="#v3-core-dataset"
+        onClick={[Function]}
+        style={
+          {
+            "display": "flex",
+            "position": "absolute",
+            "transform": "translate(-100%, -50%)",
+          }
+        }
       >
-        <a
+        <img
+          alt=""
           aria-hidden="true"
-          className="c11 c12"
-          href="#v3-core-dataset"
-          id="v3-core-dataset"
-        >
-          <img
-            alt=""
-            aria-hidden="true"
-            height={12}
-            src="test-file-stub"
-            width={12}
-          />
-        </a>
-        Core Dataset
-      </h2>
-    </span>
+          height={12}
+          src="test-file-stub"
+          width={12}
+        />
+      </a>
+      Core Dataset
+    </h2>
     <p
       className="c13"
     >
@@ -7650,29 +7854,38 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v3-variants"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Variants"
+          className="c12"
+          href="#v3-variants"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v3-variants"
-            id="v3-variants"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Variants
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Variants
+      </h2>
       <p>
         <span
           className="c24"
@@ -9293,29 +9506,38 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v3-coverage"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Coverage"
+          className="c12"
+          href="#v3-coverage"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v3-coverage"
-            id="v3-coverage"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Coverage
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Coverage
+      </h2>
       <ul
         className="c20 c21"
       >
@@ -9390,29 +9612,38 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v3-hgdp-1kg"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to HGDP + 1KG callset"
+          className="c12"
+          href="#v3-hgdp-1kg"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v3-hgdp-1kg"
-            id="v3-hgdp-1kg"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          HGDP + 1KG callset
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        HGDP + 1KG callset
+      </h2>
       <p>
         These files contain individual genotypes for all samples in the HGDP and 1KG subsets. For more information, see the
          
@@ -11148,29 +11379,38 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v3-mitochondrial-dna"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Mitochondrial DNA (mtDNA)"
+          className="c12"
+          href="#v3-mitochondrial-dna"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v3-mitochondrial-dna"
-            id="v3-mitochondrial-dna"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Mitochondrial DNA (mtDNA)
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Mitochondrial DNA (mtDNA)
+      </h2>
       <p>
         For details about these files, see the
          
@@ -11350,29 +11590,38 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v3-ancestry-classification"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Genetic ancestry group classification"
+          className="c12"
+          href="#v3-ancestry-classification"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v3-ancestry-classification"
-            id="v3-ancestry-classification"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Genetic ancestry group classification
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Genetic ancestry group classification
+      </h2>
       <p>
         For more information about these files, see our blog post on
          
@@ -11454,29 +11703,38 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v3-local-ancestry"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Local ancestry"
+          className="c12"
+          href="#v3-local-ancestry"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v3-local-ancestry"
-            id="v3-local-ancestry"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Local ancestry
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Local ancestry
+      </h2>
       <p>
         For more information about these files, see our blog posts on local ancestry inference for
          
@@ -11580,29 +11838,38 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v3-short-tandem-repeats"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Short tandem repeats"
+          className="c12"
+          href="#v3-short-tandem-repeats"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v3-short-tandem-repeats"
-            id="v3-short-tandem-repeats"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Short tandem repeats
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Short tandem repeats
+      </h2>
       <p>
         These files contain the data that underlies the
          
@@ -11961,18 +12228,67 @@ exports[`Data Page has no unexpected changes 1`] = `
         </li>
       </ul>
     </section>
-    <span
-      className="c9"
+    <h2
+      className="c9 c10 c11"
+      id="v3-secondary-analyses"
+      style={
+        {
+          "padding": "8px 0",
+        }
+      }
+    >
+      <a
+        aria-label="Copy link to Secondary Analyses"
+        className="c12"
+        href="#v3-secondary-analyses"
+        onClick={[Function]}
+        style={
+          {
+            "display": "flex",
+            "position": "absolute",
+            "transform": "translate(-100%, -50%)",
+          }
+        }
+      >
+        <img
+          alt=""
+          aria-hidden="true"
+          height={12}
+          src="test-file-stub"
+          width={12}
+        />
+      </a>
+      Secondary Analyses
+    </h2>
+    <p
+      className="c13"
+    >
+      Additional research analyses created using the core gnomAD releases in collaboration with members of the gnomAD steering committee.
+    </p>
+    <section
+      className="c16"
     >
       <h2
-        className="c10 "
-        subject="datasets"
+        className="c9 c10 c17"
+        id="v3-genomic-constraint"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
-          aria-hidden="true"
-          className="c11 c12"
-          href="#v3-secondary-analyses"
-          id="v3-secondary-analyses"
+          aria-label="Copy link to Genomic constraint"
+          className="c12"
+          href="#v3-genomic-constraint"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
           <img
             alt=""
@@ -11982,40 +12298,8 @@ exports[`Data Page has no unexpected changes 1`] = `
             width={12}
           />
         </a>
-        Secondary Analyses
+        Genomic constraint
       </h2>
-    </span>
-    <p
-      className="c13"
-    >
-      Additional research analyses created using the core gnomAD releases in collaboration with members of the gnomAD steering committee.
-    </p>
-    <section
-      className="c16"
-    >
-      <span
-        className="c9"
-      >
-        <h2
-          className="c17 "
-        >
-          <a
-            aria-hidden="true"
-            className="c11 c12"
-            href="#v3-genomic-constraint"
-            id="v3-genomic-constraint"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Genomic constraint
-        </h2>
-      </span>
       <p>
         For more information about these files, see the README included in the download.
       </p>
@@ -12159,29 +12443,38 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v3-hgdp-1kg-tutorials"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to HGDP + 1KG tutorials"
+          className="c12"
+          href="#v3-hgdp-1kg-tutorials"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v3-hgdp-1kg-tutorials"
-            id="v3-hgdp-1kg-tutorials"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          HGDP + 1KG tutorials
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        HGDP + 1KG tutorials
+      </h2>
       <p>
         For more information about these files, see the
          
@@ -13237,29 +13530,38 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v3-mito-constraint"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Mitochondrial constraint"
+          className="c12"
+          href="#v3-mito-constraint"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v3-mito-constraint"
-            id="v3-mito-constraint"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Mitochondrial constraint
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Mitochondrial constraint
+      </h2>
       <p>
         For more information about mitochondrial constraint, see
          
@@ -13413,59 +13715,75 @@ exports[`Data Page has no unexpected changes 1`] = `
         </li>
       </ul>
     </section>
-    <span
-      className="c9"
+    <h2
+      className="c9 c10 c15"
+      id="v2-liftover"
+      style={
+        {
+          "padding": "8px 0",
+        }
+      }
     >
-      <h2
-        className="c15 "
-        subject="release"
+      <a
+        aria-label="Copy link to v2 Liftover Downloads"
+        className="c12"
+        href="#v2-liftover"
+        onClick={[Function]}
+        style={
+          {
+            "display": "flex",
+            "position": "absolute",
+            "transform": "translate(-100%, -50%)",
+          }
+        }
       >
-        <a
+        <img
+          alt=""
           aria-hidden="true"
-          className="c11 c12"
-          href="#v2-liftover"
-          id="v2-liftover"
-        >
-          <img
-            alt=""
-            aria-hidden="true"
-            height={12}
-            src="test-file-stub"
-            width={12}
-          />
-        </a>
-        v2 Liftover Downloads
-      </h2>
-    </span>
+          height={12}
+          src="test-file-stub"
+          width={12}
+        />
+      </a>
+      v2 Liftover Downloads
+    </h2>
     <p
       className="c13"
     >
       The gnomAD v2.1.1 liftover data set contains data from 125,748 exomes and 15,708 whole genomes, lifted over from the GRCh37 to the GRCh38 reference sequence.
     </p>
-    <span
-      className="c9"
+    <h2
+      className="c9 c10 c11"
+      id="v2-liftover-core-dataset"
+      style={
+        {
+          "padding": "8px 0",
+        }
+      }
     >
-      <h2
-        className="c10 "
-        subject="datasets"
+      <a
+        aria-label="Copy link to Core Dataset"
+        className="c12"
+        href="#v2-liftover-core-dataset"
+        onClick={[Function]}
+        style={
+          {
+            "display": "flex",
+            "position": "absolute",
+            "transform": "translate(-100%, -50%)",
+          }
+        }
       >
-        <a
+        <img
+          alt=""
           aria-hidden="true"
-          className="c11 c12"
-          href="#v2-liftover-core-dataset"
-          id="v2-liftover-core-dataset"
-        >
-          <img
-            alt=""
-            aria-hidden="true"
-            height={12}
-            src="test-file-stub"
-            width={12}
-          />
-        </a>
-        Core Dataset
-      </h2>
-    </span>
+          height={12}
+          src="test-file-stub"
+          width={12}
+        />
+      </a>
+      Core Dataset
+    </h2>
     <p
       className="c13"
     >
@@ -13474,29 +13792,38 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v2-liftover-variants"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Variants (GRCh38 liftover)"
+          className="c12"
+          href="#v2-liftover-variants"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v2-liftover-variants"
-            id="v2-liftover-variants"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Variants (GRCh38 liftover)
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Variants (GRCh38 liftover)
+      </h2>
       <p>
         The variant dataset files below contain all subsets (non-neuro, non-cancer, controls-only, and non-TOPMed).
       </p>
@@ -16769,29 +17096,38 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v2-liftover-structural-variants"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Structural variants (GRCh38 liftover)"
+          className="c12"
+          href="#v2-liftover-structural-variants"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v2-liftover-structural-variants"
-            id="v2-liftover-structural-variants"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Structural variants (GRCh38 liftover)
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Structural variants (GRCh38 liftover)
+      </h2>
       <p>
         <span
           className="c24"
@@ -16818,59 +17154,75 @@ exports[`Data Page has no unexpected changes 1`] = `
         </li>
       </ul>
     </section>
-    <span
-      className="c9"
+    <h2
+      className="c9 c10 c15"
+      id="v2"
+      style={
+        {
+          "padding": "8px 0",
+        }
+      }
     >
-      <h2
-        className="c15 "
-        subject="release"
+      <a
+        aria-label="Copy link to v2 Downloads"
+        className="c12"
+        href="#v2"
+        onClick={[Function]}
+        style={
+          {
+            "display": "flex",
+            "position": "absolute",
+            "transform": "translate(-100%, -50%)",
+          }
+        }
       >
-        <a
+        <img
+          alt=""
           aria-hidden="true"
-          className="c11 c12"
-          href="#v2"
-          id="v2"
-        >
-          <img
-            alt=""
-            aria-hidden="true"
-            height={12}
-            src="test-file-stub"
-            width={12}
-          />
-        </a>
-        v2 Downloads
-      </h2>
-    </span>
+          height={12}
+          src="test-file-stub"
+          width={12}
+        />
+      </a>
+      v2 Downloads
+    </h2>
     <p
       className="c13"
     >
       The gnomAD v2.1.1 data set contains data from 125,748 exomes and 15,708 whole genomes, all mapped to the GRCh37/hg19 reference sequence.
     </p>
-    <span
-      className="c9"
+    <h2
+      className="c9 c10 c11"
+      id="v2-core-dataset"
+      style={
+        {
+          "padding": "8px 0",
+        }
+      }
     >
-      <h2
-        className="c10 "
-        subject="datasets"
+      <a
+        aria-label="Copy link to Core Dataset"
+        className="c12"
+        href="#v2-core-dataset"
+        onClick={[Function]}
+        style={
+          {
+            "display": "flex",
+            "position": "absolute",
+            "transform": "translate(-100%, -50%)",
+          }
+        }
       >
-        <a
+        <img
+          alt=""
           aria-hidden="true"
-          className="c11 c12"
-          href="#v2-core-dataset"
-          id="v2-core-dataset"
-        >
-          <img
-            alt=""
-            aria-hidden="true"
-            height={12}
-            src="test-file-stub"
-            width={12}
-          />
-        </a>
-        Core Dataset
-      </h2>
-    </span>
+          height={12}
+          src="test-file-stub"
+          width={12}
+        />
+      </a>
+      Core Dataset
+    </h2>
     <p
       className="c13"
     >
@@ -16879,29 +17231,38 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v2-variants"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Variants"
+          className="c12"
+          href="#v2-variants"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v2-variants"
-            id="v2-variants"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Variants
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Variants
+      </h2>
       <p>
         <span
           className="c24"
@@ -20258,29 +20619,38 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v2-browser-tables"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Browser Tables"
+          className="c12"
+          href="#v2-browser-tables"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v2-browser-tables"
-            id="v2-browser-tables"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Browser Tables
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Browser Tables
+      </h2>
       <p>
         For more information about these files, see our
          
@@ -20340,29 +20710,38 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v2-coverage"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Coverage"
+          className="c12"
+          href="#v2-coverage"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v2-coverage"
-            id="v2-coverage"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Coverage
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Coverage
+      </h2>
       <ul
         className="c20 c21"
       >
@@ -20503,29 +20882,38 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v2-structural-variants"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Structural variants"
+          className="c12"
+          href="#v2-structural-variants"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v2-structural-variants"
-            id="v2-structural-variants"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Structural variants
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Structural variants
+      </h2>
       <p>
         For information on gnomAD structural variants, see
          
@@ -20903,29 +21291,38 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v2-linkage-disequilibrium"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Linkage disequilibrium"
+          className="c12"
+          href="#v2-linkage-disequilibrium"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v2-linkage-disequilibrium"
-            id="v2-linkage-disequilibrium"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Linkage disequilibrium
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Linkage disequilibrium
+      </h2>
       <p>
         <label
           htmlFor="ld-files-population"
@@ -21178,29 +21575,38 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v2-ancestry-classification"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Ancestry classification"
+          className="c12"
+          href="#v2-ancestry-classification"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v2-ancestry-classification"
-            id="v2-ancestry-classification"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Ancestry classification
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Ancestry classification
+      </h2>
       <p>
         For more information about these files, see our blog post on
          
@@ -21282,29 +21688,38 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v2-regional-missense-constraint"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Regional Missense Constraint"
+          className="c12"
+          href="#v2-regional-missense-constraint"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v2-regional-missense-constraint"
-            id="v2-regional-missense-constraint"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Regional Missense Constraint
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Regional Missense Constraint
+      </h2>
       <ul
         className="c20 c21"
       >
@@ -21406,29 +21821,38 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v2-clinvar-grch37"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to ClinVar"
+          className="c12"
+          href="#v2-clinvar-grch37"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v2-clinvar-grch37"
-            id="v2-clinvar-grch37"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          ClinVar
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        ClinVar
+      </h2>
       <p>
         For more information about these files, including how to download a specific previous version of the gnomAD browser ClinVar GRCh37 table, see the
          
@@ -21467,29 +21891,38 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v2-resources"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Resources"
+          className="c12"
+          href="#v2-resources"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v2-resources"
-            id="v2-resources"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Resources
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Resources
+      </h2>
       <ul
         className="c20 c21"
       >
@@ -21648,18 +22081,67 @@ exports[`Data Page has no unexpected changes 1`] = `
         </li>
       </ul>
     </section>
-    <span
-      className="c9"
+    <h2
+      className="c9 c10 c11"
+      id="v2-secondary-analyses"
+      style={
+        {
+          "padding": "8px 0",
+        }
+      }
+    >
+      <a
+        aria-label="Copy link to Secondary Analyses"
+        className="c12"
+        href="#v2-secondary-analyses"
+        onClick={[Function]}
+        style={
+          {
+            "display": "flex",
+            "position": "absolute",
+            "transform": "translate(-100%, -50%)",
+          }
+        }
+      >
+        <img
+          alt=""
+          aria-hidden="true"
+          height={12}
+          src="test-file-stub"
+          width={12}
+        />
+      </a>
+      Secondary Analyses
+    </h2>
+    <p
+      className="c13"
+    >
+      Additional research analyses created using the core gnomAD releases in collaboration with members of the gnomAD steering committee.
+    </p>
+    <section
+      className="c16"
     >
       <h2
-        className="c10 "
-        subject="datasets"
+        className="c9 c10 c17"
+        id="v2-constraint"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
-          aria-hidden="true"
-          className="c11 c12"
-          href="#v2-secondary-analyses"
-          id="v2-secondary-analyses"
+          aria-label="Copy link to Constraint"
+          className="c12"
+          href="#v2-constraint"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
           <img
             alt=""
@@ -21669,40 +22151,8 @@ exports[`Data Page has no unexpected changes 1`] = `
             width={12}
           />
         </a>
-        Secondary Analyses
+        Constraint
       </h2>
-    </span>
-    <p
-      className="c13"
-    >
-      Additional research analyses created using the core gnomAD releases in collaboration with members of the gnomAD steering committee.
-    </p>
-    <section
-      className="c16"
-    >
-      <span
-        className="c9"
-      >
-        <h2
-          className="c17 "
-        >
-          <a
-            aria-hidden="true"
-            className="c11 c12"
-            href="#v2-constraint"
-            id="v2-constraint"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Constraint
-        </h2>
-      </span>
       <p>
         For information on constraint, see
          
@@ -21865,29 +22315,38 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v2-multi-nucleotide-variants"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Multi-nucleotide variants (MNVs)"
+          className="c12"
+          href="#v2-multi-nucleotide-variants"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v2-multi-nucleotide-variants"
-            id="v2-multi-nucleotide-variants"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Multi-nucleotide variants (MNVs)
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Multi-nucleotide variants (MNVs)
+      </h2>
       <p>
         For information on multi-nucleotide variants in gnomAD, see
          
@@ -22618,29 +23077,38 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v2-pext"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Proportion expressed across transcripts (pext)"
+          className="c12"
+          href="#v2-pext"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v2-pext"
-            id="v2-pext"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Proportion expressed across transcripts (pext)
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Proportion expressed across transcripts (pext)
+      </h2>
       <p>
         For information on pext, see
          
@@ -22785,29 +23253,38 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v2-variant-cooccurrence"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Variant co-occurrence"
+          className="c12"
+          href="#v2-variant-cooccurrence"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v2-variant-cooccurrence"
-            id="v2-variant-cooccurrence"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Variant co-occurrence
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Variant co-occurrence
+      </h2>
       <ul
         className="c20 c21"
       >
@@ -22942,29 +23419,38 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v2-lof-curation-results"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Loss-of-function curation results"
+          className="c12"
+          href="#v2-lof-curation-results"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v2-lof-curation-results"
-            id="v2-lof-curation-results"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Loss-of-function curation results
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Loss-of-function curation results
+      </h2>
       <p>
         For information on loss-of-function curation results, see
          
@@ -23300,59 +23786,75 @@ exports[`Data Page has no unexpected changes 1`] = `
         </li>
       </ul>
     </section>
-    <span
-      className="c9"
+    <h2
+      className="c9 c10 c15"
+      id="exac"
+      style={
+        {
+          "padding": "8px 0",
+        }
+      }
     >
-      <h2
-        className="c15 "
-        subject="release"
+      <a
+        aria-label="Copy link to ExAC Downloads"
+        className="c12"
+        href="#exac"
+        onClick={[Function]}
+        style={
+          {
+            "display": "flex",
+            "position": "absolute",
+            "transform": "translate(-100%, -50%)",
+          }
+        }
       >
-        <a
+        <img
+          alt=""
           aria-hidden="true"
-          className="c11 c12"
-          href="#exac"
-          id="exac"
-        >
-          <img
-            alt=""
-            aria-hidden="true"
-            height={12}
-            src="test-file-stub"
-            width={12}
-          />
-        </a>
-        ExAC Downloads
-      </h2>
-    </span>
+          height={12}
+          src="test-file-stub"
+          width={12}
+        />
+      </a>
+      ExAC Downloads
+    </h2>
     <p
       className="c13"
     >
       The ExAC data set contains data from 60,706 exomes, all mapped to the GRCh37/hg19 reference sequence.
     </p>
-    <span
-      className="c9"
+    <h2
+      className="c9 c10 c11"
+      id="exac-core-dataset"
+      style={
+        {
+          "padding": "8px 0",
+        }
+      }
     >
-      <h2
-        className="c10 "
-        subject="datasets"
+      <a
+        aria-label="Copy link to Core Dataset"
+        className="c12"
+        href="#exac-core-dataset"
+        onClick={[Function]}
+        style={
+          {
+            "display": "flex",
+            "position": "absolute",
+            "transform": "translate(-100%, -50%)",
+          }
+        }
       >
-        <a
+        <img
+          alt=""
           aria-hidden="true"
-          className="c11 c12"
-          href="#exac-core-dataset"
-          id="exac-core-dataset"
-        >
-          <img
-            alt=""
-            aria-hidden="true"
-            height={12}
-            src="test-file-stub"
-            width={12}
-          />
-        </a>
-        Core Dataset
-      </h2>
-    </span>
+          height={12}
+          src="test-file-stub"
+          width={12}
+        />
+      </a>
+      Core Dataset
+    </h2>
     <p
       className="c13"
     >
@@ -23361,29 +23863,38 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="exac-variants"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Variants"
+          className="c12"
+          href="#exac-variants"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#exac-variants"
-            id="exac-variants"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Variants
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Variants
+      </h2>
       <h3>
         Exomes
       </h3>
@@ -23460,29 +23971,38 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="exac-coverage"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Coverage"
+          className="c12"
+          href="#exac-coverage"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#exac-coverage"
-            id="exac-coverage"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Coverage
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Coverage
+      </h2>
       <ul
         className="c20 c21"
       >
@@ -24427,29 +24947,38 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="exac-constraint"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Constraint"
+          className="c12"
+          href="#exac-constraint"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#exac-constraint"
-            id="exac-constraint"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Constraint
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Constraint
+      </h2>
       <ul
         className="c20 c21"
       >
@@ -24491,29 +25020,38 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="exac-regional-missense-constraint"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Regional Missense Constraint"
+          className="c12"
+          href="#exac-regional-missense-constraint"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#exac-regional-missense-constraint"
-            id="exac-regional-missense-constraint"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Regional Missense Constraint
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Regional Missense Constraint
+      </h2>
       <ul
         className="c20 c21"
       >
@@ -24555,29 +25093,38 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="exac-resources"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Resources"
+          className="c12"
+          href="#exac-resources"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#exac-resources"
-            id="exac-resources"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Resources
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Resources
+      </h2>
       <ul
         className="c20 c21"
       >
@@ -24617,29 +25164,38 @@ exports[`Data Page has no unexpected changes 1`] = `
       </ul>
     </section>
     <section>
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="exac-other"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Other"
+          className="c12"
+          href="#exac-other"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#exac-other"
-            id="exac-other"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Other
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Other
+      </h2>
       <ul
         className="c20 c21"
       >
@@ -24726,29 +25282,38 @@ exports[`Data Page has no unexpected changes 1`] = `
         </li>
       </ul>
     </section>
-    <span
-      className="c9"
+    <h2
+      className="c9 c10 c17"
+      id="api"
+      style={
+        {
+          "padding": "8px 0",
+        }
+      }
     >
-      <h2
-        className="c17 "
+      <a
+        aria-label="Copy link to gnomAD API"
+        className="c12"
+        href="#api"
+        onClick={[Function]}
+        style={
+          {
+            "display": "flex",
+            "position": "absolute",
+            "transform": "translate(-100%, -50%)",
+          }
+        }
       >
-        <a
+        <img
+          alt=""
           aria-hidden="true"
-          className="c11 c12"
-          href="#api"
-          id="api"
-        >
-          <img
-            alt=""
-            aria-hidden="true"
-            height={12}
-            src="test-file-stub"
-            width={12}
-          />
-        </a>
-        gnomAD API
-      </h2>
-    </span>
+          height={12}
+          src="test-file-stub"
+          width={12}
+        />
+      </a>
+      gnomAD API
+    </h2>
     <p
       className="c13"
     >

--- a/browser/src/DataPage/downloadsHooks.ts
+++ b/browser/src/DataPage/downloadsHooks.ts
@@ -20,7 +20,7 @@ const useHeadsObserver = () => {
       rootMargin: '0% 0px -90% 0px',
     })
 
-    const elements = document.querySelectorAll('a[id]')
+    const elements = document.querySelectorAll('h2[id]')
     // @ts-expect-error
     elements.forEach((element) => observer.current.observe(element))
     // @ts-expect-error

--- a/browser/src/DataPage/downloadsPageStyles.tsx
+++ b/browser/src/DataPage/downloadsPageStyles.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 
 import { Button, ExternalLink, List, Modal, PrimaryButton, TextButton } from '@gnomad/ui'
 
-import { withAnchor } from '../AnchorLink'
+import { SectionHeading } from '../AnchorLink'
 import { logButtonClick } from '../analytics'
 
 export const FileList = styled(List)`
@@ -12,21 +12,19 @@ export const FileList = styled(List)`
   }
 `
 
-type BaseSectionTitleProps = { subject?: string }
+type SectionTitleProps = { $subject?: 'release' | 'datasets' }
 
-const BaseSectionTitle = styled.h2<BaseSectionTitleProps>`
+export const SectionTitle = styled(SectionHeading).attrs({ linkInGutter: true })<SectionTitleProps>`
   font-size: ${(props) => {
-    if (props.subject === 'release') {
+    if (props.$subject === 'release') {
       return '2.25rem'
     }
-    if (props.subject === 'datasets') {
+    if (props.$subject === 'datasets') {
       return '1.88rem'
     }
     return '1.5rem'
   }};
 `
-
-export const SectionTitle = styled(withAnchor(BaseSectionTitle))``
 
 export const StyledParagraph = styled.p`
   padding-bottom: 1rem;

--- a/browser/src/InfoPage.ts
+++ b/browser/src/InfoPage.ts
@@ -2,7 +2,8 @@ import styled from 'styled-components'
 
 import { Page } from '@gnomad/ui'
 
-export default styled(Page)`
+export default styled(Page)<{ $withSectionLinks?: boolean }>`
+  ${(props) => props.$withSectionLinks && 'padding-left: 44px;'}
   font-size: 16px;
 
   p {

--- a/browser/src/MitochondrialVariantPage/MitochondrialVariantPage.tsx
+++ b/browser/src/MitochondrialVariantPage/MitochondrialVariantPage.tsx
@@ -28,6 +28,8 @@ import MitochondrialVariantGenotypeQualityMetrics from './MitochondrialVariantGe
 import MitochondrialVariantHaplogroupFrequenciesTable from './MitochondrialVariantHaplogroupFrequenciesTable'
 import MitochondrialVariantHeteroplasmyDistribution from './MitochondrialVariantHeteroplasmyDistribution'
 import MitochondrialVariantPopulationFrequenciesTable from './MitochondrialVariantPopulationFrequenciesTable'
+import { AnchoredSectionHeading } from '../AnchorLink'
+import useScrollToHash from '../useScrollToHash'
 import MitochondrialVariantReferenceList from './MitochondrialVariantReferenceList'
 import MitochondrialVariantSiteQualityMetrics from './MitochondrialVariantSiteQualityMetrics'
 import {
@@ -173,110 +175,114 @@ type MitochondrialVariantPageProps = {
   variant: MitochondrialVariant
 }
 
-const MitochondrialVariantPage = ({ datasetId, variant }: MitochondrialVariantPageProps) => (
-  <Page>
-    <DocumentTitle title={variant.variant_id} />
-    <GnomadPageHeading
-      selectedDataset={datasetId}
-      datasetOptions={{
-        includeShortVariants: true,
-        includeStructuralVariants: false,
-        includeExac: false,
-        includeGnomad2: false,
-        includeGnomad3: true,
-        includeGnomad3Subsets: false,
-      }}
-    >
-      {variantType(variant.variant_id)}: <VariantId>{variant.variant_id} (GRCh38)</VariantId>
-    </GnomadPageHeading>
-    <Wrapper>
-      <ResponsiveSection>
-        <MitochondrialVariantAttributeList variant={variant} />
-        {variant.ac_hom_mnv > 0 && (
-          <p>
-            <Badge level="warning">Warning</Badge> In{' '}
-            {variant.ac_hom_mnv === variant.ac_hom ? (
-              'all'
-            ) : (
-              <>
-                {variant.ac_hom_mnv} of {variant.ac_hom}
-              </>
-            )}{' '}
-            individuals where this variant is homoplasmic or near-homoplasmic (heteroplasmy level ≥
-            0.95), this variant occurs in phase with another variant, potentially altering the amino
-            acid sequence.
-          </p>
-        )}
-        {variant.flags && variant.flags.includes('common_low_heteroplasmy') && (
-          <p>
-            <Badge level="warning">Warning</Badge> Common low heteroplasmy: this variant is present
-            at an overall frequency of .001 across all samples with a heteroplasmy level &gt; 0 and
-            &lt; 0.50.
-          </p>
-        )}
-      </ResponsiveSection>
-      <ResponsiveSection>
-        <h2>External Resources</h2>
-        <MitochondrialVariantReferenceList variant={variant} />
-        <h2>Feedback</h2>
-        <ExternalLink href={variantFeedbackUrl(variant, datasetId)}>
-          Report an issue with this variant
-        </ExternalLink>
-      </ResponsiveSection>
-    </Wrapper>
-    <Section>
-      <h2>Genetic Ancestry Group Frequencies</h2>
-      <MitochondrialVariantPopulationFrequenciesTable variant={variant} />
-    </Section>
-    <Section>
-      <h2>
-        Haplogroup Frequencies <InfoButton topic="haplogroup-frequencies" />
-      </h2>
-      <TableWrapper>
-        <MitochondrialVariantHaplogroupFrequenciesTable variant={variant} />
-      </TableWrapper>
-    </Section>
-    <Wrapper>
-      <ResponsiveSection>
-        <h2>Heteroplasmy Distribution</h2>
-        <MitochondrialVariantHeteroplasmyDistribution variant={variant} />
-      </ResponsiveSection>
-      <ResponsiveSection>
-        <h2>
-          Age Distribution <InfoButton topic="age" />
-        </h2>
-        <MitochondrialVariantAgeDistribution variant={variant} />
-      </ResponsiveSection>
-    </Wrapper>
-    <Wrapper>
-      <ResponsiveSection>
-        <h2>Annotations</h2>
-        <MitochondrialVariantTranscriptConsequenceList variant={variant} />
-      </ResponsiveSection>
+const MitochondrialVariantPage = ({ datasetId, variant }: MitochondrialVariantPageProps) => {
+  useScrollToHash()
 
-      {variant.clinvar && (
+  return (
+    <Page>
+      <DocumentTitle title={variant.variant_id} />
+      <GnomadPageHeading
+        selectedDataset={datasetId}
+        datasetOptions={{
+          includeShortVariants: true,
+          includeStructuralVariants: false,
+          includeExac: false,
+          includeGnomad2: false,
+          includeGnomad3: true,
+          includeGnomad3Subsets: false,
+        }}
+      >
+        {variantType(variant.variant_id)}: <VariantId>{variant.variant_id} (GRCh38)</VariantId>
+      </GnomadPageHeading>
+      <Wrapper>
         <ResponsiveSection>
-          <h2>ClinVar</h2>
-          <VariantClinvarInfo clinvar={variant.clinvar} />
+          <MitochondrialVariantAttributeList variant={variant} />
+          {variant.ac_hom_mnv > 0 && (
+            <p>
+              <Badge level="warning">Warning</Badge> In{' '}
+              {variant.ac_hom_mnv === variant.ac_hom ? (
+                'all'
+              ) : (
+                <>
+                  {variant.ac_hom_mnv} of {variant.ac_hom}
+                </>
+              )}{' '}
+              individuals where this variant is homoplasmic or near-homoplasmic (heteroplasmy level
+              ≥ 0.95), this variant occurs in phase with another variant, potentially altering the
+              amino acid sequence.
+            </p>
+          )}
+          {variant.flags && variant.flags.includes('common_low_heteroplasmy') && (
+            <p>
+              <Badge level="warning">Warning</Badge> Common low heteroplasmy: this variant is
+              present at an overall frequency of .001 across all samples with a heteroplasmy level
+              &gt; 0 and &lt; 0.50.
+            </p>
+          )}
         </ResponsiveSection>
-      )}
-    </Wrapper>
-    <Wrapper>
-      <ResponsiveSection>
-        <h2>Genotype Quality Metrics</h2>
-        <MitochondrialVariantGenotypeQualityMetrics variant={variant} />
-      </ResponsiveSection>
-      <ResponsiveSection>
-        <h2>Site Quality Metrics</h2>
-        <MitochondrialVariantSiteQualityMetrics variant={variant} />
-      </ResponsiveSection>
-    </Wrapper>
-    <Section>
-      <h2>Read Data</h2>
-      <p>Read data is not yet available for mitochondrial variants.</p>
-    </Section>
-  </Page>
-)
+        <ResponsiveSection>
+          <h2>External Resources</h2>
+          <MitochondrialVariantReferenceList variant={variant} />
+          <h2>Feedback</h2>
+          <ExternalLink href={variantFeedbackUrl(variant, datasetId)}>
+            Report an issue with this variant
+          </ExternalLink>
+        </ResponsiveSection>
+      </Wrapper>
+      <Section>
+        <h2>Genetic Ancestry Group Frequencies</h2>
+        <MitochondrialVariantPopulationFrequenciesTable variant={variant} />
+      </Section>
+      <Section>
+        <h2>
+          Haplogroup Frequencies <InfoButton topic="haplogroup-frequencies" />
+        </h2>
+        <TableWrapper>
+          <MitochondrialVariantHaplogroupFrequenciesTable variant={variant} />
+        </TableWrapper>
+      </Section>
+      <Wrapper>
+        <ResponsiveSection>
+          <h2>Heteroplasmy Distribution</h2>
+          <MitochondrialVariantHeteroplasmyDistribution variant={variant} />
+        </ResponsiveSection>
+        <ResponsiveSection>
+          <AnchoredSectionHeading id="age-distribution">
+            Age Distribution <InfoButton topic="age" />
+          </AnchoredSectionHeading>
+          <MitochondrialVariantAgeDistribution variant={variant} />
+        </ResponsiveSection>
+      </Wrapper>
+      <Wrapper>
+        <ResponsiveSection>
+          <h2>Annotations</h2>
+          <MitochondrialVariantTranscriptConsequenceList variant={variant} />
+        </ResponsiveSection>
+
+        {variant.clinvar && (
+          <ResponsiveSection>
+            <h2>ClinVar</h2>
+            <VariantClinvarInfo clinvar={variant.clinvar} />
+          </ResponsiveSection>
+        )}
+      </Wrapper>
+      <Wrapper>
+        <ResponsiveSection>
+          <h2>Genotype Quality Metrics</h2>
+          <MitochondrialVariantGenotypeQualityMetrics variant={variant} />
+        </ResponsiveSection>
+        <ResponsiveSection>
+          <h2>Site Quality Metrics</h2>
+          <MitochondrialVariantSiteQualityMetrics variant={variant} />
+        </ResponsiveSection>
+      </Wrapper>
+      <Section>
+        <h2>Read Data</h2>
+        <p>Read data is not yet available for mitochondrial variants.</p>
+      </Section>
+    </Page>
+  )
+}
 
 const operationName = 'MitochondrialVariant'
 const variantQuery = `

--- a/browser/src/MitochondrialVariantPage/MitochondrialVariantPage.tsx
+++ b/browser/src/MitochondrialVariantPage/MitochondrialVariantPage.tsx
@@ -28,7 +28,7 @@ import MitochondrialVariantGenotypeQualityMetrics from './MitochondrialVariantGe
 import MitochondrialVariantHaplogroupFrequenciesTable from './MitochondrialVariantHaplogroupFrequenciesTable'
 import MitochondrialVariantHeteroplasmyDistribution from './MitochondrialVariantHeteroplasmyDistribution'
 import MitochondrialVariantPopulationFrequenciesTable from './MitochondrialVariantPopulationFrequenciesTable'
-import { AgeDistributionHeading } from '../AnchorLink'
+import { SectionHeading } from '../AnchorLink'
 import useScrollToHash from '../useScrollToHash'
 import MitochondrialVariantReferenceList from './MitochondrialVariantReferenceList'
 import MitochondrialVariantSiteQualityMetrics from './MitochondrialVariantSiteQualityMetrics'
@@ -247,9 +247,9 @@ const MitochondrialVariantPage = ({ datasetId, variant }: MitochondrialVariantPa
           <MitochondrialVariantHeteroplasmyDistribution variant={variant} />
         </ResponsiveSection>
         <ResponsiveSection>
-          <AgeDistributionHeading>
-            Age Distribution <InfoButton topic="age" />
-          </AgeDistributionHeading>
+          <SectionHeading id="age-distribution" title="Age Distribution">
+            <InfoButton topic="age" />
+          </SectionHeading>
           <MitochondrialVariantAgeDistribution variant={variant} />
         </ResponsiveSection>
       </Wrapper>

--- a/browser/src/MitochondrialVariantPage/MitochondrialVariantPage.tsx
+++ b/browser/src/MitochondrialVariantPage/MitochondrialVariantPage.tsx
@@ -28,7 +28,7 @@ import MitochondrialVariantGenotypeQualityMetrics from './MitochondrialVariantGe
 import MitochondrialVariantHaplogroupFrequenciesTable from './MitochondrialVariantHaplogroupFrequenciesTable'
 import MitochondrialVariantHeteroplasmyDistribution from './MitochondrialVariantHeteroplasmyDistribution'
 import MitochondrialVariantPopulationFrequenciesTable from './MitochondrialVariantPopulationFrequenciesTable'
-import { AnchoredSectionHeading } from '../AnchorLink'
+import { AgeDistributionHeading } from '../AnchorLink'
 import useScrollToHash from '../useScrollToHash'
 import MitochondrialVariantReferenceList from './MitochondrialVariantReferenceList'
 import MitochondrialVariantSiteQualityMetrics from './MitochondrialVariantSiteQualityMetrics'
@@ -247,9 +247,9 @@ const MitochondrialVariantPage = ({ datasetId, variant }: MitochondrialVariantPa
           <MitochondrialVariantHeteroplasmyDistribution variant={variant} />
         </ResponsiveSection>
         <ResponsiveSection>
-          <AnchoredSectionHeading id="age-distribution">
+          <AgeDistributionHeading>
             Age Distribution <InfoButton topic="age" />
-          </AnchoredSectionHeading>
+          </AgeDistributionHeading>
           <MitochondrialVariantAgeDistribution variant={variant} />
         </ResponsiveSection>
       </Wrapper>

--- a/browser/src/MitochondrialVariantPage/__snapshots__/MitochondrialVariantPage.spec.tsx.snap
+++ b/browser/src/MitochondrialVariantPage/__snapshots__/MitochondrialVariantPage.spec.tsx.snap
@@ -1491,37 +1491,58 @@ exports[`MitochondrialVariantPage with dataset gnomad_cnv_r4 has no unexpected c
     <section
       className="MitochondrialVariantPage__ResponsiveSection-sc-1h2n2ff-2 eVwzkj"
     >
-      <h2>
-        Age Distribution 
-        <button
-          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-          onClick={[Function]}
-          type="button"
+      <span
+        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      >
+        <h2
+          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
         >
-          <img
-            alt=""
+          <a
             aria-hidden="true"
-            src="test-file-stub"
-          />
-          <span
-            style={
-              {
-                "border": "0",
-                "clip": "rect(0 0 0 0)",
-                "height": "1px",
-                "margin": "-1px",
-                "overflow": "hidden",
-                "padding": "0",
-                "position": "absolute",
-                "whiteSpace": "nowrap",
-                "width": "1px",
-              }
-            }
+            className="AnchorLink-sc-77ly3x-0 isLygD"
+            href="#age-distribution"
+            id="age-distribution"
+            onClick={[Function]}
           >
-            More information
-          </span>
-        </button>
-      </h2>
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution 
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
+      </span>
       <div>
         <div
           className="MitochondrialVariantAgeDistribution__LegendWrapper-sc-h2p9a2-0 kmBkbi"
@@ -9420,37 +9441,58 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3 has no unexpected chang
     <section
       className="MitochondrialVariantPage__ResponsiveSection-sc-1h2n2ff-2 eVwzkj"
     >
-      <h2>
-        Age Distribution 
-        <button
-          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-          onClick={[Function]}
-          type="button"
+      <span
+        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      >
+        <h2
+          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
         >
-          <img
-            alt=""
+          <a
             aria-hidden="true"
-            src="test-file-stub"
-          />
-          <span
-            style={
-              {
-                "border": "0",
-                "clip": "rect(0 0 0 0)",
-                "height": "1px",
-                "margin": "-1px",
-                "overflow": "hidden",
-                "padding": "0",
-                "position": "absolute",
-                "whiteSpace": "nowrap",
-                "width": "1px",
-              }
-            }
+            className="AnchorLink-sc-77ly3x-0 isLygD"
+            href="#age-distribution"
+            id="age-distribution"
+            onClick={[Function]}
           >
-            More information
-          </span>
-        </button>
-      </h2>
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution 
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
+      </span>
       <div>
         <div
           className="MitochondrialVariantAgeDistribution__LegendWrapper-sc-h2p9a2-0 kmBkbi"
@@ -17259,37 +17301,58 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_controls_and_biobanks h
     <section
       className="MitochondrialVariantPage__ResponsiveSection-sc-1h2n2ff-2 eVwzkj"
     >
-      <h2>
-        Age Distribution 
-        <button
-          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-          onClick={[Function]}
-          type="button"
+      <span
+        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      >
+        <h2
+          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
         >
-          <img
-            alt=""
+          <a
             aria-hidden="true"
-            src="test-file-stub"
-          />
-          <span
-            style={
-              {
-                "border": "0",
-                "clip": "rect(0 0 0 0)",
-                "height": "1px",
-                "margin": "-1px",
-                "overflow": "hidden",
-                "padding": "0",
-                "position": "absolute",
-                "whiteSpace": "nowrap",
-                "width": "1px",
-              }
-            }
+            className="AnchorLink-sc-77ly3x-0 isLygD"
+            href="#age-distribution"
+            id="age-distribution"
+            onClick={[Function]}
           >
-            More information
-          </span>
-        </button>
-      </h2>
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution 
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
+      </span>
       <div>
         <div
           className="MitochondrialVariantAgeDistribution__LegendWrapper-sc-h2p9a2-0 kmBkbi"
@@ -25098,37 +25161,58 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_non_cancer has no unexp
     <section
       className="MitochondrialVariantPage__ResponsiveSection-sc-1h2n2ff-2 eVwzkj"
     >
-      <h2>
-        Age Distribution 
-        <button
-          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-          onClick={[Function]}
-          type="button"
+      <span
+        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      >
+        <h2
+          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
         >
-          <img
-            alt=""
+          <a
             aria-hidden="true"
-            src="test-file-stub"
-          />
-          <span
-            style={
-              {
-                "border": "0",
-                "clip": "rect(0 0 0 0)",
-                "height": "1px",
-                "margin": "-1px",
-                "overflow": "hidden",
-                "padding": "0",
-                "position": "absolute",
-                "whiteSpace": "nowrap",
-                "width": "1px",
-              }
-            }
+            className="AnchorLink-sc-77ly3x-0 isLygD"
+            href="#age-distribution"
+            id="age-distribution"
+            onClick={[Function]}
           >
-            More information
-          </span>
-        </button>
-      </h2>
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution 
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
+      </span>
       <div>
         <div
           className="MitochondrialVariantAgeDistribution__LegendWrapper-sc-h2p9a2-0 kmBkbi"
@@ -32937,37 +33021,58 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_non_neuro has no unexpe
     <section
       className="MitochondrialVariantPage__ResponsiveSection-sc-1h2n2ff-2 eVwzkj"
     >
-      <h2>
-        Age Distribution 
-        <button
-          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-          onClick={[Function]}
-          type="button"
+      <span
+        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      >
+        <h2
+          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
         >
-          <img
-            alt=""
+          <a
             aria-hidden="true"
-            src="test-file-stub"
-          />
-          <span
-            style={
-              {
-                "border": "0",
-                "clip": "rect(0 0 0 0)",
-                "height": "1px",
-                "margin": "-1px",
-                "overflow": "hidden",
-                "padding": "0",
-                "position": "absolute",
-                "whiteSpace": "nowrap",
-                "width": "1px",
-              }
-            }
+            className="AnchorLink-sc-77ly3x-0 isLygD"
+            href="#age-distribution"
+            id="age-distribution"
+            onClick={[Function]}
           >
-            More information
-          </span>
-        </button>
-      </h2>
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution 
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
+      </span>
       <div>
         <div
           className="MitochondrialVariantAgeDistribution__LegendWrapper-sc-h2p9a2-0 kmBkbi"
@@ -40776,37 +40881,58 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_non_topmed has no unexp
     <section
       className="MitochondrialVariantPage__ResponsiveSection-sc-1h2n2ff-2 eVwzkj"
     >
-      <h2>
-        Age Distribution 
-        <button
-          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-          onClick={[Function]}
-          type="button"
+      <span
+        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      >
+        <h2
+          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
         >
-          <img
-            alt=""
+          <a
             aria-hidden="true"
-            src="test-file-stub"
-          />
-          <span
-            style={
-              {
-                "border": "0",
-                "clip": "rect(0 0 0 0)",
-                "height": "1px",
-                "margin": "-1px",
-                "overflow": "hidden",
-                "padding": "0",
-                "position": "absolute",
-                "whiteSpace": "nowrap",
-                "width": "1px",
-              }
-            }
+            className="AnchorLink-sc-77ly3x-0 isLygD"
+            href="#age-distribution"
+            id="age-distribution"
+            onClick={[Function]}
           >
-            More information
-          </span>
-        </button>
-      </h2>
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution 
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
+      </span>
       <div>
         <div
           className="MitochondrialVariantAgeDistribution__LegendWrapper-sc-h2p9a2-0 kmBkbi"
@@ -48615,37 +48741,58 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_non_v2 has no unexpecte
     <section
       className="MitochondrialVariantPage__ResponsiveSection-sc-1h2n2ff-2 eVwzkj"
     >
-      <h2>
-        Age Distribution 
-        <button
-          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-          onClick={[Function]}
-          type="button"
+      <span
+        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      >
+        <h2
+          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
         >
-          <img
-            alt=""
+          <a
             aria-hidden="true"
-            src="test-file-stub"
-          />
-          <span
-            style={
-              {
-                "border": "0",
-                "clip": "rect(0 0 0 0)",
-                "height": "1px",
-                "margin": "-1px",
-                "overflow": "hidden",
-                "padding": "0",
-                "position": "absolute",
-                "whiteSpace": "nowrap",
-                "width": "1px",
-              }
-            }
+            className="AnchorLink-sc-77ly3x-0 isLygD"
+            href="#age-distribution"
+            id="age-distribution"
+            onClick={[Function]}
           >
-            More information
-          </span>
-        </button>
-      </h2>
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution 
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
+      </span>
       <div>
         <div
           className="MitochondrialVariantAgeDistribution__LegendWrapper-sc-h2p9a2-0 kmBkbi"
@@ -56454,37 +56601,58 @@ exports[`MitochondrialVariantPage with dataset gnomad_r4 has no unexpected chang
     <section
       className="MitochondrialVariantPage__ResponsiveSection-sc-1h2n2ff-2 eVwzkj"
     >
-      <h2>
-        Age Distribution 
-        <button
-          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-          onClick={[Function]}
-          type="button"
+      <span
+        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      >
+        <h2
+          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
         >
-          <img
-            alt=""
+          <a
             aria-hidden="true"
-            src="test-file-stub"
-          />
-          <span
-            style={
-              {
-                "border": "0",
-                "clip": "rect(0 0 0 0)",
-                "height": "1px",
-                "margin": "-1px",
-                "overflow": "hidden",
-                "padding": "0",
-                "position": "absolute",
-                "whiteSpace": "nowrap",
-                "width": "1px",
-              }
-            }
+            className="AnchorLink-sc-77ly3x-0 isLygD"
+            href="#age-distribution"
+            id="age-distribution"
+            onClick={[Function]}
           >
-            More information
-          </span>
-        </button>
-      </h2>
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution 
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
+      </span>
       <div>
         <div
           className="MitochondrialVariantAgeDistribution__LegendWrapper-sc-h2p9a2-0 kmBkbi"
@@ -64293,37 +64461,58 @@ exports[`MitochondrialVariantPage with dataset gnomad_r4_non_ukb has no unexpect
     <section
       className="MitochondrialVariantPage__ResponsiveSection-sc-1h2n2ff-2 eVwzkj"
     >
-      <h2>
-        Age Distribution 
-        <button
-          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-          onClick={[Function]}
-          type="button"
+      <span
+        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      >
+        <h2
+          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
         >
-          <img
-            alt=""
+          <a
             aria-hidden="true"
-            src="test-file-stub"
-          />
-          <span
-            style={
-              {
-                "border": "0",
-                "clip": "rect(0 0 0 0)",
-                "height": "1px",
-                "margin": "-1px",
-                "overflow": "hidden",
-                "padding": "0",
-                "position": "absolute",
-                "whiteSpace": "nowrap",
-                "width": "1px",
-              }
-            }
+            className="AnchorLink-sc-77ly3x-0 isLygD"
+            href="#age-distribution"
+            id="age-distribution"
+            onClick={[Function]}
           >
-            More information
-          </span>
-        </button>
-      </h2>
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution 
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
+      </span>
       <div>
         <div
           className="MitochondrialVariantAgeDistribution__LegendWrapper-sc-h2p9a2-0 kmBkbi"
@@ -72132,37 +72321,58 @@ exports[`MitochondrialVariantPage with dataset gnomad_sv_r2_1 has no unexpected 
     <section
       className="MitochondrialVariantPage__ResponsiveSection-sc-1h2n2ff-2 eVwzkj"
     >
-      <h2>
-        Age Distribution 
-        <button
-          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-          onClick={[Function]}
-          type="button"
+      <span
+        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      >
+        <h2
+          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
         >
-          <img
-            alt=""
+          <a
             aria-hidden="true"
-            src="test-file-stub"
-          />
-          <span
-            style={
-              {
-                "border": "0",
-                "clip": "rect(0 0 0 0)",
-                "height": "1px",
-                "margin": "-1px",
-                "overflow": "hidden",
-                "padding": "0",
-                "position": "absolute",
-                "whiteSpace": "nowrap",
-                "width": "1px",
-              }
-            }
+            className="AnchorLink-sc-77ly3x-0 isLygD"
+            href="#age-distribution"
+            id="age-distribution"
+            onClick={[Function]}
           >
-            More information
-          </span>
-        </button>
-      </h2>
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution 
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
+      </span>
       <div>
         <div
           className="MitochondrialVariantAgeDistribution__LegendWrapper-sc-h2p9a2-0 kmBkbi"
@@ -79971,37 +80181,58 @@ exports[`MitochondrialVariantPage with dataset gnomad_sv_r2_1_controls has no un
     <section
       className="MitochondrialVariantPage__ResponsiveSection-sc-1h2n2ff-2 eVwzkj"
     >
-      <h2>
-        Age Distribution 
-        <button
-          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-          onClick={[Function]}
-          type="button"
+      <span
+        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      >
+        <h2
+          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
         >
-          <img
-            alt=""
+          <a
             aria-hidden="true"
-            src="test-file-stub"
-          />
-          <span
-            style={
-              {
-                "border": "0",
-                "clip": "rect(0 0 0 0)",
-                "height": "1px",
-                "margin": "-1px",
-                "overflow": "hidden",
-                "padding": "0",
-                "position": "absolute",
-                "whiteSpace": "nowrap",
-                "width": "1px",
-              }
-            }
+            className="AnchorLink-sc-77ly3x-0 isLygD"
+            href="#age-distribution"
+            id="age-distribution"
+            onClick={[Function]}
           >
-            More information
-          </span>
-        </button>
-      </h2>
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution 
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
+      </span>
       <div>
         <div
           className="MitochondrialVariantAgeDistribution__LegendWrapper-sc-h2p9a2-0 kmBkbi"
@@ -87810,37 +88041,58 @@ exports[`MitochondrialVariantPage with dataset gnomad_sv_r2_1_non_neuro has no u
     <section
       className="MitochondrialVariantPage__ResponsiveSection-sc-1h2n2ff-2 eVwzkj"
     >
-      <h2>
-        Age Distribution 
-        <button
-          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-          onClick={[Function]}
-          type="button"
+      <span
+        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      >
+        <h2
+          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
         >
-          <img
-            alt=""
+          <a
             aria-hidden="true"
-            src="test-file-stub"
-          />
-          <span
-            style={
-              {
-                "border": "0",
-                "clip": "rect(0 0 0 0)",
-                "height": "1px",
-                "margin": "-1px",
-                "overflow": "hidden",
-                "padding": "0",
-                "position": "absolute",
-                "whiteSpace": "nowrap",
-                "width": "1px",
-              }
-            }
+            className="AnchorLink-sc-77ly3x-0 isLygD"
+            href="#age-distribution"
+            id="age-distribution"
+            onClick={[Function]}
           >
-            More information
-          </span>
-        </button>
-      </h2>
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution 
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
+      </span>
       <div>
         <div
           className="MitochondrialVariantAgeDistribution__LegendWrapper-sc-h2p9a2-0 kmBkbi"
@@ -95649,37 +95901,58 @@ exports[`MitochondrialVariantPage with dataset gnomad_sv_r4 has no unexpected ch
     <section
       className="MitochondrialVariantPage__ResponsiveSection-sc-1h2n2ff-2 eVwzkj"
     >
-      <h2>
-        Age Distribution 
-        <button
-          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-          onClick={[Function]}
-          type="button"
+      <span
+        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      >
+        <h2
+          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
         >
-          <img
-            alt=""
+          <a
             aria-hidden="true"
-            src="test-file-stub"
-          />
-          <span
-            style={
-              {
-                "border": "0",
-                "clip": "rect(0 0 0 0)",
-                "height": "1px",
-                "margin": "-1px",
-                "overflow": "hidden",
-                "padding": "0",
-                "position": "absolute",
-                "whiteSpace": "nowrap",
-                "width": "1px",
-              }
-            }
+            className="AnchorLink-sc-77ly3x-0 isLygD"
+            href="#age-distribution"
+            id="age-distribution"
+            onClick={[Function]}
           >
-            More information
-          </span>
-        </button>
-      </h2>
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution 
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
+      </span>
       <div>
         <div
           className="MitochondrialVariantAgeDistribution__LegendWrapper-sc-h2p9a2-0 kmBkbi"

--- a/browser/src/MitochondrialVariantPage/__snapshots__/MitochondrialVariantPage.spec.tsx.snap
+++ b/browser/src/MitochondrialVariantPage/__snapshots__/MitochondrialVariantPage.spec.tsx.snap
@@ -1494,12 +1494,10 @@ exports[`MitochondrialVariantPage with dataset gnomad_cnv_r4 has no unexpected c
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -9444,12 +9442,10 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3 has no unexpected chang
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -17304,12 +17300,10 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_controls_and_biobanks h
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -25164,12 +25158,10 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_non_cancer has no unexp
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -33024,12 +33016,10 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_non_neuro has no unexpe
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -40884,12 +40874,10 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_non_topmed has no unexp
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -48744,12 +48732,10 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_non_v2 has no unexpecte
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -56604,12 +56590,10 @@ exports[`MitochondrialVariantPage with dataset gnomad_r4 has no unexpected chang
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -64464,12 +64448,10 @@ exports[`MitochondrialVariantPage with dataset gnomad_r4_non_ukb has no unexpect
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -72324,12 +72306,10 @@ exports[`MitochondrialVariantPage with dataset gnomad_sv_r2_1 has no unexpected 
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -80184,12 +80164,10 @@ exports[`MitochondrialVariantPage with dataset gnomad_sv_r2_1_controls has no un
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -88044,12 +88022,10 @@ exports[`MitochondrialVariantPage with dataset gnomad_sv_r2_1_non_neuro has no u
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -95904,12 +95880,10 @@ exports[`MitochondrialVariantPage with dataset gnomad_sv_r4 has no unexpected ch
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}

--- a/browser/src/MitochondrialVariantPage/__snapshots__/MitochondrialVariantPage.spec.tsx.snap
+++ b/browser/src/MitochondrialVariantPage/__snapshots__/MitochondrialVariantPage.spec.tsx.snap
@@ -1491,56 +1491,55 @@ exports[`MitochondrialVariantPage with dataset gnomad_cnv_r4 has no unexpected c
     <section
       className="MitochondrialVariantPage__ResponsiveSection-sc-1h2n2ff-2 eVwzkj"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <div>
         <div
           className="MitochondrialVariantAgeDistribution__LegendWrapper-sc-h2p9a2-0 kmBkbi"
@@ -9439,56 +9438,55 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3 has no unexpected chang
     <section
       className="MitochondrialVariantPage__ResponsiveSection-sc-1h2n2ff-2 eVwzkj"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <div>
         <div
           className="MitochondrialVariantAgeDistribution__LegendWrapper-sc-h2p9a2-0 kmBkbi"
@@ -17297,56 +17295,55 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_controls_and_biobanks h
     <section
       className="MitochondrialVariantPage__ResponsiveSection-sc-1h2n2ff-2 eVwzkj"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <div>
         <div
           className="MitochondrialVariantAgeDistribution__LegendWrapper-sc-h2p9a2-0 kmBkbi"
@@ -25155,56 +25152,55 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_non_cancer has no unexp
     <section
       className="MitochondrialVariantPage__ResponsiveSection-sc-1h2n2ff-2 eVwzkj"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <div>
         <div
           className="MitochondrialVariantAgeDistribution__LegendWrapper-sc-h2p9a2-0 kmBkbi"
@@ -33013,56 +33009,55 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_non_neuro has no unexpe
     <section
       className="MitochondrialVariantPage__ResponsiveSection-sc-1h2n2ff-2 eVwzkj"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <div>
         <div
           className="MitochondrialVariantAgeDistribution__LegendWrapper-sc-h2p9a2-0 kmBkbi"
@@ -40871,56 +40866,55 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_non_topmed has no unexp
     <section
       className="MitochondrialVariantPage__ResponsiveSection-sc-1h2n2ff-2 eVwzkj"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <div>
         <div
           className="MitochondrialVariantAgeDistribution__LegendWrapper-sc-h2p9a2-0 kmBkbi"
@@ -48729,56 +48723,55 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_non_v2 has no unexpecte
     <section
       className="MitochondrialVariantPage__ResponsiveSection-sc-1h2n2ff-2 eVwzkj"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <div>
         <div
           className="MitochondrialVariantAgeDistribution__LegendWrapper-sc-h2p9a2-0 kmBkbi"
@@ -56587,56 +56580,55 @@ exports[`MitochondrialVariantPage with dataset gnomad_r4 has no unexpected chang
     <section
       className="MitochondrialVariantPage__ResponsiveSection-sc-1h2n2ff-2 eVwzkj"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <div>
         <div
           className="MitochondrialVariantAgeDistribution__LegendWrapper-sc-h2p9a2-0 kmBkbi"
@@ -64445,56 +64437,55 @@ exports[`MitochondrialVariantPage with dataset gnomad_r4_non_ukb has no unexpect
     <section
       className="MitochondrialVariantPage__ResponsiveSection-sc-1h2n2ff-2 eVwzkj"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <div>
         <div
           className="MitochondrialVariantAgeDistribution__LegendWrapper-sc-h2p9a2-0 kmBkbi"
@@ -72303,56 +72294,55 @@ exports[`MitochondrialVariantPage with dataset gnomad_sv_r2_1 has no unexpected 
     <section
       className="MitochondrialVariantPage__ResponsiveSection-sc-1h2n2ff-2 eVwzkj"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <div>
         <div
           className="MitochondrialVariantAgeDistribution__LegendWrapper-sc-h2p9a2-0 kmBkbi"
@@ -80161,56 +80151,55 @@ exports[`MitochondrialVariantPage with dataset gnomad_sv_r2_1_controls has no un
     <section
       className="MitochondrialVariantPage__ResponsiveSection-sc-1h2n2ff-2 eVwzkj"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <div>
         <div
           className="MitochondrialVariantAgeDistribution__LegendWrapper-sc-h2p9a2-0 kmBkbi"
@@ -88019,56 +88008,55 @@ exports[`MitochondrialVariantPage with dataset gnomad_sv_r2_1_non_neuro has no u
     <section
       className="MitochondrialVariantPage__ResponsiveSection-sc-1h2n2ff-2 eVwzkj"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <div>
         <div
           className="MitochondrialVariantAgeDistribution__LegendWrapper-sc-h2p9a2-0 kmBkbi"
@@ -95877,56 +95865,55 @@ exports[`MitochondrialVariantPage with dataset gnomad_sv_r4 has no unexpected ch
     <section
       className="MitochondrialVariantPage__ResponsiveSection-sc-1h2n2ff-2 eVwzkj"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <div>
         <div
           className="MitochondrialVariantAgeDistribution__LegendWrapper-sc-h2p9a2-0 kmBkbi"

--- a/browser/src/Notifications.spec.tsx
+++ b/browser/src/Notifications.spec.tsx
@@ -4,14 +4,27 @@ import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globa
 
 import Notifications, { showNotification } from './Notifications'
 
+const originalVisualViewport = Object.getOwnPropertyDescriptor(window, 'visualViewport')
+
 describe('Notifications', () => {
   beforeEach(() => {
     jest.useFakeTimers()
+    Object.defineProperty(window, 'visualViewport', {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    })
   })
 
   afterEach(() => {
     jest.runOnlyPendingTimers()
     jest.useRealTimers()
+    jest.restoreAllMocks()
+    if (originalVisualViewport) {
+      Object.defineProperty(window, 'visualViewport', originalVisualViewport)
+    } else {
+      Reflect.deleteProperty(window, 'visualViewport')
+    }
   })
 
   test('positions feedback relative to the viewport with a narrow-screen width bound', () => {
@@ -100,6 +113,90 @@ describe('Notifications', () => {
     })
     expect(screen.queryByRole('alert')).toBeNull()
     unmount()
+  })
+
+  describe('mobile visual viewport', () => {
+    let viewport: EventTarget & { offsetTop: number }
+
+    beforeEach(() => {
+      viewport = Object.assign(new EventTarget(), { offsetTop: 462 })
+      Object.defineProperty(window, 'visualViewport', { value: viewport, configurable: true })
+      expect(window.visualViewport).toBe(viewport)
+    })
+
+    test.each([
+      { status: 'success', title: 'Link copied' },
+      { status: 'error', title: 'Unable to copy link' },
+    ])(
+      'keeps $status feedback below the visible top without re-rendering on pan',
+      ({ status, title }) => {
+        const renderSpy = jest.spyOn(Notifications.prototype, 'render')
+        const scrollSpy = jest.spyOn(window, 'scrollTo')
+        const { container, unmount } = render(<Notifications />)
+        const focused = document.activeElement
+        viewport.offsetTop = 500
+        act(() => {
+          showNotification({ title, status })
+        })
+        const stack = container.querySelector('strong')!.parentElement!.parentElement!
+        expect(stack.style.top).toBe('calc(500px + 1rem)')
+        viewport.offsetTop = 462
+        act(() => {
+          showNotification({ title, status })
+        })
+        expect(stack.style.top).toBe('calc(462px + 1rem)')
+        const renders = renderSpy.mock.calls.length
+
+        act(() => {
+          viewport.offsetTop = 300
+          viewport.dispatchEvent(new Event('scroll'))
+        })
+        expect(stack.style.top).toBe('calc(300px + 1rem)')
+        act(() => {
+          viewport.offsetTop = 0
+          viewport.dispatchEvent(new Event('resize'))
+        })
+        expect(stack.style.top).toBe('calc(0px + 1rem)')
+        expect(renderSpy).toHaveBeenCalledTimes(renders)
+        expect(document.activeElement).toBe(focused)
+        expect(scrollSpy).not.toHaveBeenCalled()
+        unmount()
+      }
+    )
+
+    test('listens only while notifications exist and re-reads the viewport for the next batch', () => {
+      const addListener = jest.spyOn(viewport, 'addEventListener')
+      const removeListener = jest.spyOn(viewport, 'removeEventListener')
+      const { container, unmount } = render(<Notifications />)
+      expect(addListener).not.toHaveBeenCalled()
+      act(() => {
+        showNotification({ title: 'First', duration: 1 })
+        showNotification({ title: 'Second', duration: 2 })
+      })
+      const stack = container.querySelector('strong')!.parentElement!.parentElement!
+      expect(addListener.mock.calls.map(([event]) => event)).toEqual(['scroll', 'resize'])
+      act(() => {
+        jest.advanceTimersByTime(1000)
+      })
+      expect(removeListener).not.toHaveBeenCalled()
+      act(() => {
+        jest.advanceTimersByTime(1000)
+      })
+      expect(removeListener.mock.calls).toEqual(addListener.mock.calls)
+      expect(stack.style.top).toBe('')
+      viewport.offsetTop = 200
+      viewport.dispatchEvent(new Event('scroll'))
+      expect(stack.style.top).toBe('')
+
+      act(() => {
+        showNotification({ title: 'Next batch' })
+      })
+      expect(stack.style.top).toBe('calc(200px + 1rem)')
+      expect(addListener).toHaveBeenCalledTimes(4)
+      unmount()
+      expect(removeListener.mock.calls).toEqual(addListener.mock.calls)
+      expect(jest.getTimerCount()).toBe(0)
+    })
   })
 
   test('unsubscribes and clears all removal timers on unmount', () => {

--- a/browser/src/Notifications.spec.tsx
+++ b/browser/src/Notifications.spec.tsx
@@ -1,0 +1,119 @@
+import React from 'react'
+import { act, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals'
+
+import Notifications, { showNotification } from './Notifications'
+
+describe('Notifications', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers()
+    jest.useRealTimers()
+  })
+
+  test('positions feedback relative to the viewport with a narrow-screen width bound', () => {
+    const { container, unmount } = render(<Notifications />)
+    act(() => {
+      showNotification({ title: 'Link copied', status: 'success' })
+    })
+    const notification = container.querySelector('strong')!.parentElement!
+    const styles = getComputedStyle(notification.parentElement!)
+    expect(styles.position).toBe('fixed')
+    expect(styles.top).toBe('1rem')
+    expect(styles.left).toBe('calc(100vw - 1rem)')
+    expect(styles.transform).toBe('translateX(-100%)')
+    expect(styles.zIndex).toBe('1000')
+    expect(getComputedStyle(notification).maxWidth).toBe('calc(100vw - 2rem)')
+    // Only the pre-mounted region announces success, not the visual notification too.
+    expect(notification.getAttribute('role')).toBeNull()
+    expect(notification.getAttribute('aria-live')).toBeNull()
+    unmount()
+  })
+
+  test.each(['success', 'info', 'warning'])(
+    'updates a pre-mounted polite region for %s',
+    (status) => {
+      const { unmount } = render(<Notifications />)
+      const region = screen.getByRole('status')
+      expect(region.textContent).toBe('')
+      expect(region.getAttribute('aria-atomic')).toBe('false')
+      expect(region.getAttribute('aria-relevant')).toBe('additions')
+
+      act(() => {
+        showNotification({ title: 'Notification title', message: 'Details', status, duration: 2 })
+      })
+      expect(screen.getByRole('status')).toBe(region)
+      expect(region.textContent).toBe('Notification title Details')
+      expect(region.firstElementChild?.getAttribute('aria-atomic')).toBe('true')
+
+      act(() => {
+        jest.advanceTimersByTime(2000)
+      })
+      expect(screen.getByRole('status')).toBe(region)
+      expect(region.textContent).toBe('')
+      unmount()
+    }
+  )
+
+  test('adds distinct updates for repeated messages without replacing older announcements', () => {
+    const { unmount } = render(<Notifications />)
+    const region = screen.getByRole('status')
+    act(() => {
+      showNotification({ title: 'Link copied', status: 'success', duration: 2 })
+    })
+    const firstAnnouncement = region.firstElementChild
+    act(() => {
+      jest.advanceTimersByTime(1000)
+      showNotification({ title: 'Link copied', status: 'success', duration: 2 })
+    })
+    expect(region.children).toHaveLength(2)
+    expect(region.lastElementChild).toBe(firstAnnouncement)
+    expect(region.firstElementChild).not.toBe(firstAnnouncement)
+
+    act(() => {
+      jest.advanceTimersByTime(1000)
+    })
+    expect(region.children).toHaveLength(1)
+    expect(region.textContent).toBe('Link copied')
+    act(() => {
+      jest.advanceTimersByTime(1000)
+    })
+    expect(region.textContent).toBe('')
+    unmount()
+  })
+
+  test('urgently announces errors once, outside the polite region', () => {
+    const { unmount } = render(<Notifications />)
+
+    act(() => {
+      showNotification({ title: 'Unable to copy link', status: 'error', duration: 2 })
+    })
+    expect(screen.getAllByRole('alert')).toHaveLength(1)
+    expect(screen.getByRole('alert').textContent).toBe('Unable to copy link')
+    expect(screen.getByRole('status').textContent).toBe('')
+
+    act(() => {
+      jest.advanceTimersByTime(2000)
+    })
+    expect(screen.queryByRole('alert')).toBeNull()
+    unmount()
+  })
+
+  test('unsubscribes and clears all removal timers on unmount', () => {
+    const { unmount } = render(<Notifications />)
+    act(() => {
+      showNotification({ title: 'First' })
+      showNotification({ title: 'Second', status: 'error' })
+    })
+    expect(jest.getTimerCount()).toBe(2)
+    unmount()
+    expect(jest.getTimerCount()).toBe(0)
+    act(() => {
+      showNotification({ title: 'After unmount' })
+    })
+    expect(jest.getTimerCount()).toBe(0)
+  })
+})

--- a/browser/src/Notifications.tsx
+++ b/browser/src/Notifications.tsx
@@ -70,15 +70,40 @@ class Notifications extends Component<Record<string, never>, State> {
 
   nextNotificationId = 0
 
+  container = React.createRef<HTMLDivElement>()
+
+  viewport: VisualViewport | null = null
+
   componentDidMount() {
     notificationService.subscribe(this.addNotification)
   }
 
+  componentDidUpdate() {
+    if (this.state.notifications.length === 0) {
+      this.stopTrackingViewport()
+      return
+    }
+    if (!this.viewport && window.visualViewport) {
+      this.viewport = window.visualViewport
+      this.viewport.addEventListener('scroll', this.updateViewportPosition)
+      this.viewport.addEventListener('resize', this.updateViewportPosition)
+    }
+    this.updateViewportPosition()
+  }
+
   componentWillUnmount() {
+    this.stopTrackingViewport()
     notificationService.unsubscribe(this.addNotification)
     this.removeTimeouts.forEach((timeout: any) => {
       clearTimeout(timeout)
     })
+  }
+
+  updateViewportPosition = () => {
+    if (this.container.current && this.viewport) {
+      // Mobile panning can move the visible viewport below the fixed layout viewport origin.
+      this.container.current.style.top = `calc(${this.viewport.offsetTop}px + 1rem)`
+    }
   }
 
   addNotification = ({ title, message = null, status = 'info', duration = 3 }: any) => {
@@ -99,6 +124,15 @@ class Notifications extends Component<Record<string, never>, State> {
         this.removeNotification(id)
       }, duration * 1000)
     )
+  }
+
+  stopTrackingViewport() {
+    this.viewport?.removeEventListener('scroll', this.updateViewportPosition)
+    this.viewport?.removeEventListener('resize', this.updateViewportPosition)
+    this.viewport = null
+    if (this.container.current) {
+      this.container.current.style.top = ''
+    }
   }
 
   removeNotification(id: any) {
@@ -124,7 +158,7 @@ class Notifications extends Component<Record<string, never>, State> {
               </div>
             ))}
         </PoliteAnnouncements>
-        <NotificationsContainer>
+        <NotificationsContainer ref={this.container}>
           {notifications.map((notification) => {
             const { id, title, message, status } = notification
             return (

--- a/browser/src/Notifications.tsx
+++ b/browser/src/Notifications.tsx
@@ -9,10 +9,22 @@ const NotificationsAnchor = styled.div`
 `
 
 const NotificationsContainer = styled.div`
-  position: absolute;
-  z-index: 2;
+  position: fixed;
+  z-index: 1000;
   top: 1rem;
-  right: 1rem;
+
+  /* Overflowing page content can widen the layout viewport beyond the screen. */
+  left: calc(100vw - 1rem);
+  transform: translateX(-100%);
+`
+
+const PoliteAnnouncements = styled.div`
+  position: absolute;
+  overflow: hidden;
+  width: 1px;
+  height: 1px;
+  clip-path: inset(50%);
+  white-space: nowrap;
 `
 
 const STATUS_COLOR = {
@@ -29,6 +41,7 @@ const Notification = styled.div<{ status: Status }>`
   flex-direction: column;
   box-sizing: border-box;
   width: 240px;
+  max-width: calc(100vw - 2rem);
   min-height: 30px;
   padding: 0.5rem 0.5rem 0.5rem calc(10px + 0.5rem);
   border: 1px solid #333;
@@ -100,11 +113,27 @@ class Notifications extends Component<Record<string, never>, State> {
 
     return (
       <NotificationsAnchor>
+        {/* Keep the polite region mounted; announce additions, not the whole stack or removals. */}
+        <PoliteAnnouncements role="status" aria-atomic="false" aria-relevant="additions">
+          {notifications
+            .filter(({ status }) => status !== 'error')
+            .map(({ id, title, message }) => (
+              <div key={id} aria-atomic="true">
+                {title}
+                {message ? <> {message}</> : null}
+              </div>
+            ))}
+        </PoliteAnnouncements>
         <NotificationsContainer>
           {notifications.map((notification) => {
             const { id, title, message, status } = notification
             return (
-              <Notification key={id} status={status}>
+              <Notification
+                key={id}
+                status={status}
+                role={status === 'error' ? 'alert' : undefined}
+                aria-atomic={status === 'error' ? 'true' : undefined}
+              >
                 <strong>{title}</strong>
                 {message}
               </Notification>

--- a/browser/src/SectionHeadingPages.spec.tsx
+++ b/browser/src/SectionHeadingPages.spec.tsx
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, expect, jest, test } from '@jest/globals'
+import React from 'react'
+import { BrowserRouter } from 'react-router-dom'
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import DataPage from './DataPage/DataPage'
+import HelpPage from './help/HelpPage'
+import Notifications from './Notifications'
+import StatsPage from './StatsPage/StatsPage'
+
+const originalClipboard = navigator.clipboard
+const originalIntersectionObserver = window.IntersectionObserver
+const observe = jest.fn()
+const writeText = jest.fn(() => Promise.resolve())
+
+beforeEach(() => {
+  writeText.mockClear()
+  observe.mockClear()
+  Object.defineProperty(window, 'IntersectionObserver', {
+    value: jest.fn(() => ({ observe, disconnect: jest.fn() })),
+    configurable: true,
+    writable: true,
+  })
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText },
+    configurable: true,
+  })
+})
+
+afterEach(() => {
+  window.IntersectionObserver = originalIntersectionObserver
+  Object.defineProperty(navigator, 'clipboard', { value: originalClipboard, configurable: true })
+  window.history.replaceState({}, '', '/')
+})
+
+test.each([
+  { path: '/help', Page: HelpPage, count: 1, id: 'frequently-asked-questions' },
+  { path: '/data', Page: DataPage, count: 61, id: 'v4-genetic-ancestry-group-classification' },
+  { path: '/stats', Page: StatsPage, count: 6, id: 'age-and-sex-distribution' },
+])(
+  '$path uses shared, copyable headings with stable fragment targets',
+  async ({ path, Page, count, id }) => {
+    window.history.replaceState({}, '', `${path}?dataset=gnomad_r4`)
+    const { container } = render(
+      <BrowserRouter>
+        <Notifications />
+        <Page />
+      </BrowserRouter>
+    )
+
+    const links = Array.from(container.querySelectorAll<HTMLHeadingElement>('h2[id]')).map(
+      (heading) => within(heading).getByRole('link', { name: /^Copy link to / })
+    )
+    expect(links).toHaveLength(count)
+    links.forEach((link) => {
+      const heading = link.closest('h2')!
+      expect(heading).not.toBeNull()
+      expect(heading.firstElementChild).toBe(link)
+      expect(getComputedStyle(link).position).toBe('absolute')
+      expect(getComputedStyle(link).transform).toBe('translate(-100%, -50%)')
+      expect(link.getAttribute('href')).toBe(`#${heading.id}`)
+      expect(link.getAttribute('aria-label')).toBe(`Copy link to ${heading.textContent}`)
+      expect(container.querySelectorAll(`[id="${heading.id}"]`)).toHaveLength(1)
+      expect(link.hasAttribute('aria-hidden')).toBe(false)
+    })
+
+    const heading = document.getElementById(id)!
+    const link = within(heading).getByRole('link')
+    window.history.replaceState({}, '', `${path}?dataset=gnomad_r4#previous-section`)
+    link.focus()
+    await userEvent.keyboard('{Enter}')
+    expect(writeText).toHaveBeenCalledWith(`http://localhost${path}?dataset=gnomad_r4#${id}`)
+    expect(window.location.hash).toBe(`#${id}`)
+    expect(screen.getByRole('status').textContent).toContain('Link copied')
+
+    if (path === '/data') {
+      const contents = screen.getByRole('navigation', { name: 'Data sections' })
+      expect(
+        within(contents)
+          .getAllByRole('link')
+          .map((item) => ({
+            text: item.textContent,
+            href: item.getAttribute('href'),
+          }))
+      ).toEqual([
+        { text: 'Summary', href: '#summary' },
+        { text: 'v4 Downloads', href: '#v4' },
+        { text: 'v3 Downloads', href: '#v3' },
+        { text: 'v2 Liftover Downloads', href: '#v2-liftover' },
+        { text: 'v2 Downloads', href: '#v2' },
+        { text: 'ExAC Downloads', href: '#exac' },
+        { text: 'gnomAD API', href: '#api' },
+      ])
+      expect(getComputedStyle(document.getElementById('v4')!).fontSize).toBe('2.25rem')
+      expect(getComputedStyle(document.getElementById('v4-core-dataset')!).fontSize).toBe('1.88rem')
+      expect(getComputedStyle(heading).fontSize).toBe('1.5rem')
+      expect(container.querySelector('[subject]')).toBeNull()
+      expect(observe).toHaveBeenCalledTimes(count)
+      links.forEach((sectionLink) => {
+        expect(observe).toHaveBeenCalledWith(sectionLink.closest('h2'))
+      })
+    }
+  }
+)

--- a/browser/src/ShortTandemRepeatPage/ShortTandemRepeatPage.tsx
+++ b/browser/src/ShortTandemRepeatPage/ShortTandemRepeatPage.tsx
@@ -33,6 +33,8 @@ import {
   genotypeRepunitPairs,
 } from './shortTandemRepeatHelpers'
 import { PopulationId } from '@gnomad/dataset-metadata/gnomadPopulations'
+import { AnchoredSectionHeading } from '../AnchorLink'
+import useScrollToHash from '../useScrollToHash'
 import { GenotypeQuality } from './qualityDescription'
 import { QScoreBin } from './qScore'
 
@@ -202,6 +204,8 @@ const ExternalResources = ({ shortTandemRepeat }: { shortTandemRepeat: ShortTand
 }
 
 const ShortTandemRepeatPage = ({ datasetId, shortTandemRepeat }: ShortTandemRepeatPageProps) => {
+  useScrollToHash()
+
   const { allele_size_distribution } = shortTandemRepeat
 
   const alleleSizeDistributionRepunits = [
@@ -618,9 +622,9 @@ const ShortTandemRepeatPage = ({ datasetId, shortTandemRepeat }: ShortTandemRepe
       )}
 
       <section style={{ marginBottom: '3em' }}>
-        <h2>
+        <AnchoredSectionHeading id="age-distribution">
           Age Distribution <InfoButton topic="str-age-distribution" />
-        </h2>
+        </AnchoredSectionHeading>
         <ShortTandemRepeatAgeDistributionPlot
           ageDistribution={shortTandemRepeat.age_distribution}
           maxRepeats={maxAlleleRepeats}

--- a/browser/src/ShortTandemRepeatPage/ShortTandemRepeatPage.tsx
+++ b/browser/src/ShortTandemRepeatPage/ShortTandemRepeatPage.tsx
@@ -33,7 +33,7 @@ import {
   genotypeRepunitPairs,
 } from './shortTandemRepeatHelpers'
 import { PopulationId } from '@gnomad/dataset-metadata/gnomadPopulations'
-import { AnchoredSectionHeading } from '../AnchorLink'
+import { AgeDistributionHeading } from '../AnchorLink'
 import useScrollToHash from '../useScrollToHash'
 import { GenotypeQuality } from './qualityDescription'
 import { QScoreBin } from './qScore'
@@ -622,9 +622,9 @@ const ShortTandemRepeatPage = ({ datasetId, shortTandemRepeat }: ShortTandemRepe
       )}
 
       <section style={{ marginBottom: '3em' }}>
-        <AnchoredSectionHeading id="age-distribution">
+        <AgeDistributionHeading>
           Age Distribution <InfoButton topic="str-age-distribution" />
-        </AnchoredSectionHeading>
+        </AgeDistributionHeading>
         <ShortTandemRepeatAgeDistributionPlot
           ageDistribution={shortTandemRepeat.age_distribution}
           maxRepeats={maxAlleleRepeats}

--- a/browser/src/ShortTandemRepeatPage/ShortTandemRepeatPage.tsx
+++ b/browser/src/ShortTandemRepeatPage/ShortTandemRepeatPage.tsx
@@ -33,7 +33,7 @@ import {
   genotypeRepunitPairs,
 } from './shortTandemRepeatHelpers'
 import { PopulationId } from '@gnomad/dataset-metadata/gnomadPopulations'
-import { AgeDistributionHeading } from '../AnchorLink'
+import { SectionHeading } from '../AnchorLink'
 import useScrollToHash from '../useScrollToHash'
 import { GenotypeQuality } from './qualityDescription'
 import { QScoreBin } from './qScore'
@@ -622,9 +622,9 @@ const ShortTandemRepeatPage = ({ datasetId, shortTandemRepeat }: ShortTandemRepe
       )}
 
       <section style={{ marginBottom: '3em' }}>
-        <AgeDistributionHeading>
-          Age Distribution <InfoButton topic="str-age-distribution" />
-        </AgeDistributionHeading>
+        <SectionHeading id="age-distribution" title="Age Distribution">
+          <InfoButton topic="str-age-distribution" />
+        </SectionHeading>
         <ShortTandemRepeatAgeDistributionPlot
           ageDistribution={shortTandemRepeat.age_distribution}
           maxRepeats={maxAlleleRepeats}

--- a/browser/src/ShortTandemRepeatPage/__snapshots__/ShortTandemRepeatPage.spec.tsx.snap
+++ b/browser/src/ShortTandemRepeatPage/__snapshots__/ShortTandemRepeatPage.spec.tsx.snap
@@ -769,12 +769,14 @@ exports[`ShortTandemRepeatPage with "exac" dataset has no unexected changes 1`] 
       }
     }
   >
-    <h2>
+    <AnchoredSectionHeading
+      id="age-distribution"
+    >
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </h2>
+    </AnchoredSectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -1744,12 +1746,14 @@ exports[`ShortTandemRepeatPage with "gnomad_cnv_r4" dataset has no unexected cha
       }
     }
   >
-    <h2>
+    <AnchoredSectionHeading
+      id="age-distribution"
+    >
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </h2>
+    </AnchoredSectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -2719,12 +2723,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1" dataset has no unexected chang
       }
     }
   >
-    <h2>
+    <AnchoredSectionHeading
+      id="age-distribution"
+    >
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </h2>
+    </AnchoredSectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -3694,12 +3700,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1_controls" dataset has no unexec
       }
     }
   >
-    <h2>
+    <AnchoredSectionHeading
+      id="age-distribution"
+    >
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </h2>
+    </AnchoredSectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -4669,12 +4677,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1_non_cancer" dataset has no unex
       }
     }
   >
-    <h2>
+    <AnchoredSectionHeading
+      id="age-distribution"
+    >
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </h2>
+    </AnchoredSectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -5644,12 +5654,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1_non_neuro" dataset has no unexe
       }
     }
   >
-    <h2>
+    <AnchoredSectionHeading
+      id="age-distribution"
+    >
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </h2>
+    </AnchoredSectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -6619,12 +6631,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1_non_topmed" dataset has no unex
       }
     }
   >
-    <h2>
+    <AnchoredSectionHeading
+      id="age-distribution"
+    >
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </h2>
+    </AnchoredSectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -7594,12 +7608,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r3" dataset has no unexected changes
       }
     }
   >
-    <h2>
+    <AnchoredSectionHeading
+      id="age-distribution"
+    >
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </h2>
+    </AnchoredSectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -8569,12 +8585,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_controls_and_biobanks" dataset ha
       }
     }
   >
-    <h2>
+    <AnchoredSectionHeading
+      id="age-distribution"
+    >
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </h2>
+    </AnchoredSectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -9544,12 +9562,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_non_cancer" dataset has no unexec
       }
     }
   >
-    <h2>
+    <AnchoredSectionHeading
+      id="age-distribution"
+    >
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </h2>
+    </AnchoredSectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -10519,12 +10539,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_non_neuro" dataset has no unexect
       }
     }
   >
-    <h2>
+    <AnchoredSectionHeading
+      id="age-distribution"
+    >
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </h2>
+    </AnchoredSectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -11494,12 +11516,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_non_topmed" dataset has no unexec
       }
     }
   >
-    <h2>
+    <AnchoredSectionHeading
+      id="age-distribution"
+    >
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </h2>
+    </AnchoredSectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -12469,12 +12493,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_non_v2" dataset has no unexected 
       }
     }
   >
-    <h2>
+    <AnchoredSectionHeading
+      id="age-distribution"
+    >
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </h2>
+    </AnchoredSectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -13444,12 +13470,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r4" dataset has no unexected changes
       }
     }
   >
-    <h2>
+    <AnchoredSectionHeading
+      id="age-distribution"
+    >
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </h2>
+    </AnchoredSectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -14419,12 +14447,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r4_non_ukb" dataset has no unexected
       }
     }
   >
-    <h2>
+    <AnchoredSectionHeading
+      id="age-distribution"
+    >
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </h2>
+    </AnchoredSectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -15394,12 +15424,14 @@ exports[`ShortTandemRepeatPage with "gnomad_sv_r2_1" dataset has no unexected ch
       }
     }
   >
-    <h2>
+    <AnchoredSectionHeading
+      id="age-distribution"
+    >
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </h2>
+    </AnchoredSectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -16369,12 +16401,14 @@ exports[`ShortTandemRepeatPage with "gnomad_sv_r2_1_controls" dataset has no une
       }
     }
   >
-    <h2>
+    <AnchoredSectionHeading
+      id="age-distribution"
+    >
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </h2>
+    </AnchoredSectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -17344,12 +17378,14 @@ exports[`ShortTandemRepeatPage with "gnomad_sv_r2_1_non_neuro" dataset has no un
       }
     }
   >
-    <h2>
+    <AnchoredSectionHeading
+      id="age-distribution"
+    >
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </h2>
+    </AnchoredSectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -18319,12 +18355,14 @@ exports[`ShortTandemRepeatPage with "gnomad_sv_r4" dataset has no unexected chan
       }
     }
   >
-    <h2>
+    <AnchoredSectionHeading
+      id="age-distribution"
+    >
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </h2>
+    </AnchoredSectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [

--- a/browser/src/ShortTandemRepeatPage/__snapshots__/ShortTandemRepeatPage.spec.tsx.snap
+++ b/browser/src/ShortTandemRepeatPage/__snapshots__/ShortTandemRepeatPage.spec.tsx.snap
@@ -769,14 +769,12 @@ exports[`ShortTandemRepeatPage with "exac" dataset has no unexected changes 1`] 
       }
     }
   >
-    <AnchoredSectionHeading
-      id="age-distribution"
-    >
+    <AgeDistributionHeading>
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </AnchoredSectionHeading>
+    </AgeDistributionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -1746,14 +1744,12 @@ exports[`ShortTandemRepeatPage with "gnomad_cnv_r4" dataset has no unexected cha
       }
     }
   >
-    <AnchoredSectionHeading
-      id="age-distribution"
-    >
+    <AgeDistributionHeading>
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </AnchoredSectionHeading>
+    </AgeDistributionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -2723,14 +2719,12 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1" dataset has no unexected chang
       }
     }
   >
-    <AnchoredSectionHeading
-      id="age-distribution"
-    >
+    <AgeDistributionHeading>
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </AnchoredSectionHeading>
+    </AgeDistributionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -3700,14 +3694,12 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1_controls" dataset has no unexec
       }
     }
   >
-    <AnchoredSectionHeading
-      id="age-distribution"
-    >
+    <AgeDistributionHeading>
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </AnchoredSectionHeading>
+    </AgeDistributionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -4677,14 +4669,12 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1_non_cancer" dataset has no unex
       }
     }
   >
-    <AnchoredSectionHeading
-      id="age-distribution"
-    >
+    <AgeDistributionHeading>
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </AnchoredSectionHeading>
+    </AgeDistributionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -5654,14 +5644,12 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1_non_neuro" dataset has no unexe
       }
     }
   >
-    <AnchoredSectionHeading
-      id="age-distribution"
-    >
+    <AgeDistributionHeading>
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </AnchoredSectionHeading>
+    </AgeDistributionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -6631,14 +6619,12 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1_non_topmed" dataset has no unex
       }
     }
   >
-    <AnchoredSectionHeading
-      id="age-distribution"
-    >
+    <AgeDistributionHeading>
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </AnchoredSectionHeading>
+    </AgeDistributionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -7608,14 +7594,12 @@ exports[`ShortTandemRepeatPage with "gnomad_r3" dataset has no unexected changes
       }
     }
   >
-    <AnchoredSectionHeading
-      id="age-distribution"
-    >
+    <AgeDistributionHeading>
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </AnchoredSectionHeading>
+    </AgeDistributionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -8585,14 +8569,12 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_controls_and_biobanks" dataset ha
       }
     }
   >
-    <AnchoredSectionHeading
-      id="age-distribution"
-    >
+    <AgeDistributionHeading>
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </AnchoredSectionHeading>
+    </AgeDistributionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -9562,14 +9544,12 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_non_cancer" dataset has no unexec
       }
     }
   >
-    <AnchoredSectionHeading
-      id="age-distribution"
-    >
+    <AgeDistributionHeading>
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </AnchoredSectionHeading>
+    </AgeDistributionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -10539,14 +10519,12 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_non_neuro" dataset has no unexect
       }
     }
   >
-    <AnchoredSectionHeading
-      id="age-distribution"
-    >
+    <AgeDistributionHeading>
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </AnchoredSectionHeading>
+    </AgeDistributionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -11516,14 +11494,12 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_non_topmed" dataset has no unexec
       }
     }
   >
-    <AnchoredSectionHeading
-      id="age-distribution"
-    >
+    <AgeDistributionHeading>
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </AnchoredSectionHeading>
+    </AgeDistributionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -12493,14 +12469,12 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_non_v2" dataset has no unexected 
       }
     }
   >
-    <AnchoredSectionHeading
-      id="age-distribution"
-    >
+    <AgeDistributionHeading>
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </AnchoredSectionHeading>
+    </AgeDistributionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -13470,14 +13444,12 @@ exports[`ShortTandemRepeatPage with "gnomad_r4" dataset has no unexected changes
       }
     }
   >
-    <AnchoredSectionHeading
-      id="age-distribution"
-    >
+    <AgeDistributionHeading>
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </AnchoredSectionHeading>
+    </AgeDistributionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -14447,14 +14419,12 @@ exports[`ShortTandemRepeatPage with "gnomad_r4_non_ukb" dataset has no unexected
       }
     }
   >
-    <AnchoredSectionHeading
-      id="age-distribution"
-    >
+    <AgeDistributionHeading>
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </AnchoredSectionHeading>
+    </AgeDistributionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -15424,14 +15394,12 @@ exports[`ShortTandemRepeatPage with "gnomad_sv_r2_1" dataset has no unexected ch
       }
     }
   >
-    <AnchoredSectionHeading
-      id="age-distribution"
-    >
+    <AgeDistributionHeading>
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </AnchoredSectionHeading>
+    </AgeDistributionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -16401,14 +16369,12 @@ exports[`ShortTandemRepeatPage with "gnomad_sv_r2_1_controls" dataset has no une
       }
     }
   >
-    <AnchoredSectionHeading
-      id="age-distribution"
-    >
+    <AgeDistributionHeading>
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </AnchoredSectionHeading>
+    </AgeDistributionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -17378,14 +17344,12 @@ exports[`ShortTandemRepeatPage with "gnomad_sv_r2_1_non_neuro" dataset has no un
       }
     }
   >
-    <AnchoredSectionHeading
-      id="age-distribution"
-    >
+    <AgeDistributionHeading>
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </AnchoredSectionHeading>
+    </AgeDistributionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -18355,14 +18319,12 @@ exports[`ShortTandemRepeatPage with "gnomad_sv_r4" dataset has no unexected chan
       }
     }
   >
-    <AnchoredSectionHeading
-      id="age-distribution"
-    >
+    <AgeDistributionHeading>
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </AnchoredSectionHeading>
+    </AgeDistributionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [

--- a/browser/src/ShortTandemRepeatPage/__snapshots__/ShortTandemRepeatPage.spec.tsx.snap
+++ b/browser/src/ShortTandemRepeatPage/__snapshots__/ShortTandemRepeatPage.spec.tsx.snap
@@ -769,12 +769,14 @@ exports[`ShortTandemRepeatPage with "exac" dataset has no unexected changes 1`] 
       }
     }
   >
-    <AgeDistributionHeading>
-      Age Distribution 
+    <SectionHeading
+      id="age-distribution"
+      title="Age Distribution"
+    >
       <InfoButton
         topic="str-age-distribution"
       />
-    </AgeDistributionHeading>
+    </SectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -1744,12 +1746,14 @@ exports[`ShortTandemRepeatPage with "gnomad_cnv_r4" dataset has no unexected cha
       }
     }
   >
-    <AgeDistributionHeading>
-      Age Distribution 
+    <SectionHeading
+      id="age-distribution"
+      title="Age Distribution"
+    >
       <InfoButton
         topic="str-age-distribution"
       />
-    </AgeDistributionHeading>
+    </SectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -2719,12 +2723,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1" dataset has no unexected chang
       }
     }
   >
-    <AgeDistributionHeading>
-      Age Distribution 
+    <SectionHeading
+      id="age-distribution"
+      title="Age Distribution"
+    >
       <InfoButton
         topic="str-age-distribution"
       />
-    </AgeDistributionHeading>
+    </SectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -3694,12 +3700,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1_controls" dataset has no unexec
       }
     }
   >
-    <AgeDistributionHeading>
-      Age Distribution 
+    <SectionHeading
+      id="age-distribution"
+      title="Age Distribution"
+    >
       <InfoButton
         topic="str-age-distribution"
       />
-    </AgeDistributionHeading>
+    </SectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -4669,12 +4677,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1_non_cancer" dataset has no unex
       }
     }
   >
-    <AgeDistributionHeading>
-      Age Distribution 
+    <SectionHeading
+      id="age-distribution"
+      title="Age Distribution"
+    >
       <InfoButton
         topic="str-age-distribution"
       />
-    </AgeDistributionHeading>
+    </SectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -5644,12 +5654,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1_non_neuro" dataset has no unexe
       }
     }
   >
-    <AgeDistributionHeading>
-      Age Distribution 
+    <SectionHeading
+      id="age-distribution"
+      title="Age Distribution"
+    >
       <InfoButton
         topic="str-age-distribution"
       />
-    </AgeDistributionHeading>
+    </SectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -6619,12 +6631,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1_non_topmed" dataset has no unex
       }
     }
   >
-    <AgeDistributionHeading>
-      Age Distribution 
+    <SectionHeading
+      id="age-distribution"
+      title="Age Distribution"
+    >
       <InfoButton
         topic="str-age-distribution"
       />
-    </AgeDistributionHeading>
+    </SectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -7594,12 +7608,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r3" dataset has no unexected changes
       }
     }
   >
-    <AgeDistributionHeading>
-      Age Distribution 
+    <SectionHeading
+      id="age-distribution"
+      title="Age Distribution"
+    >
       <InfoButton
         topic="str-age-distribution"
       />
-    </AgeDistributionHeading>
+    </SectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -8569,12 +8585,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_controls_and_biobanks" dataset ha
       }
     }
   >
-    <AgeDistributionHeading>
-      Age Distribution 
+    <SectionHeading
+      id="age-distribution"
+      title="Age Distribution"
+    >
       <InfoButton
         topic="str-age-distribution"
       />
-    </AgeDistributionHeading>
+    </SectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -9544,12 +9562,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_non_cancer" dataset has no unexec
       }
     }
   >
-    <AgeDistributionHeading>
-      Age Distribution 
+    <SectionHeading
+      id="age-distribution"
+      title="Age Distribution"
+    >
       <InfoButton
         topic="str-age-distribution"
       />
-    </AgeDistributionHeading>
+    </SectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -10519,12 +10539,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_non_neuro" dataset has no unexect
       }
     }
   >
-    <AgeDistributionHeading>
-      Age Distribution 
+    <SectionHeading
+      id="age-distribution"
+      title="Age Distribution"
+    >
       <InfoButton
         topic="str-age-distribution"
       />
-    </AgeDistributionHeading>
+    </SectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -11494,12 +11516,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_non_topmed" dataset has no unexec
       }
     }
   >
-    <AgeDistributionHeading>
-      Age Distribution 
+    <SectionHeading
+      id="age-distribution"
+      title="Age Distribution"
+    >
       <InfoButton
         topic="str-age-distribution"
       />
-    </AgeDistributionHeading>
+    </SectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -12469,12 +12493,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_non_v2" dataset has no unexected 
       }
     }
   >
-    <AgeDistributionHeading>
-      Age Distribution 
+    <SectionHeading
+      id="age-distribution"
+      title="Age Distribution"
+    >
       <InfoButton
         topic="str-age-distribution"
       />
-    </AgeDistributionHeading>
+    </SectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -13444,12 +13470,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r4" dataset has no unexected changes
       }
     }
   >
-    <AgeDistributionHeading>
-      Age Distribution 
+    <SectionHeading
+      id="age-distribution"
+      title="Age Distribution"
+    >
       <InfoButton
         topic="str-age-distribution"
       />
-    </AgeDistributionHeading>
+    </SectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -14419,12 +14447,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r4_non_ukb" dataset has no unexected
       }
     }
   >
-    <AgeDistributionHeading>
-      Age Distribution 
+    <SectionHeading
+      id="age-distribution"
+      title="Age Distribution"
+    >
       <InfoButton
         topic="str-age-distribution"
       />
-    </AgeDistributionHeading>
+    </SectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -15394,12 +15424,14 @@ exports[`ShortTandemRepeatPage with "gnomad_sv_r2_1" dataset has no unexected ch
       }
     }
   >
-    <AgeDistributionHeading>
-      Age Distribution 
+    <SectionHeading
+      id="age-distribution"
+      title="Age Distribution"
+    >
       <InfoButton
         topic="str-age-distribution"
       />
-    </AgeDistributionHeading>
+    </SectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -16369,12 +16401,14 @@ exports[`ShortTandemRepeatPage with "gnomad_sv_r2_1_controls" dataset has no une
       }
     }
   >
-    <AgeDistributionHeading>
-      Age Distribution 
+    <SectionHeading
+      id="age-distribution"
+      title="Age Distribution"
+    >
       <InfoButton
         topic="str-age-distribution"
       />
-    </AgeDistributionHeading>
+    </SectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -17344,12 +17378,14 @@ exports[`ShortTandemRepeatPage with "gnomad_sv_r2_1_non_neuro" dataset has no un
       }
     }
   >
-    <AgeDistributionHeading>
-      Age Distribution 
+    <SectionHeading
+      id="age-distribution"
+      title="Age Distribution"
+    >
       <InfoButton
         topic="str-age-distribution"
       />
-    </AgeDistributionHeading>
+    </SectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -18319,12 +18355,14 @@ exports[`ShortTandemRepeatPage with "gnomad_sv_r4" dataset has no unexected chan
       }
     }
   >
-    <AgeDistributionHeading>
-      Age Distribution 
+    <SectionHeading
+      id="age-distribution"
+      title="Age Distribution"
+    >
       <InfoButton
         topic="str-age-distribution"
       />
-    </AgeDistributionHeading>
+    </SectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [

--- a/browser/src/StatsPage/StatsPage.tsx
+++ b/browser/src/StatsPage/StatsPage.tsx
@@ -11,7 +11,8 @@ import SnvsPerBPAvg from '../../about/stats/snvs_per_bp_avg.png'
 
 import DocumentTitle from '../DocumentTitle'
 import Histogram from '../Histogram'
-import { SectionHeading } from '../help/HelpPage'
+import { SectionHeading } from '../AnchorLink'
+import useScrollToHash from '../useScrollToHash'
 import InfoPage from '../InfoPage'
 import Link from '../Link'
 
@@ -177,8 +178,9 @@ const barGraphTooltip = (row: any) => (
 )
 
 const StatsPage = () => {
+  useScrollToHash()
   return (
-    <InfoPage>
+    <InfoPage $withSectionLinks>
       <DocumentTitle title="Stats" />
       {/* @ts-expect-error */}
       <PageHeading id="gnomad-stats">What&apos;s in gnomAD</PageHeading>
@@ -227,9 +229,11 @@ const StatsPage = () => {
         </StatsSection>
 
         <StatsSection>
-          <SectionHeading id="age-and-sex-distribution">
-            What is the age and sex distribution in gnomAD?
-          </SectionHeading>
+          <SectionHeading
+            id="age-and-sex-distribution"
+            title="What is the age and sex distribution in gnomAD?"
+            linkInGutter
+          />
           <TwoColumnLayout>
             <ResponsiveGnomadSamplesContainer>
               <h3>Age</h3>
@@ -283,7 +287,7 @@ const StatsPage = () => {
         </StatsSection>
 
         <StatsSection>
-          <SectionHeading id="samples">Where do gnomAD samples come from?</SectionHeading>
+          <SectionHeading id="samples" title="Where do gnomAD samples come from?" linkInGutter />
           <div style={{ width: '100%' }}>
             <TwoColumnLayout>
               <StatsHighlightBlock color={gnomadBlue} title="308" text="Data Contributors" />
@@ -315,7 +319,7 @@ const StatsPage = () => {
         </StatsSection>
 
         <StatsSection>
-          <SectionHeading id="diversity">Diversity in gnomAD</SectionHeading>
+          <SectionHeading id="diversity" title="Diversity in gnomAD" linkInGutter />
 
           <h3 style={{ marginBottom: '2em' }}>Genetic ancestry groups in gnomAD by version</h3>
 
@@ -392,9 +396,11 @@ const StatsPage = () => {
         </StatsSection>
 
         <StatsSection>
-          <SectionHeading id="study-provided-labels">
-            Study-provided labels and genetic ancestry groups
-          </SectionHeading>
+          <SectionHeading
+            id="study-provided-labels"
+            title="Study-provided labels and genetic ancestry groups"
+            linkInGutter
+          />
 
           <p>
             The following table is provided in order to present how our inferred genetic ancestry
@@ -415,7 +421,7 @@ const StatsPage = () => {
         </StatsSection>
 
         <StatsSection>
-          <SectionHeading id="study-diseases">Study Diseases in gnomAD</SectionHeading>
+          <SectionHeading id="study-diseases" title="Study Diseases in gnomAD" linkInGutter />
 
           <p style={{ marginBottom: '2em' }}>
             During the sample aggregation phase of v4 we began collecting study-disease of interest
@@ -432,7 +438,7 @@ const StatsPage = () => {
         </StatsSection>
 
         <StatsSection>
-          <SectionHeading id="browser">gnomAD Browser Stats</SectionHeading>
+          <SectionHeading id="browser" title="gnomAD Browser Stats" linkInGutter />
           <p>{`The gnomAD browser averages ~200,000 page views per week and had >377,000 unique users in the last year`}</p>
           <TwoColumnLayout>
             <ResponsiveHalfWidthColumn>

--- a/browser/src/StatsPage/__snapshots__/StatsPage.spec.tsx.snap
+++ b/browser/src/StatsPage/__snapshots__/StatsPage.spec.tsx.snap
@@ -56,40 +56,41 @@ exports[`Stats Page has no unexpected changes 1`] = `
   fill: rgba(0,0,0,0.05);
 }
 
-.c25 {
-  position: absolute;
-  transform: translate(-15px,calc(50% - 0.5em));
-  display: flex;
-  align-items: center;
-  width: 15px;
-  height: 1em;
-  visibility: hidden;
-  vertical-align: middle;
-}
-
-.c23 {
+.c24 {
   position: relative;
 }
 
-.c23 :hover .c24 {
-  visibility: visible;
+.c25 {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  transform: translate(-29px,-50%);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  width: 44px;
+  height: 44px;
+  opacity: 0;
+  vertical-align: middle;
 }
 
-.c20 {
-  display: flex;
-  flex-wrap: wrap;
-  flex-direction: row;
-  padding: 0;
-  margin: 0 1em 0 0;
-  list-style-type: none;
+.c25 :hover,
+.c25 :focus,
+.c25 :focus-visible,
+.c23:hover .c25,
+.c23:focus-within .c25 {
+  opacity: 1;
 }
 
-.c21 {
-  display: flex;
-  margin: 0 1em 0.33em 0;
+.c25 :focus,
+.c25 :focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: -8px;
 }
 
 .c1 {
+  padding-left: 44px;
   font-size: 16px;
 }
 
@@ -117,6 +118,20 @@ exports[`Stats Page has no unexpected changes 1`] = `
 
 .c6 li {
   margin-bottom: 0.5em;
+}
+
+.c20 {
+  display: flex;
+  flex-wrap: wrap;
+  flex-direction: row;
+  padding: 0;
+  margin: 0 1em 0 0;
+  list-style-type: none;
+}
+
+.c21 {
+  display: flex;
+  margin: 0 1em 0.33em 0;
 }
 
 .c13 {
@@ -346,6 +361,20 @@ exports[`Stats Page has no unexpected changes 1`] = `
     padding-bottom: 0.5em;
     border-bottom: 1px solid #ccc;
     margin-bottom: 0.5em;
+  }
+}
+
+@media (hover:none) {
+  .c25 {
+    opacity: 1;
+  }
+}
+
+@media (max-width:1230px) {
+  .c25 {
+    position: static;
+    transform: none;
+    display: inline-flex;
   }
 }
 
@@ -1566,29 +1595,38 @@ exports[`Stats Page has no unexpected changes 1`] = `
     <div
       className="c4"
     >
-      <span
-        className="c23"
+      <h2
+        className="c23 c24"
+        id="age-and-sex-distribution"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
-        <h2
-          className=""
+        <a
+          aria-label="Copy link to What is the age and sex distribution in gnomAD?"
+          className="c25"
+          href="#age-and-sex-distribution"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c24 c25"
-            href="#age-and-sex-distribution"
-            id="age-and-sex-distribution"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          What is the age and sex distribution in gnomAD?
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        What is the age and sex distribution in gnomAD?
+      </h2>
       <div
         className="c5"
       >
@@ -4146,29 +4184,38 @@ exports[`Stats Page has no unexpected changes 1`] = `
     <div
       className="c4"
     >
-      <span
-        className="c23"
+      <h2
+        className="c23 c24"
+        id="samples"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
-        <h2
-          className=""
+        <a
+          aria-label="Copy link to Where do gnomAD samples come from?"
+          className="c25"
+          href="#samples"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c24 c25"
-            href="#samples"
-            id="samples"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Where do gnomAD samples come from?
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Where do gnomAD samples come from?
+      </h2>
       <div
         style={
           {
@@ -4244,29 +4291,38 @@ exports[`Stats Page has no unexpected changes 1`] = `
     <div
       className="c4"
     >
-      <span
-        className="c23"
+      <h2
+        className="c23 c24"
+        id="diversity"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
-        <h2
-          className=""
+        <a
+          aria-label="Copy link to Diversity in gnomAD"
+          className="c25"
+          href="#diversity"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c24 c25"
-            href="#diversity"
-            id="diversity"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Diversity in gnomAD
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Diversity in gnomAD
+      </h2>
       <h3
         style={
           {
@@ -8327,29 +8383,38 @@ exports[`Stats Page has no unexpected changes 1`] = `
     <div
       className="c4"
     >
-      <span
-        className="c23"
+      <h2
+        className="c23 c24"
+        id="study-provided-labels"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
-        <h2
-          className=""
+        <a
+          aria-label="Copy link to Study-provided labels and genetic ancestry groups"
+          className="c25"
+          href="#study-provided-labels"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c24 c25"
-            href="#study-provided-labels"
-            id="study-provided-labels"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Study-provided labels and genetic ancestry groups
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Study-provided labels and genetic ancestry groups
+      </h2>
       <p>
         The following table is provided in order to present how our inferred genetic ancestry groups correspond to descriptors provided by each contributing
         <a
@@ -8787,29 +8852,38 @@ exports[`Stats Page has no unexpected changes 1`] = `
     <div
       className="c4"
     >
-      <span
-        className="c23"
+      <h2
+        className="c23 c24"
+        id="study-diseases"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
-        <h2
-          className=""
+        <a
+          aria-label="Copy link to Study Diseases in gnomAD"
+          className="c25"
+          href="#study-diseases"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c24 c25"
-            href="#study-diseases"
-            id="study-diseases"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Study Diseases in gnomAD
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Study Diseases in gnomAD
+      </h2>
       <p
         style={
           {
@@ -9168,29 +9242,38 @@ exports[`Stats Page has no unexpected changes 1`] = `
     <div
       className="c4"
     >
-      <span
-        className="c23"
+      <h2
+        className="c23 c24"
+        id="browser"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
-        <h2
-          className=""
+        <a
+          aria-label="Copy link to gnomAD Browser Stats"
+          className="c25"
+          href="#browser"
+          onClick={[Function]}
+          style={
+            {
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c24 c25"
-            href="#browser"
-            id="browser"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          gnomAD Browser Stats
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        gnomAD Browser Stats
+      </h2>
       <p>
         The gnomAD browser averages ~200,000 page views per week and had &gt;377,000 unique users in the last year
       </p>

--- a/browser/src/StructuralVariantPage/StructuralVariantPage.tsx
+++ b/browser/src/StructuralVariantPage/StructuralVariantPage.tsx
@@ -17,6 +17,8 @@ import StructuralVariantConsequenceList from './StructuralVariantConsequenceList
 import StructuralVariantGenotypeQualityMetrics from './StructuralVariantGenotypeQualityMetrics'
 import StructuralVariantPopulationsTable from './StructuralVariantPopulationsTable'
 import SVReferenceList from './SVReferenceList'
+import { AnchoredSectionHeading } from '../AnchorLink'
+import useScrollToHash from '../useScrollToHash'
 
 const Wrapper = styled.div`
   display: flex;
@@ -99,6 +101,8 @@ type StructuralVariantPageProps = {
 }
 
 const StructuralVariantPage = ({ datasetId, variant }: StructuralVariantPageProps) => {
+  useScrollToHash()
+
   const genes = variant.genes || []
   return (
     <Page>
@@ -159,9 +163,9 @@ const StructuralVariantPage = ({ datasetId, variant }: StructuralVariantPageProp
         </ResponsiveSection>
 
         <ResponsiveSection>
-          <h2>
+          <AnchoredSectionHeading id="age-distribution">
             Age Distribution <InfoButton topic="age" />
-          </h2>
+          </AnchoredSectionHeading>
           {variant.age_distribution ? (
             <React.Fragment>
               {datasetId !== 'gnomad_sv_r2_1' && (

--- a/browser/src/StructuralVariantPage/StructuralVariantPage.tsx
+++ b/browser/src/StructuralVariantPage/StructuralVariantPage.tsx
@@ -17,7 +17,7 @@ import StructuralVariantConsequenceList from './StructuralVariantConsequenceList
 import StructuralVariantGenotypeQualityMetrics from './StructuralVariantGenotypeQualityMetrics'
 import StructuralVariantPopulationsTable from './StructuralVariantPopulationsTable'
 import SVReferenceList from './SVReferenceList'
-import { AnchoredSectionHeading } from '../AnchorLink'
+import { AgeDistributionHeading } from '../AnchorLink'
 import useScrollToHash from '../useScrollToHash'
 
 const Wrapper = styled.div`
@@ -163,9 +163,9 @@ const StructuralVariantPage = ({ datasetId, variant }: StructuralVariantPageProp
         </ResponsiveSection>
 
         <ResponsiveSection>
-          <AnchoredSectionHeading id="age-distribution">
+          <AgeDistributionHeading>
             Age Distribution <InfoButton topic="age" />
-          </AnchoredSectionHeading>
+          </AgeDistributionHeading>
           {variant.age_distribution ? (
             <React.Fragment>
               {datasetId !== 'gnomad_sv_r2_1' && (

--- a/browser/src/StructuralVariantPage/StructuralVariantPage.tsx
+++ b/browser/src/StructuralVariantPage/StructuralVariantPage.tsx
@@ -17,7 +17,7 @@ import StructuralVariantConsequenceList from './StructuralVariantConsequenceList
 import StructuralVariantGenotypeQualityMetrics from './StructuralVariantGenotypeQualityMetrics'
 import StructuralVariantPopulationsTable from './StructuralVariantPopulationsTable'
 import SVReferenceList from './SVReferenceList'
-import { AgeDistributionHeading } from '../AnchorLink'
+import { SectionHeading } from '../AnchorLink'
 import useScrollToHash from '../useScrollToHash'
 
 const Wrapper = styled.div`
@@ -163,9 +163,9 @@ const StructuralVariantPage = ({ datasetId, variant }: StructuralVariantPageProp
         </ResponsiveSection>
 
         <ResponsiveSection>
-          <AgeDistributionHeading>
-            Age Distribution <InfoButton topic="age" />
-          </AgeDistributionHeading>
+          <SectionHeading id="age-distribution" title="Age Distribution">
+            <InfoButton topic="age" />
+          </SectionHeading>
           {variant.age_distribution ? (
             <React.Fragment>
               {datasetId !== 'gnomad_sv_r2_1' && (

--- a/browser/src/StructuralVariantPage/__snapshots__/StructuralVariantPage.spec.tsx.snap
+++ b/browser/src/StructuralVariantPage/__snapshots__/StructuralVariantPage.spec.tsx.snap
@@ -570,37 +570,58 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with a complex varian
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <h2>
-        Age Distribution 
-        <button
-          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-          onClick={[Function]}
-          type="button"
+      <span
+        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      >
+        <h2
+          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
         >
-          <img
-            alt=""
+          <a
             aria-hidden="true"
-            src="test-file-stub"
-          />
-          <span
-            style={
-              {
-                "border": "0",
-                "clip": "rect(0 0 0 0)",
-                "height": "1px",
-                "margin": "-1px",
-                "overflow": "hidden",
-                "padding": "0",
-                "position": "absolute",
-                "whiteSpace": "nowrap",
-                "width": "1px",
-              }
-            }
+            className="AnchorLink-sc-77ly3x-0 isLygD"
+            href="#age-distribution"
+            id="age-distribution"
+            onClick={[Function]}
           >
-            More information
-          </span>
-        </button>
-      </h2>
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution 
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
+      </span>
       <p>
         Age data is not available for this variant.
       </p>
@@ -1178,37 +1199,58 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with interchromosomal
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <h2>
-        Age Distribution 
-        <button
-          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-          onClick={[Function]}
-          type="button"
+      <span
+        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      >
+        <h2
+          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
         >
-          <img
-            alt=""
+          <a
             aria-hidden="true"
-            src="test-file-stub"
-          />
-          <span
-            style={
-              {
-                "border": "0",
-                "clip": "rect(0 0 0 0)",
-                "height": "1px",
-                "margin": "-1px",
-                "overflow": "hidden",
-                "padding": "0",
-                "position": "absolute",
-                "whiteSpace": "nowrap",
-                "width": "1px",
-              }
-            }
+            className="AnchorLink-sc-77ly3x-0 isLygD"
+            href="#age-distribution"
+            id="age-distribution"
+            onClick={[Function]}
           >
-            More information
-          </span>
-        </button>
-      </h2>
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution 
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
+      </span>
       <p>
         Age data is not available for this variant.
       </p>
@@ -1786,37 +1828,58 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with interchromosomal
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <h2>
-        Age Distribution 
-        <button
-          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-          onClick={[Function]}
-          type="button"
+      <span
+        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      >
+        <h2
+          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
         >
-          <img
-            alt=""
+          <a
             aria-hidden="true"
-            src="test-file-stub"
-          />
-          <span
-            style={
-              {
-                "border": "0",
-                "clip": "rect(0 0 0 0)",
-                "height": "1px",
-                "margin": "-1px",
-                "overflow": "hidden",
-                "padding": "0",
-                "position": "absolute",
-                "whiteSpace": "nowrap",
-                "width": "1px",
-              }
-            }
+            className="AnchorLink-sc-77ly3x-0 isLygD"
+            href="#age-distribution"
+            id="age-distribution"
+            onClick={[Function]}
           >
-            More information
-          </span>
-        </button>
-      </h2>
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution 
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
+      </span>
       <p>
         Age data is not available for this variant.
       </p>
@@ -2377,37 +2440,58 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <h2>
-        Age Distribution 
-        <button
-          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-          onClick={[Function]}
-          type="button"
+      <span
+        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      >
+        <h2
+          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
         >
-          <img
-            alt=""
+          <a
             aria-hidden="true"
-            src="test-file-stub"
-          />
-          <span
-            style={
-              {
-                "border": "0",
-                "clip": "rect(0 0 0 0)",
-                "height": "1px",
-                "margin": "-1px",
-                "overflow": "hidden",
-                "padding": "0",
-                "position": "absolute",
-                "whiteSpace": "nowrap",
-                "width": "1px",
-              }
-            }
+            className="AnchorLink-sc-77ly3x-0 isLygD"
+            href="#age-distribution"
+            id="age-distribution"
+            onClick={[Function]}
           >
-            More information
-          </span>
-        </button>
-      </h2>
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution 
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
+      </span>
       <p>
         Age data is not available for this variant.
       </p>
@@ -2968,37 +3052,58 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <h2>
-        Age Distribution 
-        <button
-          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-          onClick={[Function]}
-          type="button"
+      <span
+        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      >
+        <h2
+          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
         >
-          <img
-            alt=""
+          <a
             aria-hidden="true"
-            src="test-file-stub"
-          />
-          <span
-            style={
-              {
-                "border": "0",
-                "clip": "rect(0 0 0 0)",
-                "height": "1px",
-                "margin": "-1px",
-                "overflow": "hidden",
-                "padding": "0",
-                "position": "absolute",
-                "whiteSpace": "nowrap",
-                "width": "1px",
-              }
-            }
+            className="AnchorLink-sc-77ly3x-0 isLygD"
+            href="#age-distribution"
+            id="age-distribution"
+            onClick={[Function]}
           >
-            More information
-          </span>
-        </button>
-      </h2>
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution 
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
+      </span>
       <p>
         Age data is not available for this variant.
       </p>
@@ -3557,37 +3662,58 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <h2>
-        Age Distribution 
-        <button
-          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-          onClick={[Function]}
-          type="button"
+      <span
+        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      >
+        <h2
+          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
         >
-          <img
-            alt=""
+          <a
             aria-hidden="true"
-            src="test-file-stub"
-          />
-          <span
-            style={
-              {
-                "border": "0",
-                "clip": "rect(0 0 0 0)",
-                "height": "1px",
-                "margin": "-1px",
-                "overflow": "hidden",
-                "padding": "0",
-                "position": "absolute",
-                "whiteSpace": "nowrap",
-                "width": "1px",
-              }
-            }
+            className="AnchorLink-sc-77ly3x-0 isLygD"
+            href="#age-distribution"
+            id="age-distribution"
+            onClick={[Function]}
           >
-            More information
-          </span>
-        </button>
-      </h2>
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution 
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
+      </span>
       <p>
         Age data is not available for this variant.
       </p>
@@ -4148,37 +4274,58 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <h2>
-        Age Distribution 
-        <button
-          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-          onClick={[Function]}
-          type="button"
+      <span
+        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      >
+        <h2
+          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
         >
-          <img
-            alt=""
+          <a
             aria-hidden="true"
-            src="test-file-stub"
-          />
-          <span
-            style={
-              {
-                "border": "0",
-                "clip": "rect(0 0 0 0)",
-                "height": "1px",
-                "margin": "-1px",
-                "overflow": "hidden",
-                "padding": "0",
-                "position": "absolute",
-                "whiteSpace": "nowrap",
-                "width": "1px",
-              }
-            }
+            className="AnchorLink-sc-77ly3x-0 isLygD"
+            href="#age-distribution"
+            id="age-distribution"
+            onClick={[Function]}
           >
-            More information
-          </span>
-        </button>
-      </h2>
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution 
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
+      </span>
       <p>
         Age data is not available for this variant.
       </p>
@@ -5306,37 +5453,58 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <h2>
-        Age Distribution 
-        <button
-          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-          onClick={[Function]}
-          type="button"
+      <span
+        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      >
+        <h2
+          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
         >
-          <img
-            alt=""
+          <a
             aria-hidden="true"
-            src="test-file-stub"
-          />
-          <span
-            style={
-              {
-                "border": "0",
-                "clip": "rect(0 0 0 0)",
-                "height": "1px",
-                "margin": "-1px",
-                "overflow": "hidden",
-                "padding": "0",
-                "position": "absolute",
-                "whiteSpace": "nowrap",
-                "width": "1px",
-              }
-            }
+            className="AnchorLink-sc-77ly3x-0 isLygD"
+            href="#age-distribution"
+            id="age-distribution"
+            onClick={[Function]}
           >
-            More information
-          </span>
-        </button>
-      </h2>
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution 
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
+      </span>
       <p>
         Age data is not available for this variant.
       </p>
@@ -5915,37 +6083,58 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with a compl
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <h2>
-        Age Distribution 
-        <button
-          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-          onClick={[Function]}
-          type="button"
+      <span
+        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      >
+        <h2
+          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
         >
-          <img
-            alt=""
+          <a
             aria-hidden="true"
-            src="test-file-stub"
-          />
-          <span
-            style={
-              {
-                "border": "0",
-                "clip": "rect(0 0 0 0)",
-                "height": "1px",
-                "margin": "-1px",
-                "overflow": "hidden",
-                "padding": "0",
-                "position": "absolute",
-                "whiteSpace": "nowrap",
-                "width": "1px",
-              }
-            }
+            className="AnchorLink-sc-77ly3x-0 isLygD"
+            href="#age-distribution"
+            id="age-distribution"
+            onClick={[Function]}
           >
-            More information
-          </span>
-        </button>
-      </h2>
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution 
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
+      </span>
       <p>
         Age data is not available for this variant.
       </p>
@@ -6523,37 +6712,58 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with interch
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <h2>
-        Age Distribution 
-        <button
-          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-          onClick={[Function]}
-          type="button"
+      <span
+        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      >
+        <h2
+          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
         >
-          <img
-            alt=""
+          <a
             aria-hidden="true"
-            src="test-file-stub"
-          />
-          <span
-            style={
-              {
-                "border": "0",
-                "clip": "rect(0 0 0 0)",
-                "height": "1px",
-                "margin": "-1px",
-                "overflow": "hidden",
-                "padding": "0",
-                "position": "absolute",
-                "whiteSpace": "nowrap",
-                "width": "1px",
-              }
-            }
+            className="AnchorLink-sc-77ly3x-0 isLygD"
+            href="#age-distribution"
+            id="age-distribution"
+            onClick={[Function]}
           >
-            More information
-          </span>
-        </button>
-      </h2>
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution 
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
+      </span>
       <p>
         Age data is not available for this variant.
       </p>
@@ -7131,37 +7341,58 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with interch
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <h2>
-        Age Distribution 
-        <button
-          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-          onClick={[Function]}
-          type="button"
+      <span
+        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      >
+        <h2
+          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
         >
-          <img
-            alt=""
+          <a
             aria-hidden="true"
-            src="test-file-stub"
-          />
-          <span
-            style={
-              {
-                "border": "0",
-                "clip": "rect(0 0 0 0)",
-                "height": "1px",
-                "margin": "-1px",
-                "overflow": "hidden",
-                "padding": "0",
-                "position": "absolute",
-                "whiteSpace": "nowrap",
-                "width": "1px",
-              }
-            }
+            className="AnchorLink-sc-77ly3x-0 isLygD"
+            href="#age-distribution"
+            id="age-distribution"
+            onClick={[Function]}
           >
-            More information
-          </span>
-        </button>
-      </h2>
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution 
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
+      </span>
       <p>
         Age data is not available for this variant.
       </p>
@@ -7722,37 +7953,58 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <h2>
-        Age Distribution 
-        <button
-          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-          onClick={[Function]}
-          type="button"
+      <span
+        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      >
+        <h2
+          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
         >
-          <img
-            alt=""
+          <a
             aria-hidden="true"
-            src="test-file-stub"
-          />
-          <span
-            style={
-              {
-                "border": "0",
-                "clip": "rect(0 0 0 0)",
-                "height": "1px",
-                "margin": "-1px",
-                "overflow": "hidden",
-                "padding": "0",
-                "position": "absolute",
-                "whiteSpace": "nowrap",
-                "width": "1px",
-              }
-            }
+            className="AnchorLink-sc-77ly3x-0 isLygD"
+            href="#age-distribution"
+            id="age-distribution"
+            onClick={[Function]}
           >
-            More information
-          </span>
-        </button>
-      </h2>
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution 
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
+      </span>
       <p>
         Age data is not available for this variant.
       </p>
@@ -8313,37 +8565,58 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <h2>
-        Age Distribution 
-        <button
-          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-          onClick={[Function]}
-          type="button"
+      <span
+        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      >
+        <h2
+          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
         >
-          <img
-            alt=""
+          <a
             aria-hidden="true"
-            src="test-file-stub"
-          />
-          <span
-            style={
-              {
-                "border": "0",
-                "clip": "rect(0 0 0 0)",
-                "height": "1px",
-                "margin": "-1px",
-                "overflow": "hidden",
-                "padding": "0",
-                "position": "absolute",
-                "whiteSpace": "nowrap",
-                "width": "1px",
-              }
-            }
+            className="AnchorLink-sc-77ly3x-0 isLygD"
+            href="#age-distribution"
+            id="age-distribution"
+            onClick={[Function]}
           >
-            More information
-          </span>
-        </button>
-      </h2>
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution 
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
+      </span>
       <p>
         Age data is not available for this variant.
       </p>
@@ -8902,37 +9175,58 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <h2>
-        Age Distribution 
-        <button
-          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-          onClick={[Function]}
-          type="button"
+      <span
+        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      >
+        <h2
+          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
         >
-          <img
-            alt=""
+          <a
             aria-hidden="true"
-            src="test-file-stub"
-          />
-          <span
-            style={
-              {
-                "border": "0",
-                "clip": "rect(0 0 0 0)",
-                "height": "1px",
-                "margin": "-1px",
-                "overflow": "hidden",
-                "padding": "0",
-                "position": "absolute",
-                "whiteSpace": "nowrap",
-                "width": "1px",
-              }
-            }
+            className="AnchorLink-sc-77ly3x-0 isLygD"
+            href="#age-distribution"
+            id="age-distribution"
+            onClick={[Function]}
           >
-            More information
-          </span>
-        </button>
-      </h2>
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution 
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
+      </span>
       <p>
         Age data is not available for this variant.
       </p>
@@ -9493,37 +9787,58 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <h2>
-        Age Distribution 
-        <button
-          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-          onClick={[Function]}
-          type="button"
+      <span
+        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      >
+        <h2
+          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
         >
-          <img
-            alt=""
+          <a
             aria-hidden="true"
-            src="test-file-stub"
-          />
-          <span
-            style={
-              {
-                "border": "0",
-                "clip": "rect(0 0 0 0)",
-                "height": "1px",
-                "margin": "-1px",
-                "overflow": "hidden",
-                "padding": "0",
-                "position": "absolute",
-                "whiteSpace": "nowrap",
-                "width": "1px",
-              }
-            }
+            className="AnchorLink-sc-77ly3x-0 isLygD"
+            href="#age-distribution"
+            id="age-distribution"
+            onClick={[Function]}
           >
-            More information
-          </span>
-        </button>
-      </h2>
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution 
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
+      </span>
       <p>
         Age data is not available for this variant.
       </p>
@@ -10651,37 +10966,58 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <h2>
-        Age Distribution 
-        <button
-          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-          onClick={[Function]}
-          type="button"
+      <span
+        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      >
+        <h2
+          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
         >
-          <img
-            alt=""
+          <a
             aria-hidden="true"
-            src="test-file-stub"
-          />
-          <span
-            style={
-              {
-                "border": "0",
-                "clip": "rect(0 0 0 0)",
-                "height": "1px",
-                "margin": "-1px",
-                "overflow": "hidden",
-                "padding": "0",
-                "position": "absolute",
-                "whiteSpace": "nowrap",
-                "width": "1px",
-              }
-            }
+            className="AnchorLink-sc-77ly3x-0 isLygD"
+            href="#age-distribution"
+            id="age-distribution"
+            onClick={[Function]}
           >
-            More information
-          </span>
-        </button>
-      </h2>
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution 
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
+      </span>
       <p>
         Age data is not available for this variant.
       </p>
@@ -11260,37 +11596,58 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with a comp
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <h2>
-        Age Distribution 
-        <button
-          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-          onClick={[Function]}
-          type="button"
+      <span
+        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      >
+        <h2
+          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
         >
-          <img
-            alt=""
+          <a
             aria-hidden="true"
-            src="test-file-stub"
-          />
-          <span
-            style={
-              {
-                "border": "0",
-                "clip": "rect(0 0 0 0)",
-                "height": "1px",
-                "margin": "-1px",
-                "overflow": "hidden",
-                "padding": "0",
-                "position": "absolute",
-                "whiteSpace": "nowrap",
-                "width": "1px",
-              }
-            }
+            className="AnchorLink-sc-77ly3x-0 isLygD"
+            href="#age-distribution"
+            id="age-distribution"
+            onClick={[Function]}
           >
-            More information
-          </span>
-        </button>
-      </h2>
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution 
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
+      </span>
       <p>
         Age data is not available for this variant.
       </p>
@@ -11868,37 +12225,58 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with interc
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <h2>
-        Age Distribution 
-        <button
-          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-          onClick={[Function]}
-          type="button"
+      <span
+        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      >
+        <h2
+          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
         >
-          <img
-            alt=""
+          <a
             aria-hidden="true"
-            src="test-file-stub"
-          />
-          <span
-            style={
-              {
-                "border": "0",
-                "clip": "rect(0 0 0 0)",
-                "height": "1px",
-                "margin": "-1px",
-                "overflow": "hidden",
-                "padding": "0",
-                "position": "absolute",
-                "whiteSpace": "nowrap",
-                "width": "1px",
-              }
-            }
+            className="AnchorLink-sc-77ly3x-0 isLygD"
+            href="#age-distribution"
+            id="age-distribution"
+            onClick={[Function]}
           >
-            More information
-          </span>
-        </button>
-      </h2>
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution 
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
+      </span>
       <p>
         Age data is not available for this variant.
       </p>
@@ -12476,37 +12854,58 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with interc
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <h2>
-        Age Distribution 
-        <button
-          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-          onClick={[Function]}
-          type="button"
+      <span
+        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      >
+        <h2
+          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
         >
-          <img
-            alt=""
+          <a
             aria-hidden="true"
-            src="test-file-stub"
-          />
-          <span
-            style={
-              {
-                "border": "0",
-                "clip": "rect(0 0 0 0)",
-                "height": "1px",
-                "margin": "-1px",
-                "overflow": "hidden",
-                "padding": "0",
-                "position": "absolute",
-                "whiteSpace": "nowrap",
-                "width": "1px",
-              }
-            }
+            className="AnchorLink-sc-77ly3x-0 isLygD"
+            href="#age-distribution"
+            id="age-distribution"
+            onClick={[Function]}
           >
-            More information
-          </span>
-        </button>
-      </h2>
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution 
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
+      </span>
       <p>
         Age data is not available for this variant.
       </p>
@@ -13067,37 +13466,58 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <h2>
-        Age Distribution 
-        <button
-          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-          onClick={[Function]}
-          type="button"
+      <span
+        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      >
+        <h2
+          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
         >
-          <img
-            alt=""
+          <a
             aria-hidden="true"
-            src="test-file-stub"
-          />
-          <span
-            style={
-              {
-                "border": "0",
-                "clip": "rect(0 0 0 0)",
-                "height": "1px",
-                "margin": "-1px",
-                "overflow": "hidden",
-                "padding": "0",
-                "position": "absolute",
-                "whiteSpace": "nowrap",
-                "width": "1px",
-              }
-            }
+            className="AnchorLink-sc-77ly3x-0 isLygD"
+            href="#age-distribution"
+            id="age-distribution"
+            onClick={[Function]}
           >
-            More information
-          </span>
-        </button>
-      </h2>
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution 
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
+      </span>
       <p>
         Age data is not available for this variant.
       </p>
@@ -13658,37 +14078,58 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <h2>
-        Age Distribution 
-        <button
-          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-          onClick={[Function]}
-          type="button"
+      <span
+        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      >
+        <h2
+          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
         >
-          <img
-            alt=""
+          <a
             aria-hidden="true"
-            src="test-file-stub"
-          />
-          <span
-            style={
-              {
-                "border": "0",
-                "clip": "rect(0 0 0 0)",
-                "height": "1px",
-                "margin": "-1px",
-                "overflow": "hidden",
-                "padding": "0",
-                "position": "absolute",
-                "whiteSpace": "nowrap",
-                "width": "1px",
-              }
-            }
+            className="AnchorLink-sc-77ly3x-0 isLygD"
+            href="#age-distribution"
+            id="age-distribution"
+            onClick={[Function]}
           >
-            More information
-          </span>
-        </button>
-      </h2>
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution 
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
+      </span>
       <p>
         Age data is not available for this variant.
       </p>
@@ -14247,37 +14688,58 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <h2>
-        Age Distribution 
-        <button
-          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-          onClick={[Function]}
-          type="button"
+      <span
+        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      >
+        <h2
+          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
         >
-          <img
-            alt=""
+          <a
             aria-hidden="true"
-            src="test-file-stub"
-          />
-          <span
-            style={
-              {
-                "border": "0",
-                "clip": "rect(0 0 0 0)",
-                "height": "1px",
-                "margin": "-1px",
-                "overflow": "hidden",
-                "padding": "0",
-                "position": "absolute",
-                "whiteSpace": "nowrap",
-                "width": "1px",
-              }
-            }
+            className="AnchorLink-sc-77ly3x-0 isLygD"
+            href="#age-distribution"
+            id="age-distribution"
+            onClick={[Function]}
           >
-            More information
-          </span>
-        </button>
-      </h2>
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution 
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
+      </span>
       <p>
         Age data is not available for this variant.
       </p>
@@ -14838,37 +15300,58 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <h2>
-        Age Distribution 
-        <button
-          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-          onClick={[Function]}
-          type="button"
+      <span
+        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      >
+        <h2
+          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
         >
-          <img
-            alt=""
+          <a
             aria-hidden="true"
-            src="test-file-stub"
-          />
-          <span
-            style={
-              {
-                "border": "0",
-                "clip": "rect(0 0 0 0)",
-                "height": "1px",
-                "margin": "-1px",
-                "overflow": "hidden",
-                "padding": "0",
-                "position": "absolute",
-                "whiteSpace": "nowrap",
-                "width": "1px",
-              }
-            }
+            className="AnchorLink-sc-77ly3x-0 isLygD"
+            href="#age-distribution"
+            id="age-distribution"
+            onClick={[Function]}
           >
-            More information
-          </span>
-        </button>
-      </h2>
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution 
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
+      </span>
       <p>
         Age data is not available for this variant.
       </p>
@@ -15996,37 +16479,58 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <h2>
-        Age Distribution 
-        <button
-          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-          onClick={[Function]}
-          type="button"
+      <span
+        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      >
+        <h2
+          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
         >
-          <img
-            alt=""
+          <a
             aria-hidden="true"
-            src="test-file-stub"
-          />
-          <span
-            style={
-              {
-                "border": "0",
-                "clip": "rect(0 0 0 0)",
-                "height": "1px",
-                "margin": "-1px",
-                "overflow": "hidden",
-                "padding": "0",
-                "position": "absolute",
-                "whiteSpace": "nowrap",
-                "width": "1px",
-              }
-            }
+            className="AnchorLink-sc-77ly3x-0 isLygD"
+            href="#age-distribution"
+            id="age-distribution"
+            onClick={[Function]}
           >
-            More information
-          </span>
-        </button>
-      </h2>
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution 
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
+      </span>
       <p>
         Age data is not available for this variant.
       </p>

--- a/browser/src/StructuralVariantPage/__snapshots__/StructuralVariantPage.spec.tsx.snap
+++ b/browser/src/StructuralVariantPage/__snapshots__/StructuralVariantPage.spec.tsx.snap
@@ -573,12 +573,10 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with a complex varian
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -1202,12 +1200,10 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with interchromosomal
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -1831,12 +1827,10 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with interchromosomal
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -2443,12 +2437,10 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -3055,12 +3047,10 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -3665,12 +3655,10 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -4277,12 +4265,10 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -5456,12 +5442,10 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -6086,12 +6070,10 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with a compl
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -6715,12 +6697,10 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with interch
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -7344,12 +7324,10 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with interch
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -7956,12 +7934,10 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -8568,12 +8544,10 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -9178,12 +9152,10 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -9790,12 +9762,10 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -10969,12 +10939,10 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -11599,12 +11567,10 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with a comp
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -12228,12 +12194,10 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with interc
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -12857,12 +12821,10 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with interc
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -13469,12 +13431,10 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -14081,12 +14041,10 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -14691,12 +14649,10 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -15303,12 +15259,10 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -16482,12 +16436,10 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}

--- a/browser/src/StructuralVariantPage/__snapshots__/StructuralVariantPage.spec.tsx.snap
+++ b/browser/src/StructuralVariantPage/__snapshots__/StructuralVariantPage.spec.tsx.snap
@@ -570,56 +570,55 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with a complex varian
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <p>
         Age data is not available for this variant.
       </p>
@@ -1197,56 +1196,55 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with interchromosomal
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <p>
         Age data is not available for this variant.
       </p>
@@ -1824,56 +1822,55 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with interchromosomal
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <p>
         Age data is not available for this variant.
       </p>
@@ -2434,56 +2431,55 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <p>
         Age data is not available for this variant.
       </p>
@@ -3044,56 +3040,55 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <p>
         Age data is not available for this variant.
       </p>
@@ -3652,56 +3647,55 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <p>
         Age data is not available for this variant.
       </p>
@@ -4262,56 +4256,55 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <p>
         Age data is not available for this variant.
       </p>
@@ -5439,56 +5432,55 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <p>
         Age data is not available for this variant.
       </p>
@@ -6067,56 +6059,55 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with a compl
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <p>
         Age data is not available for this variant.
       </p>
@@ -6694,56 +6685,55 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with interch
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <p>
         Age data is not available for this variant.
       </p>
@@ -7321,56 +7311,55 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with interch
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <p>
         Age data is not available for this variant.
       </p>
@@ -7931,56 +7920,55 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <p>
         Age data is not available for this variant.
       </p>
@@ -8541,56 +8529,55 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <p>
         Age data is not available for this variant.
       </p>
@@ -9149,56 +9136,55 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <p>
         Age data is not available for this variant.
       </p>
@@ -9759,56 +9745,55 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <p>
         Age data is not available for this variant.
       </p>
@@ -10936,56 +10921,55 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <p>
         Age data is not available for this variant.
       </p>
@@ -11564,56 +11548,55 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with a comp
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <p>
         Age data is not available for this variant.
       </p>
@@ -12191,56 +12174,55 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with interc
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <p>
         Age data is not available for this variant.
       </p>
@@ -12818,56 +12800,55 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with interc
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <p>
         Age data is not available for this variant.
       </p>
@@ -13428,56 +13409,55 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <p>
         Age data is not available for this variant.
       </p>
@@ -14038,56 +14018,55 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <p>
         Age data is not available for this variant.
       </p>
@@ -14646,56 +14625,55 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <p>
         Age data is not available for this variant.
       </p>
@@ -15256,56 +15234,55 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <p>
         Age data is not available for this variant.
       </p>
@@ -16433,56 +16410,55 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <p>
         Age data is not available for this variant.
       </p>

--- a/browser/src/VariantPage/VariantPage.spec.tsx
+++ b/browser/src/VariantPage/VariantPage.spec.tsx
@@ -4,8 +4,10 @@ import renderer from 'react-test-renderer'
 import { mockQueries } from '../../../tests/__helpers__/queries'
 import Query, { BaseQuery } from '../Query'
 import { forDatasetsMatching } from '../../../tests/__helpers__/datasets'
-import VariantPage from './VariantPage'
-import { v2VariantFactory, v3VariantFactory } from '../__factories__/Variant'
+import VariantPage, { Variant, VariantPageContent } from './VariantPage'
+import { v2VariantFactory, v3VariantFactory, sequencingFactory } from '../__factories__/Variant'
+import clinvarVariantFactory from '../__factories__/ClinvarVariant'
+import { DatasetId } from '@gnomad/dataset-metadata/metadata'
 import { BrowserRouter } from 'react-router-dom'
 
 jest.mock('../Query', () => {
@@ -98,5 +100,98 @@ describe('VariantPage with the dataset exac', () => {
       </BrowserRouter>
     )
     expect(tree).toMatchSnapshot()
+  })
+})
+
+const sectionTitles = {
+  'external-resources': 'External Resources',
+  feedback: 'Feedback',
+  'genetic-ancestry-group-frequencies': 'Genetic Ancestry Group Frequencies',
+  'related-variants': 'Related Variants',
+  'variant-effect-predictor': 'Ensembl Variant Effect Predictor',
+  'lof-curation': 'LoF Curation',
+  'in-silico-predictors': 'In Silico Predictors',
+  'genomic-constraint': 'Genomic Constraint of Surrounding 1kb Region',
+  clinvar: 'ClinVar',
+  'age-distribution': 'Age Distribution',
+  'genotype-quality-metrics': 'Genotype Quality Metrics',
+  'site-quality-metrics': 'Site Quality Metrics',
+  'read-data': 'Read Data',
+}
+
+const conditionalIds = [
+  'lof-curation',
+  'in-silico-predictors',
+  'genomic-constraint',
+  'clinvar',
+  'age-distribution',
+]
+
+const expectSections = (variant: Variant, datasetId: DatasetId, present: string[]) => {
+  setMockApiResponses({ ReadData: () => ({ variant_0: { exome: null, genome: [] } }) })
+  const tree = renderer.create(
+    <BrowserRouter>
+      <VariantPageContent datasetId={datasetId} variant={variant} />
+    </BrowserRouter>
+  )
+  const expectedIds = Object.keys(sectionTitles).filter(
+    (id) => !conditionalIds.includes(id) || present.includes(id)
+  )
+  const headings = tree.root.findAllByType('h2')
+  expect(headings.map(({ props }) => props.id)).toEqual(expectedIds)
+  headings.forEach((heading) => {
+    const title = sectionTitles[heading.props.id as keyof typeof sectionTitles]
+    expect(heading.children).toContain(title)
+    expect(heading.findByType('a').props).toMatchObject({
+      href: `#${heading.props.id}`,
+      'aria-label': `Copy link to ${title}`,
+    })
+  })
+  const ids = tree.root
+    .findAll((node) => typeof node.type === 'string' && !!node.props.id)
+    .map(({ props }) => props.id)
+  expect(new Set(ids).size).toBe(ids.length)
+  tree.unmount()
+}
+
+describe('short-variant section permalinks', () => {
+  test('v4 exposes all 13 stable, uniquely named targets, including empty LoF and missing constraint data', () => {
+    const variant = v3VariantFactory.build()
+    variant.lof_curations = []
+    variant.in_silico_predictors = [{ id: 'cadd', value: '10', flags: [] }]
+    variant.clinvar = clinvarVariantFactory.build()
+    expectSections(variant, 'gnomad_r4', conditionalIds)
+  })
+
+  test.each([null, []])('omits missing conditional sections with predictors %j', (predictors) => {
+    const variant = v3VariantFactory.build()
+    variant.genome = { ...variant.genome!, age_distribution: null }
+    variant.in_silico_predictors = predictors
+    expectSections(variant, 'gnomad_r2_1', [])
+  })
+
+  test.each(['exome', 'genome'] as const)(
+    'keeps the age target for %s age data alone',
+    (source) => {
+      const variant = v3VariantFactory.build()
+      variant.exome = null
+      variant.genome = null
+      variant[source] = sequencingFactory.build()
+      expectSections(variant, 'gnomad_r4', ['genomic-constraint', 'age-distribution'])
+    }
+  )
+
+  test('does not expose the age target for joint-only age data', () => {
+    const variant = v3VariantFactory.build()
+    variant.genome = { ...variant.genome!, age_distribution: null }
+    variant.joint = {
+      ...sequencingFactory.build(),
+      freq_comparison_stats: {
+        contingency_table_test: [],
+        cochran_mantel_haenszel_test: { chisq: 0, p_value: 1 },
+        stat_union: { p_value: 1, stat_test_name: '', gen_ancs: [] },
+      },
+    }
+    expectSections(variant, 'gnomad_r4', ['genomic-constraint'])
   })
 })

--- a/browser/src/VariantPage/VariantPage.tsx
+++ b/browser/src/VariantPage/VariantPage.tsx
@@ -48,6 +48,8 @@ import {
   FullLocalAncestryPopulationId,
 } from '@gnomad/dataset-metadata/gnomadPopulations'
 import { Filter } from '../QCFilter'
+import { AnchoredSectionHeading } from '../AnchorLink'
+import useScrollToHash from '../useScrollToHash'
 
 const Section = styled.section`
   width: 100%;
@@ -333,6 +335,8 @@ type VariantPageContentProps = {
 }
 
 export const VariantPageContent = ({ datasetId, variant }: VariantPageContentProps) => {
+  useScrollToHash()
+
   return (
     <FlexWrapper>
       <ResponsiveSection>
@@ -429,9 +433,9 @@ export const VariantPageContent = ({ datasetId, variant }: VariantPageContentPro
         <ResponsiveSection>
           {((variant.exome || {}).age_distribution || (variant.genome || {}).age_distribution) && (
             <React.Fragment>
-              <h2>
+              <AnchoredSectionHeading id="age-distribution">
                 Age Distribution <InfoButton topic="age" />
-              </h2>
+              </AnchoredSectionHeading>
               {isV3Subset(datasetId) && (
                 <p>
                   Age distribution is based on the full gnomAD dataset, not the selected subset.

--- a/browser/src/VariantPage/VariantPage.tsx
+++ b/browser/src/VariantPage/VariantPage.tsx
@@ -48,7 +48,7 @@ import {
   FullLocalAncestryPopulationId,
 } from '@gnomad/dataset-metadata/gnomadPopulations'
 import { Filter } from '../QCFilter'
-import { AgeDistributionHeading } from '../AnchorLink'
+import { SectionHeading } from '../AnchorLink'
 import useScrollToHash from '../useScrollToHash'
 
 const Section = styled.section`
@@ -366,38 +366,41 @@ export const VariantPageContent = ({ datasetId, variant }: VariantPageContentPro
         )}
       </ResponsiveSection>
       <ResponsiveSection>
-        <h2>External Resources</h2>
+        <SectionHeading id="external-resources" title="External Resources" />
         {/* @ts-expect-error TS(2739) FIXME: Type '{ variant_id: string; chrom: string; flags: ... Remove this comment to see the full error message */}
         <ReferenceList variant={variant} />
-        <h2>Feedback</h2>
+        <SectionHeading id="feedback" title="Feedback" />
         <ExternalLink href={variantFeedbackUrl(variant, datasetId)}>
           Report an issue with this variant
         </ExternalLink>
       </ResponsiveSection>
 
       <Section>
-        <h2>
-          Genetic Ancestry Group Frequencies <InfoButton topic="ancestry" />
-        </h2>
+        <SectionHeading
+          id="genetic-ancestry-group-frequencies"
+          title="Genetic Ancestry Group Frequencies"
+        >
+          <InfoButton topic="ancestry" />
+        </SectionHeading>
         <VariantPopulationFrequencies datasetId={datasetId} variant={variant} />
       </Section>
 
       <Section>
-        <h2>Related Variants</h2>
+        <SectionHeading id="related-variants" title="Related Variants" />
         <VariantRelatedVariants datasetId={datasetId} variant={variant} />
       </Section>
 
       <Section>
-        <h2>Ensembl Variant Effect Predictor</h2>
+        <SectionHeading id="variant-effect-predictor" title="Ensembl Variant Effect Predictor" />
         {/* @ts-expect-error TS(2741) FIXME: Property 'reference_genome' is missing in type '{ ... Remove this comment to see the full error message */}
         <VariantTranscriptConsequences variant={variant} />
       </Section>
 
       {variant.lof_curations && (
         <Section>
-          <h2>
-            LoF Curation <InfoButton topic="lof-curation" />
-          </h2>
+          <SectionHeading id="lof-curation" title="LoF Curation">
+            <InfoButton topic="lof-curation" />
+          </SectionHeading>
           {/* @ts-expect-error TS(2322) FIXME: Type '{ variant_id: string; chrom: string; flags: ... Remove this comment to see the full error message */}
           <VariantLoFCurationResults variant={variant} />
         </Section>
@@ -406,13 +409,16 @@ export const VariantPageContent = ({ datasetId, variant }: VariantPageContentPro
       <FlexWrapper>
         {variant.in_silico_predictors && variant.in_silico_predictors.length && (
           <ResponsiveSection>
-            <h2>In Silico Predictors</h2>
+            <SectionHeading id="in-silico-predictors" title="In Silico Predictors" />
             <VariantInSilicoPredictors variant={variant} datasetId={datasetId} />
           </ResponsiveSection>
         )}
         {hasNonCodingConstraints(datasetId) && (
           <ResponsiveSection>
-            <h2>Genomic Constraint of Surrounding 1kb Region</h2>
+            <SectionHeading
+              id="genomic-constraint"
+              title="Genomic Constraint of Surrounding 1kb Region"
+            />
             <GnomadNonCodingConstraintTableVariant
               variantId={variant.variant_id}
               chrom={variant.chrom}
@@ -424,7 +430,7 @@ export const VariantPageContent = ({ datasetId, variant }: VariantPageContentPro
 
       {variant.clinvar && (
         <Section>
-          <h2>ClinVar</h2>
+          <SectionHeading id="clinvar" title="ClinVar" />
           <VariantClinvarInfo clinvar={variant.clinvar} />
         </Section>
       )}
@@ -433,9 +439,9 @@ export const VariantPageContent = ({ datasetId, variant }: VariantPageContentPro
         <ResponsiveSection>
           {((variant.exome || {}).age_distribution || (variant.genome || {}).age_distribution) && (
             <React.Fragment>
-              <AgeDistributionHeading>
-                Age Distribution <InfoButton topic="age" />
-              </AgeDistributionHeading>
+              <SectionHeading id="age-distribution" title="Age Distribution">
+                <InfoButton topic="age" />
+              </SectionHeading>
               {isV3Subset(datasetId) && (
                 <p>
                   Age distribution is based on the full gnomAD dataset, not the selected subset.
@@ -448,15 +454,15 @@ export const VariantPageContent = ({ datasetId, variant }: VariantPageContentPro
       </FlexWrapper>
 
       <ResponsiveSection>
-        <h2>Genotype Quality Metrics</h2>
+        <SectionHeading id="genotype-quality-metrics" title="Genotype Quality Metrics" />
         <VariantGenotypeQualityMetrics datasetId={datasetId} variant={variant} />
       </ResponsiveSection>
       <ResponsiveSection>
-        <h2>Site Quality Metrics</h2>
+        <SectionHeading id="site-quality-metrics" title="Site Quality Metrics" />
         <VariantSiteQualityMetrics datasetId={datasetId} variant={variant} />
       </ResponsiveSection>
       <Section>
-        <h2>Read Data</h2>
+        <SectionHeading id="read-data" title="Read Data" />
         <ReadData datasetId={datasetId} variantIds={[variant.variant_id]} />
       </Section>
     </FlexWrapper>

--- a/browser/src/VariantPage/VariantPage.tsx
+++ b/browser/src/VariantPage/VariantPage.tsx
@@ -48,7 +48,7 @@ import {
   FullLocalAncestryPopulationId,
 } from '@gnomad/dataset-metadata/gnomadPopulations'
 import { Filter } from '../QCFilter'
-import { AnchoredSectionHeading } from '../AnchorLink'
+import { AgeDistributionHeading } from '../AnchorLink'
 import useScrollToHash from '../useScrollToHash'
 
 const Section = styled.section`
@@ -433,9 +433,9 @@ export const VariantPageContent = ({ datasetId, variant }: VariantPageContentPro
         <ResponsiveSection>
           {((variant.exome || {}).age_distribution || (variant.genome || {}).age_distribution) && (
             <React.Fragment>
-              <AnchoredSectionHeading id="age-distribution">
+              <AgeDistributionHeading>
                 Age Distribution <InfoButton topic="age" />
-              </AnchoredSectionHeading>
+              </AgeDistributionHeading>
               {isV3Subset(datasetId) && (
                 <p>
                   Age distribution is based on the full gnomAD dataset, not the selected subset.

--- a/browser/src/VariantPage/__snapshots__/VariantPage.spec.tsx.snap
+++ b/browser/src/VariantPage/__snapshots__/VariantPage.spec.tsx.snap
@@ -1629,37 +1629,58 @@ exports[`VariantPage with the dataset "gnomad_r3" has no unexpected changes 1`] 
       <section
         className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
       >
-        <h2>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
+        <span
+          className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+        >
+          <h2
+            className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
           >
-            <img
-              alt=""
+            <a
               aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
-              }
+              className="AnchorLink-sc-77ly3x-0 isLygD"
+              href="#age-distribution"
+              id="age-distribution"
+              onClick={[Function]}
             >
-              More information
-            </span>
-          </button>
-        </h2>
+              <img
+                alt=""
+                aria-hidden="true"
+                height={12}
+                src="test-file-stub"
+                width={12}
+              />
+            </a>
+            Age Distribution 
+            <button
+              className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+              onClick={[Function]}
+              type="button"
+            >
+              <img
+                alt=""
+                aria-hidden="true"
+                src="test-file-stub"
+              />
+              <span
+                style={
+                  {
+                    "border": "0",
+                    "clip": "rect(0 0 0 0)",
+                    "height": "1px",
+                    "margin": "-1px",
+                    "overflow": "hidden",
+                    "padding": "0",
+                    "position": "absolute",
+                    "whiteSpace": "nowrap",
+                    "width": "1px",
+                  }
+                }
+              >
+                More information
+              </span>
+            </button>
+          </h2>
+        </span>
         <div>
           <div
             className="GnomadAgeDistribution__LegendWrapper-sc-ty24oq-0 fPhNex"
@@ -9040,37 +9061,58 @@ exports[`VariantPage with the dataset "gnomad_r3_controls_and_biobanks" has no u
       <section
         className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
       >
-        <h2>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
+        <span
+          className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+        >
+          <h2
+            className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
           >
-            <img
-              alt=""
+            <a
               aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
-              }
+              className="AnchorLink-sc-77ly3x-0 isLygD"
+              href="#age-distribution"
+              id="age-distribution"
+              onClick={[Function]}
             >
-              More information
-            </span>
-          </button>
-        </h2>
+              <img
+                alt=""
+                aria-hidden="true"
+                height={12}
+                src="test-file-stub"
+                width={12}
+              />
+            </a>
+            Age Distribution 
+            <button
+              className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+              onClick={[Function]}
+              type="button"
+            >
+              <img
+                alt=""
+                aria-hidden="true"
+                src="test-file-stub"
+              />
+              <span
+                style={
+                  {
+                    "border": "0",
+                    "clip": "rect(0 0 0 0)",
+                    "height": "1px",
+                    "margin": "-1px",
+                    "overflow": "hidden",
+                    "padding": "0",
+                    "position": "absolute",
+                    "whiteSpace": "nowrap",
+                    "width": "1px",
+                  }
+                }
+              >
+                More information
+              </span>
+            </button>
+          </h2>
+        </span>
         <p>
           Age distribution is based on the full gnomAD dataset, not the selected subset.
         </p>
@@ -16454,37 +16496,58 @@ exports[`VariantPage with the dataset "gnomad_r3_non_cancer" has no unexpected c
       <section
         className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
       >
-        <h2>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
+        <span
+          className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+        >
+          <h2
+            className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
           >
-            <img
-              alt=""
+            <a
               aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
-              }
+              className="AnchorLink-sc-77ly3x-0 isLygD"
+              href="#age-distribution"
+              id="age-distribution"
+              onClick={[Function]}
             >
-              More information
-            </span>
-          </button>
-        </h2>
+              <img
+                alt=""
+                aria-hidden="true"
+                height={12}
+                src="test-file-stub"
+                width={12}
+              />
+            </a>
+            Age Distribution 
+            <button
+              className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+              onClick={[Function]}
+              type="button"
+            >
+              <img
+                alt=""
+                aria-hidden="true"
+                src="test-file-stub"
+              />
+              <span
+                style={
+                  {
+                    "border": "0",
+                    "clip": "rect(0 0 0 0)",
+                    "height": "1px",
+                    "margin": "-1px",
+                    "overflow": "hidden",
+                    "padding": "0",
+                    "position": "absolute",
+                    "whiteSpace": "nowrap",
+                    "width": "1px",
+                  }
+                }
+              >
+                More information
+              </span>
+            </button>
+          </h2>
+        </span>
         <p>
           Age distribution is based on the full gnomAD dataset, not the selected subset.
         </p>
@@ -23868,37 +23931,58 @@ exports[`VariantPage with the dataset "gnomad_r3_non_neuro" has no unexpected ch
       <section
         className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
       >
-        <h2>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
+        <span
+          className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+        >
+          <h2
+            className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
           >
-            <img
-              alt=""
+            <a
               aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
-              }
+              className="AnchorLink-sc-77ly3x-0 isLygD"
+              href="#age-distribution"
+              id="age-distribution"
+              onClick={[Function]}
             >
-              More information
-            </span>
-          </button>
-        </h2>
+              <img
+                alt=""
+                aria-hidden="true"
+                height={12}
+                src="test-file-stub"
+                width={12}
+              />
+            </a>
+            Age Distribution 
+            <button
+              className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+              onClick={[Function]}
+              type="button"
+            >
+              <img
+                alt=""
+                aria-hidden="true"
+                src="test-file-stub"
+              />
+              <span
+                style={
+                  {
+                    "border": "0",
+                    "clip": "rect(0 0 0 0)",
+                    "height": "1px",
+                    "margin": "-1px",
+                    "overflow": "hidden",
+                    "padding": "0",
+                    "position": "absolute",
+                    "whiteSpace": "nowrap",
+                    "width": "1px",
+                  }
+                }
+              >
+                More information
+              </span>
+            </button>
+          </h2>
+        </span>
         <p>
           Age distribution is based on the full gnomAD dataset, not the selected subset.
         </p>
@@ -31282,37 +31366,58 @@ exports[`VariantPage with the dataset "gnomad_r3_non_topmed" has no unexpected c
       <section
         className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
       >
-        <h2>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
+        <span
+          className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+        >
+          <h2
+            className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
           >
-            <img
-              alt=""
+            <a
               aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
-              }
+              className="AnchorLink-sc-77ly3x-0 isLygD"
+              href="#age-distribution"
+              id="age-distribution"
+              onClick={[Function]}
             >
-              More information
-            </span>
-          </button>
-        </h2>
+              <img
+                alt=""
+                aria-hidden="true"
+                height={12}
+                src="test-file-stub"
+                width={12}
+              />
+            </a>
+            Age Distribution 
+            <button
+              className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+              onClick={[Function]}
+              type="button"
+            >
+              <img
+                alt=""
+                aria-hidden="true"
+                src="test-file-stub"
+              />
+              <span
+                style={
+                  {
+                    "border": "0",
+                    "clip": "rect(0 0 0 0)",
+                    "height": "1px",
+                    "margin": "-1px",
+                    "overflow": "hidden",
+                    "padding": "0",
+                    "position": "absolute",
+                    "whiteSpace": "nowrap",
+                    "width": "1px",
+                  }
+                }
+              >
+                More information
+              </span>
+            </button>
+          </h2>
+        </span>
         <p>
           Age distribution is based on the full gnomAD dataset, not the selected subset.
         </p>
@@ -38696,37 +38801,58 @@ exports[`VariantPage with the dataset "gnomad_r3_non_v2" has no unexpected chang
       <section
         className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
       >
-        <h2>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
+        <span
+          className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+        >
+          <h2
+            className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
           >
-            <img
-              alt=""
+            <a
               aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
-              }
+              className="AnchorLink-sc-77ly3x-0 isLygD"
+              href="#age-distribution"
+              id="age-distribution"
+              onClick={[Function]}
             >
-              More information
-            </span>
-          </button>
-        </h2>
+              <img
+                alt=""
+                aria-hidden="true"
+                height={12}
+                src="test-file-stub"
+                width={12}
+              />
+            </a>
+            Age Distribution 
+            <button
+              className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+              onClick={[Function]}
+              type="button"
+            >
+              <img
+                alt=""
+                aria-hidden="true"
+                src="test-file-stub"
+              />
+              <span
+                style={
+                  {
+                    "border": "0",
+                    "clip": "rect(0 0 0 0)",
+                    "height": "1px",
+                    "margin": "-1px",
+                    "overflow": "hidden",
+                    "padding": "0",
+                    "position": "absolute",
+                    "whiteSpace": "nowrap",
+                    "width": "1px",
+                  }
+                }
+              >
+                More information
+              </span>
+            </button>
+          </h2>
+        </span>
         <p>
           Age distribution is based on the full gnomAD dataset, not the selected subset.
         </p>
@@ -45779,37 +45905,58 @@ exports[`VariantPage with the dataset exac has no unexpected changes 1`] = `
       <section
         className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
       >
-        <h2>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
+        <span
+          className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+        >
+          <h2
+            className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
           >
-            <img
-              alt=""
+            <a
               aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
-              }
+              className="AnchorLink-sc-77ly3x-0 isLygD"
+              href="#age-distribution"
+              id="age-distribution"
+              onClick={[Function]}
             >
-              More information
-            </span>
-          </button>
-        </h2>
+              <img
+                alt=""
+                aria-hidden="true"
+                height={12}
+                src="test-file-stub"
+                width={12}
+              />
+            </a>
+            Age Distribution 
+            <button
+              className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+              onClick={[Function]}
+              type="button"
+            >
+              <img
+                alt=""
+                aria-hidden="true"
+                src="test-file-stub"
+              />
+              <span
+                style={
+                  {
+                    "border": "0",
+                    "clip": "rect(0 0 0 0)",
+                    "height": "1px",
+                    "margin": "-1px",
+                    "overflow": "hidden",
+                    "padding": "0",
+                    "position": "absolute",
+                    "whiteSpace": "nowrap",
+                    "width": "1px",
+                  }
+                }
+              >
+                More information
+              </span>
+            </button>
+          </h2>
+        </span>
         <div>
           <div
             className="GnomadAgeDistribution__LegendWrapper-sc-ty24oq-0 fPhNex"
@@ -52160,37 +52307,58 @@ exports[`VariantPage with the dataset gnomad_r2_1 has no unexpected changes 1`] 
       <section
         className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
       >
-        <h2>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
+        <span
+          className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+        >
+          <h2
+            className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
           >
-            <img
-              alt=""
+            <a
               aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
-              }
+              className="AnchorLink-sc-77ly3x-0 isLygD"
+              href="#age-distribution"
+              id="age-distribution"
+              onClick={[Function]}
             >
-              More information
-            </span>
-          </button>
-        </h2>
+              <img
+                alt=""
+                aria-hidden="true"
+                height={12}
+                src="test-file-stub"
+                width={12}
+              />
+            </a>
+            Age Distribution 
+            <button
+              className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+              onClick={[Function]}
+              type="button"
+            >
+              <img
+                alt=""
+                aria-hidden="true"
+                src="test-file-stub"
+              />
+              <span
+                style={
+                  {
+                    "border": "0",
+                    "clip": "rect(0 0 0 0)",
+                    "height": "1px",
+                    "margin": "-1px",
+                    "overflow": "hidden",
+                    "padding": "0",
+                    "position": "absolute",
+                    "whiteSpace": "nowrap",
+                    "width": "1px",
+                  }
+                }
+              >
+                More information
+              </span>
+            </button>
+          </h2>
+        </span>
         <div>
           <div
             className="GnomadAgeDistribution__LegendWrapper-sc-ty24oq-0 fPhNex"
@@ -59692,37 +59860,58 @@ exports[`VariantPage with the dataset gnomad_r2_1_controls has no unexpected cha
       <section
         className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
       >
-        <h2>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
+        <span
+          className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+        >
+          <h2
+            className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
           >
-            <img
-              alt=""
+            <a
               aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
-              }
+              className="AnchorLink-sc-77ly3x-0 isLygD"
+              href="#age-distribution"
+              id="age-distribution"
+              onClick={[Function]}
             >
-              More information
-            </span>
-          </button>
-        </h2>
+              <img
+                alt=""
+                aria-hidden="true"
+                height={12}
+                src="test-file-stub"
+                width={12}
+              />
+            </a>
+            Age Distribution 
+            <button
+              className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+              onClick={[Function]}
+              type="button"
+            >
+              <img
+                alt=""
+                aria-hidden="true"
+                src="test-file-stub"
+              />
+              <span
+                style={
+                  {
+                    "border": "0",
+                    "clip": "rect(0 0 0 0)",
+                    "height": "1px",
+                    "margin": "-1px",
+                    "overflow": "hidden",
+                    "padding": "0",
+                    "position": "absolute",
+                    "whiteSpace": "nowrap",
+                    "width": "1px",
+                  }
+                }
+              >
+                More information
+              </span>
+            </button>
+          </h2>
+        </span>
         <div>
           <div
             className="GnomadAgeDistribution__LegendWrapper-sc-ty24oq-0 fPhNex"
@@ -67224,37 +67413,58 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_cancer has no unexpected c
       <section
         className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
       >
-        <h2>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
+        <span
+          className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+        >
+          <h2
+            className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
           >
-            <img
-              alt=""
+            <a
               aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
-              }
+              className="AnchorLink-sc-77ly3x-0 isLygD"
+              href="#age-distribution"
+              id="age-distribution"
+              onClick={[Function]}
             >
-              More information
-            </span>
-          </button>
-        </h2>
+              <img
+                alt=""
+                aria-hidden="true"
+                height={12}
+                src="test-file-stub"
+                width={12}
+              />
+            </a>
+            Age Distribution 
+            <button
+              className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+              onClick={[Function]}
+              type="button"
+            >
+              <img
+                alt=""
+                aria-hidden="true"
+                src="test-file-stub"
+              />
+              <span
+                style={
+                  {
+                    "border": "0",
+                    "clip": "rect(0 0 0 0)",
+                    "height": "1px",
+                    "margin": "-1px",
+                    "overflow": "hidden",
+                    "padding": "0",
+                    "position": "absolute",
+                    "whiteSpace": "nowrap",
+                    "width": "1px",
+                  }
+                }
+              >
+                More information
+              </span>
+            </button>
+          </h2>
+        </span>
         <div>
           <div
             className="GnomadAgeDistribution__LegendWrapper-sc-ty24oq-0 fPhNex"
@@ -74756,37 +74966,58 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_neuro has no unexpected ch
       <section
         className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
       >
-        <h2>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
+        <span
+          className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+        >
+          <h2
+            className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
           >
-            <img
-              alt=""
+            <a
               aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
-              }
+              className="AnchorLink-sc-77ly3x-0 isLygD"
+              href="#age-distribution"
+              id="age-distribution"
+              onClick={[Function]}
             >
-              More information
-            </span>
-          </button>
-        </h2>
+              <img
+                alt=""
+                aria-hidden="true"
+                height={12}
+                src="test-file-stub"
+                width={12}
+              />
+            </a>
+            Age Distribution 
+            <button
+              className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+              onClick={[Function]}
+              type="button"
+            >
+              <img
+                alt=""
+                aria-hidden="true"
+                src="test-file-stub"
+              />
+              <span
+                style={
+                  {
+                    "border": "0",
+                    "clip": "rect(0 0 0 0)",
+                    "height": "1px",
+                    "margin": "-1px",
+                    "overflow": "hidden",
+                    "padding": "0",
+                    "position": "absolute",
+                    "whiteSpace": "nowrap",
+                    "width": "1px",
+                  }
+                }
+              >
+                More information
+              </span>
+            </button>
+          </h2>
+        </span>
         <div>
           <div
             className="GnomadAgeDistribution__LegendWrapper-sc-ty24oq-0 fPhNex"
@@ -82288,37 +82519,58 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_topmed has no unexpected c
       <section
         className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
       >
-        <h2>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
+        <span
+          className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+        >
+          <h2
+            className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
           >
-            <img
-              alt=""
+            <a
               aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
-              }
+              className="AnchorLink-sc-77ly3x-0 isLygD"
+              href="#age-distribution"
+              id="age-distribution"
+              onClick={[Function]}
             >
-              More information
-            </span>
-          </button>
-        </h2>
+              <img
+                alt=""
+                aria-hidden="true"
+                height={12}
+                src="test-file-stub"
+                width={12}
+              />
+            </a>
+            Age Distribution 
+            <button
+              className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+              onClick={[Function]}
+              type="button"
+            >
+              <img
+                alt=""
+                aria-hidden="true"
+                src="test-file-stub"
+              />
+              <span
+                style={
+                  {
+                    "border": "0",
+                    "clip": "rect(0 0 0 0)",
+                    "height": "1px",
+                    "margin": "-1px",
+                    "overflow": "hidden",
+                    "padding": "0",
+                    "position": "absolute",
+                    "whiteSpace": "nowrap",
+                    "width": "1px",
+                  }
+                }
+              >
+                More information
+              </span>
+            </button>
+          </h2>
+        </span>
         <div>
           <div
             className="GnomadAgeDistribution__LegendWrapper-sc-ty24oq-0 fPhNex"

--- a/browser/src/VariantPage/__snapshots__/VariantPage.spec.tsx.snap
+++ b/browser/src/VariantPage/__snapshots__/VariantPage.spec.tsx.snap
@@ -1632,12 +1632,10 @@ exports[`VariantPage with the dataset "gnomad_r3" has no unexpected changes 1`] 
         <span
           className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
         >
-          <h2
-            className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-          >
+          <h2>
             <a
-              aria-hidden="true"
-              className="AnchorLink-sc-77ly3x-0 isLygD"
+              aria-label="Copy link to Age Distribution"
+              className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
               href="#age-distribution"
               id="age-distribution"
               onClick={[Function]}
@@ -9064,12 +9062,10 @@ exports[`VariantPage with the dataset "gnomad_r3_controls_and_biobanks" has no u
         <span
           className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
         >
-          <h2
-            className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-          >
+          <h2>
             <a
-              aria-hidden="true"
-              className="AnchorLink-sc-77ly3x-0 isLygD"
+              aria-label="Copy link to Age Distribution"
+              className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
               href="#age-distribution"
               id="age-distribution"
               onClick={[Function]}
@@ -16499,12 +16495,10 @@ exports[`VariantPage with the dataset "gnomad_r3_non_cancer" has no unexpected c
         <span
           className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
         >
-          <h2
-            className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-          >
+          <h2>
             <a
-              aria-hidden="true"
-              className="AnchorLink-sc-77ly3x-0 isLygD"
+              aria-label="Copy link to Age Distribution"
+              className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
               href="#age-distribution"
               id="age-distribution"
               onClick={[Function]}
@@ -23934,12 +23928,10 @@ exports[`VariantPage with the dataset "gnomad_r3_non_neuro" has no unexpected ch
         <span
           className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
         >
-          <h2
-            className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-          >
+          <h2>
             <a
-              aria-hidden="true"
-              className="AnchorLink-sc-77ly3x-0 isLygD"
+              aria-label="Copy link to Age Distribution"
+              className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
               href="#age-distribution"
               id="age-distribution"
               onClick={[Function]}
@@ -31369,12 +31361,10 @@ exports[`VariantPage with the dataset "gnomad_r3_non_topmed" has no unexpected c
         <span
           className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
         >
-          <h2
-            className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-          >
+          <h2>
             <a
-              aria-hidden="true"
-              className="AnchorLink-sc-77ly3x-0 isLygD"
+              aria-label="Copy link to Age Distribution"
+              className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
               href="#age-distribution"
               id="age-distribution"
               onClick={[Function]}
@@ -38804,12 +38794,10 @@ exports[`VariantPage with the dataset "gnomad_r3_non_v2" has no unexpected chang
         <span
           className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
         >
-          <h2
-            className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-          >
+          <h2>
             <a
-              aria-hidden="true"
-              className="AnchorLink-sc-77ly3x-0 isLygD"
+              aria-label="Copy link to Age Distribution"
+              className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
               href="#age-distribution"
               id="age-distribution"
               onClick={[Function]}
@@ -45908,12 +45896,10 @@ exports[`VariantPage with the dataset exac has no unexpected changes 1`] = `
         <span
           className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
         >
-          <h2
-            className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-          >
+          <h2>
             <a
-              aria-hidden="true"
-              className="AnchorLink-sc-77ly3x-0 isLygD"
+              aria-label="Copy link to Age Distribution"
+              className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
               href="#age-distribution"
               id="age-distribution"
               onClick={[Function]}
@@ -52310,12 +52296,10 @@ exports[`VariantPage with the dataset gnomad_r2_1 has no unexpected changes 1`] 
         <span
           className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
         >
-          <h2
-            className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-          >
+          <h2>
             <a
-              aria-hidden="true"
-              className="AnchorLink-sc-77ly3x-0 isLygD"
+              aria-label="Copy link to Age Distribution"
+              className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
               href="#age-distribution"
               id="age-distribution"
               onClick={[Function]}
@@ -59863,12 +59847,10 @@ exports[`VariantPage with the dataset gnomad_r2_1_controls has no unexpected cha
         <span
           className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
         >
-          <h2
-            className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-          >
+          <h2>
             <a
-              aria-hidden="true"
-              className="AnchorLink-sc-77ly3x-0 isLygD"
+              aria-label="Copy link to Age Distribution"
+              className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
               href="#age-distribution"
               id="age-distribution"
               onClick={[Function]}
@@ -67416,12 +67398,10 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_cancer has no unexpected c
         <span
           className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
         >
-          <h2
-            className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-          >
+          <h2>
             <a
-              aria-hidden="true"
-              className="AnchorLink-sc-77ly3x-0 isLygD"
+              aria-label="Copy link to Age Distribution"
+              className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
               href="#age-distribution"
               id="age-distribution"
               onClick={[Function]}
@@ -74969,12 +74949,10 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_neuro has no unexpected ch
         <span
           className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
         >
-          <h2
-            className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-          >
+          <h2>
             <a
-              aria-hidden="true"
-              className="AnchorLink-sc-77ly3x-0 isLygD"
+              aria-label="Copy link to Age Distribution"
+              className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
               href="#age-distribution"
               id="age-distribution"
               onClick={[Function]}
@@ -82522,12 +82500,10 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_topmed has no unexpected c
         <span
           className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
         >
-          <h2
-            className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-          >
+          <h2>
             <a
-              aria-hidden="true"
-              className="AnchorLink-sc-77ly3x-0 isLygD"
+              aria-label="Copy link to Age Distribution"
+              className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
               href="#age-distribution"
               id="age-distribution"
               onClick={[Function]}

--- a/browser/src/VariantPage/__snapshots__/VariantPage.spec.tsx.snap
+++ b/browser/src/VariantPage/__snapshots__/VariantPage.spec.tsx.snap
@@ -643,7 +643,24 @@ exports[`VariantPage with the dataset "gnomad_r3" has no unexpected changes 1`] 
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="external-resources"
+      >
+        <a
+          aria-label="Copy link to External Resources"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#external-resources"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         External Resources
       </h2>
       <ul
@@ -674,7 +691,24 @@ exports[`VariantPage with the dataset "gnomad_r3" has no unexpected changes 1`] 
           </a>
         </li>
       </ul>
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="feedback"
+      >
+        <a
+          aria-label="Copy link to Feedback"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#feedback"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Feedback
       </h2>
       <a
@@ -689,8 +723,26 @@ exports[`VariantPage with the dataset "gnomad_r3" has no unexpected changes 1`] 
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
-        Genetic Ancestry Group Frequencies 
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="genetic-ancestry-group-frequencies"
+      >
+        <a
+          aria-label="Copy link to Genetic Ancestry Group Frequencies"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#genetic-ancestry-group-frequencies"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Genetic Ancestry Group Frequencies
+         
         <button
           className="InfoButton__Button-sc-13t5e82-0 faZoWY"
           onClick={[Function]}
@@ -1438,7 +1490,24 @@ exports[`VariantPage with the dataset "gnomad_r3" has no unexpected changes 1`] 
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="related-variants"
+      >
+        <a
+          aria-label="Copy link to Related Variants"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#related-variants"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Related Variants
       </h2>
       <div
@@ -1465,7 +1534,24 @@ exports[`VariantPage with the dataset "gnomad_r3" has no unexpected changes 1`] 
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="variant-effect-predictor"
+      >
+        <a
+          aria-label="Copy link to Ensembl Variant Effect Predictor"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#variant-effect-predictor"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Ensembl Variant Effect Predictor
       </h2>
       <div>
@@ -1617,7 +1703,24 @@ exports[`VariantPage with the dataset "gnomad_r3" has no unexpected changes 1`] 
       <section
         className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
       >
-        <h2>
+        <h2
+          className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+          id="genomic-constraint"
+        >
+          <a
+            aria-label="Copy link to Genomic Constraint of Surrounding 1kb Region"
+            className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+            href="#genomic-constraint"
+            onClick={[Function]}
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
           Genomic Constraint of Surrounding 1kb Region
         </h2>
         This variant does not have non coding constraint data for the surrounding region.
@@ -1629,56 +1732,55 @@ exports[`VariantPage with the dataset "gnomad_r3" has no unexpected changes 1`] 
       <section
         className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
       >
-        <span
-          className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+        <h2
+          className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+          id="age-distribution"
         >
-          <h2>
-            <a
-              aria-label="Copy link to Age Distribution"
-              className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-              href="#age-distribution"
-              id="age-distribution"
-              onClick={[Function]}
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                height={12}
-                src="test-file-stub"
-                width={12}
-              />
-            </a>
-            Age Distribution 
-            <button
-              className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-              onClick={[Function]}
-              type="button"
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                src="test-file-stub"
-              />
-              <span
-                style={
-                  {
-                    "border": "0",
-                    "clip": "rect(0 0 0 0)",
-                    "height": "1px",
-                    "margin": "-1px",
-                    "overflow": "hidden",
-                    "padding": "0",
-                    "position": "absolute",
-                    "whiteSpace": "nowrap",
-                    "width": "1px",
-                  }
+          <a
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+            href="#age-distribution"
+            onClick={[Function]}
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution
+           
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
                 }
-              >
-                More information
-              </span>
-            </button>
-          </h2>
-        </span>
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
         <div>
           <div
             className="GnomadAgeDistribution__LegendWrapper-sc-ty24oq-0 fPhNex"
@@ -3260,7 +3362,24 @@ exports[`VariantPage with the dataset "gnomad_r3" has no unexpected changes 1`] 
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="genotype-quality-metrics"
+      >
+        <a
+          aria-label="Copy link to Genotype Quality Metrics"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#genotype-quality-metrics"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Genotype Quality Metrics
       </h2>
       <div>
@@ -4803,7 +4922,24 @@ exports[`VariantPage with the dataset "gnomad_r3" has no unexpected changes 1`] 
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="site-quality-metrics"
+      >
+        <a
+          aria-label="Copy link to Site Quality Metrics"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#site-quality-metrics"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Site Quality Metrics
       </h2>
       <div
@@ -7364,7 +7500,24 @@ exports[`VariantPage with the dataset "gnomad_r3" has no unexpected changes 1`] 
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="read-data"
+      >
+        <a
+          aria-label="Copy link to Read Data"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#read-data"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Read Data
       </h2>
       <div
@@ -8073,7 +8226,24 @@ exports[`VariantPage with the dataset "gnomad_r3_controls_and_biobanks" has no u
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="external-resources"
+      >
+        <a
+          aria-label="Copy link to External Resources"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#external-resources"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         External Resources
       </h2>
       <ul
@@ -8104,7 +8274,24 @@ exports[`VariantPage with the dataset "gnomad_r3_controls_and_biobanks" has no u
           </a>
         </li>
       </ul>
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="feedback"
+      >
+        <a
+          aria-label="Copy link to Feedback"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#feedback"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Feedback
       </h2>
       <a
@@ -8119,8 +8306,26 @@ exports[`VariantPage with the dataset "gnomad_r3_controls_and_biobanks" has no u
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
-        Genetic Ancestry Group Frequencies 
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="genetic-ancestry-group-frequencies"
+      >
+        <a
+          aria-label="Copy link to Genetic Ancestry Group Frequencies"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#genetic-ancestry-group-frequencies"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Genetic Ancestry Group Frequencies
+         
         <button
           className="InfoButton__Button-sc-13t5e82-0 faZoWY"
           onClick={[Function]}
@@ -8868,7 +9073,24 @@ exports[`VariantPage with the dataset "gnomad_r3_controls_and_biobanks" has no u
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="related-variants"
+      >
+        <a
+          aria-label="Copy link to Related Variants"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#related-variants"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Related Variants
       </h2>
       <div
@@ -8895,7 +9117,24 @@ exports[`VariantPage with the dataset "gnomad_r3_controls_and_biobanks" has no u
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="variant-effect-predictor"
+      >
+        <a
+          aria-label="Copy link to Ensembl Variant Effect Predictor"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#variant-effect-predictor"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Ensembl Variant Effect Predictor
       </h2>
       <div>
@@ -9047,7 +9286,24 @@ exports[`VariantPage with the dataset "gnomad_r3_controls_and_biobanks" has no u
       <section
         className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
       >
-        <h2>
+        <h2
+          className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+          id="genomic-constraint"
+        >
+          <a
+            aria-label="Copy link to Genomic Constraint of Surrounding 1kb Region"
+            className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+            href="#genomic-constraint"
+            onClick={[Function]}
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
           Genomic Constraint of Surrounding 1kb Region
         </h2>
         This variant does not have non coding constraint data for the surrounding region.
@@ -9059,56 +9315,55 @@ exports[`VariantPage with the dataset "gnomad_r3_controls_and_biobanks" has no u
       <section
         className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
       >
-        <span
-          className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+        <h2
+          className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+          id="age-distribution"
         >
-          <h2>
-            <a
-              aria-label="Copy link to Age Distribution"
-              className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-              href="#age-distribution"
-              id="age-distribution"
-              onClick={[Function]}
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                height={12}
-                src="test-file-stub"
-                width={12}
-              />
-            </a>
-            Age Distribution 
-            <button
-              className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-              onClick={[Function]}
-              type="button"
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                src="test-file-stub"
-              />
-              <span
-                style={
-                  {
-                    "border": "0",
-                    "clip": "rect(0 0 0 0)",
-                    "height": "1px",
-                    "margin": "-1px",
-                    "overflow": "hidden",
-                    "padding": "0",
-                    "position": "absolute",
-                    "whiteSpace": "nowrap",
-                    "width": "1px",
-                  }
+          <a
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+            href="#age-distribution"
+            onClick={[Function]}
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution
+           
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
                 }
-              >
-                More information
-              </span>
-            </button>
-          </h2>
-        </span>
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
         <p>
           Age distribution is based on the full gnomAD dataset, not the selected subset.
         </p>
@@ -10693,7 +10948,24 @@ exports[`VariantPage with the dataset "gnomad_r3_controls_and_biobanks" has no u
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="genotype-quality-metrics"
+      >
+        <a
+          aria-label="Copy link to Genotype Quality Metrics"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#genotype-quality-metrics"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Genotype Quality Metrics
       </h2>
       <div>
@@ -12236,7 +12508,24 @@ exports[`VariantPage with the dataset "gnomad_r3_controls_and_biobanks" has no u
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="site-quality-metrics"
+      >
+        <a
+          aria-label="Copy link to Site Quality Metrics"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#site-quality-metrics"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Site Quality Metrics
       </h2>
       <div
@@ -14797,7 +15086,24 @@ exports[`VariantPage with the dataset "gnomad_r3_controls_and_biobanks" has no u
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="read-data"
+      >
+        <a
+          aria-label="Copy link to Read Data"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#read-data"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Read Data
       </h2>
       <div
@@ -15506,7 +15812,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_cancer" has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="external-resources"
+      >
+        <a
+          aria-label="Copy link to External Resources"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#external-resources"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         External Resources
       </h2>
       <ul
@@ -15537,7 +15860,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_cancer" has no unexpected c
           </a>
         </li>
       </ul>
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="feedback"
+      >
+        <a
+          aria-label="Copy link to Feedback"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#feedback"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Feedback
       </h2>
       <a
@@ -15552,8 +15892,26 @@ exports[`VariantPage with the dataset "gnomad_r3_non_cancer" has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
-        Genetic Ancestry Group Frequencies 
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="genetic-ancestry-group-frequencies"
+      >
+        <a
+          aria-label="Copy link to Genetic Ancestry Group Frequencies"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#genetic-ancestry-group-frequencies"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Genetic Ancestry Group Frequencies
+         
         <button
           className="InfoButton__Button-sc-13t5e82-0 faZoWY"
           onClick={[Function]}
@@ -16301,7 +16659,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_cancer" has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="related-variants"
+      >
+        <a
+          aria-label="Copy link to Related Variants"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#related-variants"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Related Variants
       </h2>
       <div
@@ -16328,7 +16703,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_cancer" has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="variant-effect-predictor"
+      >
+        <a
+          aria-label="Copy link to Ensembl Variant Effect Predictor"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#variant-effect-predictor"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Ensembl Variant Effect Predictor
       </h2>
       <div>
@@ -16480,7 +16872,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_cancer" has no unexpected c
       <section
         className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
       >
-        <h2>
+        <h2
+          className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+          id="genomic-constraint"
+        >
+          <a
+            aria-label="Copy link to Genomic Constraint of Surrounding 1kb Region"
+            className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+            href="#genomic-constraint"
+            onClick={[Function]}
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
           Genomic Constraint of Surrounding 1kb Region
         </h2>
         This variant does not have non coding constraint data for the surrounding region.
@@ -16492,56 +16901,55 @@ exports[`VariantPage with the dataset "gnomad_r3_non_cancer" has no unexpected c
       <section
         className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
       >
-        <span
-          className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+        <h2
+          className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+          id="age-distribution"
         >
-          <h2>
-            <a
-              aria-label="Copy link to Age Distribution"
-              className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-              href="#age-distribution"
-              id="age-distribution"
-              onClick={[Function]}
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                height={12}
-                src="test-file-stub"
-                width={12}
-              />
-            </a>
-            Age Distribution 
-            <button
-              className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-              onClick={[Function]}
-              type="button"
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                src="test-file-stub"
-              />
-              <span
-                style={
-                  {
-                    "border": "0",
-                    "clip": "rect(0 0 0 0)",
-                    "height": "1px",
-                    "margin": "-1px",
-                    "overflow": "hidden",
-                    "padding": "0",
-                    "position": "absolute",
-                    "whiteSpace": "nowrap",
-                    "width": "1px",
-                  }
+          <a
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+            href="#age-distribution"
+            onClick={[Function]}
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution
+           
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
                 }
-              >
-                More information
-              </span>
-            </button>
-          </h2>
-        </span>
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
         <p>
           Age distribution is based on the full gnomAD dataset, not the selected subset.
         </p>
@@ -18126,7 +18534,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_cancer" has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="genotype-quality-metrics"
+      >
+        <a
+          aria-label="Copy link to Genotype Quality Metrics"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#genotype-quality-metrics"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Genotype Quality Metrics
       </h2>
       <div>
@@ -19669,7 +20094,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_cancer" has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="site-quality-metrics"
+      >
+        <a
+          aria-label="Copy link to Site Quality Metrics"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#site-quality-metrics"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Site Quality Metrics
       </h2>
       <div
@@ -22230,7 +22672,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_cancer" has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="read-data"
+      >
+        <a
+          aria-label="Copy link to Read Data"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#read-data"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Read Data
       </h2>
       <div
@@ -22939,7 +23398,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_neuro" has no unexpected ch
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="external-resources"
+      >
+        <a
+          aria-label="Copy link to External Resources"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#external-resources"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         External Resources
       </h2>
       <ul
@@ -22970,7 +23446,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_neuro" has no unexpected ch
           </a>
         </li>
       </ul>
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="feedback"
+      >
+        <a
+          aria-label="Copy link to Feedback"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#feedback"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Feedback
       </h2>
       <a
@@ -22985,8 +23478,26 @@ exports[`VariantPage with the dataset "gnomad_r3_non_neuro" has no unexpected ch
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
-        Genetic Ancestry Group Frequencies 
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="genetic-ancestry-group-frequencies"
+      >
+        <a
+          aria-label="Copy link to Genetic Ancestry Group Frequencies"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#genetic-ancestry-group-frequencies"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Genetic Ancestry Group Frequencies
+         
         <button
           className="InfoButton__Button-sc-13t5e82-0 faZoWY"
           onClick={[Function]}
@@ -23734,7 +24245,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_neuro" has no unexpected ch
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="related-variants"
+      >
+        <a
+          aria-label="Copy link to Related Variants"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#related-variants"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Related Variants
       </h2>
       <div
@@ -23761,7 +24289,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_neuro" has no unexpected ch
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="variant-effect-predictor"
+      >
+        <a
+          aria-label="Copy link to Ensembl Variant Effect Predictor"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#variant-effect-predictor"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Ensembl Variant Effect Predictor
       </h2>
       <div>
@@ -23913,7 +24458,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_neuro" has no unexpected ch
       <section
         className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
       >
-        <h2>
+        <h2
+          className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+          id="genomic-constraint"
+        >
+          <a
+            aria-label="Copy link to Genomic Constraint of Surrounding 1kb Region"
+            className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+            href="#genomic-constraint"
+            onClick={[Function]}
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
           Genomic Constraint of Surrounding 1kb Region
         </h2>
         This variant does not have non coding constraint data for the surrounding region.
@@ -23925,56 +24487,55 @@ exports[`VariantPage with the dataset "gnomad_r3_non_neuro" has no unexpected ch
       <section
         className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
       >
-        <span
-          className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+        <h2
+          className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+          id="age-distribution"
         >
-          <h2>
-            <a
-              aria-label="Copy link to Age Distribution"
-              className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-              href="#age-distribution"
-              id="age-distribution"
-              onClick={[Function]}
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                height={12}
-                src="test-file-stub"
-                width={12}
-              />
-            </a>
-            Age Distribution 
-            <button
-              className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-              onClick={[Function]}
-              type="button"
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                src="test-file-stub"
-              />
-              <span
-                style={
-                  {
-                    "border": "0",
-                    "clip": "rect(0 0 0 0)",
-                    "height": "1px",
-                    "margin": "-1px",
-                    "overflow": "hidden",
-                    "padding": "0",
-                    "position": "absolute",
-                    "whiteSpace": "nowrap",
-                    "width": "1px",
-                  }
+          <a
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+            href="#age-distribution"
+            onClick={[Function]}
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution
+           
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
                 }
-              >
-                More information
-              </span>
-            </button>
-          </h2>
-        </span>
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
         <p>
           Age distribution is based on the full gnomAD dataset, not the selected subset.
         </p>
@@ -25559,7 +26120,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_neuro" has no unexpected ch
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="genotype-quality-metrics"
+      >
+        <a
+          aria-label="Copy link to Genotype Quality Metrics"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#genotype-quality-metrics"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Genotype Quality Metrics
       </h2>
       <div>
@@ -27102,7 +27680,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_neuro" has no unexpected ch
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="site-quality-metrics"
+      >
+        <a
+          aria-label="Copy link to Site Quality Metrics"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#site-quality-metrics"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Site Quality Metrics
       </h2>
       <div
@@ -29663,7 +30258,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_neuro" has no unexpected ch
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="read-data"
+      >
+        <a
+          aria-label="Copy link to Read Data"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#read-data"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Read Data
       </h2>
       <div
@@ -30372,7 +30984,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_topmed" has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="external-resources"
+      >
+        <a
+          aria-label="Copy link to External Resources"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#external-resources"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         External Resources
       </h2>
       <ul
@@ -30403,7 +31032,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_topmed" has no unexpected c
           </a>
         </li>
       </ul>
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="feedback"
+      >
+        <a
+          aria-label="Copy link to Feedback"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#feedback"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Feedback
       </h2>
       <a
@@ -30418,8 +31064,26 @@ exports[`VariantPage with the dataset "gnomad_r3_non_topmed" has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
-        Genetic Ancestry Group Frequencies 
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="genetic-ancestry-group-frequencies"
+      >
+        <a
+          aria-label="Copy link to Genetic Ancestry Group Frequencies"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#genetic-ancestry-group-frequencies"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Genetic Ancestry Group Frequencies
+         
         <button
           className="InfoButton__Button-sc-13t5e82-0 faZoWY"
           onClick={[Function]}
@@ -31167,7 +31831,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_topmed" has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="related-variants"
+      >
+        <a
+          aria-label="Copy link to Related Variants"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#related-variants"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Related Variants
       </h2>
       <div
@@ -31194,7 +31875,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_topmed" has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="variant-effect-predictor"
+      >
+        <a
+          aria-label="Copy link to Ensembl Variant Effect Predictor"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#variant-effect-predictor"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Ensembl Variant Effect Predictor
       </h2>
       <div>
@@ -31346,7 +32044,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_topmed" has no unexpected c
       <section
         className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
       >
-        <h2>
+        <h2
+          className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+          id="genomic-constraint"
+        >
+          <a
+            aria-label="Copy link to Genomic Constraint of Surrounding 1kb Region"
+            className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+            href="#genomic-constraint"
+            onClick={[Function]}
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
           Genomic Constraint of Surrounding 1kb Region
         </h2>
         This variant does not have non coding constraint data for the surrounding region.
@@ -31358,56 +32073,55 @@ exports[`VariantPage with the dataset "gnomad_r3_non_topmed" has no unexpected c
       <section
         className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
       >
-        <span
-          className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+        <h2
+          className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+          id="age-distribution"
         >
-          <h2>
-            <a
-              aria-label="Copy link to Age Distribution"
-              className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-              href="#age-distribution"
-              id="age-distribution"
-              onClick={[Function]}
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                height={12}
-                src="test-file-stub"
-                width={12}
-              />
-            </a>
-            Age Distribution 
-            <button
-              className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-              onClick={[Function]}
-              type="button"
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                src="test-file-stub"
-              />
-              <span
-                style={
-                  {
-                    "border": "0",
-                    "clip": "rect(0 0 0 0)",
-                    "height": "1px",
-                    "margin": "-1px",
-                    "overflow": "hidden",
-                    "padding": "0",
-                    "position": "absolute",
-                    "whiteSpace": "nowrap",
-                    "width": "1px",
-                  }
+          <a
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+            href="#age-distribution"
+            onClick={[Function]}
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution
+           
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
                 }
-              >
-                More information
-              </span>
-            </button>
-          </h2>
-        </span>
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
         <p>
           Age distribution is based on the full gnomAD dataset, not the selected subset.
         </p>
@@ -32992,7 +33706,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_topmed" has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="genotype-quality-metrics"
+      >
+        <a
+          aria-label="Copy link to Genotype Quality Metrics"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#genotype-quality-metrics"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Genotype Quality Metrics
       </h2>
       <div>
@@ -34535,7 +35266,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_topmed" has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="site-quality-metrics"
+      >
+        <a
+          aria-label="Copy link to Site Quality Metrics"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#site-quality-metrics"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Site Quality Metrics
       </h2>
       <div
@@ -37096,7 +37844,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_topmed" has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="read-data"
+      >
+        <a
+          aria-label="Copy link to Read Data"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#read-data"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Read Data
       </h2>
       <div
@@ -37805,7 +38570,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_v2" has no unexpected chang
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="external-resources"
+      >
+        <a
+          aria-label="Copy link to External Resources"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#external-resources"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         External Resources
       </h2>
       <ul
@@ -37836,7 +38618,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_v2" has no unexpected chang
           </a>
         </li>
       </ul>
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="feedback"
+      >
+        <a
+          aria-label="Copy link to Feedback"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#feedback"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Feedback
       </h2>
       <a
@@ -37851,8 +38650,26 @@ exports[`VariantPage with the dataset "gnomad_r3_non_v2" has no unexpected chang
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
-        Genetic Ancestry Group Frequencies 
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="genetic-ancestry-group-frequencies"
+      >
+        <a
+          aria-label="Copy link to Genetic Ancestry Group Frequencies"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#genetic-ancestry-group-frequencies"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Genetic Ancestry Group Frequencies
+         
         <button
           className="InfoButton__Button-sc-13t5e82-0 faZoWY"
           onClick={[Function]}
@@ -38600,7 +39417,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_v2" has no unexpected chang
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="related-variants"
+      >
+        <a
+          aria-label="Copy link to Related Variants"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#related-variants"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Related Variants
       </h2>
       <div
@@ -38627,7 +39461,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_v2" has no unexpected chang
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="variant-effect-predictor"
+      >
+        <a
+          aria-label="Copy link to Ensembl Variant Effect Predictor"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#variant-effect-predictor"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Ensembl Variant Effect Predictor
       </h2>
       <div>
@@ -38779,7 +39630,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_v2" has no unexpected chang
       <section
         className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
       >
-        <h2>
+        <h2
+          className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+          id="genomic-constraint"
+        >
+          <a
+            aria-label="Copy link to Genomic Constraint of Surrounding 1kb Region"
+            className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+            href="#genomic-constraint"
+            onClick={[Function]}
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
           Genomic Constraint of Surrounding 1kb Region
         </h2>
         This variant does not have non coding constraint data for the surrounding region.
@@ -38791,56 +39659,55 @@ exports[`VariantPage with the dataset "gnomad_r3_non_v2" has no unexpected chang
       <section
         className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
       >
-        <span
-          className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+        <h2
+          className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+          id="age-distribution"
         >
-          <h2>
-            <a
-              aria-label="Copy link to Age Distribution"
-              className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-              href="#age-distribution"
-              id="age-distribution"
-              onClick={[Function]}
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                height={12}
-                src="test-file-stub"
-                width={12}
-              />
-            </a>
-            Age Distribution 
-            <button
-              className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-              onClick={[Function]}
-              type="button"
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                src="test-file-stub"
-              />
-              <span
-                style={
-                  {
-                    "border": "0",
-                    "clip": "rect(0 0 0 0)",
-                    "height": "1px",
-                    "margin": "-1px",
-                    "overflow": "hidden",
-                    "padding": "0",
-                    "position": "absolute",
-                    "whiteSpace": "nowrap",
-                    "width": "1px",
-                  }
+          <a
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+            href="#age-distribution"
+            onClick={[Function]}
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution
+           
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
                 }
-              >
-                More information
-              </span>
-            </button>
-          </h2>
-        </span>
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
         <p>
           Age distribution is based on the full gnomAD dataset, not the selected subset.
         </p>
@@ -40425,7 +41292,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_v2" has no unexpected chang
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="genotype-quality-metrics"
+      >
+        <a
+          aria-label="Copy link to Genotype Quality Metrics"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#genotype-quality-metrics"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Genotype Quality Metrics
       </h2>
       <div>
@@ -41968,7 +42852,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_v2" has no unexpected chang
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="site-quality-metrics"
+      >
+        <a
+          aria-label="Copy link to Site Quality Metrics"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#site-quality-metrics"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Site Quality Metrics
       </h2>
       <div
@@ -44529,7 +45430,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_v2" has no unexpected chang
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="read-data"
+      >
+        <a
+          aria-label="Copy link to Read Data"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#read-data"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Read Data
       </h2>
       <div
@@ -45165,7 +46083,24 @@ exports[`VariantPage with the dataset exac has no unexpected changes 1`] = `
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="external-resources"
+      >
+        <a
+          aria-label="Copy link to External Resources"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#external-resources"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         External Resources
       </h2>
       <ul
@@ -45184,7 +46119,24 @@ exports[`VariantPage with the dataset exac has no unexpected changes 1`] = `
           </a>
         </li>
       </ul>
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="feedback"
+      >
+        <a
+          aria-label="Copy link to Feedback"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#feedback"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Feedback
       </h2>
       <a
@@ -45199,8 +46151,26 @@ exports[`VariantPage with the dataset exac has no unexpected changes 1`] = `
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
-        Genetic Ancestry Group Frequencies 
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="genetic-ancestry-group-frequencies"
+      >
+        <a
+          aria-label="Copy link to Genetic Ancestry Group Frequencies"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#genetic-ancestry-group-frequencies"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Genetic Ancestry Group Frequencies
+         
         <button
           className="InfoButton__Button-sc-13t5e82-0 faZoWY"
           onClick={[Function]}
@@ -45711,7 +46681,24 @@ exports[`VariantPage with the dataset exac has no unexpected changes 1`] = `
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="related-variants"
+      >
+        <a
+          aria-label="Copy link to Related Variants"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#related-variants"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Related Variants
       </h2>
       <div
@@ -45738,7 +46725,24 @@ exports[`VariantPage with the dataset exac has no unexpected changes 1`] = `
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="variant-effect-predictor"
+      >
+        <a
+          aria-label="Copy link to Ensembl Variant Effect Predictor"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#variant-effect-predictor"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Ensembl Variant Effect Predictor
       </h2>
       <div>
@@ -45893,56 +46897,55 @@ exports[`VariantPage with the dataset exac has no unexpected changes 1`] = `
       <section
         className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
       >
-        <span
-          className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+        <h2
+          className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+          id="age-distribution"
         >
-          <h2>
-            <a
-              aria-label="Copy link to Age Distribution"
-              className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-              href="#age-distribution"
-              id="age-distribution"
-              onClick={[Function]}
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                height={12}
-                src="test-file-stub"
-                width={12}
-              />
-            </a>
-            Age Distribution 
-            <button
-              className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-              onClick={[Function]}
-              type="button"
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                src="test-file-stub"
-              />
-              <span
-                style={
-                  {
-                    "border": "0",
-                    "clip": "rect(0 0 0 0)",
-                    "height": "1px",
-                    "margin": "-1px",
-                    "overflow": "hidden",
-                    "padding": "0",
-                    "position": "absolute",
-                    "whiteSpace": "nowrap",
-                    "width": "1px",
-                  }
+          <a
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+            href="#age-distribution"
+            onClick={[Function]}
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution
+           
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
                 }
-              >
-                More information
-              </span>
-            </button>
-          </h2>
-        </span>
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
         <div>
           <div
             className="GnomadAgeDistribution__LegendWrapper-sc-ty24oq-0 fPhNex"
@@ -46881,7 +47884,24 @@ exports[`VariantPage with the dataset exac has no unexpected changes 1`] = `
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="genotype-quality-metrics"
+      >
+        <a
+          aria-label="Copy link to Genotype Quality Metrics"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#genotype-quality-metrics"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Genotype Quality Metrics
       </h2>
       <div>
@@ -48405,7 +49425,24 @@ exports[`VariantPage with the dataset exac has no unexpected changes 1`] = `
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="site-quality-metrics"
+      >
+        <a
+          aria-label="Copy link to Site Quality Metrics"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#site-quality-metrics"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Site Quality Metrics
       </h2>
       <div
@@ -50749,7 +51786,24 @@ exports[`VariantPage with the dataset exac has no unexpected changes 1`] = `
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="read-data"
+      >
+        <a
+          aria-label="Copy link to Read Data"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#read-data"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Read Data
       </h2>
       <div
@@ -51521,7 +52575,24 @@ exports[`VariantPage with the dataset gnomad_r2_1 has no unexpected changes 1`] 
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="external-resources"
+      >
+        <a
+          aria-label="Copy link to External Resources"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#external-resources"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         External Resources
       </h2>
       <ul
@@ -51540,7 +52611,24 @@ exports[`VariantPage with the dataset gnomad_r2_1 has no unexpected changes 1`] 
           </a>
         </li>
       </ul>
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="feedback"
+      >
+        <a
+          aria-label="Copy link to Feedback"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#feedback"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Feedback
       </h2>
       <a
@@ -51555,8 +52643,26 @@ exports[`VariantPage with the dataset gnomad_r2_1 has no unexpected changes 1`] 
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
-        Genetic Ancestry Group Frequencies 
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="genetic-ancestry-group-frequencies"
+      >
+        <a
+          aria-label="Copy link to Genetic Ancestry Group Frequencies"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#genetic-ancestry-group-frequencies"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Genetic Ancestry Group Frequencies
+         
         <button
           className="InfoButton__Button-sc-13t5e82-0 faZoWY"
           onClick={[Function]}
@@ -52111,7 +53217,24 @@ exports[`VariantPage with the dataset gnomad_r2_1 has no unexpected changes 1`] 
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="related-variants"
+      >
+        <a
+          aria-label="Copy link to Related Variants"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#related-variants"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Related Variants
       </h2>
       <div
@@ -52138,7 +53261,24 @@ exports[`VariantPage with the dataset gnomad_r2_1 has no unexpected changes 1`] 
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="variant-effect-predictor"
+      >
+        <a
+          aria-label="Copy link to Ensembl Variant Effect Predictor"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#variant-effect-predictor"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Ensembl Variant Effect Predictor
       </h2>
       <div>
@@ -52293,56 +53433,55 @@ exports[`VariantPage with the dataset gnomad_r2_1 has no unexpected changes 1`] 
       <section
         className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
       >
-        <span
-          className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+        <h2
+          className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+          id="age-distribution"
         >
-          <h2>
-            <a
-              aria-label="Copy link to Age Distribution"
-              className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-              href="#age-distribution"
-              id="age-distribution"
-              onClick={[Function]}
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                height={12}
-                src="test-file-stub"
-                width={12}
-              />
-            </a>
-            Age Distribution 
-            <button
-              className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-              onClick={[Function]}
-              type="button"
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                src="test-file-stub"
-              />
-              <span
-                style={
-                  {
-                    "border": "0",
-                    "clip": "rect(0 0 0 0)",
-                    "height": "1px",
-                    "margin": "-1px",
-                    "overflow": "hidden",
-                    "padding": "0",
-                    "position": "absolute",
-                    "whiteSpace": "nowrap",
-                    "width": "1px",
-                  }
+          <a
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+            href="#age-distribution"
+            onClick={[Function]}
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution
+           
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
                 }
-              >
-                More information
-              </span>
-            </button>
-          </h2>
-        </span>
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
         <div>
           <div
             className="GnomadAgeDistribution__LegendWrapper-sc-ty24oq-0 fPhNex"
@@ -54053,7 +55192,24 @@ exports[`VariantPage with the dataset gnomad_r2_1 has no unexpected changes 1`] 
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="genotype-quality-metrics"
+      >
+        <a
+          aria-label="Copy link to Genotype Quality Metrics"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#genotype-quality-metrics"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Genotype Quality Metrics
       </h2>
       <div>
@@ -55599,7 +56755,24 @@ exports[`VariantPage with the dataset gnomad_r2_1 has no unexpected changes 1`] 
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="site-quality-metrics"
+      >
+        <a
+          aria-label="Copy link to Site Quality Metrics"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#site-quality-metrics"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Site Quality Metrics
       </h2>
       <div
@@ -58300,7 +59473,24 @@ exports[`VariantPage with the dataset gnomad_r2_1 has no unexpected changes 1`] 
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="read-data"
+      >
+        <a
+          aria-label="Copy link to Read Data"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#read-data"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Read Data
       </h2>
       <div
@@ -59072,7 +60262,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_controls has no unexpected cha
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="external-resources"
+      >
+        <a
+          aria-label="Copy link to External Resources"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#external-resources"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         External Resources
       </h2>
       <ul
@@ -59091,7 +60298,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_controls has no unexpected cha
           </a>
         </li>
       </ul>
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="feedback"
+      >
+        <a
+          aria-label="Copy link to Feedback"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#feedback"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Feedback
       </h2>
       <a
@@ -59106,8 +60330,26 @@ exports[`VariantPage with the dataset gnomad_r2_1_controls has no unexpected cha
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
-        Genetic Ancestry Group Frequencies 
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="genetic-ancestry-group-frequencies"
+      >
+        <a
+          aria-label="Copy link to Genetic Ancestry Group Frequencies"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#genetic-ancestry-group-frequencies"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Genetic Ancestry Group Frequencies
+         
         <button
           className="InfoButton__Button-sc-13t5e82-0 faZoWY"
           onClick={[Function]}
@@ -59662,7 +60904,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_controls has no unexpected cha
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="related-variants"
+      >
+        <a
+          aria-label="Copy link to Related Variants"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#related-variants"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Related Variants
       </h2>
       <div
@@ -59689,7 +60948,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_controls has no unexpected cha
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="variant-effect-predictor"
+      >
+        <a
+          aria-label="Copy link to Ensembl Variant Effect Predictor"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#variant-effect-predictor"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Ensembl Variant Effect Predictor
       </h2>
       <div>
@@ -59844,56 +61120,55 @@ exports[`VariantPage with the dataset gnomad_r2_1_controls has no unexpected cha
       <section
         className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
       >
-        <span
-          className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+        <h2
+          className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+          id="age-distribution"
         >
-          <h2>
-            <a
-              aria-label="Copy link to Age Distribution"
-              className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-              href="#age-distribution"
-              id="age-distribution"
-              onClick={[Function]}
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                height={12}
-                src="test-file-stub"
-                width={12}
-              />
-            </a>
-            Age Distribution 
-            <button
-              className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-              onClick={[Function]}
-              type="button"
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                src="test-file-stub"
-              />
-              <span
-                style={
-                  {
-                    "border": "0",
-                    "clip": "rect(0 0 0 0)",
-                    "height": "1px",
-                    "margin": "-1px",
-                    "overflow": "hidden",
-                    "padding": "0",
-                    "position": "absolute",
-                    "whiteSpace": "nowrap",
-                    "width": "1px",
-                  }
+          <a
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+            href="#age-distribution"
+            onClick={[Function]}
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution
+           
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
                 }
-              >
-                More information
-              </span>
-            </button>
-          </h2>
-        </span>
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
         <div>
           <div
             className="GnomadAgeDistribution__LegendWrapper-sc-ty24oq-0 fPhNex"
@@ -61604,7 +62879,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_controls has no unexpected cha
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="genotype-quality-metrics"
+      >
+        <a
+          aria-label="Copy link to Genotype Quality Metrics"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#genotype-quality-metrics"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Genotype Quality Metrics
       </h2>
       <div>
@@ -63150,7 +64442,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_controls has no unexpected cha
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="site-quality-metrics"
+      >
+        <a
+          aria-label="Copy link to Site Quality Metrics"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#site-quality-metrics"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Site Quality Metrics
       </h2>
       <div
@@ -65851,7 +67160,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_controls has no unexpected cha
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="read-data"
+      >
+        <a
+          aria-label="Copy link to Read Data"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#read-data"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Read Data
       </h2>
       <div
@@ -66623,7 +67949,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_cancer has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="external-resources"
+      >
+        <a
+          aria-label="Copy link to External Resources"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#external-resources"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         External Resources
       </h2>
       <ul
@@ -66642,7 +67985,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_cancer has no unexpected c
           </a>
         </li>
       </ul>
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="feedback"
+      >
+        <a
+          aria-label="Copy link to Feedback"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#feedback"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Feedback
       </h2>
       <a
@@ -66657,8 +68017,26 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_cancer has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
-        Genetic Ancestry Group Frequencies 
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="genetic-ancestry-group-frequencies"
+      >
+        <a
+          aria-label="Copy link to Genetic Ancestry Group Frequencies"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#genetic-ancestry-group-frequencies"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Genetic Ancestry Group Frequencies
+         
         <button
           className="InfoButton__Button-sc-13t5e82-0 faZoWY"
           onClick={[Function]}
@@ -67213,7 +68591,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_cancer has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="related-variants"
+      >
+        <a
+          aria-label="Copy link to Related Variants"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#related-variants"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Related Variants
       </h2>
       <div
@@ -67240,7 +68635,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_cancer has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="variant-effect-predictor"
+      >
+        <a
+          aria-label="Copy link to Ensembl Variant Effect Predictor"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#variant-effect-predictor"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Ensembl Variant Effect Predictor
       </h2>
       <div>
@@ -67395,56 +68807,55 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_cancer has no unexpected c
       <section
         className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
       >
-        <span
-          className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+        <h2
+          className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+          id="age-distribution"
         >
-          <h2>
-            <a
-              aria-label="Copy link to Age Distribution"
-              className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-              href="#age-distribution"
-              id="age-distribution"
-              onClick={[Function]}
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                height={12}
-                src="test-file-stub"
-                width={12}
-              />
-            </a>
-            Age Distribution 
-            <button
-              className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-              onClick={[Function]}
-              type="button"
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                src="test-file-stub"
-              />
-              <span
-                style={
-                  {
-                    "border": "0",
-                    "clip": "rect(0 0 0 0)",
-                    "height": "1px",
-                    "margin": "-1px",
-                    "overflow": "hidden",
-                    "padding": "0",
-                    "position": "absolute",
-                    "whiteSpace": "nowrap",
-                    "width": "1px",
-                  }
+          <a
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+            href="#age-distribution"
+            onClick={[Function]}
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution
+           
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
                 }
-              >
-                More information
-              </span>
-            </button>
-          </h2>
-        </span>
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
         <div>
           <div
             className="GnomadAgeDistribution__LegendWrapper-sc-ty24oq-0 fPhNex"
@@ -69155,7 +70566,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_cancer has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="genotype-quality-metrics"
+      >
+        <a
+          aria-label="Copy link to Genotype Quality Metrics"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#genotype-quality-metrics"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Genotype Quality Metrics
       </h2>
       <div>
@@ -70701,7 +72129,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_cancer has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="site-quality-metrics"
+      >
+        <a
+          aria-label="Copy link to Site Quality Metrics"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#site-quality-metrics"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Site Quality Metrics
       </h2>
       <div
@@ -73402,7 +74847,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_cancer has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="read-data"
+      >
+        <a
+          aria-label="Copy link to Read Data"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#read-data"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Read Data
       </h2>
       <div
@@ -74174,7 +75636,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_neuro has no unexpected ch
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="external-resources"
+      >
+        <a
+          aria-label="Copy link to External Resources"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#external-resources"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         External Resources
       </h2>
       <ul
@@ -74193,7 +75672,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_neuro has no unexpected ch
           </a>
         </li>
       </ul>
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="feedback"
+      >
+        <a
+          aria-label="Copy link to Feedback"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#feedback"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Feedback
       </h2>
       <a
@@ -74208,8 +75704,26 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_neuro has no unexpected ch
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
-        Genetic Ancestry Group Frequencies 
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="genetic-ancestry-group-frequencies"
+      >
+        <a
+          aria-label="Copy link to Genetic Ancestry Group Frequencies"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#genetic-ancestry-group-frequencies"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Genetic Ancestry Group Frequencies
+         
         <button
           className="InfoButton__Button-sc-13t5e82-0 faZoWY"
           onClick={[Function]}
@@ -74764,7 +76278,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_neuro has no unexpected ch
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="related-variants"
+      >
+        <a
+          aria-label="Copy link to Related Variants"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#related-variants"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Related Variants
       </h2>
       <div
@@ -74791,7 +76322,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_neuro has no unexpected ch
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="variant-effect-predictor"
+      >
+        <a
+          aria-label="Copy link to Ensembl Variant Effect Predictor"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#variant-effect-predictor"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Ensembl Variant Effect Predictor
       </h2>
       <div>
@@ -74946,56 +76494,55 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_neuro has no unexpected ch
       <section
         className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
       >
-        <span
-          className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+        <h2
+          className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+          id="age-distribution"
         >
-          <h2>
-            <a
-              aria-label="Copy link to Age Distribution"
-              className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-              href="#age-distribution"
-              id="age-distribution"
-              onClick={[Function]}
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                height={12}
-                src="test-file-stub"
-                width={12}
-              />
-            </a>
-            Age Distribution 
-            <button
-              className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-              onClick={[Function]}
-              type="button"
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                src="test-file-stub"
-              />
-              <span
-                style={
-                  {
-                    "border": "0",
-                    "clip": "rect(0 0 0 0)",
-                    "height": "1px",
-                    "margin": "-1px",
-                    "overflow": "hidden",
-                    "padding": "0",
-                    "position": "absolute",
-                    "whiteSpace": "nowrap",
-                    "width": "1px",
-                  }
+          <a
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+            href="#age-distribution"
+            onClick={[Function]}
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution
+           
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
                 }
-              >
-                More information
-              </span>
-            </button>
-          </h2>
-        </span>
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
         <div>
           <div
             className="GnomadAgeDistribution__LegendWrapper-sc-ty24oq-0 fPhNex"
@@ -76706,7 +78253,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_neuro has no unexpected ch
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="genotype-quality-metrics"
+      >
+        <a
+          aria-label="Copy link to Genotype Quality Metrics"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#genotype-quality-metrics"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Genotype Quality Metrics
       </h2>
       <div>
@@ -78252,7 +79816,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_neuro has no unexpected ch
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="site-quality-metrics"
+      >
+        <a
+          aria-label="Copy link to Site Quality Metrics"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#site-quality-metrics"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Site Quality Metrics
       </h2>
       <div
@@ -80953,7 +82534,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_neuro has no unexpected ch
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="read-data"
+      >
+        <a
+          aria-label="Copy link to Read Data"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#read-data"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Read Data
       </h2>
       <div
@@ -81725,7 +83323,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_topmed has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="external-resources"
+      >
+        <a
+          aria-label="Copy link to External Resources"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#external-resources"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         External Resources
       </h2>
       <ul
@@ -81744,7 +83359,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_topmed has no unexpected c
           </a>
         </li>
       </ul>
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="feedback"
+      >
+        <a
+          aria-label="Copy link to Feedback"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#feedback"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Feedback
       </h2>
       <a
@@ -81759,8 +83391,26 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_topmed has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
-        Genetic Ancestry Group Frequencies 
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="genetic-ancestry-group-frequencies"
+      >
+        <a
+          aria-label="Copy link to Genetic Ancestry Group Frequencies"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#genetic-ancestry-group-frequencies"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Genetic Ancestry Group Frequencies
+         
         <button
           className="InfoButton__Button-sc-13t5e82-0 faZoWY"
           onClick={[Function]}
@@ -82315,7 +83965,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_topmed has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="related-variants"
+      >
+        <a
+          aria-label="Copy link to Related Variants"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#related-variants"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Related Variants
       </h2>
       <div
@@ -82342,7 +84009,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_topmed has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="variant-effect-predictor"
+      >
+        <a
+          aria-label="Copy link to Ensembl Variant Effect Predictor"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#variant-effect-predictor"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Ensembl Variant Effect Predictor
       </h2>
       <div>
@@ -82497,56 +84181,55 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_topmed has no unexpected c
       <section
         className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
       >
-        <span
-          className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+        <h2
+          className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+          id="age-distribution"
         >
-          <h2>
-            <a
-              aria-label="Copy link to Age Distribution"
-              className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-              href="#age-distribution"
-              id="age-distribution"
-              onClick={[Function]}
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                height={12}
-                src="test-file-stub"
-                width={12}
-              />
-            </a>
-            Age Distribution 
-            <button
-              className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-              onClick={[Function]}
-              type="button"
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                src="test-file-stub"
-              />
-              <span
-                style={
-                  {
-                    "border": "0",
-                    "clip": "rect(0 0 0 0)",
-                    "height": "1px",
-                    "margin": "-1px",
-                    "overflow": "hidden",
-                    "padding": "0",
-                    "position": "absolute",
-                    "whiteSpace": "nowrap",
-                    "width": "1px",
-                  }
+          <a
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+            href="#age-distribution"
+            onClick={[Function]}
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution
+           
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
                 }
-              >
-                More information
-              </span>
-            </button>
-          </h2>
-        </span>
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
         <div>
           <div
             className="GnomadAgeDistribution__LegendWrapper-sc-ty24oq-0 fPhNex"
@@ -84257,7 +85940,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_topmed has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="genotype-quality-metrics"
+      >
+        <a
+          aria-label="Copy link to Genotype Quality Metrics"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#genotype-quality-metrics"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Genotype Quality Metrics
       </h2>
       <div>
@@ -85803,7 +87503,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_topmed has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="site-quality-metrics"
+      >
+        <a
+          aria-label="Copy link to Site Quality Metrics"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#site-quality-metrics"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Site Quality Metrics
       </h2>
       <div
@@ -88504,7 +90221,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_topmed has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="read-data"
+      >
+        <a
+          aria-label="Copy link to Read Data"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#read-data"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Read Data
       </h2>
       <div

--- a/browser/src/help/HelpPage.tsx
+++ b/browser/src/help/HelpPage.tsx
@@ -8,15 +8,15 @@ import { Button, Link as BaseLink, List, ListItem, PageHeading, Searchbox } from
 
 import helpPageTableOfContents, { FaqTopic } from '../../help/helpPageTableOfContents'
 
-import { withAnchor } from '../AnchorLink'
+import { SectionHeading, withAnchor } from '../AnchorLink'
 import DocumentTitle from '../DocumentTitle'
 import Link from '../Link'
+import useScrollToHash from '../useScrollToHash'
 
 import helpTopics, { indexTexts } from './helpTopics' // eslint-disable-line import/no-unresolved,import/extensions
 import slugify from './slugify'
 
-export const SectionHeading = withAnchor(styled.h2``)
-export const SectionSubheading = withAnchor(styled.h3`
+const SectionSubheading = withAnchor(styled.h3`
   margin-bottom: 0.5em;
 `)
 
@@ -72,7 +72,7 @@ const HelpContentWrapper = styled.div`
   overflow: auto;
   box-sizing: border-box;
   width: 100%;
-  padding: 0 15px;
+  padding: 0 15px 0 44px;
 `
 
 const HelpContent = styled.div`
@@ -118,6 +118,7 @@ const ToggleButton = styled(Button)`
 `
 
 const HelpPage = () => {
+  useScrollToHash()
   const history = useHistory()
 
   return (
@@ -190,9 +191,11 @@ const HelpPage = () => {
           </section>
 
           <section>
-            <SectionHeading id="frequently-asked-questions">
-              Frequently asked questions
-            </SectionHeading>
+            <SectionHeading
+              id="frequently-asked-questions"
+              title="Frequently asked questions"
+              linkInGutter
+            />
             {helpPageTableOfContents.faq.map((section: FaqTopic) => (
               <div key={section.heading}>
                 <SectionSubheading id={slugify(section.heading)}>

--- a/browser/src/help/__snapshots__/HelpPage.spec.tsx.snap
+++ b/browser/src/help/__snapshots__/HelpPage.spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Help Page has no unexpected changes 1`] = `
-.c15 {
+.c18 {
   box-sizing: border-box;
   height: calc(2em + 2px);
   padding: 0.375em 0.75em;
@@ -17,21 +17,21 @@ exports[`Help Page has no unexpected changes 1`] = `
   user-select: none;
 }
 
-.c15:active,
-.c15:hover {
+.c18:active,
+.c18:hover {
   background-color: #cbd3da;
 }
 
-.c15:disabled {
+.c18:disabled {
   background-color: rgba(248,249,250,0.5);
   cursor: not-allowed;
 }
 
-.c15:focus {
+.c18:focus {
   box-shadow: 0 0 0 0.2em rgba(108,117,125,0.5);
 }
 
-.c15 svg {
+.c18 svg {
   position: relative;
   top: 0.11em;
   width: 0.9em;
@@ -105,7 +105,7 @@ exports[`Help Page has no unexpected changes 1`] = `
   background-image: none;
 }
 
-.c28 {
+.c31 {
   height: calc(2em + 2px);
   padding: 0.375em 1.5em 0.375em 0.75em;
   border: 1px solid #6c757d;
@@ -118,42 +118,42 @@ exports[`Help Page has no unexpected changes 1`] = `
   line-height: 1.25;
 }
 
-.c28:focus {
+.c31:focus {
   outline: none;
   border-color: rgb(70,130,180);
   box-shadow: 0 0 0 0.2em rgba(70,130,180,0.5);
 }
 
-.c21 {
+.c24 {
   border-collapse: collapse;
   border-spacing: 0;
 }
 
-.c21 td,
-.c21 th {
+.c24 td,
+.c24 th {
   padding: 0.5em 10px 0.5em 0;
   text-align: left;
 }
 
-.c21 thead td,
-.c21 thead th {
+.c24 thead td,
+.c24 thead th {
   border-bottom: 1px solid #000;
   background-position: center right;
   background-repeat: no-repeat;
 }
 
-.c21 thead td[aria-sort='ascending'],
-.c21 thead th[aria-sort='ascending'] {
+.c24 thead td[aria-sort='ascending'],
+.c24 thead th[aria-sort='ascending'] {
   background-image: url('data:image/gif;base64,R0lGODlhFQAEAIAAACMtMP///yH5BAEAAAEALAAAAAAVAAQAAAINjI8Bya2wnINUMopZAQA7');
 }
 
-.c21 thead td[aria-sort='descending'],
-.c21 thead th[aria-sort='descending'] {
+.c24 thead td[aria-sort='descending'],
+.c24 thead th[aria-sort='descending'] {
   background-image: url('data:image/gif;base64,R0lGODlhFQAEAIAAACMtMP///yH5BAEAAAEALAAAAAAVAAQAAAINjB+gC+jP2ptn0WskLQA7');
 }
 
-.c21 thead td button,
-.c21 thead th button {
+.c24 thead td button,
+.c24 thead th button {
   padding: 0;
   border: none;
   background: none;
@@ -164,19 +164,19 @@ exports[`Help Page has no unexpected changes 1`] = `
   user-select: none;
 }
 
-.c21 tbody td,
-.c21 tbody th {
+.c24 tbody td,
+.c24 tbody th {
   border-bottom: 1px solid #ccc;
   font-weight: normal;
 }
 
-.c21 tfoot td,
-.c21 tfoot th {
+.c24 tfoot td,
+.c24 tfoot th {
   border-top: 1px solid #ccc;
   font-weight: bold;
 }
 
-.c13 {
+.c17 {
   position: absolute;
   transform: translate(-15px,calc(50% - 0.5em));
   display: flex;
@@ -187,21 +187,66 @@ exports[`Help Page has no unexpected changes 1`] = `
   vertical-align: middle;
 }
 
-.c11 {
+.c14 {
   position: relative;
 }
 
-.c11 :hover .c12 {
+.c14 :hover .c16 {
   visibility: visible;
 }
 
-.c20 {
+.c12 {
+  position: relative;
+}
+
+.c13 {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  transform: translate(-29px,-50%);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  width: 44px;
+  height: 44px;
+  opacity: 0;
+  vertical-align: middle;
+}
+
+.c13 :hover,
+.c13 :focus,
+.c13 :focus-visible,
+.c11:hover .c13,
+.c11:focus-within .c13 {
+  opacity: 1;
+}
+
+.c13 :focus,
+.c13 :focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: -8px;
+}
+
+.c23 {
   overflow-x: auto;
   overflow-y: hidden;
 }
 
-.c30 {
+.c33 {
   margin-top: 1em;
+  margin-bottom: 1em;
+}
+
+.c33 td {
+  text-align: right;
+}
+
+.c32 {
+  margin: 1em 1em 0 0;
+}
+
+.c30 {
   margin-bottom: 1em;
 }
 
@@ -209,94 +254,82 @@ exports[`Help Page has no unexpected changes 1`] = `
   text-align: right;
 }
 
-.c29 {
-  margin: 1em 1em 0 0;
-}
-
-.c27 {
-  margin-bottom: 1em;
-}
-
-.c27 td {
+.c25 td {
   text-align: right;
 }
 
-.c22 td {
-  text-align: right;
-}
-
-.c22 tbody tr:last-child th,
-.c22 tbody tr:last-child td {
+.c25 tbody tr:last-child th,
+.c25 tbody tr:last-child td {
   border-bottom-color: #000;
 }
 
-.c25 {
+.c28 {
   overflow: hidden;
   width: 100%;
   height: 100%;
   margin-bottom: 1em;
 }
 
-.c26 {
+.c29 {
   pointer-events: visible;
   fill: none;
 }
 
-.c26:hover {
+.c29:hover {
   fill: rgba(0,0,0,0.05);
 }
 
-.c23 {
+.c26 {
   display: flex;
   flex-direction: row;
 }
 
-.c24 {
+.c27 {
   width: calc(50% - 15px);
 }
 
-.c19 {
+.c22 {
   --code-background-color: #eef0f3;
   font-size: 16px;
 }
 
-.c19 h1,
-.c19 h2,
-.c19 h3 {
+.c22 h1,
+.c22 h2,
+.c22 h3 {
   font-weight: bold;
 }
 
-.c19 h1 {
+.c22 h1 {
   font-size: 2em;
 }
 
-.c19 h2 {
+.c22 h2 {
   font-size: 1.5em;
 }
 
-.c19 p {
+.c22 p {
   margin-top: 15px;
   margin-bottom: 15px;
   line-height: 1.6;
 }
 
-.c19 a {
+.c22 a {
   color: #428bca;
   text-decoration: none;
 }
 
-.c19 img {
+.c22 img {
   max-width: 100%;
 }
 
-.c19 blockquote {
+.c22 blockquote {
   margin: 0 0 0 10px;
   font-size: 14px;
   font-style: italic;
   line-height: 1.4;
 }
 
-.c19 code {
+.c22 code {
   padding: 0.15em 0.35em;
   border: 1px solid rgba(0,0,0,0.1);
   border-radius: 0.3em;
@@ -305,7 +338,7 @@ exports[`Help Page has no unexpected changes 1`] = `
   font-size: 0.9em;
 }
 
-.c19 pre {
+.c22 pre {
   overflow-x: auto;
   padding: 1em;
   border: 1px solid rgba(0,0,0,0.1);
@@ -315,7 +348,7 @@ exports[`Help Page has no unexpected changes 1`] = `
   line-height: 1.5;
 }
 
-.c19 pre code {
+.c22 pre code {
   padding: 0;
   border: 0;
   border-radius: 0;
@@ -323,23 +356,23 @@ exports[`Help Page has no unexpected changes 1`] = `
   font-size: 0.875em;
 }
 
-.c19 ol,
-.c19 ul {
+.c22 ol,
+.c22 ul {
   padding-left: 20px;
   margin: 1em 0;
 }
 
-.c19 li {
+.c22 li {
   margin-bottom: 0.5em;
   line-height: 1.6;
 }
 
-.c19 table {
+.c22 table {
   border-collapse: collapse;
   border-spacing: 0;
 }
 
-.c19 td {
+.c22 td {
   padding: 0.5em 10px 0.5em 0;
   border-bottom: 1px solid #ccc;
   font-weight: normal;
@@ -347,7 +380,7 @@ exports[`Help Page has no unexpected changes 1`] = `
   text-align: left;
 }
 
-.c19 th {
+.c22 th {
   padding: 0.5em 10px 0.5em 0;
   border-bottom: 1px solid #000;
   background-position: center right;
@@ -356,7 +389,7 @@ exports[`Help Page has no unexpected changes 1`] = `
   line-height: 1.6;
 }
 
-.c14 {
+.c15 {
   margin-bottom: 0.5em;
 }
 
@@ -394,7 +427,7 @@ exports[`Help Page has no unexpected changes 1`] = `
   overflow: auto;
   box-sizing: border-box;
   width: 100%;
-  padding: 0 15px;
+  padding: 0 15px 0 44px;
 }
 
 .c6 {
@@ -406,32 +439,32 @@ exports[`Help Page has no unexpected changes 1`] = `
   line-height: 1.4;
 }
 
-.c17 {
+.c20 {
   padding-left: 0;
   list-style-type: none;
   margin-bottom: 1em;
 }
 
-.c17 summary {
+.c20 summary {
   padding: 0.25em;
   cursor: pointer;
 }
 
-.c17 summary h4 {
+.c20 summary h4 {
   display: inline;
   font-weight: normal;
 }
 
-.c17 details[open] summary h4 {
+.c20 details[open] summary h4 {
   font-weight: bold;
 }
 
-.c18 {
+.c21 {
   padding-left: 10px;
   border-left: 1px solid #999;
 }
 
-.c16 {
+.c19 {
   font-size: 12px;
 }
 
@@ -454,14 +487,28 @@ exports[`Help Page has no unexpected changes 1`] = `
   }
 }
 
+@media (hover:none) {
+  .c13 {
+    opacity: 1;
+  }
+}
+
+@media (max-width:1230px) {
+  .c13 {
+    position: static;
+    transform: none;
+    display: inline-flex;
+  }
+}
+
 @media (max-width:700px) {
-  .c23 {
+  .c26 {
     flex-direction: column;
   }
 }
 
 @media (max-width:700px) {
-  .c24 {
+  .c27 {
     width: 100%;
   }
 }
@@ -1006,39 +1053,48 @@ exports[`Help Page has no unexpected changes 1`] = `
         </ul>
       </section>
       <section>
-        <span
-          className="c11"
+        <h2
+          className="c11 c12"
+          id="frequently-asked-questions"
+          style={
+            {
+              "padding": "8px 0",
+            }
+          }
         >
-          <h2
-            className=""
+          <a
+            aria-label="Copy link to Frequently asked questions"
+            className="c13"
+            href="#frequently-asked-questions"
+            onClick={[Function]}
+            style={
+              {
+                "display": "flex",
+                "position": "absolute",
+                "transform": "translate(-100%, -50%)",
+              }
+            }
           >
-            <a
+            <img
+              alt=""
               aria-hidden="true"
-              className="c12 c13"
-              href="#frequently-asked-questions"
-              id="frequently-asked-questions"
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                height={12}
-                src="test-file-stub"
-                width={12}
-              />
-            </a>
-            Frequently asked questions
-          </h2>
-        </span>
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Frequently asked questions
+        </h2>
         <div>
           <span
-            className="c11"
+            className="c14"
           >
             <h3
-              className="c14"
+              className="c15"
             >
               <a
                 aria-hidden="true"
-                className="c12 c13"
+                className="c16 c17"
                 href="#general"
                 id="general"
               >
@@ -1056,7 +1112,7 @@ exports[`Help Page has no unexpected changes 1`] = `
           <button
             backgroundColor="#f8f9fa"
             borderColor="#6c757d"
-            className="c15 c16"
+            className="c18 c19"
             onClick={[Function]}
             type="button"
           >
@@ -1066,14 +1122,14 @@ exports[`Help Page has no unexpected changes 1`] = `
           <button
             backgroundColor="#f8f9fa"
             borderColor="#6c757d"
-            className="c15 c16"
+            className="c18 c19"
             onClick={[Function]}
             type="button"
           >
             Hide all answers in this section
           </button>
           <ul
-            className="c17"
+            className="c20"
           >
             <li>
               <details>
@@ -1083,10 +1139,10 @@ exports[`Help Page has no unexpected changes 1`] = `
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1112,10 +1168,10 @@ The gnomAD v2.1 data set contained data from 125,748 exomes and 15,708 whole gen
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1151,10 +1207,10 @@ Below is a list of all features not included in the v4 MVP and where to find the
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1182,10 +1238,10 @@ Yes, we have a few different videos that cover how gnomAD is created as well as 
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1209,10 +1265,10 @@ Please see our terms of use and other policies on our [policy page](/policies).
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1236,10 +1292,10 @@ The gnomAD resource does not currently have permission, access, or staffing to i
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1263,10 +1319,10 @@ question: 'Can I get access to individual-level genotype data from gnomAD?'
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1298,10 +1354,10 @@ All investigators who contribute data to gnomAD join the gnomAD Consortium. See 
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1329,10 +1385,10 @@ Likely because of differences between the projects in sample inclusion and varia
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1363,10 +1419,10 @@ More details on our QC process can be found in our blog posts:
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1390,10 +1446,10 @@ With 730,947 exomes and 76,215 genomes, the gnomAD v4.1 call set is the largest 
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1417,10 +1473,10 @@ Short read sequencing can produce mapping issues when a gene has a highly homolo
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1449,10 +1505,10 @@ question: 'How do you pronounce gnomAD?'
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1472,14 +1528,14 @@ Our policy is to release allele counts (AC) as they are observed in the database
         </div>
         <div>
           <span
-            className="c11"
+            className="c14"
           >
             <h3
-              className="c14"
+              className="c15"
             >
               <a
                 aria-hidden="true"
-                className="c12 c13"
+                className="c16 c17"
                 href="#constraint"
                 id="constraint"
               >
@@ -1497,7 +1553,7 @@ Our policy is to release allele counts (AC) as they are observed in the database
           <button
             backgroundColor="#f8f9fa"
             borderColor="#6c757d"
-            className="c15 c16"
+            className="c18 c19"
             onClick={[Function]}
             type="button"
           >
@@ -1507,14 +1563,14 @@ Our policy is to release allele counts (AC) as they are observed in the database
           <button
             backgroundColor="#f8f9fa"
             borderColor="#6c757d"
-            className="c15 c16"
+            className="c18 c19"
             onClick={[Function]}
             type="button"
           >
             Hide all answers in this section
           </button>
           <ul
-            className="c17"
+            className="c20"
           >
             <li>
               <details>
@@ -1524,10 +1580,10 @@ Our policy is to release allele counts (AC) as they are observed in the database
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1551,10 +1607,10 @@ We used a mutational model that accounts for local sequence context, CpG methyla
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1578,10 +1634,10 @@ Please review our [gene constraint](/help/constraint#methods) help text to learn
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1605,10 +1661,10 @@ We only included single nucleotide variants that were found in the MANE Select (
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1632,10 +1688,10 @@ Nonsense, splice acceptor, and splice donor variants caused by single nucleotide
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1671,10 +1727,10 @@ In addition, there are 19 MANE select transcripts that are missing constraint sc
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1700,10 +1756,10 @@ LOEUF stands for the "loss-of-function observed/expected upper bound fraction." 
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1727,10 +1783,10 @@ LOEUF is pronounced like its French-inspired name "l'œuf". Another accepted pro
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1750,14 +1806,14 @@ Descriptions of the fields in these files can be found in the [README file](/dow
         </div>
         <div>
           <span
-            className="c11"
+            className="c14"
           >
             <h3
-              className="c14"
+              className="c15"
             >
               <a
                 aria-hidden="true"
-                className="c12 c13"
+                className="c16 c17"
                 href="#technical-details"
                 id="technical-details"
               >
@@ -1775,7 +1831,7 @@ Descriptions of the fields in these files can be found in the [README file](/dow
           <button
             backgroundColor="#f8f9fa"
             borderColor="#6c757d"
-            className="c15 c16"
+            className="c18 c19"
             onClick={[Function]}
             type="button"
           >
@@ -1785,14 +1841,14 @@ Descriptions of the fields in these files can be found in the [README file](/dow
           <button
             backgroundColor="#f8f9fa"
             borderColor="#6c757d"
-            className="c15 c16"
+            className="c18 c19"
             onClick={[Function]}
             type="button"
           >
             Hide all answers in this section
           </button>
           <ul
-            className="c17"
+            className="c20"
           >
             <li>
               <details>
@@ -1802,10 +1858,10 @@ Descriptions of the fields in these files can be found in the [README file](/dow
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1829,10 +1885,10 @@ gnomAD v4 and v3 are based on GRCh38, and gnomAD v2 and ExAC files are based on 
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1856,10 +1912,10 @@ We use VEP to annotate variants on GENCODE transcripts. For details on the versi
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1883,10 +1939,10 @@ The majority of samples from the 1000 Genomes Project for which exome sequencing
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1910,10 +1966,10 @@ No. We were not given permission from NHLBI to include individuals from several 
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1938,10 +1994,10 @@ All of the "cancer" samples in ExAC and v2 are blood ("germline") samples from T
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1965,7 +2021,7 @@ See [ancestry documentation](/help/ancestry) and [blog post](https://gnomad.broa
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div>
                     <div>
@@ -2005,10 +2061,10 @@ See [ancestry documentation](/help/ancestry) and [blog post](https://gnomad.broa
                           gnomAD v3
                         </h4>
                         <div
-                          className="c20"
+                          className="c23"
                         >
                           <table
-                            className="c21 c22"
+                            className="c24 c25"
                           >
                             <thead>
                               <tr>
@@ -2387,10 +2443,10 @@ See [ancestry documentation](/help/ancestry) and [blog post](https://gnomad.broa
                           gnomAD v2
                         </h4>
                         <div
-                          className="c20"
+                          className="c23"
                         >
                           <table
-                            className="c21 c22"
+                            className="c24 c25"
                           >
                             <thead>
                               <tr>
@@ -2953,10 +3009,10 @@ See [ancestry documentation](/help/ancestry) and [blog post](https://gnomad.broa
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -2980,10 +3036,10 @@ Individuals were classified as "remaining individuals" if they did not unambiguo
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -3048,22 +3104,22 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <p>
                     For gnomAD v4, the age distribution is:
                   </p>
                   <div
-                    className="c23"
+                    className="c26"
                   >
                     <div
-                      className="c24"
+                      className="c27"
                     >
                       <p>
                         Exomes
                       </p>
                       <div
-                        className="c25"
+                        className="c28"
                       >
                         <svg
                           height={250}
@@ -4153,7 +4209,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                               y={170.2124439358423}
                             />
                             <rect
-                              className="c26"
+                              className="c29"
                               height={180}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
@@ -4170,7 +4226,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                               y={174.45670831872127}
                             />
                             <rect
-                              className="c26"
+                              className="c29"
                               height={180}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
@@ -4187,7 +4243,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                               y={173.67762417172705}
                             />
                             <rect
-                              className="c26"
+                              className="c29"
                               height={180}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
@@ -4204,7 +4260,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                               y={102.9653555805755}
                             />
                             <rect
-                              className="c26"
+                              className="c29"
                               height={180}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
@@ -4221,7 +4277,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                               y={78.89846619538936}
                             />
                             <rect
-                              className="c26"
+                              className="c29"
                               height={180}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
@@ -4238,7 +4294,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                               y={62.019417117333276}
                             />
                             <rect
-                              className="c26"
+                              className="c29"
                               height={180}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
@@ -4255,7 +4311,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                               y={42.07718857860057}
                             />
                             <rect
-                              className="c26"
+                              className="c29"
                               height={180}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
@@ -4272,7 +4328,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                               y={0}
                             />
                             <rect
-                              className="c26"
+                              className="c29"
                               height={180}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
@@ -4289,7 +4345,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                               y={41.57717934993262}
                             />
                             <rect
-                              className="c26"
+                              className="c29"
                               height={180}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
@@ -4306,7 +4362,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                               y={169.54797984458924}
                             />
                             <rect
-                              className="c26"
+                              className="c29"
                               height={180}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
@@ -4323,7 +4379,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                               y={175.32549511803467}
                             />
                             <rect
-                              className="c26"
+                              className="c29"
                               height={180}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
@@ -4340,7 +4396,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                               y={176.7607375551413}
                             />
                             <rect
-                              className="c26"
+                              className="c29"
                               height={180}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
@@ -4353,13 +4409,13 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                       </div>
                     </div>
                     <div
-                      className="c24"
+                      className="c27"
                     >
                       <p>
                         Genomes
                       </p>
                       <div
-                        className="c25"
+                        className="c28"
                       >
                         <svg
                           height={250}
@@ -5363,7 +5419,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                               y={21.979920616390384}
                             />
                             <rect
-                              className="c26"
+                              className="c29"
                               height={180}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
@@ -5380,7 +5436,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                               y={124.02054634601916}
                             />
                             <rect
-                              className="c26"
+                              className="c29"
                               height={180}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
@@ -5397,7 +5453,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                               y={121.12070978286248}
                             />
                             <rect
-                              className="c26"
+                              className="c29"
                               height={180}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
@@ -5414,7 +5470,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                               y={110.99229512024282}
                             />
                             <rect
-                              className="c26"
+                              className="c29"
                               height={180}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
@@ -5431,7 +5487,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                               y={56.06350688769553}
                             />
                             <rect
-                              className="c26"
+                              className="c29"
                               height={180}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
@@ -5448,7 +5504,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                               y={0}
                             />
                             <rect
-                              className="c26"
+                              className="c29"
                               height={180}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
@@ -5465,7 +5521,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                               y={28.66215269670792}
                             />
                             <rect
-                              className="c26"
+                              className="c29"
                               height={180}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
@@ -5482,7 +5538,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                               y={42.06864347420032}
                             />
                             <rect
-                              className="c26"
+                              className="c29"
                               height={180}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
@@ -5499,7 +5555,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                               y={57.744571561989254}
                             />
                             <rect
-                              className="c26"
+                              className="c29"
                               height={180}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
@@ -5516,7 +5572,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                               y={97.83796404389446}
                             />
                             <rect
-                              className="c26"
+                              className="c29"
                               height={180}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
@@ -5533,7 +5589,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                               y={129.48400653747373}
                             />
                             <rect
-                              className="c26"
+                              className="c29"
                               height={180}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
@@ -5550,7 +5606,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                               y={161.59234181648375}
                             />
                             <rect
-                              className="c26"
+                              className="c29"
                               height={180}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
@@ -5574,13 +5630,13 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                       For gnomAD v3, the age distribution is:
                     </p>
                     <div
-                      className="c23"
+                      className="c26"
                     >
                       <div
-                        className="c24"
+                        className="c27"
                       >
                         <div
-                          className="c25"
+                          className="c28"
                         >
                           <svg
                             height={250}
@@ -6627,7 +6683,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={32.13021629888574}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -6644,7 +6700,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={123.8409438496832}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -6661,7 +6717,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={116.84072536596022}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -6678,7 +6734,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={105.08193139611099}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -6695,7 +6751,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={53.05221760978806}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -6712,7 +6768,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={0}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -6729,7 +6785,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={25.68057679702863}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -6746,7 +6802,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={36.22023159274634}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -6763,7 +6819,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={54.38933799431943}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -6780,7 +6836,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={95.32881800305879}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -6797,7 +6853,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={129.54336901900808}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -6814,7 +6870,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={162.1455101594931}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -6831,16 +6887,16 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                       For gnomAD v2, the age distribution is:
                     </p>
                     <div
-                      className="c23"
+                      className="c26"
                     >
                       <div
-                        className="c24"
+                        className="c27"
                       >
                         <p>
                           Exomes
                         </p>
                         <div
-                          className="c25"
+                          className="c28"
                         >
                           <svg
                             height={250}
@@ -8016,7 +8072,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={143.88087922476956}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -8033,7 +8089,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={131.4582840935949}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -8050,7 +8106,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={115.53297092885843}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -8067,7 +8123,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={59.64547388324272}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -8084,7 +8140,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={33.155282439139675}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -8101,7 +8157,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={0}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -8118,7 +8174,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={10.777593949420945}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -8135,7 +8191,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={30.61687544315764}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -8152,7 +8208,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={54.043961238477905}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -8169,7 +8225,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={95.04136138028835}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -8186,7 +8242,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={121.34719924367762}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -8203,7 +8259,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={152.55967856298747}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -8216,13 +8272,13 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                         </div>
                       </div>
                       <div
-                        className="c24"
+                        className="c27"
                       >
                         <p>
                           Genomes
                         </p>
                         <div
-                          className="c25"
+                          className="c28"
                         >
                           <svg
                             height={250}
@@ -9398,7 +9454,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={0}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -9415,7 +9471,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={135.53528945281522}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -9432,7 +9488,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={132.68041237113403}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -9449,7 +9505,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={114.12371134020619}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -9466,7 +9522,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={82.72006344171294}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -9483,7 +9539,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={61.0943695479778}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -9500,7 +9556,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={90.4996034892942}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -9517,7 +9573,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={108.55670103092785}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -9534,7 +9590,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={134.3219666931007}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -9551,7 +9607,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={154.1633624107851}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -9568,7 +9624,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={169.00872323552736}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -9585,7 +9641,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={175.0039651070579}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -9613,10 +9669,10 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -9695,10 +9751,10 @@ We used a combination of X-chromosome homozygosity (F-stat, [impute_sex function
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -9722,10 +9778,10 @@ Sex for the v4 exomes and genomes was determined using normalized coverage on ch
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -9749,10 +9805,10 @@ For information on how we handle related individuals please see our [Relatedness
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -9776,10 +9832,10 @@ The gene page summarizes the most severe functional consequence and protein-leve
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -9803,10 +9859,10 @@ Annotations may have changed depending on the version of GENCODE used (such as c
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -9857,10 +9913,10 @@ Flags that will appear at the top of gene/transcript pages:
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -9893,10 +9949,10 @@ Several other classes of problems relate to fundamental issues with dbSNP such a
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -9920,10 +9976,10 @@ A gene search in the new browser will return variants in the CDS regions of the 
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -9949,10 +10005,10 @@ The issue is now fixed for new gVCFs generated by HaplotypeCaller moving forward
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -9976,10 +10032,10 @@ Unfortunately, for many reasons (including consent and data usage restrictions) 
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -10005,10 +10061,10 @@ You can also obtain information on all variants from the VCFs and Hail Tables av
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -10032,10 +10088,10 @@ Please visit our [downloads page](/downloads).
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -10055,14 +10111,14 @@ Please see our gnomAD Hail Table [help text](/help/v4-hts)
         </div>
         <div>
           <span
-            className="c11"
+            className="c14"
           >
             <h3
-              className="c14"
+              className="c15"
             >
               <a
                 aria-hidden="true"
-                className="c12 c13"
+                className="c16 c17"
                 href="#coverage"
                 id="coverage"
               >
@@ -10080,7 +10136,7 @@ Please see our gnomAD Hail Table [help text](/help/v4-hts)
           <button
             backgroundColor="#f8f9fa"
             borderColor="#6c757d"
-            className="c15 c16"
+            className="c18 c19"
             onClick={[Function]}
             type="button"
           >
@@ -10090,14 +10146,14 @@ Please see our gnomAD Hail Table [help text](/help/v4-hts)
           <button
             backgroundColor="#f8f9fa"
             borderColor="#6c757d"
-            className="c15 c16"
+            className="c18 c19"
             onClick={[Function]}
             type="button"
           >
             Hide all answers in this section
           </button>
           <ul
-            className="c17"
+            className="c20"
           >
             <li>
               <details>
@@ -10107,10 +10163,10 @@ Please see our gnomAD Hail Table [help text](/help/v4-hts)
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -10188,10 +10244,10 @@ Coverage was calculated separately for exomes and genomes on a ~10% subset of th
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -10215,10 +10271,10 @@ The best way to tell if a variant is missing because of a lack of coverage vs mi
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -10242,10 +10298,10 @@ Sometimes a large apparent drop in AN can occur because a variant was called in 
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -10280,14 +10336,14 @@ The calling intervals for our exomes include the bait-covered regions ±50 bp. T
         </div>
         <div>
           <span
-            className="c11"
+            className="c14"
           >
             <h3
-              className="c14"
+              className="c15"
             >
               <a
                 aria-hidden="true"
-                className="c12 c13"
+                className="c16 c17"
                 href="#mitochondrial-dna"
                 id="mitochondrial-dna"
               >
@@ -10305,7 +10361,7 @@ The calling intervals for our exomes include the bait-covered regions ±50 bp. T
           <button
             backgroundColor="#f8f9fa"
             borderColor="#6c757d"
-            className="c15 c16"
+            className="c18 c19"
             onClick={[Function]}
             type="button"
           >
@@ -10315,14 +10371,14 @@ The calling intervals for our exomes include the bait-covered regions ±50 bp. T
           <button
             backgroundColor="#f8f9fa"
             borderColor="#6c757d"
-            className="c15 c16"
+            className="c18 c19"
             onClick={[Function]}
             type="button"
           >
             Hide all answers in this section
           </button>
           <ul
-            className="c17"
+            className="c20"
           >
             <li>
               <details>
@@ -10332,10 +10388,10 @@ The calling intervals for our exomes include the bait-covered regions ±50 bp. T
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -10359,10 +10415,10 @@ Mitochondrial DNA variants are called using a specialized GATK pipeline that add
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -10386,10 +10442,10 @@ The gnomAD v3.1 data set contains 76,156 whole genomes, of which 56,434 samples 
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -10413,10 +10469,10 @@ Nuclear sequences of mitochondrial origin (NUMTs) are derived from pieces of mtD
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -10440,10 +10496,10 @@ In gnomAD v3.1 we chose to filter out variants with heteroplasmy below 10%, sinc
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -10467,10 +10523,10 @@ mtDNA does not recombine and is inherited maternally. mtDNA sequences have histo
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -10494,10 +10550,10 @@ Variants that are homoplasmic in any of the ~5000 haplogroups in the [Phylotree]
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -10521,10 +10577,10 @@ For each variant, we report the overall population frequency across all gnomAD s
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -10548,13 +10604,13 @@ We report allele frequencies by mitochondrial haplogroup as well as by [inferred
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <h4>
                     N lineages ("Eurasian")
                   </h4>
                   <table
-                    className="c21 c27"
+                    className="c24 c30"
                   >
                     <thead>
                       <tr>
@@ -10844,7 +10900,7 @@ We report allele frequencies by mitochondrial haplogroup as well as by [inferred
                     L lineages ("African")
                   </h4>
                   <table
-                    className="c21 c27"
+                    className="c24 c30"
                   >
                     <thead>
                       <tr>
@@ -10978,7 +11034,7 @@ We report allele frequencies by mitochondrial haplogroup as well as by [inferred
                     M lineages ("Asian")
                   </h4>
                   <table
-                    className="c21 c27"
+                    className="c24 c30"
                   >
                     <thead>
                       <tr>
@@ -11119,10 +11175,10 @@ We report allele frequencies by mitochondrial haplogroup as well as by [inferred
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <select
-                    className="c28 c29"
+                    className="c31 c32"
                     id="haplogroup-selected"
                     onChange={[Function]}
                     value="All"
@@ -11283,7 +11339,7 @@ We report allele frequencies by mitochondrial haplogroup as well as by [inferred
                     </optgroup>
                   </select>
                   <select
-                    className="c28 c29"
+                    className="c31 c32"
                     id="ancestry-selected"
                     onChange={[Function]}
                     value="All"
@@ -11349,7 +11405,7 @@ We report allele frequencies by mitochondrial haplogroup as well as by [inferred
                     </optgroup>
                   </select>
                   <table
-                    className="c21 c30"
+                    className="c24 c33"
                   >
                     <thead>
                       <tr>
@@ -11402,10 +11458,10 @@ We report allele frequencies by mitochondrial haplogroup as well as by [inferred
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -11449,10 +11505,10 @@ Mitochondrial variants were subjected to mitochondrial-specific filters and flag
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -11472,14 +11528,14 @@ Homoplasmic and heteroplasmic counts for all sites can be downloaded in VCF form
         </div>
         <div>
           <span
-            className="c11"
+            className="c14"
           >
             <h3
-              className="c14"
+              className="c15"
             >
               <a
                 aria-hidden="true"
-                className="c12 c13"
+                className="c16 c17"
                 href="#variant-co-occurrence"
                 id="variant-co-occurrence"
               >
@@ -11497,7 +11553,7 @@ Homoplasmic and heteroplasmic counts for all sites can be downloaded in VCF form
           <button
             backgroundColor="#f8f9fa"
             borderColor="#6c757d"
-            className="c15 c16"
+            className="c18 c19"
             onClick={[Function]}
             type="button"
           >
@@ -11507,14 +11563,14 @@ Homoplasmic and heteroplasmic counts for all sites can be downloaded in VCF form
           <button
             backgroundColor="#f8f9fa"
             borderColor="#6c757d"
-            className="c15 c16"
+            className="c18 c19"
             onClick={[Function]}
             type="button"
           >
             Hide all answers in this section
           </button>
           <ul
-            className="c17"
+            className="c20"
           >
             <li>
               <details>
@@ -11524,10 +11580,10 @@ Homoplasmic and heteroplasmic counts for all sites can be downloaded in VCF form
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -11551,10 +11607,10 @@ We used the exome sequencing samples from gnomAD v2.1 (n = 125,748; GRCh37) to e
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -11582,10 +11638,10 @@ For more information, see our [publication](https://www.nature.com/articles/s415
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -11609,10 +11665,10 @@ When the probability of a pair of variants being in _trans_ (P<sub>trans</sub>) 
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -11636,10 +11692,10 @@ We suggest using the population-specific estimates, when available and when ance
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -11669,10 +11725,10 @@ Finally, the likelihood that the variants are on different haplotypes is calcula
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---

--- a/browser/src/useScrollToHash.spec.tsx
+++ b/browser/src/useScrollToHash.spec.tsx
@@ -1,0 +1,104 @@
+import React from 'react'
+import { render, act } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals'
+
+import useScrollToHash from './useScrollToHash'
+
+const TestComponent = () => {
+  useScrollToHash()
+  return <div id="age-distribution">Age Distribution</div>
+}
+
+// jsdom implements neither scrollIntoView nor layout, so both are stubbed.
+const scrollIntoView = jest.fn()
+window.HTMLElement.prototype.scrollIntoView = scrollIntoView
+
+const originalGetBoundingClientRect = window.HTMLElement.prototype.getBoundingClientRect
+
+// Report the target as `top` pixels from the top of the viewport.
+const mockOffsetFromViewportTop = (top: number) => {
+  window.HTMLElement.prototype.getBoundingClientRect = jest.fn(
+    () => ({ top } as DOMRect)
+  ) as typeof originalGetBoundingClientRect
+}
+
+const flushAnimationFrames = async (count = 3) => {
+  for (let i = 0; i < count; i += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    await act(async () => {
+      await new Promise((resolve) => {
+        requestAnimationFrame(() => resolve(null))
+      })
+    })
+  }
+}
+
+describe('useScrollToHash', () => {
+  beforeEach(() => {
+    scrollIntoView.mockClear()
+    window.location.hash = ''
+    mockOffsetFromViewportTop(500)
+  })
+
+  afterEach(() => {
+    window.HTMLElement.prototype.getBoundingClientRect = originalGetBoundingClientRect
+  })
+
+  test('scrolls to the element identified by the hash', async () => {
+    window.location.hash = '#age-distribution'
+    render(<TestComponent />)
+    await flushAnimationFrames()
+    expect(scrollIntoView).toHaveBeenCalled()
+  })
+
+  test('keeps re-aligning while the page is still growing', async () => {
+    window.location.hash = '#age-distribution'
+    render(<TestComponent />)
+    await flushAnimationFrames(3)
+    // The target never reaches the top here, standing in for a document too short to scroll
+    // that far, so the hook should have tried more than once.
+    expect(scrollIntoView.mock.calls.length).toBeGreaterThan(1)
+  })
+
+  test('does not scroll once the element is already at the top', async () => {
+    window.location.hash = '#age-distribution'
+    mockOffsetFromViewportTop(0)
+    render(<TestComponent />)
+    await flushAnimationFrames()
+    expect(scrollIntoView).not.toHaveBeenCalled()
+  })
+
+  test('stops re-aligning once the reader scrolls', async () => {
+    window.location.hash = '#age-distribution'
+    render(<TestComponent />)
+    await flushAnimationFrames(1)
+    const callsBeforeUserScroll = scrollIntoView.mock.calls.length
+
+    act(() => {
+      window.dispatchEvent(new Event('wheel'))
+    })
+    await flushAnimationFrames(3)
+
+    expect(scrollIntoView.mock.calls.length).toBe(callsBeforeUserScroll)
+  })
+
+  test('does not scroll when the URL has no hash', async () => {
+    render(<TestComponent />)
+    await flushAnimationFrames()
+    expect(scrollIntoView).not.toHaveBeenCalled()
+  })
+
+  test('does not scroll when no element matches the hash', async () => {
+    window.location.hash = '#not-a-section-on-this-page'
+    render(<TestComponent />)
+    await flushAnimationFrames()
+    expect(scrollIntoView).not.toHaveBeenCalled()
+  })
+
+  test('does not throw when the hash is not a valid CSS selector', async () => {
+    window.location.hash = '#123 not a selector'
+    expect(() => render(<TestComponent />)).not.toThrow()
+    await flushAnimationFrames()
+    expect(scrollIntoView).not.toHaveBeenCalled()
+  })
+})

--- a/browser/src/useScrollToHash.spec.tsx
+++ b/browser/src/useScrollToHash.spec.tsx
@@ -105,6 +105,42 @@ describe('useScrollToHash', () => {
     }
   )
 
+  test.each(['#another-section', ''])(
+    'stops aligning and detaches listeners when the hash changes to "%s"',
+    (hash) => {
+      const frameCallbacks: FrameRequestCallback[] = []
+      const requestFrame = jest
+        .spyOn(window, 'requestAnimationFrame')
+        .mockImplementation((callback) => {
+          frameCallbacks.push(callback)
+          return frameCallbacks.length
+        })
+      const removeEventListener = jest.spyOn(window, 'removeEventListener')
+      jest.spyOn(performance, 'now').mockReturnValue(0)
+      window.location.hash = '#age-distribution'
+      render(<TestComponent />)
+
+      act(() => {
+        frameCallbacks.shift()!(0)
+      })
+      expect(scrollIntoView).toHaveBeenCalledTimes(1)
+      expect(frameCallbacks).toHaveLength(1)
+
+      window.location.hash = hash
+      act(() => {
+        frameCallbacks.shift()!(16)
+      })
+
+      expect(scrollIntoView).toHaveBeenCalledTimes(1)
+      expect(requestFrame).toHaveBeenCalledTimes(2)
+      expect(frameCallbacks).toHaveLength(0)
+      expect(removeEventListener).toHaveBeenCalledWith('wheel', expect.any(Function))
+      expect(removeEventListener).toHaveBeenCalledWith('touchstart', expect.any(Function))
+      expect(removeEventListener).toHaveBeenCalledWith('keydown', expect.any(Function))
+      expect(removeEventListener).toHaveBeenCalledWith('mousedown', expect.any(Function))
+    }
+  )
+
   test('stops scheduling frames and detaches listeners when the settle window expires', () => {
     const frameCallbacks: FrameRequestCallback[] = []
     const requestFrame = jest

--- a/browser/src/useScrollToHash.spec.tsx
+++ b/browser/src/useScrollToHash.spec.tsx
@@ -6,7 +6,7 @@ import useScrollToHash from './useScrollToHash'
 
 const TestComponent = () => {
   useScrollToHash()
-  return <div id="age-distribution">Age Distribution</div>
+  return <h2 id="age-distribution">Age Distribution</h2>
 }
 
 // jsdom implements neither scrollIntoView nor layout, so both are stubbed.
@@ -45,11 +45,11 @@ describe('useScrollToHash', () => {
     jest.restoreAllMocks()
   })
 
-  test('scrolls to the element identified by the hash', async () => {
+  test('scrolls to the hash target without inheriting CSS smooth scrolling', async () => {
     window.location.hash = '#age-distribution'
     render(<TestComponent />)
     await flushAnimationFrames()
-    expect(scrollIntoView).toHaveBeenCalled()
+    expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'instant' })
   })
 
   test('keeps re-aligning while the page is still growing', async () => {

--- a/browser/src/useScrollToHash.spec.tsx
+++ b/browser/src/useScrollToHash.spec.tsx
@@ -42,6 +42,7 @@ describe('useScrollToHash', () => {
 
   afterEach(() => {
     window.HTMLElement.prototype.getBoundingClientRect = originalGetBoundingClientRect
+    jest.restoreAllMocks()
   })
 
   test('scrolls to the element identified by the hash', async () => {
@@ -68,18 +69,84 @@ describe('useScrollToHash', () => {
     expect(scrollIntoView).not.toHaveBeenCalled()
   })
 
-  test('stops re-aligning once the reader scrolls', async () => {
+  test('re-aligns after an aligned frame if later content moves the target', async () => {
     window.location.hash = '#age-distribution'
+    mockOffsetFromViewportTop(0)
     render(<TestComponent />)
     await flushAnimationFrames(1)
-    const callsBeforeUserScroll = scrollIntoView.mock.calls.length
+    expect(scrollIntoView).not.toHaveBeenCalled()
 
+    mockOffsetFromViewportTop(200)
+    await flushAnimationFrames(1)
+    expect(scrollIntoView).toHaveBeenCalled()
+  })
+
+  test.each(['wheel', 'touchstart', 'keydown', 'mousedown'])(
+    'cancels the pending frame and detaches listeners on reader %s input',
+    async (eventType) => {
+      const cancelFrame = jest.spyOn(window, 'cancelAnimationFrame')
+      const removeEventListener = jest.spyOn(window, 'removeEventListener')
+      window.location.hash = '#age-distribution'
+      render(<TestComponent />)
+      await flushAnimationFrames(1)
+      const callsBeforeUserScroll = scrollIntoView.mock.calls.length
+
+      act(() => {
+        window.dispatchEvent(new Event(eventType))
+      })
+      await flushAnimationFrames(3)
+
+      expect(scrollIntoView.mock.calls.length).toBe(callsBeforeUserScroll)
+      expect(cancelFrame).toHaveBeenCalled()
+      expect(removeEventListener).toHaveBeenCalledWith('wheel', expect.any(Function))
+      expect(removeEventListener).toHaveBeenCalledWith('touchstart', expect.any(Function))
+      expect(removeEventListener).toHaveBeenCalledWith('keydown', expect.any(Function))
+      expect(removeEventListener).toHaveBeenCalledWith('mousedown', expect.any(Function))
+    }
+  )
+
+  test('stops scheduling frames and detaches listeners when the settle window expires', () => {
+    const frameCallbacks: FrameRequestCallback[] = []
+    const requestFrame = jest
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback) => {
+        frameCallbacks.push(callback)
+        return frameCallbacks.length
+      })
+    const removeEventListener = jest.spyOn(window, 'removeEventListener')
+    let now = 0
+    jest.spyOn(performance, 'now').mockImplementation(() => now)
+    window.location.hash = '#age-distribution'
+
+    render(<TestComponent />)
+    expect(frameCallbacks).toHaveLength(1)
+
+    now = 2001
     act(() => {
-      window.dispatchEvent(new Event('wheel'))
+      frameCallbacks.shift()!(now)
     })
-    await flushAnimationFrames(3)
 
-    expect(scrollIntoView.mock.calls.length).toBe(callsBeforeUserScroll)
+    expect(requestFrame).toHaveBeenCalledTimes(1)
+    expect(frameCallbacks).toHaveLength(0)
+    expect(removeEventListener).toHaveBeenCalledWith('wheel', expect.any(Function))
+    expect(removeEventListener).toHaveBeenCalledWith('touchstart', expect.any(Function))
+    expect(removeEventListener).toHaveBeenCalledWith('keydown', expect.any(Function))
+    expect(removeEventListener).toHaveBeenCalledWith('mousedown', expect.any(Function))
+  })
+
+  test('cancels the pending frame and detaches listeners on unmount', () => {
+    const cancelFrame = jest.spyOn(window, 'cancelAnimationFrame')
+    const removeEventListener = jest.spyOn(window, 'removeEventListener')
+    window.location.hash = '#age-distribution'
+
+    const { unmount } = render(<TestComponent />)
+    unmount()
+
+    expect(cancelFrame).toHaveBeenCalled()
+    expect(removeEventListener).toHaveBeenCalledWith('wheel', expect.any(Function))
+    expect(removeEventListener).toHaveBeenCalledWith('touchstart', expect.any(Function))
+    expect(removeEventListener).toHaveBeenCalledWith('keydown', expect.any(Function))
+    expect(removeEventListener).toHaveBeenCalledWith('mousedown', expect.any(Function))
   })
 
   test('does not scroll when the URL has no hash', async () => {

--- a/browser/src/useScrollToHash.ts
+++ b/browser/src/useScrollToHash.ts
@@ -1,0 +1,66 @@
+import { useEffect } from 'react'
+
+// How long to keep re-aligning after mount while the rest of the page renders.
+const SETTLE_TIMEOUT_MS = 2000
+
+// The app scrolls to the URL's hash when a page's code finishes loading (see App.tsx). Pages
+// whose content renders only after a query resolves are still showing a loading message at that
+// point, so their sections are not yet in the document and that scroll finds nothing. Such pages
+// call this hook from the component that renders once their data is available.
+//
+// A single scroll on mount is not enough: the sections below the target have not rendered yet,
+// so the document is often too short for the browser to bring the target all the way to the top
+// and the scroll is clamped to the bottom of the page. Keep re-aligning while the page grows,
+// stopping early if the reader takes over.
+const useScrollToHash = () => {
+  useEffect(() => {
+    const { hash } = window.location
+    if (!hash) {
+      return undefined
+    }
+
+    // The id is used with getElementById rather than a selector, since an arbitrary hash from
+    // the URL is not necessarily a valid selector.
+    const id = hash.slice(1)
+    const start = performance.now()
+    let animationFrame = 0
+    let readerTookOver = false
+
+    const stopAligning = () => {
+      readerTookOver = true
+    }
+
+    const align = () => {
+      if (readerTookOver) {
+        return
+      }
+
+      const target = document.getElementById(id)
+      if (target && Math.abs(target.getBoundingClientRect().top) > 1) {
+        target.scrollIntoView()
+      }
+
+      if (performance.now() - start < SETTLE_TIMEOUT_MS) {
+        animationFrame = requestAnimationFrame(align)
+      }
+    }
+
+    // Deliberate input only. A plain 'scroll' listener would also catch our own scrolling.
+    window.addEventListener('wheel', stopAligning, { passive: true })
+    window.addEventListener('touchstart', stopAligning, { passive: true })
+    window.addEventListener('keydown', stopAligning)
+    window.addEventListener('mousedown', stopAligning)
+
+    animationFrame = requestAnimationFrame(align)
+
+    return () => {
+      cancelAnimationFrame(animationFrame)
+      window.removeEventListener('wheel', stopAligning)
+      window.removeEventListener('touchstart', stopAligning)
+      window.removeEventListener('keydown', stopAligning)
+      window.removeEventListener('mousedown', stopAligning)
+    }
+  }, [])
+}
+
+export default useScrollToHash

--- a/browser/src/useScrollToHash.ts
+++ b/browser/src/useScrollToHash.ts
@@ -3,7 +3,7 @@ import { useEffect } from 'react'
 // How long to keep re-aligning after mount while the rest of the page renders.
 const SETTLE_TIMEOUT_MS = 2000
 
-// App.tsx scrolls before query-loaded sections exist. Data-loaded pages retry here while
+// App.tsx can scroll before lazy or query-loaded sections exist. Pages retry here while
 // layout settles: short documents can clamp scrolling, and later content can move an already
 // aligned target. Stop after the bounded window or as soon as the reader takes over.
 const useScrollToHash = () => {
@@ -48,7 +48,8 @@ const useScrollToHash = () => {
 
       const target = document.getElementById(id)
       if (target && Math.abs(target.getBoundingClientRect().top) > 1) {
-        target.scrollIntoView()
+        // Animated scrolling would restart on every frame on pages with smooth-scroll CSS.
+        target.scrollIntoView({ behavior: 'instant' })
       }
 
       if (performance.now() - start < SETTLE_TIMEOUT_MS) {

--- a/browser/src/useScrollToHash.ts
+++ b/browser/src/useScrollToHash.ts
@@ -3,15 +3,9 @@ import { useEffect } from 'react'
 // How long to keep re-aligning after mount while the rest of the page renders.
 const SETTLE_TIMEOUT_MS = 2000
 
-// The app scrolls to the URL's hash when a page's code finishes loading (see App.tsx). Pages
-// whose content renders only after a query resolves are still showing a loading message at that
-// point, so their sections are not yet in the document and that scroll finds nothing. Such pages
-// call this hook from the component that renders once their data is available.
-//
-// A single scroll on mount is not enough: the sections below the target have not rendered yet,
-// so the document is often too short for the browser to bring the target all the way to the top
-// and the scroll is clamped to the bottom of the page. Keep re-aligning while the page grows,
-// stopping early if the reader takes over.
+// App.tsx scrolls before query-loaded sections exist. Data-loaded pages retry here while
+// layout settles: short documents can clamp scrolling, and later content can move an already
+// aligned target. Stop after the bounded window or as soon as the reader takes over.
 const useScrollToHash = () => {
   useEffect(() => {
     const { hash } = window.location
@@ -23,15 +17,32 @@ const useScrollToHash = () => {
     // the URL is not necessarily a valid selector.
     const id = hash.slice(1)
     const start = performance.now()
-    let animationFrame = 0
-    let readerTookOver = false
+    let animationFrame: number | undefined
+    let finished = false
 
-    const stopAligning = () => {
-      readerTookOver = true
+    const removeInputListeners = () => {
+      window.removeEventListener('wheel', finish)
+      window.removeEventListener('touchstart', finish)
+      window.removeEventListener('keydown', finish)
+      window.removeEventListener('mousedown', finish)
+    }
+
+    function finish() {
+      if (finished) {
+        return
+      }
+
+      finished = true
+      if (animationFrame !== undefined) {
+        cancelAnimationFrame(animationFrame)
+        animationFrame = undefined
+      }
+      removeInputListeners()
     }
 
     const align = () => {
-      if (readerTookOver) {
+      animationFrame = undefined
+      if (finished) {
         return
       }
 
@@ -42,24 +53,20 @@ const useScrollToHash = () => {
 
       if (performance.now() - start < SETTLE_TIMEOUT_MS) {
         animationFrame = requestAnimationFrame(align)
+      } else {
+        finish()
       }
     }
 
     // Deliberate input only. A plain 'scroll' listener would also catch our own scrolling.
-    window.addEventListener('wheel', stopAligning, { passive: true })
-    window.addEventListener('touchstart', stopAligning, { passive: true })
-    window.addEventListener('keydown', stopAligning)
-    window.addEventListener('mousedown', stopAligning)
+    window.addEventListener('wheel', finish, { passive: true })
+    window.addEventListener('touchstart', finish, { passive: true })
+    window.addEventListener('keydown', finish)
+    window.addEventListener('mousedown', finish)
 
     animationFrame = requestAnimationFrame(align)
 
-    return () => {
-      cancelAnimationFrame(animationFrame)
-      window.removeEventListener('wheel', stopAligning)
-      window.removeEventListener('touchstart', stopAligning)
-      window.removeEventListener('keydown', stopAligning)
-      window.removeEventListener('mousedown', stopAligning)
-    }
+    return finish
   }, [])
 }
 

--- a/browser/src/useScrollToHash.ts
+++ b/browser/src/useScrollToHash.ts
@@ -46,6 +46,11 @@ const useScrollToHash = () => {
         return
       }
 
+      if (window.location.hash !== hash) {
+        finish()
+        return
+      }
+
       const target = document.getElementById(id)
       if (target && Math.abs(target.getBoundingClientRect().top) > 1) {
         // Animated scrolling would restart on every frame on pages with smooth-scroll CSS.

--- a/tests/e2e/DataPageNavigation.playwright.spec.ts
+++ b/tests/e2e/DataPageNavigation.playwright.spec.ts
@@ -2,6 +2,10 @@ import { expect, test } from '@playwright/test'
 
 test.use({ viewport: { width: 1440, height: 900 } })
 
+type SettlingWindow = typeof window & {
+  hashSettling: { firstFrame?: number; hashChanged?: number }
+}
+
 test('Data table of contents renders links and follows navigation and scrolling', async ({
   page,
 }) => {
@@ -46,6 +50,61 @@ test('Data table of contents renders links and follows navigation and scrolling'
     contents.getByRole('link', { name: 'Linkage disequilibrium', exact: true })
   ).toHaveAttribute('href', '#v2-linkage-disequilibrium')
   await expect(hgdpLink).toHaveCount(0)
+})
+;['browser Back after reload', 'a new fragment'].forEach((navigation) => {
+  test(`Data hash settling yields to ${navigation}`, async ({ page }) => {
+    await page.addInitScript(() => {
+      const trace: SettlingWindow['hashSettling'] = {}
+      ;(window as SettlingWindow).hashSettling = trace
+      const getBoundingClientRect = Element.prototype.getBoundingClientRect
+      // Observe the hook's first target measurement without changing real browser geometry.
+      Element.prototype.getBoundingClientRect = function measureTarget() {
+        if (this.id === 'v4' && location.hash === '#v4' && trace.firstFrame === undefined) {
+          trace.firstFrame = performance.now()
+        }
+        return getBoundingClientRect.call(this)
+      }
+      window.addEventListener('hashchange', () => {
+        if (trace.firstFrame !== undefined && trace.hashChanged === undefined) {
+          trace.hashChanged = performance.now()
+        }
+      })
+    })
+
+    if (navigation === 'browser Back after reload') {
+      await page.goto('/data?dataset=gnomad_r4')
+      await expect(page.locator('h2#v3')).toBeAttached()
+      await page.goto('/data?dataset=gnomad_r4#v3')
+      await page.goto('/data?dataset=gnomad_r4#v4')
+      await page.reload({ waitUntil: 'commit' })
+    } else {
+      await page.goto('/data?dataset=gnomad_r4#v4', { waitUntil: 'commit' })
+    }
+    await page.waitForFunction(
+      () => (window as SettlingWindow).hashSettling.firstFrame !== undefined
+    )
+
+    // Toolbar/address-bar navigation does not dispatch the page input that cancels settling.
+    if (navigation === 'browser Back after reload') {
+      await page.goBack({ waitUntil: 'commit' })
+    } else {
+      await page.goto('/data?dataset=gnomad_r4#v3', { waitUntil: 'commit' })
+    }
+    await page.waitForFunction(
+      () => (window as SettlingWindow).hashSettling.hashChanged !== undefined
+    )
+    const trace = await page.evaluate(() => (window as SettlingWindow).hashSettling)
+    expect(trace.hashChanged! - trace.firstFrame!).toBeLessThan(1000)
+
+    // The new target must still win after the entire two-second settling window.
+    await page.waitForTimeout(2200)
+    expect(new URL(page.url()).hash).toBe('#v3')
+    await expect
+      .poll(() =>
+        page.locator('h2#v3').evaluate((element) => Math.abs(element.getBoundingClientRect().top))
+      )
+      .toBeLessThanOrEqual(2)
+  })
 })
 
 test('Data deep links settle promptly even with smooth scrolling enabled', async ({ page }) => {

--- a/tests/e2e/DataPageNavigation.playwright.spec.ts
+++ b/tests/e2e/DataPageNavigation.playwright.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test } from '@playwright/test'
+
+test.use({ viewport: { width: 1440, height: 900 } })
+
+test('Data table of contents renders links and follows navigation and scrolling', async ({
+  page,
+}) => {
+  await page.goto('/data?dataset=gnomad_r4')
+  const contents = page.getByRole('navigation', { name: 'Data sections' })
+  await expect(contents.getByRole('link')).toHaveText([
+    'Summary',
+    'v4 Downloads',
+    'v3 Downloads',
+    'v2 Liftover Downloads',
+    'v2 Downloads',
+    'ExAC Downloads',
+    'gnomAD API',
+  ])
+
+  const v3Link = contents.getByRole('link', { name: 'v3 Downloads', exact: true })
+  await v3Link.click()
+  await expect(page.locator('h2#v3')).toBeInViewport()
+  await expect(v3Link.locator('..')).toHaveCSS('font-weight', '700')
+
+  const hgdpLink = contents.getByRole('link', { name: 'HGDP + 1KG callset', exact: true })
+  await expect(hgdpLink).toHaveAttribute('href', '#v3-hgdp-1kg')
+  await hgdpLink.click()
+  await expect(page.locator('h2#v3-hgdp-1kg')).toBeInViewport()
+  await expect(hgdpLink.locator('..')).toHaveCSS('font-weight', '700')
+  await expect
+    .poll(() =>
+      page
+        .locator('h2#v3-hgdp-1kg')
+        .evaluate((element) => Math.abs(element.getBoundingClientRect().top))
+    )
+    .toBeLessThanOrEqual(2)
+
+  const v2Offset = await page
+    .locator('h2#v2')
+    .evaluate((element) => element.getBoundingClientRect().top)
+  await page.mouse.move(600, 450)
+  await page.mouse.wheel(0, v2Offset - 20)
+  const v2Link = contents.getByRole('link', { name: 'v2 Downloads', exact: true })
+  await expect(v2Link.locator('..')).toHaveCSS('font-weight', '700')
+  await expect(
+    contents.getByRole('link', { name: 'Linkage disequilibrium', exact: true })
+  ).toHaveAttribute('href', '#v2-linkage-disequilibrium')
+  await expect(hgdpLink).toHaveCount(0)
+})
+
+test('Data deep links settle promptly even with smooth scrolling enabled', async ({ page }) => {
+  await page.goto('/data?dataset=gnomad_r4#v4-variants', { waitUntil: 'commit' })
+  const heading = page.locator('h2#v4-variants')
+  await expect(heading).toBeAttached()
+  await expect(page.locator('html')).toHaveCSS('scroll-behavior', 'smooth')
+
+  // A restarted smooth scroll remains stationary for the entire two-second retry window.
+  await expect
+    .poll(() => heading.evaluate((element) => Math.abs(element.getBoundingClientRect().top)), {
+      timeout: 1000,
+    })
+    .toBeLessThanOrEqual(2)
+})

--- a/tests/e2e/MobileNotificationFeedback.playwright.spec.ts
+++ b/tests/e2e/MobileNotificationFeedback.playwright.spec.ts
@@ -1,0 +1,77 @@
+import { expect, test } from '@playwright/test'
+
+const variants = [
+  { family: 'structural', path: '/variant/DEL_CHR19_2C6DA7E7?dataset=gnomad_sv_r4' },
+  { family: 'mitochondrial', path: '/variant/M-8602-T-C?dataset=gnomad_r4' },
+  { family: 'STR', path: '/short-tandem-repeat/ATXN1?dataset=gnomad_r4' },
+  { family: 'short', path: '/variant/1-55051215-G-GA?dataset=gnomad_r4' },
+]
+const screenSize = { width: 320, height: 720 }
+
+test.describe('Mobile permalink feedback', () => {
+  test.use({ viewport: screenSize, hasTouch: true, isMobile: true })
+
+  variants.forEach(({ family, path }) => {
+    ;[false, true].forEach((copyFails) => {
+      test(`${family} keeps ${copyFails ? 'failure' : 'success'} feedback on screen`, async ({
+        page,
+      }, testInfo) => {
+        test.setTimeout(60_000)
+        await page.context().grantPermissions(['clipboard-read', 'clipboard-write'])
+        if (copyFails) {
+          await page.addInitScript(() => {
+            Object.defineProperty(navigator, 'clipboard', {
+              configurable: true,
+              value: { writeText: () => Promise.reject(new Error('Clipboard permission denied')) },
+            })
+          })
+        }
+        await page.goto(`${path}#age-distribution`)
+        const link = page.getByRole('link', { name: 'Copy link to Age Distribution', exact: true })
+        await expect(link).toBeAttached({ timeout: 45_000 })
+        // Wait out the heading's scroll-settling window before measuring either viewport.
+        await page.waitForTimeout(2500)
+        const offsetBeforeCopy = await page.evaluate(() => window.visualViewport!.offsetTop)
+        expect(offsetBeforeCopy, 'Fixture must pan the real visual viewport').toBeGreaterThan(0)
+        const target = (await link.boundingBox())!
+        expect(target.x).toBeGreaterThanOrEqual(0)
+        expect(target.y).toBeGreaterThanOrEqual(0)
+        expect(target.x + target.width).toBeLessThanOrEqual(screenSize.width)
+        expect(target.y + target.height).toBeLessThanOrEqual(screenSize.height)
+        // locator.tap() auto-scrolls, disturbing the visual viewport in overflowing mobile pages.
+        await page.touchscreen.tap(target.x + target.width / 2, target.y + target.height / 2)
+
+        const title = copyFails ? 'Unable to copy link' : 'Link copied'
+        const card = page
+          .locator('strong')
+          .filter({ hasText: new RegExp(`^${title}$`) })
+          .locator('..')
+        await expect(card).toBeVisible()
+        await expect(page.getByRole(copyFails ? 'alert' : 'status')).toHaveText(title)
+        const feedback = (await card.boundingBox())!
+        expect(feedback.x).toBeGreaterThanOrEqual(0)
+        expect(feedback.y).toBeGreaterThanOrEqual(0)
+        expect(feedback.x + feedback.width).toBeLessThanOrEqual(screenSize.width)
+        expect(feedback.y + feedback.height).toBeLessThanOrEqual(screenSize.height)
+        const viewport = await page.evaluate(() => ({
+          offsetTop: window.visualViewport!.offsetTop,
+          width: window.visualViewport!.width,
+          height: window.visualViewport!.height,
+        }))
+        expect(viewport.offsetTop, 'Feedback must remain visible while panned').toBeGreaterThan(0)
+        expect(new URL(page.url()).hash).toBe('#age-distribution')
+        if (!copyFails) {
+          expect(await page.evaluate(() => navigator.clipboard.readText())).toBe(page.url())
+        }
+        await testInfo.attach('visible-feedback', {
+          body: await page.screenshot(),
+          contentType: 'image/png',
+        })
+        await testInfo.attach('viewport-geometry', {
+          body: JSON.stringify({ family, copyFails, offsetBeforeCopy, viewport, target, feedback }),
+          contentType: 'application/json',
+        })
+      })
+    })
+  })
+})

--- a/tests/e2e/SectionHeadingPages.playwright.spec.ts
+++ b/tests/e2e/SectionHeadingPages.playwright.spec.ts
@@ -1,0 +1,85 @@
+import { expect, test } from '@playwright/test'
+
+const sections = [
+  { path: '/help', id: 'frequently-asked-questions', title: 'Frequently asked questions' },
+  { path: '/data', id: 'v4-variants', title: 'Variants' },
+  {
+    path: '/stats',
+    id: 'age-and-sex-distribution',
+    title: 'What is the age and sex distribution in gnomAD?',
+  },
+]
+
+;[1440, 320].forEach((width) => {
+  test.describe(`Shared headings at ${width}px`, () => {
+    test.use({ viewport: { width, height: 900 } })
+
+    sections.forEach(({ path, id, title }) => {
+      test(`${path} preserves deep links and exposes a complete copy target`, async ({ page }) => {
+        await page.context().grantPermissions(['clipboard-read', 'clipboard-write'])
+        await page.goto(`${path}?dataset=gnomad_r4#${id}`)
+        const heading = page.locator(`h2#${id}`)
+        await expect(heading).toBeAttached()
+        // Check the final layout after the shared scroll-settling window.
+        await page.waitForTimeout(2200)
+        await expect(heading).toBeInViewport()
+        await page.reload()
+        await expect(heading).toBeAttached()
+        await page.waitForTimeout(2200)
+        await expect(heading).toBeInViewport()
+
+        const titleLayout = await heading.evaluate((element) => {
+          const titleText = Array.from(element.childNodes).find(
+            (node) => node.nodeType === Node.TEXT_NODE
+          )!
+          const firstCharacter = document.createRange()
+          firstCharacter.setStart(titleText, 0)
+          firstCharacter.setEnd(titleText, 1)
+          const indent =
+            firstCharacter.getBoundingClientRect().left - element.getBoundingClientRect().left
+          const textRange = document.createRange()
+          textRange.selectNodeContents(titleText)
+          const textBox = textRange.getBoundingClientRect()
+          const iconBox = element.querySelector('img')!.getBoundingClientRect()
+          return {
+            indent,
+            verticalOffset: iconBox.y + iconBox.height / 2 - (textBox.y + textBox.height / 2),
+          }
+        })
+        expect(Math.abs(titleLayout.indent)).toBeLessThanOrEqual(1)
+        expect(Math.abs(titleLayout.verticalOffset)).toBeLessThanOrEqual(2)
+
+        const link = heading.getByRole('link', { name: `Copy link to ${title}`, exact: true })
+        await link.focus()
+        await expect(link).toHaveCSS('opacity', '1')
+        await expect(link).toBeInViewport({ ratio: 1 })
+        const box = (await link.boundingBox())!
+        expect(box.width).toBeGreaterThanOrEqual(44)
+        expect(box.height).toBeGreaterThanOrEqual(44)
+        expect(box.x).toBeGreaterThanOrEqual(0)
+        expect(box.x + box.width).toBeLessThanOrEqual(width)
+        const headingBox = (await heading.boundingBox())!
+        expect(box.x + box.width).toBeLessThanOrEqual(headingBox.x + 1)
+        if (path === '/help') {
+          const subheadingBox = (await page
+            .getByRole('heading', { name: 'General', exact: true })
+            .boundingBox())!
+          expect(Math.abs(headingBox.x - subheadingBox.x)).toBeLessThanOrEqual(1)
+        }
+        expect(
+          await link.evaluate((element) => {
+            const bounds = element.getBoundingClientRect()
+            return element.contains(
+              document.elementFromPoint(bounds.x + 1, bounds.y + bounds.height / 2)
+            )
+          })
+        ).toBe(true)
+
+        await page.keyboard.press('Enter')
+        await expect(page.getByRole('status')).toHaveText('Link copied')
+        expect(await page.evaluate(() => navigator.clipboard.readText())).toBe(page.url())
+        expect(new URL(page.url()).hash).toBe(`#${id}`)
+      })
+    })
+  })
+})

--- a/tests/e2e/VariantPage.playwright.spec.ts
+++ b/tests/e2e/VariantPage.playwright.spec.ts
@@ -1,14 +1,59 @@
 import { test, expect } from '@playwright/test'
 
 test.describe('Variant page', () => {
-  test('v4 renders without crashes', async ({ page }) => {
+  test.describe('narrow touch viewport', () => {
+    test.use({ viewport: { width: 320, height: 720 }, hasTouch: true, isMobile: true })
+
+    test('keeps the whole permalink target and feedback on screen', async ({ page }) => {
+      await page.context().grantPermissions(['clipboard-read', 'clipboard-write'])
+      await page.goto('/variant/1-55051215-G-GA?dataset=gnomad_r4#age-distribution')
+      const link = page.getByRole('link', { name: 'Copy link to Age Distribution' })
+      await expect(link).toBeAttached({ timeout: 30_000 })
+      await expect(link).toHaveCSS('opacity', '1')
+      const target = await link.boundingBox()
+      expect(target!.width).toBeGreaterThanOrEqual(44)
+      expect(target!.height).toBeGreaterThanOrEqual(44)
+      expect(target!.x).toBeGreaterThanOrEqual(0)
+      expect(target!.x + target!.width).toBeLessThanOrEqual(320)
+      await link.tap()
+
+      const card = page
+        .locator('strong')
+        .filter({ hasText: /^Link copied$/ })
+        .locator('..')
+      await expect(card).toBeInViewport({ ratio: 1 })
+      const feedback = await card.boundingBox()
+      expect(feedback!.x).toBeGreaterThanOrEqual(0)
+      expect(feedback!.x + feedback!.width).toBeLessThanOrEqual(320)
+    })
+  })
+
+  test('v4 renders after navigating from the homepage', async ({ page }) => {
     await page.goto('/')
     await page.getByRole('link', { name: '-55051215-G-GA' }).click()
 
-    // expect variant query to finish loading, and to render
     await expect(
       page.getByText('Insertion (1 base):1-55051215-G-GA (GRCh38)Copy variant IDGene page')
+    ).toBeVisible({ timeout: 30_000 })
+    await expect(
+      page.locator('table').filter({ hasText: 'ExomesGenomesTotalFilters' })
     ).toBeVisible()
+    await expect(
+      page.getByText('Genetic Ancestry Group Frequencies More informationgnomADHGDP1KGLocal')
+    ).toBeVisible()
+    await expect(page.getByText('Variant Effect PredictorThis')).toBeVisible()
+    await page
+      .getByText('Age Distribution More informationExomeGenomeVariant carriersAll individuals<')
+      .click()
+  })
+
+  test('v4 deep link and copyable Age Distribution anchor work', async ({ page }) => {
+    test.setTimeout(60_000)
+    await page.goto('/variant/1-55051215-G-GA?dataset=gnomad_r4#age-distribution')
+
+    await expect(
+      page.getByText('Insertion (1 base):1-55051215-G-GA (GRCh38)Copy variant IDGene page')
+    ).toBeVisible({ timeout: 30_000 })
 
     await expect(
       page.locator('table').filter({ hasText: 'ExomesGenomesTotalFilters' })
@@ -20,8 +65,48 @@ test.describe('Variant page', () => {
 
     await expect(page.getByText('Variant Effect PredictorThis')).toBeVisible()
 
-    await page
-      .getByText('Age Distribution More informationExomeGenomeVariant carriersAll individuals<')
-      .click()
+    const ageDistributionLink = page.getByRole('link', {
+      name: 'Copy link to Age Distribution',
+    })
+    await expect(ageDistributionLink).toBeAttached({ timeout: 30_000 })
+    // Check the final layout, not merely an aligned frame inside the two-second settle window.
+    await page.waitForTimeout(2200)
+    expect(
+      Math.abs(await ageDistributionLink.evaluate((link) => link.getBoundingClientRect().top))
+    ).toBeLessThanOrEqual(2)
+
+    const linkTarget = await ageDistributionLink.boundingBox()
+    expect(linkTarget).not.toBeNull()
+    expect(linkTarget!.width).toBeGreaterThanOrEqual(44)
+    expect(linkTarget!.height).toBeGreaterThanOrEqual(44)
+    await page.mouse.move(Math.max(linkTarget!.x + 2, 1), linkTarget!.y + linkTarget!.height / 2)
+    await expect(ageDistributionLink).toHaveCSS('opacity', '1')
+
+    await page.mouse.move(1200, 600)
+    await page.context().grantPermissions(['clipboard-read', 'clipboard-write'])
+    // Fragment navigation sets the sequential focus starting point at the link.
+    await page.keyboard.press('Shift+Tab')
+    await expect(ageDistributionLink).not.toBeFocused()
+    await page.keyboard.press('Tab')
+    await expect(ageDistributionLink).toBeFocused()
+    await expect(ageDistributionLink).toHaveCSS('opacity', '1')
+    await page.keyboard.press('Enter')
+
+    const copyNotification = page
+      .locator('strong')
+      .filter({ hasText: /^Link copied$/ })
+      .locator('..')
+    await expect(copyNotification).toBeInViewport({ ratio: 1 })
+    await expect(page.getByRole('status')).toHaveText('Link copied')
+    await expect
+      .poll(() =>
+        copyNotification.evaluate(
+          (notification) => getComputedStyle(notification.parentElement!).position
+        )
+      )
+      .toBe('fixed')
+    expect(new URL(page.url()).hash).toBe('#age-distribution')
+    expect(new URL(page.url()).searchParams.get('dataset')).toBe('gnomad_r4')
+    expect(await page.evaluate(() => navigator.clipboard.readText())).toBe(page.url())
   })
 })

--- a/tests/e2e/VariantPage.playwright.spec.ts
+++ b/tests/e2e/VariantPage.playwright.spec.ts
@@ -4,27 +4,35 @@ test.describe('Variant page', () => {
   test.describe('narrow touch viewport', () => {
     test.use({ viewport: { width: 320, height: 720 }, hasTouch: true, isMobile: true })
 
-    test('keeps the whole permalink target and feedback on screen', async ({ page }) => {
-      await page.context().grantPermissions(['clipboard-read', 'clipboard-write'])
-      await page.goto('/variant/1-55051215-G-GA?dataset=gnomad_r4#age-distribution')
-      const link = page.getByRole('link', { name: 'Copy link to Age Distribution' })
-      await expect(link).toBeAttached({ timeout: 30_000 })
-      await expect(link).toHaveCSS('opacity', '1')
-      const target = await link.boundingBox()
-      expect(target!.width).toBeGreaterThanOrEqual(44)
-      expect(target!.height).toBeGreaterThanOrEqual(44)
-      expect(target!.x).toBeGreaterThanOrEqual(0)
-      expect(target!.x + target!.width).toBeLessThanOrEqual(320)
-      await link.tap()
+    const sections = [
+      ['age-distribution', 'Age Distribution'],
+      ['genomic-constraint', 'Genomic Constraint of Surrounding 1kb Region'],
+    ]
+    sections.forEach(([id, title]) => {
+      test(`keeps the whole ${title} target and feedback on screen`, async ({ page }) => {
+        await page.context().grantPermissions(['clipboard-read', 'clipboard-write'])
+        await page.goto(`/variant/1-55051215-G-GA?dataset=gnomad_r4#${id}`)
+        const link = page.getByRole('link', { name: `Copy link to ${title}` })
+        await expect(link).toBeAttached({ timeout: 30_000 })
+        await expect(link).toHaveCSS('opacity', '1')
+        const target = await link.boundingBox()
+        expect(target!.width).toBeGreaterThanOrEqual(44)
+        expect(target!.height).toBeGreaterThanOrEqual(44)
+        expect(target!.x).toBeGreaterThanOrEqual(0)
+        expect(target!.x + target!.width).toBeLessThanOrEqual(320)
+        await link.tap()
 
-      const card = page
-        .locator('strong')
-        .filter({ hasText: /^Link copied$/ })
-        .locator('..')
-      await expect(card).toBeInViewport({ ratio: 1 })
-      const feedback = await card.boundingBox()
-      expect(feedback!.x).toBeGreaterThanOrEqual(0)
-      expect(feedback!.x + feedback!.width).toBeLessThanOrEqual(320)
+        const card = page
+          .locator('strong')
+          .filter({ hasText: /^Link copied$/ })
+          .locator('..')
+        await expect(card).toBeInViewport({ ratio: 1 })
+        const feedback = await card.boundingBox()
+        expect(feedback!.x).toBeGreaterThanOrEqual(0)
+        expect(feedback!.x + feedback!.width).toBeLessThanOrEqual(320)
+        expect(new URL(page.url()).hash).toBe(`#${id}`)
+        expect(await page.evaluate(() => navigator.clipboard.readText())).toBe(page.url())
+      })
     })
   })
 
@@ -45,6 +53,33 @@ test.describe('Variant page', () => {
     await page
       .getByText('Age Distribution More informationExomeGenomeVariant carriersAll individuals<')
       .click()
+  })
+
+  test('non-age deep links survive refresh and copying another section navigates natively', async ({
+    page,
+  }) => {
+    test.setTimeout(60_000)
+    await page.context().grantPermissions(['clipboard-read', 'clipboard-write'])
+    await page.goto('/variant/1-55051215-G-GA?dataset=gnomad_r4#variant-effect-predictor')
+    const heading = page.locator('h2#variant-effect-predictor')
+    const expectSettledHeading = async () => {
+      await expect(heading).toBeAttached({ timeout: 30_000 })
+      await page.waitForTimeout(2200)
+      expect(
+        Math.abs(await heading.evaluate((element) => element.getBoundingClientRect().top))
+      ).toBeLessThanOrEqual(2)
+    }
+    await expectSettledHeading()
+    await page.reload()
+    await expectSettledHeading()
+
+    await page.getByRole('link', { name: 'Copy link to Read Data' }).click()
+    await expect(page.locator('h2#read-data')).toBeInViewport()
+    expect(new URL(page.url()).pathname).toBe('/variant/1-55051215-G-GA')
+    expect(new URL(page.url()).search).toBe('?dataset=gnomad_r4')
+    expect(new URL(page.url()).hash).toBe('#read-data')
+    expect(await page.evaluate(() => navigator.clipboard.readText())).toBe(page.url())
+    await expect(page.getByRole('status')).toHaveText('Link copied')
   })
 
   test('v4 deep link and copyable Age Distribution anchor work', async ({ page }) => {
@@ -72,7 +107,11 @@ test.describe('Variant page', () => {
     // Check the final layout, not merely an aligned frame inside the two-second settle window.
     await page.waitForTimeout(2200)
     expect(
-      Math.abs(await ageDistributionLink.evaluate((link) => link.getBoundingClientRect().top))
+      Math.abs(
+        await page
+          .locator('h2#age-distribution')
+          .evaluate((heading) => heading.getBoundingClientRect().top)
+      )
     ).toBeLessThanOrEqual(2)
 
     const linkTarget = await ageDistributionLink.boundingBox()
@@ -84,7 +123,9 @@ test.describe('Variant page', () => {
 
     await page.mouse.move(1200, 600)
     await page.context().grantPermissions(['clipboard-read', 'clipboard-write'])
-    // Fragment navigation sets the sequential focus starting point at the link.
+    // The heading target starts sequential focus before its permalink.
+    await page.keyboard.press('Tab')
+    await expect(ageDistributionLink).toBeFocused()
     await page.keyboard.press('Shift+Tab')
     await expect(ageDistributionLink).not.toBeFocused()
     await page.keyboard.press('Tab')


### PR DESCRIPTION
### What # issue does this PR resolve (If applicable)

resolves: #1921

### Merge strategy

- [x] I understand that this PR will be squashed down into a single commit in `main`

### What does this PR do?

The ClinGen team is working through updated draft guidance for variant classification, which
covers using population references like gnomAD as evidence. Their curation interface needs to
link a reviewer directly to a variant's age distribution, rather than dropping them at the top
of the page to scroll and hunt for it.

This adds an `age-distribution` anchor to the Age Distribution heading, so
`/variant/1-55051215-G-GA?dataset=gnomad_r4#age-distribution` opens with that section in view.

### Architecture & Design

**Anchors reuse `withAnchor`.** Rather than inventing an affordance, this reuses the HOC already
behind the downloads and help page anchors, so the hover link icon looks and behaves the way it
does everywhere else on the site. A new `AnchoredSectionHeading` is exported from `AnchorLink.tsx`
so the four pages share one definition, mirroring how `DataPage/downloadsPageStyles.tsx` defines
its `SectionTitle` once.

**Copying is opt-in.** Clicking the icon copies the section URL, which suits a curation workflow
where the link gets pasted elsewhere. This is gated behind a new `copyUrlOnClick` prop, set only
by `AnchoredSectionHeading`, so the existing help, policies, and downloads anchors are unchanged.
It uses the same `navigator.clipboard` feature detection as the "Copy variant ID" button on the
variant page, and keeps `href` intact so right-click and middle-click still work.

**Why these pages need their own scrolling.** `App.tsx` already scrolls to the URL hash, but it
fires when a page's *code* finishes loading. These four pages render their content only after a
GraphQL query resolves, so at that moment the page still shows "Loading variant..." and the
section does not exist. The new `useScrollToHash` hook is therefore called from the component
that renders once data is available.

**Why the hook re-aligns rather than scrolling once.** A single scroll on mount lands in the wrong
place: the sections *below* the target have not rendered yet, so the document is too short for the
browser to bring the heading to the top and the scroll is clamped to the bottom of the page. This
was measured on a running browser — the heading sat at document offset 1809 while the page was
only 2558px tall, so `scrollY` clamped at 1658 and the heading came to rest 151px too low. The
amount varied per dataset, since each has a different quantity of late-arriving content. The hook
re-aligns on each animation frame for up to 2s while the page grows, stops as soon as the heading
is in place, and bails out immediately if the reader scrolls, touches, types, or clicks, so it
never fights someone who has started reading.

No new dependencies.

### Implementation

- Add `useScrollToHash`, which aligns the hash target while the page finishes rendering and yields
  to reader input
- Export `AnchoredSectionHeading` from `AnchorLink.tsx`, and add an opt-in `copyUrlOnClick` prop to
  `withAnchor` plus a `copyLinkToSection` helper that writes the absolute URL and shows the existing
  notification toast
- Use the anchored heading with `id="age-distribution"` and call `useScrollToHash` on the short
  variant, mitochondrial, structural variant, and short tandem repeat pages
- Regenerate the four page snapshots for the added anchor markup

### Tests

11 new tests, all passing:

- `useScrollToHash.spec.tsx` (7) — scrolls to the hash target; keeps re-aligning while the page
  grows; does not scroll when already aligned; stops once the reader scrolls; no-ops with no hash,
  with an unmatched hash, and with a hash that is not a valid CSS selector
- `AnchorLink.spec.tsx` (4) — renders the anchor and its id; leaves the clipboard alone for plain
  `withAnchor` consumers; copies the full section URL from `AnchoredSectionHeading`; does not throw
  where the Clipboard API is unavailable

68 snapshots across the four page suites were regenerated. The diff is limited to the added anchor
markup and the `onClick` handler.

**Coverage gaps, stated plainly:** jsdom has no layout engine, so `getBoundingClientRect` is
stubbed in the hook's tests. Those tests prove the retry loop runs and terminates correctly; they
do *not* prove it fixes real scroll clamping. That was verified by driving a real browser against
the dev server across `gnomad_r4`, `gnomad_r2_1`, `gnomad_r3`, and `exac` — all four land the
heading at 0px from the viewport top — but that verification is not committed and will not catch a
regression. A Playwright assertion in `tests/e2e/VariantPage.playwright.spec.ts` would be the place
to lock it in; happy to add one if reviewers want it, noting Playwright is not currently a CI gate
for browser changes.

### UI Changes (If applicable)

**With the changes in this PR**
[v4 short variant](https://gnomad.broadinstitute.org/variant/1-55051215-G-GA?dataset=gnomad_r4) now has link that, when clicked, copies a URL focused on the age distribution for the given variant:
<img width="766" height="445" alt="image" src="https://github.com/user-attachments/assets/d0e2dea7-626a-49fa-a978-56ceff25043c" />

This also applies to structural, mito, and TR variants:
[v4 SV](https://gnomad.broadinstitute.org/variant/DEL_CHR19_2C6DA7E7?dataset=gnomad_sv_r4) has same behavior as short variant (though reloaded page won't have the age distribution at the top due to shorter page length):
<img width="1231" height="876" alt="image" src="https://github.com/user-attachments/assets/d8d4b00e-5c69-4d07-a502-7436a36ff63a" />

[v4 mito](https://gnomad.broadinstitute.org/variant/M-8602-T-C?dataset=gnomad_r4)
<img width="1223" height="696" alt="image" src="https://github.com/user-attachments/assets/fb461a09-5670-4e66-8ae3-efc6b2d19157" />

[TR](https://gnomad.broadinstitute.org/short-tandem-repeat/ATXN1?dataset=gnomad_r4)
<img width="1228" height="401" alt="image" src="https://github.com/user-attachments/assets/421bf4c8-0fb6-4348-857d-cf695b376c92" />

### Requires additional attention

1. **`MitochondrialVariantPage.tsx` looks far larger than it is.** Hosting a hook meant converting
   its concise arrow body (`=> (`) to a block body, which re-indented the entire JSX tree. Review
   it with `git diff -w`; the real change is 5 lines.

2. **The 2s settle window in `useScrollToHash` is a judgement call.** Measurements showed ~110ms
   between the clamped scroll and the corrected one, so 2s is comfortable, but content arriving
   after that on a very slow connection would leave the heading short. Worth a sanity check on the
   number.

3. **Short pages cannot always put the heading at the top, and this is not fixable by scrolling.**
   On e.g. `/variant/DEL_CHR19_413F7B28?dataset=gnomad_sv_r4#age-distribution`, the heading is
   478px from the end of a 1547px document, so reaching the top would require `scrollY=1069`
   against a ceiling of 647. The page is already scrolled to its end and the section is fully
   visible, just not at the top. The only lever would be padding the bottom of pages with empty
   space sitewide, which seems a poor trade for an edge case — flagging in case reviewers disagree.

4. **Mobile and breakpoint testing.** The deep link was checked across five viewports, straddling
   the 992px breakpoint where `ResponsiveSection` collapses to a single column. The heading lands
   0px from the top of the viewport in all of them:

   | Viewport | Deep link | Icon reachable |
   | --- | --- | --- |
   | iPhone 13 (390x844, touch) | 0px | tap |
   | Pixel 7 (412x915, touch) | 0px | tap |
   | iPad Mini (768x1024, touch) | 0px | tap |
   | narrow desktop (900x800, mouse) | 0px | hover |
   | wide desktop (1280x900, mouse) | 0px | hover |

   Below the breakpoint the document roughly doubles in height (3092px to 4866px on iPhone), which
   makes the clamping fix matter more, not less. Two caveats: this is Chromium device emulation
   rather than real hardware or WebKit, so iOS Safari's handling of `:hover` on tap is assumed
   rather than verified; and on touch the copy affordance needs two taps — one to reveal the icon,
   one to hit a 15x12px target. That awkwardness is inherited from the existing sitewide
   `withAnchor` design rather than introduced here, so this PR does not diverge from it, but
   reviewers may have a view.

5. **A changelog entry still needs writing** to announce this to users, once this PR is reviewed.

### Verification

- [x] I have the relevant `make` targets to run CI checks locally and verified that they succeed
      (note: `make validate-browser` arrives with #1903 and is not on `main` yet, so the equivalent
      steps from `browser-ci.yml` were run — eslint, stylelint, tsc, `pnpm build`, and the full
      Jest project: 1776 passing across 69 suites)
- [x] (If UI) I have tested this across desktop and mobile breakpoints.
- [x] (If a LLM/AI agent runner was used, e.g. OpenCode, Aider, or ClaudeCode) I have instructed the
      agent runner to load the `AGENTS.md` file into its context, and verified the the required
      `Assisted-by` trailer is on each commit.
