### PR TITLE
fix(reads-nginx): update forwarded for header, unquote status code

### DIFF
--- a/deploy/dockerfiles/reads/reads.nginx.conf
+++ b/deploy/dockerfiles/reads/reads.nginx.conf
@@ -5,7 +5,7 @@ log_format json_combined escape=json
 '"httpRequest":{'
 '"requestMethod":"$request_method",'
 '"requestUrl":"$scheme://$host$request_uri",'
-'"status":"$status",'
+'"status":$status,'
 '"responseSize":$bytes_sent,'
 '"userAgent":"$http_user_agent",'
 '"remoteIp":"$remote_addr",'
@@ -84,7 +84,7 @@ server {
   location ~* ^/preview-reads(/.*)?$ {
     rewrite ^/preview-reads(/.*)?$ /reads$1? break;
     proxy_pass http://127.0.0.1:8000;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-For $http_x_forwarded_for;
   }
 
   # Return not found by default for all paths
@@ -106,7 +106,7 @@ server {
   location = /reads/ {
     # Proxy requests to api container
     proxy_pass http://127.0.0.1:8000;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-For $http_x_forwarded_for;
   }
 
   ###################


### PR DESCRIPTION
Related to https://github.com/broadinstitute/gnomad-terraform/pull/229.

This PR is a minor update to the NGINX config for the Reads service.

In the Reads logs, the `$proxy_add_x_forwarded_for` value was duplicating the original client's remote IP address, so that it appeared at the beginning and the end of the value. The `$http_x_forwarded_for` has the correct value, which is the same list of IPs without the duplication.

Also, the status code was unquoted so that it would not appear in the logs as a string.
