### PR TITLE
fix(nginx-cache): reduce max size of nginx cache

### DIFF
--- a/deploy/dockerfiles/browser/browser.nginx.conf
+++ b/deploy/dockerfiles/browser/browser.nginx.conf
@@ -59,7 +59,7 @@ log_format json_combined escape=json
 '}'
 '}';
 
-proxy_cache_path /var/cache/nginx levels=1:2 keys_zone=gnomadCache:30m max_size=20g inactive=30d;
+proxy_cache_path /var/cache/nginx levels=1:2 keys_zone=gnomadCache:30m max_size=16g inactive=30d;
 
 server {
   listen 80 default_server;


### PR DESCRIPTION
Related to #1927.

We set the NGINX cache max size to 20 gb, but the ephemeral volume that stores this cache in GKE is also set to 20 gb.

Because NGINX's cache size is not a hard cap, the cache can temporarily exceed the max value before evicting older cached items. Temporary proxy files also share the same volume. Both these factors can cause the volume to exceed its 20 GB limit, resulting in Pod eviction in GKE.

This PR lowers the NGINX cache max size to 16 GB. Doing so provides sufficient headroom for temp files and cache growth + eviction, so that the GKE volume limit is not exceeded.
