### PR TITLE
feat(API): move compression to NGINX and add GCP trace ids for log correlation

### DIFF
--- a/deploy/dockerfiles/browser/browser.dockerfile
+++ b/deploy/dockerfiles/browser/browser.dockerfile
@@ -42,5 +42,5 @@ COPY deploy/dockerfiles/browser/browser.proxy_cache.conf /etc/nginx/browser.prox
 COPY deploy/dockerfiles/browser/browser.nginx.conf /etc/nginx/browser.nginx.conf.template
 
 CMD REAL_IP_CONFIG=$([ -z "${PROXY_IPS:-}" ] || echo "$PROXY_IPS" | awk 'BEGIN { RS="," } { print "set_real_ip_from " $1 ";" }') \
-  envsubst "\$API_URL \$REAL_IP_CONFIG" < /etc/nginx/browser.nginx.conf.template > /etc/nginx/conf.d/default.conf && \
+  envsubst "\$API_URL \$REAL_IP_CONFIG \$GCP_PROJECT" < /etc/nginx/browser.nginx.conf.template > /etc/nginx/conf.d/default.conf && \
   nginx -g "daemon off;"

--- a/deploy/dockerfiles/browser/browser.nginx.conf
+++ b/deploy/dockerfiles/browser/browser.nginx.conf
@@ -1,23 +1,40 @@
-# Extract W3C trace ID when available.
+# Pass in the W3C traceparent header ($http_traceparent).
+# Try to extract a valid 32-character trace ID and set it as
+# $traceparent_trace_id.
+# Matches: <2 hex>-<32 hex>-<16 hex>-<2 hex>.
+# Capture group 1 (inside parentheses) is the trace ID.
+# If there is no valid match, the map value is empty.
 map $http_traceparent $traceparent_trace_id {
     default "";
     "~*^[0-9a-f]{2}-([0-9a-f]{32})-[0-9a-f]{16}-[0-9a-f]{2}$" $1;
 }
 
-# Fall back to Google's legacy trace context.
+# Pass in Google's legacy trace context header ($http_x_cloud_trace_context).
+# Try to extract a valid 32-character trace ID and set it as $cloud_trace_id.
+# Matches: <32 hex> followed by "/" or the end of the string.
+# Capture group 1 (inside parentheses) is the trace ID.
+# If there is no valid match, the map value is empty.
 map $http_x_cloud_trace_context $cloud_trace_id {
     default "";
     "~*^([0-9a-f]{32})(?:/|$)" $1;
 }
 
-# Prefer traceparent, then X-Cloud-Trace-Context.
+# Combine the trace IDs extracted above, preferring the W3C trace ID when both
+# formats are present.
+# The combined value has the form "<traceparent-trace-id>:<cloud-trace-id>".
+# Match either a W3C trace ID before the colon or, if absent, a legacy
+# Cloud Trace ID after the colon. Set the result as $gcp_trace_id.
 map "$traceparent_trace_id:$cloud_trace_id" $gcp_trace_id {
     default "";
     "~^([0-9a-f]{32}):" $1;
     "~^:([0-9a-f]{32})$" $1;
 }
 
-# Only construct a GCP trace resource when GCP_PROJECT is configured.
+# Combine GCP_PROJECT and the extracted trace ID.
+# Only construct a complete GCP trace resource when both the project 
+# and trace ID are available.
+# The resulting value is suitable for
+# logging.googleapis.com/trace: "projects/<project>/traces/<trace-id>".
 map "$GCP_PROJECT:$gcp_trace_id" $gcp_trace {
     default "";
     "~^([^:]+):([0-9a-f]{32})$" "projects/$1/traces/$2";

--- a/deploy/dockerfiles/browser/browser.nginx.conf
+++ b/deploy/dockerfiles/browser/browser.nginx.conf
@@ -1,7 +1,33 @@
+# Extract W3C trace ID when available.
+map $http_traceparent $traceparent_trace_id {
+    default "";
+    "~*^[0-9a-f]{2}-([0-9a-f]{32})-[0-9a-f]{16}-[0-9a-f]{2}$" $1;
+}
+
+# Fall back to Google's legacy trace context.
+map $http_x_cloud_trace_context $cloud_trace_id {
+    default "";
+    "~*^([0-9a-f]{32})(?:/|$)" $1;
+}
+
+# Prefer traceparent, then X-Cloud-Trace-Context.
+map "$traceparent_trace_id:$cloud_trace_id" $gcp_trace_id {
+    default "";
+    "~^([0-9a-f]{32}):" $1;
+    "~^:([0-9a-f]{32})$" $1;
+}
+
+# Only construct a GCP trace resource when GCP_PROJECT is configured.
+map "$GCP_PROJECT:$gcp_trace_id" $gcp_trace {
+    default "";
+    "~^([^:]+):([0-9a-f]{32})$" "projects/$1/traces/$2";
+}
+
 # Log access information in JSON format so that individual fields can
 # be queried in Stackdriver.
 log_format json_combined escape=json
 '{'
+'"logging.googleapis.com/trace":"$gcp_trace",'
 '"httpRequest":{'
 '"requestMethod":"$request_method",'
 '"requestUrl":"$scheme://$host$request_uri",'
@@ -57,7 +83,11 @@ server {
     # Proxy requests to api container
     # $API_URL is replaced at runtime with the API_URL environment variable.
     proxy_pass $API_URL;
+
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Cloud-Trace-Context $http_x_cloud_trace_context;
+    proxy_set_header traceparent $http_traceparent;
+
     include /etc/nginx/browser.proxy_cache.conf;
   }
 
@@ -71,7 +101,11 @@ server {
     # Proxy requests to api container
     # $API_URL is replaced at runtime with the API_URL environment variable.
     proxy_pass $API_URL;
+
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Cloud-Trace-Context $http_x_cloud_trace_context;
+    proxy_set_header traceparent $http_traceparent;
+
     include /etc/nginx/browser.proxy_cache.conf;
   }
 

--- a/deploy/dockerfiles/browser/browser.nginx.conf
+++ b/deploy/dockerfiles/browser/browser.nginx.conf
@@ -48,6 +48,12 @@ server {
   ###############
 
   location /api/ {
+    gzip on;
+    gzip_proxied any;
+    gzip_vary on;
+    gzip_types
+      application/json;
+
     # Proxy requests to api container
     # $API_URL is replaced at runtime with the API_URL environment variable.
     proxy_pass $API_URL;
@@ -56,6 +62,12 @@ server {
   }
 
   location = /api {
+    gzip on;
+    gzip_proxied any;
+    gzip_vary on;
+    gzip_types
+      application/json;
+
     # Proxy requests to api container
     # $API_URL is replaced at runtime with the API_URL environment variable.
     proxy_pass $API_URL;

--- a/deploy/dockerfiles/browser/browser.nginx.conf
+++ b/deploy/dockerfiles/browser/browser.nginx.conf
@@ -1,17 +1,17 @@
 # Pass in the W3C traceparent header ($http_traceparent).
 # Try to extract a valid 32-character trace ID and set it as
 # $traceparent_trace_id.
-# Matches: <2 hex>-<32 hex>-<16 hex>-<2 hex>.
+# Matches: 00-<32 hex>-<16 hex>-<2 hex>.
 # Capture group 1 (inside parentheses) is the trace ID.
 # If there is no valid match, the map value is empty.
 map $http_traceparent $traceparent_trace_id {
     default "";
-    "~*^[0-9a-f]{2}-([0-9a-f]{32})-[0-9a-f]{16}-[0-9a-f]{2}$" $1;
+    "~*^00-([0-9a-f]{32})-[0-9a-f]{16}-[0-9a-f]{2}$" $1;
 }
 
 # Pass in Google's legacy trace context header ($http_x_cloud_trace_context).
 # Try to extract a valid 32-character trace ID and set it as $cloud_trace_id.
-# Matches: <32 hex> followed by "/" or the end of the string.
+# Matches: <32 hex>, followed by "/" and legacy span ID and options.
 # Capture group 1 (inside parentheses) is the trace ID.
 # If there is no valid match, the map value is empty.
 map $http_x_cloud_trace_context $cloud_trace_id {

--- a/graphql-api/package.json
+++ b/graphql-api/package.json
@@ -18,7 +18,6 @@
     "@types/on-headers": "^1.0.0",
     "@types/redis": "^4.0.11",
     "bottleneck": "^2.19.5",
-    "compression": "^1.7.4",
     "cors": "^2.8.5",
     "express": "^4.20.0",
     "express-graphql": "^0.12.0",

--- a/graphql-api/src/app.ts
+++ b/graphql-api/src/app.ts
@@ -1,4 +1,3 @@
-import compression from 'compression'
 import cors from 'cors'
 import { randomUUID } from 'crypto'
 import express from 'express'
@@ -13,7 +12,6 @@ import { closeCache } from './cache'
 import { loadWhitelist } from './whitelist'
 
 const app = express()
-app.use(compression())
 app.use(cors())
 app.use(express.json())
 

--- a/graphql-api/src/app.ts
+++ b/graphql-api/src/app.ts
@@ -17,25 +17,24 @@ import { loadWhitelist } from './whitelist'
 // fall back to Google's legacy X-Cloud-Trace-Context header.
 const getGcpTraceId = (request: any) => {
   // Prefer W3C Trace Context.
-  const traceParent = request.get('traceparent')
+  // Matches: 00-<32 hex>-<16 hex>-<2 hex>.
+  // Capture group 1 (inside parentheses) is the 32-character trace ID.
+  const traceParentMatch = request
+    .get('traceparent')
+    ?.match(/^00-([\da-f]{32})-[\da-f]{16}-[\da-f]{2}$/i)
 
-  if (traceParent) {
-    // Matches: <2 hex>-<32 hex>-<16 hex>-<2 hex>.
-    // Capture group 1 (inside parentheses) is the 32-character trace ID.
-    const match = traceParent.match(
-      /^[\da-f]{2}-([\da-f]{32})-[\da-f]{16}-[\da-f]{2}$/i
-    )
-
-    if (match) {
-      return match[1]
-    }
+  if (traceParentMatch) {
+    return traceParentMatch[1]
   }
 
   // Fall back to Google's legacy trace context header.
-  // Matches: <32 hex> followed by "/" or the end of the string.
+  // Matches: <32 hex>, followed by "/" and legacy span ID and options.
   // Capture group 1 (inside parentheses) is the 32-character trace ID.
-  const match = request.get('X-Cloud-Trace-Context')?.match(/^([\da-f]{32})(?:\/|$)/i)
-  return match?.[1]
+  const cloudTraceMatch = request
+    .get('X-Cloud-Trace-Context')
+    ?.match(/^([\da-f]{32})(?:\/|$)/i)
+
+  return cloudTraceMatch?.[1]
 }
 
 const app = express()

--- a/graphql-api/src/app.ts
+++ b/graphql-api/src/app.ts
@@ -27,17 +27,8 @@ const getGcpTraceId = (request: any) => {
   }
 
   // Fall back to Google's legacy trace context header.
-  const cloudTrace = request.get('X-Cloud-Trace-Context')
-
-  if (cloudTrace) {
-    const match = cloudTrace.match(/^([\da-f]{32})(?:\/|$)/i)
-
-    if (match) {
-      return match[1]
-    }
-  }
-
-  return null
+  const match = request.get('X-Cloud-Trace-Context')?.match(/^([\da-f]{32})(?:\/|$)/i)
+  return match?.[1]
 }
 
 const app = express()

--- a/graphql-api/src/app.ts
+++ b/graphql-api/src/app.ts
@@ -11,12 +11,17 @@ import { requestStore } from './request-context'
 import { closeCache } from './cache'
 import { loadWhitelist } from './whitelist'
 
-// Extract the trace ID from W3C or GCP trace context.
+// Extract the original trace ID from the request for Node's logs.
+// NGINX independently extracts the same ID for its own logs, so both logs
+// can be correlated to the original request. Prefer W3C Trace Context and
+// fall back to Google's legacy X-Cloud-Trace-Context header.
 const getGcpTraceId = (request: any) => {
   // Prefer W3C Trace Context.
   const traceParent = request.get('traceparent')
 
   if (traceParent) {
+    // Matches: <2 hex>-<32 hex>-<16 hex>-<2 hex>.
+    // Capture group 1 (inside parentheses) is the 32-character trace ID.
     const match = traceParent.match(
       /^[\da-f]{2}-([\da-f]{32})-[\da-f]{16}-[\da-f]{2}$/i
     )
@@ -27,6 +32,8 @@ const getGcpTraceId = (request: any) => {
   }
 
   // Fall back to Google's legacy trace context header.
+  // Matches: <32 hex> followed by "/" or the end of the string.
+  // Capture group 1 (inside parentheses) is the 32-character trace ID.
   const match = request.get('X-Cloud-Trace-Context')?.match(/^([\da-f]{32})(?:\/|$)/i)
   return match?.[1]
 }

--- a/graphql-api/src/app.ts
+++ b/graphql-api/src/app.ts
@@ -11,6 +11,35 @@ import { requestStore } from './request-context'
 import { closeCache } from './cache'
 import { loadWhitelist } from './whitelist'
 
+// Extract the trace ID from W3C or GCP trace context.
+const getGcpTraceId = (request: any) => {
+  // Prefer W3C Trace Context.
+  const traceParent = request.get('traceparent')
+
+  if (traceParent) {
+    const match = traceParent.match(
+      /^[\da-f]{2}-([\da-f]{32})-[\da-f]{16}-[\da-f]{2}$/i
+    )
+
+    if (match) {
+      return match[1]
+    }
+  }
+
+  // Fall back to Google's legacy trace context header.
+  const cloudTrace = request.get('X-Cloud-Trace-Context')
+
+  if (cloudTrace) {
+    const match = cloudTrace.match(/^([\da-f]{32})(?:\/|$)/i)
+
+    if (match) {
+      return match[1]
+    }
+  }
+
+  return null
+}
+
 const app = express()
 app.use(cors())
 app.use(express.json())
@@ -25,12 +54,20 @@ app.get('/health/ready', (_req: any, res: any) => {
 })
 
 app.use((req: any, res: any, next: any) => {
+  const traceId = config.GCP_PROJECT
+    ? getGcpTraceId(req)
+    : null
+
   const store = {
     requestId: randomUUID(),
     startAt: performance.now(),
     startCpu: process.cpuUsage(),
     startHeapUsed: process.memoryUsage().heapUsed,
+    trace: traceId
+      ? `projects/${config.GCP_PROJECT}/traces/${traceId}`
+      : null,
   }
+
   res.setHeader('x-request-id', store.requestId)
   requestStore.run(store, () => {
     logger.info({
@@ -65,36 +102,39 @@ app.use((req: any, res: any, next: any) => {
   onFinished(res, () => {
     if (!ctx) return
 
-    // Process-wide resources consumed while this request was in flight.
-    // Concurrent requests contribute to these values (both cpu/memory)!
-    const memory = process.memoryUsage()
-    const cpu = process.cpuUsage(ctx.startCpu)
-    logger.info({
-      requestId: ctx.requestId,
-      event: 'requestEnd',
-      latencyMs: performance.now() - ctx.startAt,
-      cpuUserMicros: cpu.user,
-      cpuSystemMicros: cpu.system,
-      heapUsed: memory.heapUsed,
-      heapDeltaBytes:  memory.heapUsed - ctx.startHeapUsed,
-      httpRequest: {
-        requestMethod: req.method,
-        requestUrl: `${req.protocol}://${req.hostname}${req.originalUrl || req.url}`,
-        userAgent: req.headers['user-agent'],
-        remoteIp: req.ip,
-        referer: req.headers.referer || req.headers.referrer,
-        protocol: `HTTP/${req.httpVersionMajor}.${req.httpVersionMinor}`,
-        status: res.statusCode,
-        responseSizeBytes: res.getHeader('content-length')
-      },
-      graphqlRequest: req.graphqlParams
-        ? {
-            graphqlQueryOperationName: req.graphqlParams.operationName,
-            graphqlQueryString: req.graphqlParams.query,
-            graphqlQueryVariables: req.graphqlParams.variables,
-            graphqlQueryCost: req.graphqlQueryCost,
-          }
-        : undefined,
+    requestStore.run(ctx, () => {
+      // Process-wide resources consumed while this request was in flight.
+      // Concurrent requests contribute to these values (both cpu/memory)!
+      const memory = process.memoryUsage()
+      const cpu = process.cpuUsage(ctx.startCpu)
+
+      logger.info({
+        requestId: ctx.requestId,
+        event: 'requestEnd',
+        latencyMs: performance.now() - ctx.startAt,
+        cpuUserMicros: cpu.user,
+        cpuSystemMicros: cpu.system,
+        heapUsed: memory.heapUsed,
+        heapDeltaBytes:  memory.heapUsed - ctx.startHeapUsed,
+        httpRequest: {
+          requestMethod: req.method,
+          requestUrl: `${req.protocol}://${req.hostname}${req.originalUrl || req.url}`,
+          userAgent: req.headers['user-agent'],
+          remoteIp: req.ip,
+          referer: req.headers.referer || req.headers.referrer,
+          protocol: `HTTP/${req.httpVersionMajor}.${req.httpVersionMinor}`,
+          status: res.statusCode,
+          responseSizeBytes: res.getHeader('content-length')
+        },
+        graphqlRequest: req.graphqlParams
+          ? {
+              graphqlQueryOperationName: req.graphqlParams.operationName,
+              graphqlQueryString: req.graphqlParams.query,
+              graphqlQueryVariables: req.graphqlParams.variables,
+              graphqlQueryCost: req.graphqlQueryCost,
+            }
+          : undefined,
+      })
     })
   })
   next()

--- a/graphql-api/src/config.ts
+++ b/graphql-api/src/config.ts
@@ -48,6 +48,9 @@ const config: Record<string, any> = {
   JSON_CACHE_LARGE_GENES: env.JSON_CACHE_LARGE_GENES === 'true' || false,
   JSON_CACHE_COMPRESSION: env.JSON_CACHE_COMPRESSION === 'true' || false,
   REDIS_CACHE_PREFIX: env.REDIS_CACHE_PREFIX || '',
+
+  // GCP
+  GCP_PROJECT: env.GCP_PROJECT,
 }
 
 const requiredConfig = ['ELASTICSEARCH_URL']

--- a/graphql-api/src/logger.ts
+++ b/graphql-api/src/logger.ts
@@ -37,30 +37,27 @@ const formatLogEntry = (obj: any) => {
 const addTrace = (record: any) => {
   const trace = requestStore.getStore()?.trace
 
-  if (trace) {
-    record['logging.googleapis.com/trace'] = trace
-  }
+  return trace
+    ? {
+        ...record,
+        'logging.googleapis.com/trace': trace,
+      }
+    : record
 }
 
 const logger = {
   info: (obj: any) => {
-    const record = formatLogEntry(obj)
-    addTrace(record)
-    // @ts-expect-error TS(2339) FIXME: Property 'severity' does not exist on type '{}'.
+    const record = addTrace(formatLogEntry(obj))
     record.severity = Severity.INFO
     console.log(JSON.stringify(record)) // eslint-disable-line no-console
   },
   warn: (obj: any) => {
-    const record = formatLogEntry(obj)
-    addTrace(record)
-    // @ts-expect-error TS(2339) FIXME: Property 'severity' does not exist on type '{}'.
+    const record = addTrace(formatLogEntry(obj))
     record.severity = Severity.WARNING
     console.log(JSON.stringify(record)) // eslint-disable-line no-console
   },
   error: (obj: any) => {
-    const record = formatLogEntry(obj)
-    addTrace(record)
-    // @ts-expect-error TS(2339) FIXME: Property 'severity' does not exist on type '{}'.
+    const record = addTrace(formatLogEntry(obj))
     record.severity = Severity.ERROR
     console.error(JSON.stringify(record)) // eslint-disable-line no-console
   },

--- a/graphql-api/src/logger.ts
+++ b/graphql-api/src/logger.ts
@@ -1,3 +1,5 @@
+import { requestStore } from './request-context'
+
 // https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#logseverity
 const Severity = {
   INFO: 'INFO',
@@ -32,21 +34,32 @@ const formatLogEntry = (obj: any) => {
   return record
 }
 
+const addTrace = (record: any) => {
+  const trace = requestStore.getStore()?.trace
+
+  if (trace) {
+    record['logging.googleapis.com/trace'] = trace
+  }
+}
+
 const logger = {
   info: (obj: any) => {
     const record = formatLogEntry(obj)
+    addTrace(record)
     // @ts-expect-error TS(2339) FIXME: Property 'severity' does not exist on type '{}'.
     record.severity = Severity.INFO
     console.log(JSON.stringify(record)) // eslint-disable-line no-console
   },
   warn: (obj: any) => {
     const record = formatLogEntry(obj)
+    addTrace(record)
     // @ts-expect-error TS(2339) FIXME: Property 'severity' does not exist on type '{}'.
     record.severity = Severity.WARNING
     console.log(JSON.stringify(record)) // eslint-disable-line no-console
   },
   error: (obj: any) => {
     const record = formatLogEntry(obj)
+    addTrace(record)
     // @ts-expect-error TS(2339) FIXME: Property 'severity' does not exist on type '{}'.
     record.severity = Severity.ERROR
     console.error(JSON.stringify(record)) // eslint-disable-line no-console

--- a/graphql-api/src/request-context.ts
+++ b/graphql-api/src/request-context.ts
@@ -3,8 +3,9 @@ import { AsyncLocalStorage } from 'async_hooks'
 export interface RequestContext {
   requestId: string
   startAt: number
-  startCpu: NodeJS.CpuUsage,
-  startHeapUsed: number,
+  startCpu: NodeJS.CpuUsage
+  startHeapUsed: number
+  trace: string | null
 }
 export const requestStore = new AsyncLocalStorage<RequestContext>()
 export const getRequestContext = () => requestStore.getStore()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -405,9 +405,6 @@ importers:
       bottleneck:
         specifier: ^2.19.5
         version: 2.19.5
-      compression:
-        specifier: ^1.7.4
-        version: 1.7.4
       cors:
         specifier: ^2.8.5
         version: 2.8.5
@@ -499,6 +496,7 @@ packages:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.12
       '@jridgewell/trace-mapping': 0.3.29
+    dev: true
 
   /@ardatan/aggregate-error@0.0.6:
     resolution: {integrity: sha512-vyrkEHG1jrukmzTPtyWB4NLPauUw5bQeg4uhn8f+1SSynmrOcyvlb1GKQjjgoBzElLdfXCRYX8UnBlhklOHYRQ==}
@@ -578,6 +576,7 @@ packages:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/generator@7.23.0:
     resolution: {integrity: sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==}
@@ -653,17 +652,17 @@ packages:
       '@babel/helper-split-export-declaration': 7.22.6
       semver: 6.3.1
 
-  /@babel/helper-create-class-features-plugin@7.27.1(@babel/core@7.28.0):
+  /@babel/helper-create-class-features-plugin@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-QwGAmuvM17btKU5VqXfb+Giw4JcN0hjuufz3DYnpeVDvZLAObloM77bhMXiqry3Iio+Ai4phVRDwl6WU10+r5A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.23.0
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-member-expression-to-functions': 7.27.1
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.0)
+      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.23.0)
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
       '@babel/traverse': 7.28.0
       semver: 6.3.1
@@ -681,24 +680,13 @@ packages:
       regexpu-core: 5.3.2
       semver: 6.3.1
 
-  /@babel/helper-create-regexp-features-plugin@7.22.15(@babel/core@7.28.0):
-    resolution: {integrity: sha512-29FkPLFjn4TPEa3RE7GpW+qbE8tlsu3jntNYNfcGsc49LphF1PQIiD+vMZ1z1xVOKt+93khA9tc2JBs3kBjA7w==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.28.0
-      '@babel/helper-annotate-as-pure': 7.22.5
-      regexpu-core: 5.3.2
-      semver: 6.3.1
-
-  /@babel/helper-create-regexp-features-plugin@7.27.1(@babel/core@7.28.0):
+  /@babel/helper-create-regexp-features-plugin@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-uVDC72XVf8UbrH5qQTc18Agb8emwjTiZrQE11Nv3CuBEZmVvTwwE9CBUEvHku06gQCAyYf8Nv6ja1IN+6LMbxQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.23.0
       '@babel/helper-annotate-as-pure': 7.27.3
       regexpu-core: 6.2.0
       semver: 6.3.1
@@ -717,12 +705,12 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@babel/helper-define-polyfill-provider@0.6.5(@babel/core@7.28.0):
+  /@babel/helper-define-polyfill-provider@0.6.5(@babel/core@7.23.0):
     resolution: {integrity: sha512-uJnGFcPsWQK8fvjgGP5LZUZZsYGIoPeRjSF5PGwrelYgq7Q15/Ft9NGFp1zglwgIv//W0uG4BevRuSJRyylZPg==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.23.0
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
       debug: 4.4.1
@@ -795,6 +783,19 @@ packages:
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/helper-validator-identifier': 7.22.20
 
+  /@babel/helper-module-transforms@7.27.3(@babel/core@7.23.0):
+    resolution: {integrity: sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.23.0
+      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-validator-identifier': 7.27.1
+      '@babel/traverse': 7.28.0
+    transitivePeerDependencies:
+      - supports-color
+
   /@babel/helper-module-transforms@7.27.3(@babel/core@7.28.0):
     resolution: {integrity: sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==}
     engines: {node: '>=6.9.0'}
@@ -807,6 +808,7 @@ packages:
       '@babel/traverse': 7.28.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/helper-optimise-call-expression@7.22.5:
     resolution: {integrity: sha512-HBwaojN0xFRx4yIvpwGqxiV2tUfl7401jlok564NgB9EHS1y6QT17FmKWm4ztqjeVdXLuC4fSvHc5ePpQjoTbw==}
@@ -839,13 +841,13 @@ packages:
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-wrap-function': 7.22.20
 
-  /@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.28.0):
+  /@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-7fiA521aVw8lSPeI4ZOD3vRFkoqkJcS+z4hFo82bFSH/2tNd6eJ5qCVMS5OzDmZh/kaHQeBaeyxK6wljcPtveA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.23.0
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-wrap-function': 7.27.1
       '@babel/traverse': 7.28.0
@@ -863,13 +865,13 @@ packages:
       '@babel/helper-member-expression-to-functions': 7.23.0
       '@babel/helper-optimise-call-expression': 7.22.5
 
-  /@babel/helper-replace-supers@7.27.1(@babel/core@7.28.0):
+  /@babel/helper-replace-supers@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-7EHz6qDZc8RYS5ElPoShMheWvEgERonFCs7IAonWLLUTXW59DP14bCZt89/GKyreYn8g3S83m21FelHKbeDCKA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.23.0
       '@babel/helper-member-expression-to-functions': 7.27.1
       '@babel/helper-optimise-call-expression': 7.27.1
       '@babel/traverse': 7.28.0
@@ -961,6 +963,7 @@ packages:
     dependencies:
       '@babel/template': 7.27.2
       '@babel/types': 7.28.2
+    dev: true
 
   /@babel/highlight@7.22.20:
     resolution: {integrity: sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==}
@@ -984,25 +987,25 @@ packages:
     dependencies:
       '@babel/types': 7.28.2
 
-  /@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.27.1(@babel/core@7.28.0):
+  /@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-QPG3C9cCVRQLxAVwmefEmwdTanECuUBMQZ/ym5kiw3XKCGA7qkuQLcjWWHcrD/GKbn/WmJwaezfuuAOcyKlRPA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/traverse': 7.28.0
     transitivePeerDependencies:
       - supports-color
 
-  /@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1(@babel/core@7.28.0):
+  /@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-qNeq3bCKnGgLkEXUuFry6dPlGfCdQNZbn7yUAPCInwAJHMU7THJfrBSozkcWq5sNM6RcF3S8XyQL2A52KNR9IA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.27.1
 
   /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.22.15(@babel/core@7.23.0):
@@ -1014,13 +1017,13 @@ packages:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.28.0):
+  /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-g4L7OYun04N1WyqMNjldFwlfPCLVkgB54A/YCXICZYBsvJJE3kByKv9c9+R/nAfmIfjl2rKYLNyMHboYbZaWaA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.27.1
 
   /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.22.15(@babel/core@7.23.0):
@@ -1034,26 +1037,26 @@ packages:
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/plugin-transform-optional-chaining': 7.23.0(@babel/core@7.23.0)
 
-  /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.28.0):
+  /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-oO02gcONcD5O1iTLi/6frMJBIwWEHceWGSGqrpCmEL8nogiS6J9PBlE48CaK20/Jx1LuRml9aDftLgdjXT8+Cw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.13.0
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/plugin-transform-optional-chaining': 7.27.1(@babel/core@7.28.0)
+      '@babel/plugin-transform-optional-chaining': 7.27.1(@babel/core@7.23.0)
     transitivePeerDependencies:
       - supports-color
 
-  /@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.27.1(@babel/core@7.28.0):
+  /@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-6BpaYGDavZqkI6yT+KSPdpZFfpnd68UKXbcjI9pJ13pvHhPrCKWOOLp+ysvMeA+DxnhuPpgIaRpxRxo5A9t5jw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/traverse': 7.28.0
     transitivePeerDependencies:
@@ -1114,14 +1117,6 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.23.0
-
-  /@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.28.0):
-    resolution: {integrity: sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.28.0
 
   /@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.23.0):
     resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
@@ -1191,13 +1186,13 @@ packages:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-syntax-import-assertions@7.27.1(@babel/core@7.28.0):
+  /@babel/plugin-syntax-import-assertions@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-UT/Jrhw57xg4ILHLFnzFpPDlMbcdEicaAtjPQpbj9wa8T4r5KVWCimHcL/460g8Ht0DMxDyjsLgiWSkVjnwPFg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.27.1
 
   /@babel/plugin-syntax-import-attributes@7.22.5(@babel/core@7.23.0):
@@ -1209,13 +1204,13 @@ packages:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-syntax-import-attributes@7.27.1(@babel/core@7.28.0):
+  /@babel/plugin-syntax-import-attributes@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.27.1
 
   /@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.23.0):
@@ -1328,16 +1323,6 @@ packages:
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.0)
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.28.0):
-    resolution: {integrity: sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.28.0
-      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.28.0)
-      '@babel/helper-plugin-utils': 7.22.5
-
   /@babel/plugin-transform-arrow-functions@7.22.5(@babel/core@7.23.0):
     resolution: {integrity: sha512-26lTNXoVRdAnsaDXPpvCNUq+OVWEVC6bx7Vvz9rC53F2bagUWW4u4ii2+h8Fejfh7RYqPxn+libeFBBck9muEw==}
     engines: {node: '>=6.9.0'}
@@ -1347,13 +1332,13 @@ packages:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.28.0):
+  /@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-8Z4TGic6xW70FKThA5HYEKKyBpOOsucTOD1DjU3fZxDg+K3zBJcXMFnt/4yQiZnf5+MiOMSXQ9PaEK/Ilh1DeA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.27.1
 
   /@babel/plugin-transform-async-generator-functions@7.22.15(@babel/core@7.23.0):
@@ -1368,15 +1353,15 @@ packages:
       '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.23.0)
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.23.0)
 
-  /@babel/plugin-transform-async-generator-functions@7.28.0(@babel/core@7.28.0):
+  /@babel/plugin-transform-async-generator-functions@7.28.0(@babel/core@7.23.0):
     resolution: {integrity: sha512-BEOdvX4+M765icNPZeidyADIvQ1m1gmunXufXxvRESy/jNNyfovIqUyE7MVgGBjWktCoJlzvFA1To2O4ymIO3Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.28.0)
+      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.23.0)
       '@babel/traverse': 7.28.0
     transitivePeerDependencies:
       - supports-color
@@ -1392,16 +1377,16 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.23.0)
 
-  /@babel/plugin-transform-async-to-generator@7.27.1(@babel/core@7.28.0):
+  /@babel/plugin-transform-async-to-generator@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-NREkZsZVJS4xmTr8qzE5y8AfIPqsdQfRuUiLRTEzb7Qii8iFWCyDKaUV2c0rCuh4ljDZ98ALHP/PetiBV2nddA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.23.0
       '@babel/helper-module-imports': 7.27.1
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.28.0)
+      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.23.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -1414,13 +1399,13 @@ packages:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.28.0):
+  /@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-cnqkuOtZLapWYZUYM5rVIdv1nXYuFVIltZ6ZJ7nIj585QsjKM5dhL2Fu/lICXZ1OyIAFc7Qy+bvDAtTXqGrlhg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.27.1
 
   /@babel/plugin-transform-block-scoping@7.23.0(@babel/core@7.23.0):
@@ -1432,13 +1417,13 @@ packages:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-block-scoping@7.28.0(@babel/core@7.28.0):
+  /@babel/plugin-transform-block-scoping@7.28.0(@babel/core@7.23.0):
     resolution: {integrity: sha512-gKKnwjpdx5sER/wl0WN0efUBFzF/56YZO0RJrSYP4CljXnP31ByY7fol89AzomdlLNzI36AvOTmYHsnZTCkq8Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.27.1
 
   /@babel/plugin-transform-class-properties@7.22.5(@babel/core@7.23.0):
@@ -1451,14 +1436,14 @@ packages:
       '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.23.0)
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-class-properties@7.27.1(@babel/core@7.28.0):
+  /@babel/plugin-transform-class-properties@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-D0VcalChDMtuRvJIu3U/fwWjf8ZMykz5iZsg77Nuj821vCKI3zCyRLwRdWbsuJ/uRwZhZ002QtCqIkwC/ZkvbA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.28.0
-      '@babel/helper-create-class-features-plugin': 7.27.1(@babel/core@7.28.0)
+      '@babel/core': 7.23.0
+      '@babel/helper-create-class-features-plugin': 7.27.1(@babel/core@7.23.0)
       '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
@@ -1474,14 +1459,14 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.23.0)
 
-  /@babel/plugin-transform-class-static-block@7.27.1(@babel/core@7.28.0):
+  /@babel/plugin-transform-class-static-block@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-s734HmYU78MVzZ++joYM+NkJusItbdRcbm+AGRgJCt3iA+yux0QpD9cBVdz3tKyrjVYWRl7j0mHSmv4lhV0aoA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.12.0
     dependencies:
-      '@babel/core': 7.28.0
-      '@babel/helper-create-class-features-plugin': 7.27.1(@babel/core@7.28.0)
+      '@babel/core': 7.23.0
+      '@babel/helper-create-class-features-plugin': 7.27.1(@babel/core@7.23.0)
       '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
@@ -1503,18 +1488,18 @@ packages:
       '@babel/helper-split-export-declaration': 7.22.6
       globals: 11.12.0
 
-  /@babel/plugin-transform-classes@7.28.0(@babel/core@7.28.0):
+  /@babel/plugin-transform-classes@7.28.0(@babel/core@7.23.0):
     resolution: {integrity: sha512-IjM1IoJNw72AZFlj33Cu8X0q2XK/6AaVC3jQu+cgQ5lThWD5ajnuUAml80dqRmOhmPkTH8uAwnpMu9Rvj0LTRA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.23.0
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-globals': 7.28.0
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.0)
+      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.23.0)
       '@babel/traverse': 7.28.0
     transitivePeerDependencies:
       - supports-color
@@ -1529,13 +1514,13 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/template': 7.22.15
 
-  /@babel/plugin-transform-computed-properties@7.27.1(@babel/core@7.28.0):
+  /@babel/plugin-transform-computed-properties@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-lj9PGWvMTVksbWiDT2tW68zGS/cyo4AkZ/QTp0sQT0mjPopCmrSkzxeXkznjqBxzDI6TclZhOJbBmbBLjuOZUw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/template': 7.27.2
 
@@ -1548,13 +1533,13 @@ packages:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-destructuring@7.28.0(@babel/core@7.28.0):
+  /@babel/plugin-transform-destructuring@7.28.0(@babel/core@7.23.0):
     resolution: {integrity: sha512-v1nrSMBiKcodhsyJ4Gf+Z0U/yawmJDBOTpEB3mcQY52r9RIyPneGyAS/yM6seP/8I+mWI3elOMtT5dB8GJVs+A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/traverse': 7.28.0
     transitivePeerDependencies:
@@ -1570,14 +1555,14 @@ packages:
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.0)
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-dotall-regex@7.27.1(@babel/core@7.28.0):
+  /@babel/plugin-transform-dotall-regex@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-gEbkDVGRvjj7+T1ivxrfgygpT7GUd4vmODtYpbs0gZATdkX8/iSnOtZSxiZnsgm1YjTgjI6VKBGSJJevkrclzw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.28.0
-      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.28.0)
+      '@babel/core': 7.23.0
+      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.23.0)
       '@babel/helper-plugin-utils': 7.27.1
 
   /@babel/plugin-transform-duplicate-keys@7.22.5(@babel/core@7.23.0):
@@ -1589,23 +1574,23 @@ packages:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.28.0):
+  /@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-MTyJk98sHvSs+cvZ4nOauwTTG1JeonDjSGvGGUNHreGQns+Mpt6WX/dVzWBHgg+dYZhkC4X+zTDfkTU+Vy9y7Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.27.1
 
-  /@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.27.1(@babel/core@7.28.0):
+  /@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-hkGcueTEzuhB30B3eJCbCYeCaaEQOmQR0AdvzpD4LoN0GXMWzzGSuRrxR2xTnCrvNbVwK9N6/jQ92GSLfiZWoQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.28.0
-      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.28.0)
+      '@babel/core': 7.23.0
+      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.23.0)
       '@babel/helper-plugin-utils': 7.27.1
 
   /@babel/plugin-transform-dynamic-import@7.22.11(@babel/core@7.23.0):
@@ -1618,24 +1603,24 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.23.0)
 
-  /@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.28.0):
+  /@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-MHzkWQcEmjzzVW9j2q8LGjwGWpG2mjwaaB0BNQwst3FIjqsg8Ct/mIZlvSPJvfi9y2AC8mi/ktxbFVL9pZ1I4A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.27.1
 
-  /@babel/plugin-transform-explicit-resource-management@7.28.0(@babel/core@7.28.0):
+  /@babel/plugin-transform-explicit-resource-management@7.28.0(@babel/core@7.23.0):
     resolution: {integrity: sha512-K8nhUcn3f6iB+P3gwCv/no7OdzOZQcKchW6N389V6PD8NUWKZHzndOd9sPDVbMoBsbmjMqlB4L9fm+fEFNVlwQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-transform-destructuring': 7.28.0(@babel/core@7.28.0)
+      '@babel/plugin-transform-destructuring': 7.28.0(@babel/core@7.23.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -1649,13 +1634,13 @@ packages:
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.22.15
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-exponentiation-operator@7.27.1(@babel/core@7.28.0):
+  /@babel/plugin-transform-exponentiation-operator@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-uspvXnhHvGKf2r4VVtBpeFnuDWsJLQ6MF6lGJLC89jBR1uoVeqM416AZtTuhTezOfgHicpJQmoD5YUakO/YmXQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.27.1
 
   /@babel/plugin-transform-export-namespace-from@7.22.11(@babel/core@7.23.0):
@@ -1668,13 +1653,13 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.23.0)
 
-  /@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.28.0):
+  /@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-tQvHWSZ3/jH2xuq/vZDy0jNn+ZdXJeM8gHvX4lnJmsc3+50yPlWdZXIc5ay+umX+2/tJIqHqiEqcJvxlmIvRvQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.27.1
 
   /@babel/plugin-transform-flow-strip-types@7.23.3(@babel/core@7.23.0):
@@ -1696,13 +1681,13 @@ packages:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-for-of@7.27.1(@babel/core@7.28.0):
+  /@babel/plugin-transform-for-of@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-BfbWFFEJFQzLCQ5N8VocnCtA8J1CLkNTe2Ms2wocj75dd6VpiqS5Z5quTYcUoo4Yq+DN0rtikODccuv7RU81sw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
@@ -1719,13 +1704,13 @@ packages:
       '@babel/helper-function-name': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-function-name@7.27.1(@babel/core@7.28.0):
+  /@babel/plugin-transform-function-name@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-1bQeydJF9Nr1eBCMMbC+hdwmRlsv5XYOMu03YSWFwNs0HsAmtSxxF1fyuYPqemVldVyFmlCU7w8UE14LupUSZQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.23.0
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/traverse': 7.28.0
@@ -1742,13 +1727,13 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.23.0)
 
-  /@babel/plugin-transform-json-strings@7.27.1(@babel/core@7.28.0):
+  /@babel/plugin-transform-json-strings@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-6WVLVJiTjqcQauBhn1LkICsR2H+zm62I3h9faTDKt1qP4jn2o72tSvqMwtGFKGTpojce0gJs+76eZ2uCHRZh0Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.27.1
 
   /@babel/plugin-transform-literals@7.22.5(@babel/core@7.23.0):
@@ -1760,13 +1745,13 @@ packages:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-literals@7.27.1(@babel/core@7.28.0):
+  /@babel/plugin-transform-literals@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-0HCFSepIpLTkLcsi86GG3mTUzxV5jpmbv97hTETW3yzrAij8aqlD36toB1D0daVFJM8NK6GvKO0gslVQmm+zZA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.27.1
 
   /@babel/plugin-transform-logical-assignment-operators@7.22.11(@babel/core@7.23.0):
@@ -1779,13 +1764,13 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.23.0)
 
-  /@babel/plugin-transform-logical-assignment-operators@7.27.1(@babel/core@7.28.0):
+  /@babel/plugin-transform-logical-assignment-operators@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-SJvDs5dXxiae4FbSL1aBJlG4wvl594N6YEVVn9e3JGulwioy6z3oPjx/sQBO3Y4NwUu5HNix6KJ3wBZoewcdbw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.27.1
 
   /@babel/plugin-transform-member-expression-literals@7.22.5(@babel/core@7.23.0):
@@ -1797,13 +1782,13 @@ packages:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.28.0):
+  /@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-hqoBX4dcZ1I33jCSWcXrP+1Ku7kdqXf1oeah7ooKOIiAdKQ+uqftgCFNOSzA5AMS2XIHEYeGFg4cKRCdpxzVOQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.27.1
 
   /@babel/plugin-transform-modules-amd@7.23.0(@babel/core@7.23.0):
@@ -1816,14 +1801,14 @@ packages:
       '@babel/helper-module-transforms': 7.23.0(@babel/core@7.23.0)
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.28.0):
+  /@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-iCsytMg/N9/oFq6n+gFTvUYDZQOMK5kEdeYxmxt91fcJGycfxVP9CnrxoliM0oumFERba2i8ZtwRUCMhvP1LnA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.28.0
-      '@babel/helper-module-transforms': 7.27.3(@babel/core@7.28.0)
+      '@babel/core': 7.23.0
+      '@babel/helper-module-transforms': 7.27.3(@babel/core@7.23.0)
       '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
@@ -1839,14 +1824,14 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-simple-access': 7.22.5
 
-  /@babel/plugin-transform-modules-commonjs@7.27.1(@babel/core@7.28.0):
+  /@babel/plugin-transform-modules-commonjs@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-OJguuwlTYlN0gBZFRPqwOGNWssZjfIUdS7HMYtN8c1KmwpwHFBwTeFZrg9XZa+DFTitWOW5iTAG7tyCUPsCCyw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.28.0
-      '@babel/helper-module-transforms': 7.27.3(@babel/core@7.28.0)
+      '@babel/core': 7.23.0
+      '@babel/helper-module-transforms': 7.27.3(@babel/core@7.23.0)
       '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
@@ -1863,14 +1848,14 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-validator-identifier': 7.22.20
 
-  /@babel/plugin-transform-modules-systemjs@7.27.1(@babel/core@7.28.0):
+  /@babel/plugin-transform-modules-systemjs@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-w5N1XzsRbc0PQStASMksmUeqECuzKuTJer7kFagK8AXgpCMkeDMO5S+aaFb7A51ZYDF7XI34qsTX+fkHiIm5yA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.28.0
-      '@babel/helper-module-transforms': 7.27.3(@babel/core@7.28.0)
+      '@babel/core': 7.23.0
+      '@babel/helper-module-transforms': 7.27.3(@babel/core@7.23.0)
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
       '@babel/traverse': 7.28.0
@@ -1887,14 +1872,14 @@ packages:
       '@babel/helper-module-transforms': 7.23.0(@babel/core@7.23.0)
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.28.0):
+  /@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-iQBE/xC5BV1OxJbp6WG7jq9IWiD+xxlZhLrdwpPkTX3ydmXdvoCpyfJN7acaIBZaOqTfr76pgzqBJflNbeRK+w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.28.0
-      '@babel/helper-module-transforms': 7.27.3(@babel/core@7.28.0)
+      '@babel/core': 7.23.0
+      '@babel/helper-module-transforms': 7.27.3(@babel/core@7.23.0)
       '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
@@ -1909,14 +1894,14 @@ packages:
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.0)
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-named-capturing-groups-regex@7.27.1(@babel/core@7.28.0):
+  /@babel/plugin-transform-named-capturing-groups-regex@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-SstR5JYy8ddZvD6MhV0tM/j16Qds4mIpJTOd1Yu9J9pJjH93bxHECF7pgtc28XvkzTD6Pxcm/0Z73Hvk7kb3Ng==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.28.0
-      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.28.0)
+      '@babel/core': 7.23.0
+      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.23.0)
       '@babel/helper-plugin-utils': 7.27.1
 
   /@babel/plugin-transform-new-target@7.22.5(@babel/core@7.23.0):
@@ -1928,13 +1913,13 @@ packages:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-new-target@7.27.1(@babel/core@7.28.0):
+  /@babel/plugin-transform-new-target@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-f6PiYeqXQ05lYq3TIfIDu/MtliKUbNwkGApPUvyo6+tc7uaR4cPjPe7DFPr15Uyycg2lZU6btZ575CuQoYh7MQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.27.1
 
   /@babel/plugin-transform-nullish-coalescing-operator@7.22.11(@babel/core@7.23.0):
@@ -1947,13 +1932,13 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.23.0)
 
-  /@babel/plugin-transform-nullish-coalescing-operator@7.27.1(@babel/core@7.28.0):
+  /@babel/plugin-transform-nullish-coalescing-operator@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-aGZh6xMo6q9vq1JGcw58lZ1Z0+i0xB2x0XaauNIUXd6O1xXc3RwoWEBlsTQrY4KQ9Jf0s5rgD6SiNkaUdJegTA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.27.1
 
   /@babel/plugin-transform-numeric-separator@7.22.11(@babel/core@7.23.0):
@@ -1966,13 +1951,13 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.23.0)
 
-  /@babel/plugin-transform-numeric-separator@7.27.1(@babel/core@7.28.0):
+  /@babel/plugin-transform-numeric-separator@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-fdPKAcujuvEChxDBJ5c+0BTaS6revLV7CJL08e4m3de8qJfNIuCc2nc7XJYOjBoTMJeqSmwXJ0ypE14RCjLwaw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.27.1
 
   /@babel/plugin-transform-object-rest-spread@7.22.15(@babel/core@7.23.0):
@@ -1988,17 +1973,17 @@ packages:
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.23.0)
       '@babel/plugin-transform-parameters': 7.22.15(@babel/core@7.23.0)
 
-  /@babel/plugin-transform-object-rest-spread@7.28.0(@babel/core@7.28.0):
+  /@babel/plugin-transform-object-rest-spread@7.28.0(@babel/core@7.23.0):
     resolution: {integrity: sha512-9VNGikXxzu5eCiQjdE4IZn8sb9q7Xsk5EXLDBKUYg1e/Tve8/05+KJEtcxGxAgCY5t/BpKQM+JEL/yT4tvgiUA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.23.0
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-transform-destructuring': 7.28.0(@babel/core@7.28.0)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.28.0)
+      '@babel/plugin-transform-destructuring': 7.28.0(@babel/core@7.23.0)
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.23.0)
       '@babel/traverse': 7.28.0
     transitivePeerDependencies:
       - supports-color
@@ -2013,15 +1998,15 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-replace-supers': 7.22.20(@babel/core@7.23.0)
 
-  /@babel/plugin-transform-object-super@7.27.1(@babel/core@7.28.0):
+  /@babel/plugin-transform-object-super@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-SFy8S9plRPbIcxlJ8A6mT/CxFdJx/c04JEctz4jf8YZaVS2px34j7NXRrlGlHkN/M2gnpL37ZpGRGVFLd3l8Ng==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.0)
+      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.23.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -2035,13 +2020,13 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.23.0)
 
-  /@babel/plugin-transform-optional-catch-binding@7.27.1(@babel/core@7.28.0):
+  /@babel/plugin-transform-optional-catch-binding@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-txEAEKzYrHEX4xSZN4kJ+OfKXFVSWKB2ZxM9dpcE3wT7smwkNmXo5ORRlVzMVdJbD+Q8ILTgSD7959uj+3Dm3Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.27.1
 
   /@babel/plugin-transform-optional-chaining@7.23.0(@babel/core@7.23.0):
@@ -2055,13 +2040,13 @@ packages:
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.23.0)
 
-  /@babel/plugin-transform-optional-chaining@7.27.1(@babel/core@7.28.0):
+  /@babel/plugin-transform-optional-chaining@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-BQmKPPIuc8EkZgNKsv0X4bPmOoayeu4F1YCwx2/CfmDSXDbp7GnzlUH+/ul5VGfRg1AoFPsrIThlEBj2xb4CAg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
@@ -2076,13 +2061,13 @@ packages:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-parameters@7.27.7(@babel/core@7.28.0):
+  /@babel/plugin-transform-parameters@7.27.7(@babel/core@7.23.0):
     resolution: {integrity: sha512-qBkYTYCb76RRxUM6CcZA5KRu8K4SM8ajzVeUgVdMVO9NN9uI/GaVmBg/WKJJGnNokV9SY8FxNOVWGXzqzUidBg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.27.1
 
   /@babel/plugin-transform-private-methods@7.22.5(@babel/core@7.23.0):
@@ -2095,14 +2080,14 @@ packages:
       '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.23.0)
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-private-methods@7.27.1(@babel/core@7.28.0):
+  /@babel/plugin-transform-private-methods@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-10FVt+X55AjRAYI9BrdISN9/AQWHqldOeZDUoLyif1Kn05a56xVBXb8ZouL8pZ9jem8QpXaOt8TS7RHUIS+GPA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.28.0
-      '@babel/helper-create-class-features-plugin': 7.27.1(@babel/core@7.28.0)
+      '@babel/core': 7.23.0
+      '@babel/helper-create-class-features-plugin': 7.27.1(@babel/core@7.23.0)
       '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
@@ -2119,15 +2104,15 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.23.0)
 
-  /@babel/plugin-transform-private-property-in-object@7.27.1(@babel/core@7.28.0):
+  /@babel/plugin-transform-private-property-in-object@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-5J+IhqTi1XPa0DXF83jYOaARrX+41gOewWbkPyjMNRDqgOCqdffGh8L3f/Ek5utaEBZExjSAzcyjmV9SSAWObQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.23.0
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-create-class-features-plugin': 7.27.1(@babel/core@7.28.0)
+      '@babel/helper-create-class-features-plugin': 7.27.1(@babel/core@7.23.0)
       '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
@@ -2141,13 +2126,13 @@ packages:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-property-literals@7.27.1(@babel/core@7.28.0):
+  /@babel/plugin-transform-property-literals@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-oThy3BCuCha8kDZ8ZkgOg2exvPYUlprMukKQXI1r1pJ47NCvxfkEy8vK+r/hT9nF0Aa4H1WUPZZjHTFtAhGfmQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.27.1
 
   /@babel/plugin-transform-react-display-name@7.22.5(@babel/core@7.23.0):
@@ -2205,23 +2190,23 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
       regenerator-transform: 0.15.2
 
-  /@babel/plugin-transform-regenerator@7.28.1(@babel/core@7.28.0):
+  /@babel/plugin-transform-regenerator@7.28.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-P0QiV/taaa3kXpLY+sXla5zec4E+4t4Aqc9ggHlfZ7a2cp8/x/Gv08jfwEtn9gnnYIMvHx6aoOZ8XJL8eU71Dg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.27.1
 
-  /@babel/plugin-transform-regexp-modifiers@7.27.1(@babel/core@7.28.0):
+  /@babel/plugin-transform-regexp-modifiers@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-TtEciroaiODtXvLZv4rmfMhkCv8jx3wgKpL68PuiPh2M4fvz5jhsA7697N1gMvkvr/JTF13DrFYyEbY9U7cVPA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.28.0
-      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.28.0)
+      '@babel/core': 7.23.0
+      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.23.0)
       '@babel/helper-plugin-utils': 7.27.1
 
   /@babel/plugin-transform-reserved-words@7.22.5(@babel/core@7.23.0):
@@ -2233,13 +2218,13 @@ packages:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.28.0):
+  /@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-V2ABPHIJX4kC7HegLkYoDpfg9PVmuWy/i6vUM5eGK22bx4YVFD3M5F0QQnWQoDs6AGsUWTVOopBiMFQgHaSkVw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.27.1
 
   /@babel/plugin-transform-runtime@7.22.15(@babel/core@7.23.0):
@@ -2268,13 +2253,13 @@ packages:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.28.0):
+  /@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-N/wH1vcn4oYawbJ13Y/FxcQrWk63jhfNa7jef0ih7PHSIHX2LB7GWE1rkPrOnka9kwMxb6hMl19p7lidA+EHmQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.27.1
 
   /@babel/plugin-transform-spread@7.22.5(@babel/core@7.23.0):
@@ -2287,13 +2272,13 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
 
-  /@babel/plugin-transform-spread@7.27.1(@babel/core@7.28.0):
+  /@babel/plugin-transform-spread@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-kpb3HUqaILBJcRFVhFUs6Trdd4mkrzcGXss+6/mxUd273PfbWqSDHRzMT2234gIg2QYfAjvXLSquP1xECSg09Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
@@ -2308,13 +2293,13 @@ packages:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.28.0):
+  /@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-lhInBO5bi/Kowe2/aLdBAawijx+q1pQzicSgnkB6dUPc1+RC8QmJHKf2OjvU+NZWitguJHEaEmbV6VWEouT58g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.27.1
 
   /@babel/plugin-transform-template-literals@7.22.5(@babel/core@7.23.0):
@@ -2326,13 +2311,13 @@ packages:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-template-literals@7.27.1(@babel/core@7.28.0):
+  /@babel/plugin-transform-template-literals@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-fBJKiV7F2DxZUkg5EtHKXQdbsbURW3DZKQUWphDum0uRP6eHGGa/He9mc0mypL680pb+e/lDIthRohlv8NCHkg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.27.1
 
   /@babel/plugin-transform-typeof-symbol@7.22.5(@babel/core@7.23.0):
@@ -2344,13 +2329,13 @@ packages:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.28.0):
+  /@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-RiSILC+nRJM7FY5srIyc4/fGIwUhyDuuBSdWn4y6yT6gm652DpCHZjIipgn6B7MQ1ITOUnAKWixEUjQRIBIcLw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.27.1
 
   /@babel/plugin-transform-typescript@7.22.15(@babel/core@7.23.0):
@@ -2374,13 +2359,13 @@ packages:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.28.0):
+  /@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-Ysg4v6AmF26k9vpfFuTZg8HRfVWzsh1kVfowA23y9j/Gu6dOuahdUVhkLqpObp3JIv27MLSii6noRnuKN8H0Mg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.27.1
 
   /@babel/plugin-transform-unicode-property-regex@7.22.5(@babel/core@7.23.0):
@@ -2393,14 +2378,14 @@ packages:
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.0)
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-unicode-property-regex@7.27.1(@babel/core@7.28.0):
+  /@babel/plugin-transform-unicode-property-regex@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-uW20S39PnaTImxp39O5qFlHLS9LJEmANjMG7SxIhap8rCHqu0Ik+tLEPX5DKmHn6CsWQ7j3lix2tFOa5YtL12Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.28.0
-      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.28.0)
+      '@babel/core': 7.23.0
+      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.23.0)
       '@babel/helper-plugin-utils': 7.27.1
 
   /@babel/plugin-transform-unicode-regex@7.22.5(@babel/core@7.23.0):
@@ -2413,14 +2398,14 @@ packages:
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.0)
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.28.0):
+  /@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-xvINq24TRojDuyt6JGtHmkVkrfVV3FPT16uytxImLeBZqW3/H52yN+kM1MGuyPkIQxrzKwPHs5U/MP3qKyzkGw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.28.0
-      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.28.0)
+      '@babel/core': 7.23.0
+      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.23.0)
       '@babel/helper-plugin-utils': 7.27.1
 
   /@babel/plugin-transform-unicode-sets-regex@7.22.5(@babel/core@7.23.0):
@@ -2433,14 +2418,14 @@ packages:
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.0)
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-unicode-sets-regex@7.27.1(@babel/core@7.28.0):
+  /@babel/plugin-transform-unicode-sets-regex@7.27.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-EtkOujbc4cgvb0mlpQefi4NTPBzhSIevblFevACNLUspmrALgmEBdL/XfnyyITfd8fKBZrZys92zOWcik7j9Tw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.28.0
-      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.28.0)
+      '@babel/core': 7.23.0
+      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.23.0)
       '@babel/helper-plugin-utils': 7.27.1
 
   /@babel/preset-env@7.22.20(@babel/core@7.23.0):
@@ -2533,81 +2518,81 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@babel/preset-env@7.28.0(@babel/core@7.28.0):
+  /@babel/preset-env@7.28.0(@babel/core@7.23.0):
     resolution: {integrity: sha512-VmaxeGOwuDqzLl5JUkIRM1X2Qu2uKGxHEQWh+cvvbl7JuJRgKGJSfsEF/bUaxFhJl/XAyxBe7q7qSuTbKFuCyg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/compat-data': 7.28.0
-      '@babel/core': 7.28.0
+      '@babel/core': 7.23.0
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.28.0)
-      '@babel/plugin-syntax-import-assertions': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-syntax-import-attributes': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.28.0)
-      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-transform-async-generator-functions': 7.28.0(@babel/core@7.28.0)
-      '@babel/plugin-transform-async-to-generator': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-transform-block-scoped-functions': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-transform-block-scoping': 7.28.0(@babel/core@7.28.0)
-      '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-transform-class-static-block': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-transform-classes': 7.28.0(@babel/core@7.28.0)
-      '@babel/plugin-transform-computed-properties': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-transform-destructuring': 7.28.0(@babel/core@7.28.0)
-      '@babel/plugin-transform-dotall-regex': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-transform-duplicate-keys': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-transform-dynamic-import': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-transform-explicit-resource-management': 7.28.0(@babel/core@7.28.0)
-      '@babel/plugin-transform-exponentiation-operator': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-transform-json-strings': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-transform-logical-assignment-operators': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-transform-modules-systemjs': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-transform-numeric-separator': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-transform-object-rest-spread': 7.28.0(@babel/core@7.28.0)
-      '@babel/plugin-transform-object-super': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-transform-optional-catch-binding': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-transform-optional-chaining': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.28.0)
-      '@babel/plugin-transform-private-methods': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-transform-private-property-in-object': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-transform-property-literals': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-transform-regenerator': 7.28.1(@babel/core@7.28.0)
-      '@babel/plugin-transform-regexp-modifiers': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-transform-reserved-words': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-transform-spread': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-transform-sticky-regex': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-transform-typeof-symbol': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-transform-unicode-escapes': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-transform-unicode-property-regex': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-transform-unicode-sets-regex': 7.27.1(@babel/core@7.28.0)
-      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.28.0)
-      babel-plugin-polyfill-corejs2: 0.4.14(@babel/core@7.28.0)
-      babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.28.0)
-      babel-plugin-polyfill-regenerator: 0.6.5(@babel/core@7.28.0)
+      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.27.1(@babel/core@7.23.0)
+      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.23.0)
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.27.1(@babel/core@7.23.0)
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.27.1(@babel/core@7.23.0)
+      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.27.1(@babel/core@7.23.0)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.23.0)
+      '@babel/plugin-syntax-import-assertions': 7.27.1(@babel/core@7.23.0)
+      '@babel/plugin-syntax-import-attributes': 7.27.1(@babel/core@7.23.0)
+      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.23.0)
+      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.23.0)
+      '@babel/plugin-transform-async-generator-functions': 7.28.0(@babel/core@7.23.0)
+      '@babel/plugin-transform-async-to-generator': 7.27.1(@babel/core@7.23.0)
+      '@babel/plugin-transform-block-scoped-functions': 7.27.1(@babel/core@7.23.0)
+      '@babel/plugin-transform-block-scoping': 7.28.0(@babel/core@7.23.0)
+      '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.23.0)
+      '@babel/plugin-transform-class-static-block': 7.27.1(@babel/core@7.23.0)
+      '@babel/plugin-transform-classes': 7.28.0(@babel/core@7.23.0)
+      '@babel/plugin-transform-computed-properties': 7.27.1(@babel/core@7.23.0)
+      '@babel/plugin-transform-destructuring': 7.28.0(@babel/core@7.23.0)
+      '@babel/plugin-transform-dotall-regex': 7.27.1(@babel/core@7.23.0)
+      '@babel/plugin-transform-duplicate-keys': 7.27.1(@babel/core@7.23.0)
+      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.27.1(@babel/core@7.23.0)
+      '@babel/plugin-transform-dynamic-import': 7.27.1(@babel/core@7.23.0)
+      '@babel/plugin-transform-explicit-resource-management': 7.28.0(@babel/core@7.23.0)
+      '@babel/plugin-transform-exponentiation-operator': 7.27.1(@babel/core@7.23.0)
+      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.23.0)
+      '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.23.0)
+      '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.23.0)
+      '@babel/plugin-transform-json-strings': 7.27.1(@babel/core@7.23.0)
+      '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.23.0)
+      '@babel/plugin-transform-logical-assignment-operators': 7.27.1(@babel/core@7.23.0)
+      '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.23.0)
+      '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.23.0)
+      '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.23.0)
+      '@babel/plugin-transform-modules-systemjs': 7.27.1(@babel/core@7.23.0)
+      '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.23.0)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.27.1(@babel/core@7.23.0)
+      '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.23.0)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.27.1(@babel/core@7.23.0)
+      '@babel/plugin-transform-numeric-separator': 7.27.1(@babel/core@7.23.0)
+      '@babel/plugin-transform-object-rest-spread': 7.28.0(@babel/core@7.23.0)
+      '@babel/plugin-transform-object-super': 7.27.1(@babel/core@7.23.0)
+      '@babel/plugin-transform-optional-catch-binding': 7.27.1(@babel/core@7.23.0)
+      '@babel/plugin-transform-optional-chaining': 7.27.1(@babel/core@7.23.0)
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.23.0)
+      '@babel/plugin-transform-private-methods': 7.27.1(@babel/core@7.23.0)
+      '@babel/plugin-transform-private-property-in-object': 7.27.1(@babel/core@7.23.0)
+      '@babel/plugin-transform-property-literals': 7.27.1(@babel/core@7.23.0)
+      '@babel/plugin-transform-regenerator': 7.28.1(@babel/core@7.23.0)
+      '@babel/plugin-transform-regexp-modifiers': 7.27.1(@babel/core@7.23.0)
+      '@babel/plugin-transform-reserved-words': 7.27.1(@babel/core@7.23.0)
+      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.23.0)
+      '@babel/plugin-transform-spread': 7.27.1(@babel/core@7.23.0)
+      '@babel/plugin-transform-sticky-regex': 7.27.1(@babel/core@7.23.0)
+      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.23.0)
+      '@babel/plugin-transform-typeof-symbol': 7.27.1(@babel/core@7.23.0)
+      '@babel/plugin-transform-unicode-escapes': 7.27.1(@babel/core@7.23.0)
+      '@babel/plugin-transform-unicode-property-regex': 7.27.1(@babel/core@7.23.0)
+      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.23.0)
+      '@babel/plugin-transform-unicode-sets-regex': 7.27.1(@babel/core@7.23.0)
+      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.23.0)
+      babel-plugin-polyfill-corejs2: 0.4.14(@babel/core@7.23.0)
+      babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.23.0)
+      babel-plugin-polyfill-regenerator: 0.6.5(@babel/core@7.23.0)
       core-js-compat: 3.44.0
       semver: 6.3.1
     transitivePeerDependencies:
@@ -2630,16 +2615,6 @@ packages:
       '@babel/core': ^7.0.0-0 || ^8.0.0-0 <8.0.0
     dependencies:
       '@babel/core': 7.23.0
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/types': 7.23.0
-      esutils: 2.0.3
-
-  /@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.28.0):
-    resolution: {integrity: sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0 || ^8.0.0-0 <8.0.0
-    dependencies:
-      '@babel/core': 7.28.0
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/types': 7.23.0
       esutils: 2.0.3
@@ -5374,14 +5349,14 @@ packages:
       '@types/babel__traverse': 7.20.2
     dev: true
 
-  /babel-plugin-polyfill-corejs2@0.4.14(@babel/core@7.28.0):
+  /babel-plugin-polyfill-corejs2@0.4.14(@babel/core@7.23.0):
     resolution: {integrity: sha512-Co2Y9wX854ts6U8gAAPXfn0GmAyctHuK8n0Yhfjd6t30g7yvKjspvvOo9yG+z52PZRgFErt7Ka2pYnXCjLKEpg==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
       '@babel/compat-data': 7.28.0
-      '@babel/core': 7.28.0
-      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.28.0)
+      '@babel/core': 7.23.0
+      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.23.0)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -5398,13 +5373,13 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /babel-plugin-polyfill-corejs3@0.13.0(@babel/core@7.28.0):
+  /babel-plugin-polyfill-corejs3@0.13.0(@babel/core@7.23.0):
     resolution: {integrity: sha512-U+GNwMdSFgzVmfhNm8GJUX88AadB3uo9KpJqS3FaqNIPKgySuvMb+bHPsOmmuWyIcuqZj/pzt1RUIUZns4y2+A==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.28.0
-      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.28.0)
+      '@babel/core': 7.23.0
+      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.23.0)
       core-js-compat: 3.44.0
     transitivePeerDependencies:
       - supports-color
@@ -5430,13 +5405,13 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /babel-plugin-polyfill-regenerator@0.6.5(@babel/core@7.28.0):
+  /babel-plugin-polyfill-regenerator@0.6.5(@babel/core@7.23.0):
     resolution: {integrity: sha512-ISqQ2frbiNU9vIJkzg7dlPpznPZ4jOiUQ1uSmB0fEHeowtN3COYRsXr/xexn64NpU13P06jc/L5TgiJXOgrbEg==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.28.0
-      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.28.0)
+      '@babel/core': 7.23.0
+      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.23.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -5662,11 +5637,6 @@ packages:
     engines: {node: '>=18'}
     dependencies:
       run-applescript: 7.0.0
-
-  /bytes@3.0.0:
-    resolution: {integrity: sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==}
-    engines: {node: '>= 0.8'}
-    dev: false
 
   /bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -6043,21 +6013,6 @@ packages:
     engines: {node: '>= 0.6'}
     dependencies:
       mime-db: 1.54.0
-
-  /compression@1.7.4:
-    resolution: {integrity: sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==}
-    engines: {node: '>= 0.8.0'}
-    dependencies:
-      accepts: 1.3.8
-      bytes: 3.0.0
-      compressible: 2.0.18
-      debug: 2.6.9
-      on-headers: 1.0.2
-      safe-buffer: 5.1.2
-      vary: 1.1.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
 
   /compression@1.8.0:
     resolution: {integrity: sha512-k6WLKfunuqCYD3t6AsuPGvQWaKwuLLh2/xHNcX4qE+vIfDNXpSqnrhwA7O53R7WVQUnt8dVAIW+YHr7xTgOgGA==}
@@ -9699,7 +9654,7 @@ packages:
       '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.23.0)
       '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.23.0)
       '@babel/plugin-transform-modules-commonjs': 7.23.0(@babel/core@7.23.0)
-      '@babel/preset-env': 7.28.0(@babel/core@7.28.0)
+      '@babel/preset-env': 7.28.0(@babel/core@7.23.0)
       '@babel/preset-flow': 7.23.3(@babel/core@7.23.0)
       '@babel/preset-typescript': 7.23.0(@babel/core@7.23.0)
       '@babel/register': 7.22.15(@babel/core@7.23.0)


### PR DESCRIPTION
There are 2 updates in this PR:
1. The compression of the API responses were moved from Node to NGINX. This change will help cut down response latency and CPU usage.
2. We are now extracting the GCP trace id from incoming request headers and attaching it to our logs to allow for trace correlation.

The first change is relatively small, while the second has a few moving parts.
- In NGINX, extract the trace id from an incoming request. Use it in the access log by setting it to the `logging.googleapis.com/trace` field
- Separately, use helpers in Node to try to use the trace id from any incoming request and pass it to the Node logger
- Inject the trace id in any subsequent logs in Node
- NGINX and Node logs that originate from the same request can now be associated with each other using the trace id

The logging update is optional, so deployments outside of GCP will not be negatively affected.
