### PR TITLE
Improve ClinVar testing

### DIFF
--- a/browser/src/ClinvarVariantsTrack/ClinvarVariantTrack.tsx
+++ b/browser/src/ClinvarVariantsTrack/ClinvarVariantTrack.tsx
@@ -295,7 +295,7 @@ const UnmemoizedClinvarVariantTrack = ({ referenceGenome, transcripts, variants 
 export const ClinvarVariantTrack = React.memo(UnmemoizedClinvarVariantTrack)
 
 type ClinvarVariantsProps = {
-  clinvarVariants: ClinvarVariant[]
+  clinvarVariants: ClinvarVariant[] | null | undefined
   clinvarReleaseDate: string
   referenceGenome: ReferenceGenome
   transcripts: Transcript[]
@@ -311,6 +311,27 @@ const ClinvarVariants = ({
   zoomRegion = null,
   pageType,
 }: ClinvarVariantsProps) => {
+  const heading = (
+    <TrackPageSection>
+      <h2>ClinVar variants</h2>
+    </TrackPageSection>
+  )
+
+  const clinvarUnavailableMessage = (
+    <TrackPageSection as="p">
+      ClinVar variants could not be loaded. Other data on this page is unaffected.
+    </TrackPageSection>
+  )
+
+  if (!clinvarVariants) {
+    return (
+      <>
+        {heading}
+        {clinvarUnavailableMessage}
+      </>
+    )
+  }
+
   const clinvarVariantTrack = (
     <>
       <ClinvarVariantTrack
@@ -330,9 +351,7 @@ const ClinvarVariants = ({
 
   return (
     <>
-      <TrackPageSection>
-        <h2>ClinVar variants</h2>
-      </TrackPageSection>
+      {heading}
       {clinvarVariants.length > 0 ? clinvarVariantTrack : noClinvarVariantsFoundMessage}
     </>
   )

--- a/browser/src/ClinvarVariantsTrack/ClinvarVariantTrack.tsx
+++ b/browser/src/ClinvarVariantsTrack/ClinvarVariantTrack.tsx
@@ -5,7 +5,8 @@ import { Track } from '@gnomad/region-viewer'
 import { Button, Checkbox, Modal, ExternalLink } from '@gnomad/ui'
 import CategoryFilterControl from '../CategoryFilterControl'
 import InfoButton from '../help/InfoButton'
-import { TrackPageSection } from '../TrackPage'
+import filterVariantsInZoomRegion from '../RegionViewer/filterVariantsInZoomRegion'
+import { PageType, TrackPageSection } from '../TrackPage'
 import {
   VEP_CONSEQUENCE_CATEGORIES,
   VEP_CONSEQUENCE_CATEGORY_LABELS,
@@ -21,8 +22,10 @@ import {
 import ClinvarAllVariantsPlot from './ClinvarAllVariantsPlot'
 import ClinvarBinnedVariantsPlot from './ClinvarBinnedVariantsPlot'
 import ClinvarVariantDetails from './ClinvarVariantDetails'
+import formatClinvarDate from './formatClinvarDate'
 import { ClinvarVariant } from '../VariantPage/VariantPage'
 import { Transcript } from '../TranscriptPage/TranscriptPage'
+import { ReferenceGenome } from '../../../dataset-metadata/metadata'
 
 const TopPanel = styled.div`
   display: flex;
@@ -98,7 +101,7 @@ type Props = {
   variants: ClinvarVariant[]
 }
 
-const ClinvarVariantTrack = ({ referenceGenome, transcripts, variants }: Props) => {
+const UnmemoizedClinvarVariantTrack = ({ referenceGenome, transcripts, variants }: Props) => {
   const [selectedVariant, setSelectedVariant] = useState(null)
 
   const [includedClinicalSignificanceCategories, setIncludedClinicalSignificanceCategories] =
@@ -289,4 +292,50 @@ const ClinvarVariantTrack = ({ referenceGenome, transcripts, variants }: Props) 
   )
 }
 
-export default React.memo(ClinvarVariantTrack)
+export const ClinvarVariantTrack = React.memo(UnmemoizedClinvarVariantTrack)
+
+type ClinvarVariantsProps = {
+  clinvarVariants: ClinvarVariant[]
+  clinvarReleaseDate: string
+  referenceGenome: ReferenceGenome
+  transcripts: Transcript[]
+  zoomRegion?: { start: number; stop: number } | null
+  pageType: PageType
+}
+
+const ClinvarVariants = ({
+  clinvarVariants,
+  clinvarReleaseDate,
+  referenceGenome,
+  transcripts,
+  zoomRegion = null,
+  pageType,
+}: ClinvarVariantsProps) => {
+  const clinvarVariantTrack = (
+    <>
+      <ClinvarVariantTrack
+        referenceGenome={referenceGenome}
+        transcripts={transcripts}
+        variants={filterVariantsInZoomRegion(clinvarVariants, zoomRegion)}
+      />
+      <TrackPageSection as="p">
+        Data displayed here is from ClinVar&apos;s {formatClinvarDate(clinvarReleaseDate)} release.
+      </TrackPageSection>
+    </>
+  )
+
+  const noClinvarVariantsFoundMessage = (
+    <TrackPageSection as="p">{`No ClinVar variants found in this ${pageType}.`}</TrackPageSection>
+  )
+
+  return (
+    <>
+      <TrackPageSection>
+        <h2>ClinVar variants</h2>
+      </TrackPageSection>
+      {clinvarVariants.length > 0 ? clinvarVariantTrack : noClinvarVariantsFoundMessage}
+    </>
+  )
+}
+
+export default ClinvarVariants

--- a/browser/src/ClinvarVariantsTrack/ClinvarVariantsTrack.spec.tsx
+++ b/browser/src/ClinvarVariantsTrack/ClinvarVariantsTrack.spec.tsx
@@ -229,10 +229,12 @@ describe('Clinvar Variants Track', () => {
 describe('ClinvarVariants', () => {
   const renderClinvarVariants = ({
     clinvarVariants,
+    clinvarReleaseDate = '2023-03-01',
     pageType = 'gene',
     zoomRegion = null,
   }: {
     clinvarVariants: ClinvarVariant[] | null | undefined
+    clinvarReleaseDate?: string
     pageType?: PageType
     zoomRegion?: { start: number; stop: number } | null
   }) =>
@@ -241,7 +243,7 @@ describe('ClinvarVariants', () => {
         <RegionViewerContext.Provider value={childPropsWithNonEmptyRegions}>
           <ClinvarVariants
             clinvarVariants={clinvarVariants}
-            clinvarReleaseDate="2023-03-01"
+            clinvarReleaseDate={clinvarReleaseDate}
             referenceGenome="GRCh38"
             transcripts={mockTranscripts}
             pageType={pageType}
@@ -310,4 +312,15 @@ describe('ClinvarVariants', () => {
       expect(screen.getByText(/ClinVar variants could not be loaded/)).not.toBeNull()
     }
   )
+
+  test('shows a malformed-date warning, rather than throwing, when the release date is malformed', () => {
+    expect(() =>
+      renderClinvarVariants({
+        clinvarVariants: mockClinvarVariantsOfEachCategory,
+        clinvarReleaseDate: 'not-a-date',
+      })
+    ).not.toThrow()
+
+    expect(screen.getByText(/Malformed date string: "not-a-date"/)).not.toBeNull()
+  })
 })

--- a/browser/src/ClinvarVariantsTrack/ClinvarVariantsTrack.spec.tsx
+++ b/browser/src/ClinvarVariantsTrack/ClinvarVariantsTrack.spec.tsx
@@ -230,9 +230,11 @@ describe('ClinvarVariants', () => {
   const renderClinvarVariants = ({
     clinvarVariants,
     pageType = 'gene',
+    zoomRegion = null,
   }: {
-    clinvarVariants: ClinvarVariant[]
+    clinvarVariants: ClinvarVariant[] | null | undefined
     pageType?: PageType
+    zoomRegion?: { start: number; stop: number } | null
   }) =>
     render(
       <BrowserRouter>
@@ -243,6 +245,7 @@ describe('ClinvarVariants', () => {
             referenceGenome="GRCh38"
             transcripts={mockTranscripts}
             pageType={pageType}
+            zoomRegion={zoomRegion}
           />
         </RegionViewerContext.Provider>
       </BrowserRouter>
@@ -265,6 +268,46 @@ describe('ClinvarVariants', () => {
 
       expect(screen.getByText(`No ClinVar variants found in this ${pageType}.`)).not.toBeNull()
       expect(asFragment()).toMatchSnapshot()
+    }
+  )
+
+  test.each([
+    ['null', null],
+    ['undefined', undefined],
+  ] as [string, ClinvarVariant[] | null | undefined][])(
+    'reports that the data could not be loaded, rather than that none were found, when the list is %s',
+    (_label, clinvarVariants) => {
+      const { asFragment } = renderClinvarVariants({ clinvarVariants })
+
+      expect(screen.getByRole('heading', { name: 'ClinVar variants' })).not.toBeNull()
+      expect(screen.getByText(/ClinVar variants could not be loaded/)).not.toBeNull()
+      expect(screen.queryByText(/No ClinVar variants found/)).toBeNull()
+      expect(asFragment()).toMatchSnapshot()
+    }
+  )
+
+  test.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['empty', []],
+  ] as [string, ClinvarVariant[] | null | undefined][])(
+    'renders without throwing when the list is %s',
+    (_label, clinvarVariants) => {
+      expect(() => renderClinvarVariants({ clinvarVariants })).not.toThrow()
+    }
+  )
+
+  test.each([
+    ['null', null],
+    ['undefined', undefined],
+  ] as [string, ClinvarVariant[] | null | undefined][])(
+    'renders without throwing when a zoom region is set and the list is %s',
+    (_label, clinvarVariants) => {
+      expect(() =>
+        renderClinvarVariants({ clinvarVariants, zoomRegion: { start: 100, stop: 200 } })
+      ).not.toThrow()
+
+      expect(screen.getByText(/ClinVar variants could not be loaded/)).not.toBeNull()
     }
   )
 })

--- a/browser/src/ClinvarVariantsTrack/ClinvarVariantsTrack.spec.tsx
+++ b/browser/src/ClinvarVariantsTrack/ClinvarVariantsTrack.spec.tsx
@@ -4,39 +4,96 @@ import clinvarVariantFactory from '../__factories__/ClinvarVariant'
 import { ClinvarVariant } from '../VariantPage/VariantPage'
 import React from 'react'
 import userEvent from '@testing-library/user-event'
-import ClinvarVariantTrack from './ClinvarVariantTrack'
+import ClinvarVariants, { ClinvarVariantTrack } from './ClinvarVariantTrack'
 import { Transcript } from '../TranscriptPage/TranscriptPage'
 import transcriptFactory from '../__factories__/Transcript'
 import { render, screen } from '@testing-library/react'
 import renderer from 'react-test-renderer'
 import { RegionViewerContext, regionViewerScale } from '@gnomad/region-viewer'
 import { BrowserRouter } from 'react-router-dom'
+import { PageType } from '../TrackPage'
+
+const mockClinvarVariants: ClinvarVariant[] = [
+  clinvarVariantFactory.build({ gold_stars: 0, major_consequence: 'missense_variant' }),
+  clinvarVariantFactory.build({ gold_stars: 1, major_consequence: 'missense_variant' }),
+  clinvarVariantFactory.build({ gold_stars: 2, major_consequence: 'missense_variant' }),
+  clinvarVariantFactory.build({ gold_stars: 3, major_consequence: 'missense_variant' }),
+  clinvarVariantFactory.build({ gold_stars: 4, major_consequence: 'missense_variant' }),
+]
+
+const mockClinvarVariantsOfEachCategory: ClinvarVariant[] = [
+  clinvarVariantFactory.build({
+    clinical_significance: 'Pathogenic',
+    major_consequence: 'frameshift_variant',
+    gold_stars: 4,
+    in_gnomad: true,
+    pos: 60,
+  }),
+  clinvarVariantFactory.build({
+    clinical_significance: 'Likely pathogenic',
+    major_consequence: 'stop_gained',
+    gold_stars: 3,
+    in_gnomad: true,
+    pos: 120,
+  }),
+  clinvarVariantFactory.build({
+    clinical_significance: 'Uncertain significance',
+    major_consequence: 'missense_variant',
+    gold_stars: 2,
+    pos: 180,
+  }),
+  clinvarVariantFactory.build({
+    clinical_significance: 'Conflicting classifications of pathogenicity',
+    major_consequence: 'splice_region_variant',
+    gold_stars: 1,
+    pos: 240,
+  }),
+  clinvarVariantFactory.build({
+    clinical_significance: 'Benign',
+    major_consequence: 'synonymous_variant',
+    gold_stars: 2,
+    in_gnomad: true,
+    pos: 300,
+  }),
+  clinvarVariantFactory.build({
+    clinical_significance: 'Likely benign',
+    major_consequence: 'missense_variant',
+    gold_stars: 1,
+    pos: 360,
+  }),
+  clinvarVariantFactory.build({
+    clinical_significance: 'drug response',
+    major_consequence: 'intron_variant',
+    gold_stars: 0,
+    pos: 420,
+  }),
+]
+
+const mockTranscripts: Transcript[] = [
+  transcriptFactory.build(),
+  transcriptFactory.build(),
+  transcriptFactory.build(),
+  transcriptFactory.build(),
+]
+
+const childProps = {
+  centerPanelWidth: 3,
+  isPositionDefined: () => true,
+  leftPanelWidth: 4,
+  regions: [],
+  rightPanelWidth: 5,
+  scalePosition: regionViewerScale([], [0, 500]),
+}
+
+const plottedRegions = [{ start: 1, stop: 500 }]
+const childPropsWithNonEmptyRegions = {
+  ...childProps,
+  centerPanelWidth: 500,
+  regions: plottedRegions,
+  scalePosition: regionViewerScale(plottedRegions, [0, 500]),
+}
 
 describe('Clinvar Variants Track', () => {
-  const mockClinvarVariants: ClinvarVariant[] = [
-    clinvarVariantFactory.build({ gold_stars: 0, major_consequence: 'missense_variant' }),
-    clinvarVariantFactory.build({ gold_stars: 1, major_consequence: 'missense_variant' }),
-    clinvarVariantFactory.build({ gold_stars: 2, major_consequence: 'missense_variant' }),
-    clinvarVariantFactory.build({ gold_stars: 3, major_consequence: 'missense_variant' }),
-    clinvarVariantFactory.build({ gold_stars: 4, major_consequence: 'missense_variant' }),
-  ]
-
-  const mockTranscripts: Transcript[] = [
-    transcriptFactory.build(),
-    transcriptFactory.build(),
-    transcriptFactory.build(),
-    transcriptFactory.build(),
-  ]
-
-  const childProps = {
-    centerPanelWidth: 3,
-    isPositionDefined: () => true,
-    leftPanelWidth: 4,
-    regions: [],
-    rightPanelWidth: 5,
-    scalePosition: regionViewerScale([], [0, 500]),
-  }
-
   test('renders correctly with default props', () => {
     const tree = renderer.create(
       <RegionViewerContext.Provider value={childProps}>
@@ -48,6 +105,42 @@ describe('Clinvar Variants Track', () => {
       </RegionViewerContext.Provider>
     )
     expect(tree).toMatchSnapshot()
+  })
+
+  test('renders the collapsed binned-variants plot correctly', () => {
+    const { asFragment } = render(
+      <BrowserRouter>
+        <RegionViewerContext.Provider value={childPropsWithNonEmptyRegions}>
+          <ClinvarVariantTrack
+            referenceGenome="GRCh38"
+            transcripts={mockTranscripts}
+            variants={mockClinvarVariantsOfEachCategory}
+          />
+        </RegionViewerContext.Provider>
+      </BrowserRouter>
+    )
+
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  test('renders the expanded all-variants plot correctly', async () => {
+    const user = userEvent.setup()
+    const { asFragment } = render(
+      <BrowserRouter>
+        <RegionViewerContext.Provider value={childPropsWithNonEmptyRegions}>
+          <ClinvarVariantTrack
+            referenceGenome="GRCh38"
+            transcripts={mockTranscripts}
+            variants={mockClinvarVariantsOfEachCategory}
+          />
+        </RegionViewerContext.Provider>
+      </BrowserRouter>
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Expand to all variants' }))
+
+    expect(screen.getByRole('button', { name: 'Collapse to bins' })).not.toBeNull()
+    expect(asFragment()).toMatchSnapshot()
   })
 
   test('Allow user to change to different review status filters', async () => {
@@ -131,4 +224,47 @@ describe('Clinvar Variants Track', () => {
     )
     expect(screen.getByText('ClinVar variants (1)')).not.toBeNull()
   })
+})
+
+describe('ClinvarVariants', () => {
+  const renderClinvarVariants = ({
+    clinvarVariants,
+    pageType = 'gene',
+  }: {
+    clinvarVariants: ClinvarVariant[]
+    pageType?: PageType
+  }) =>
+    render(
+      <BrowserRouter>
+        <RegionViewerContext.Provider value={childPropsWithNonEmptyRegions}>
+          <ClinvarVariants
+            clinvarVariants={clinvarVariants}
+            clinvarReleaseDate="2023-03-01"
+            referenceGenome="GRCh38"
+            transcripts={mockTranscripts}
+            pageType={pageType}
+          />
+        </RegionViewerContext.Provider>
+      </BrowserRouter>
+    )
+
+  test('renders the heading, the track and the release date when variants are present', () => {
+    const { asFragment } = renderClinvarVariants({
+      clinvarVariants: mockClinvarVariantsOfEachCategory,
+    })
+
+    expect(screen.getByRole('heading', { name: 'ClinVar variants' })).not.toBeNull()
+    expect(screen.getByText(/Data displayed here is from ClinVar/)).not.toBeNull()
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  test.each(['gene', 'transcript', 'region'] as PageType[])(
+    'reports that none were found on a %s page when the list is empty',
+    (pageType) => {
+      const { asFragment } = renderClinvarVariants({ clinvarVariants: [], pageType })
+
+      expect(screen.getByText(`No ClinVar variants found in this ${pageType}.`)).not.toBeNull()
+      expect(asFragment()).toMatchSnapshot()
+    }
+  )
 })

--- a/browser/src/ClinvarVariantsTrack/__snapshots__/ClinvarVariantsTrack.spec.tsx.snap
+++ b/browser/src/ClinvarVariantsTrack/__snapshots__/ClinvarVariantsTrack.spec.tsx.snap
@@ -8730,3 +8730,77 @@ exports[`ClinvarVariants reports that none were found on a transcript page when 
   </p>
 </DocumentFragment>
 `;
+
+exports[`ClinvarVariants reports that the data could not be loaded, rather than that none were found, when the list is null 1`] = `
+<DocumentFragment>
+  .c0 {
+  padding: 0 80px 0 115px;
+}
+
+@media (max-width:900px) {
+  .c0 {
+    padding: 0;
+  }
+}
+
+<div
+    class="c0"
+  >
+    <h2>
+      ClinVar variants
+    </h2>
+  </div>
+  .c0 {
+  padding: 0 80px 0 115px;
+}
+
+@media (max-width:900px) {
+  .c0 {
+    padding: 0;
+  }
+}
+
+<p
+    class="c0"
+  >
+    ClinVar variants could not be loaded. Other data on this page is unaffected.
+  </p>
+</DocumentFragment>
+`;
+
+exports[`ClinvarVariants reports that the data could not be loaded, rather than that none were found, when the list is undefined 1`] = `
+<DocumentFragment>
+  .c0 {
+  padding: 0 80px 0 115px;
+}
+
+@media (max-width:900px) {
+  .c0 {
+    padding: 0;
+  }
+}
+
+<div
+    class="c0"
+  >
+    <h2>
+      ClinVar variants
+    </h2>
+  </div>
+  .c0 {
+  padding: 0 80px 0 115px;
+}
+
+@media (max-width:900px) {
+  .c0 {
+    padding: 0;
+  }
+}
+
+<p
+    class="c0"
+  >
+    ClinVar variants could not be loaded. Other data on this page is unaffected.
+  </p>
+</DocumentFragment>
+`;

--- a/browser/src/ClinvarVariantsTrack/__snapshots__/ClinvarVariantsTrack.spec.tsx.snap
+++ b/browser/src/ClinvarVariantsTrack/__snapshots__/ClinvarVariantsTrack.spec.tsx.snap
@@ -947,3 +947,7786 @@ exports[`Clinvar Variants Track renders correctly with default props 1`] = `
   </div>,
 ]
 `;
+
+exports[`Clinvar Variants Track renders the collapsed binned-variants plot correctly 1`] = `
+<DocumentFragment>
+  .c19 {
+  box-sizing: border-box;
+  height: calc(2em + 2px);
+  padding: 0.375em 0.75em;
+  border-color: #6c757d;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0.5em;
+  background-color: #f8f9fa;
+  cursor: pointer;
+  font-size: 1em;
+  line-height: 1.25;
+  outline: none;
+  user-select: none;
+}
+
+.c19:active,
+.c19:hover {
+  background-color: #cbd3da;
+}
+
+.c19:disabled {
+  background-color: rgba(248,249,250,0.5);
+  cursor: not-allowed;
+}
+
+.c19:focus {
+  box-shadow: 0 0 0 0.2em rgba(108,117,125,0.5);
+}
+
+.c19 svg {
+  position: relative;
+  top: 0.11em;
+  width: 0.9em;
+  height: 0.9em;
+}
+
+.c24 {
+  user-select: none;
+}
+
+.c25 {
+  margin-right: 0.5em;
+}
+
+.c28 {
+  color: #1173bb;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.c28:visited,
+.c28:active {
+  color: #1173bb;
+}
+
+.c28:focus,
+.c28:hover {
+  text-decoration: underline;
+}
+
+.c11 {
+  box-sizing: border-box;
+  width: 35px;
+  height: 20px;
+  padding: 0;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+  margin-right: 0.75em;
+  background: none;
+  cursor: pointer;
+  user-select: none;
+  line-height: 18px;
+  outline: none;
+}
+
+.c11:active,
+.c11:hover {
+  border-color: #b7b7b7;
+}
+
+.c11:focus {
+  box-shadow: 0 0 0 0.2em rgba(221,221,221,0.5);
+}
+
+.c11 ::-moz-focus-inner {
+  border: 0;
+}
+
+.c9 {
+  position: relative;
+  display: inline-block;
+  box-sizing: border-box;
+  width: 14px;
+  height: 14px;
+  padding: 1px;
+  border-width: 1px;
+  margin: 0 0.7em;
+  border-color: #000;
+  border-radius: 3px;
+  border-style: solid;
+  font-size: 10px;
+}
+
+.c9 >img {
+  position: absolute;
+  top: 1px;
+  left: 1px;
+  width: 10px;
+  height: 10px;
+}
+
+.c7 {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 :focus+.c8 {
+  border-color: #428bca;
+  box-shadow: 0 0 0 0.2em #428bca;
+}
+
+.c5 {
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  overflow: hidden;
+  border-color: #E6573D;
+  border-style: solid;
+  border-width: 1px;
+}
+
+.c5:first-child {
+  border-top-left-radius: 0.5em;
+  border-bottom-left-radius: 0.5em;
+}
+
+.c5:nth-last-child(2) {
+  border-top-right-radius: 0.5em;
+  border-bottom-right-radius: 0.5em;
+}
+
+.c12 {
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  overflow: hidden;
+  border-color: #FAB470;
+  border-style: solid;
+  border-width: 1px;
+}
+
+.c12:first-child {
+  border-top-left-radius: 0.5em;
+  border-bottom-left-radius: 0.5em;
+}
+
+.c12:nth-last-child(2) {
+  border-top-right-radius: 0.5em;
+  border-bottom-right-radius: 0.5em;
+}
+
+.c14 {
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  overflow: hidden;
+  border-color: #5E6F9E;
+  border-style: solid;
+  border-width: 1px;
+}
+
+.c14:first-child {
+  border-top-left-radius: 0.5em;
+  border-bottom-left-radius: 0.5em;
+}
+
+.c14:nth-last-child(2) {
+  border-top-right-radius: 0.5em;
+  border-bottom-right-radius: 0.5em;
+}
+
+.c16 {
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  overflow: hidden;
+  border-color: #bababa;
+  border-style: solid;
+  border-width: 1px;
+}
+
+.c16:first-child {
+  border-top-left-radius: 0.5em;
+  border-bottom-left-radius: 0.5em;
+}
+
+.c16:nth-last-child(2) {
+  border-top-right-radius: 0.5em;
+  border-bottom-right-radius: 0.5em;
+}
+
+.c6 {
+  display: inline-flex;
+  flex-grow: 1;
+  align-items: center;
+  background: linear-gradient(to right, rgba(230,87,61,0.5), rgba(230,87,61,0.5) 2em, rgba(0, 0, 0, 0) 2em, rgba(0, 0, 0, 0));
+  background-repeat: no-repeat;
+  font-size: 14px;
+  user-select: none;
+}
+
+.c13 {
+  display: inline-flex;
+  flex-grow: 1;
+  align-items: center;
+  background: linear-gradient(to right, rgba(250,180,112,0.5), rgba(250,180,112,0.5) 2em, rgba(0, 0, 0, 0) 2em, rgba(0, 0, 0, 0));
+  background-repeat: no-repeat;
+  font-size: 14px;
+  user-select: none;
+}
+
+.c15 {
+  display: inline-flex;
+  flex-grow: 1;
+  align-items: center;
+  background: linear-gradient(to right, rgba(94,111,158,0.5), rgba(94,111,158,0.5) 2em, rgba(0, 0, 0, 0) 2em, rgba(0, 0, 0, 0));
+  background-repeat: no-repeat;
+  font-size: 14px;
+  user-select: none;
+}
+
+.c17 {
+  display: inline-flex;
+  flex-grow: 1;
+  align-items: center;
+  background: linear-gradient(to right, rgba(186,186,186,0.5), rgba(186,186,186,0.5) 2em, rgba(0, 0, 0, 0) 2em, rgba(0, 0, 0, 0));
+  background-repeat: no-repeat;
+  font-size: 14px;
+  user-select: none;
+}
+
+.c10 {
+  padding: 0.375em 0.75em;
+  line-height: 1.15em;
+}
+
+.c20 {
+  width: 35px;
+  height: 20px;
+  padding: 0;
+  border-radius: 5px;
+  margin: 0 0.5em;
+}
+
+.c3 {
+  display: inline-flex;
+  flex-flow: row wrap;
+  align-items: center;
+}
+
+.c21 {
+  display: inline-flex;
+  align-self: center;
+  outline: none;
+  padding: 0 3px;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.c21 img {
+  position: relative;
+  top: 0.13em;
+  width: 14px;
+  height: 14px;
+  border-radius: 7px;
+}
+
+.c21:focus img {
+  box-shadow: 0 0 0 0.2em rgba(70,130,180,0.5);
+}
+
+.c0 {
+  padding: 0 80px 0 115px;
+}
+
+.c1 {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  margin-bottom: 1em;
+}
+
+.c2 {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5em;
+}
+
+.c22 {
+  display: flex;
+  flex-flow: row wrap;
+}
+
+.c22 input[type='checkbox'] {
+  position: relative;
+  top: 2px;
+}
+
+.c22 label {
+  margin-left: 1em;
+}
+
+.c22 label:first-child {
+  margin-left: 0;
+}
+
+.c23 {
+  margin-right: 1ch;
+}
+
+.c26 {
+  width: 35px;
+  height: 20px;
+  padding: 0;
+  border-radius: 5px;
+  line-height: 18px;
+}
+
+.c27 {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+@media (max-width:1200px) {
+  .c3 .c4 {
+    border-radius: 0.5em;
+    margin: 0 0.5em 0.5em 0;
+  }
+
+  .c3 .c18 {
+    margin: 0 0.5em 0.5em;
+  }
+}
+
+@media (max-width:900px) {
+  .c0 {
+    padding: 0;
+  }
+}
+
+@media (max-width:600px) {
+  .c2 {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+
+@media (max-width:600px) {
+  .c22 {
+    margin-bottom: 0.5em;
+  }
+}
+
+<div
+    class="c0"
+  >
+    <div
+      class="c1"
+    >
+      <div
+        class="c2"
+      >
+        <div>
+          <div
+            breakpoint="1200"
+            class="c3"
+            id="clinvar-track-included-categories"
+          >
+            <span
+              bordercolor="#E6573D"
+              class="c4 c5"
+            >
+              <label
+                backgroundcolor="rgba(230,87,61,0.5)"
+                class="c6"
+                for="clinvar-track-included-categories-pathogenic"
+              >
+                <input
+                  checked=""
+                  class="c7"
+                  id="clinvar-track-included-categories-pathogenic"
+                  type="checkbox"
+                />
+                <span
+                  aria-hidden="true"
+                  class="c8 c9"
+                >
+                  <img
+                    alt=""
+                    src="test-file-stub"
+                  />
+                </span>
+                <span
+                  class="c10"
+                >
+                  Pathogenic / likely pathogenic
+                </span>
+              </label>
+              <button
+                class="c11"
+              >
+                only
+              </button>
+            </span>
+            <span
+              bordercolor="#FAB470"
+              class="c4 c12"
+            >
+              <label
+                backgroundcolor="rgba(250,180,112,0.5)"
+                class="c13"
+                for="clinvar-track-included-categories-uncertain"
+              >
+                <input
+                  checked=""
+                  class="c7"
+                  id="clinvar-track-included-categories-uncertain"
+                  type="checkbox"
+                />
+                <span
+                  aria-hidden="true"
+                  class="c8 c9"
+                >
+                  <img
+                    alt=""
+                    src="test-file-stub"
+                  />
+                </span>
+                <span
+                  class="c10"
+                >
+                  Uncertain significance / conflicting
+                </span>
+              </label>
+              <button
+                class="c11"
+              >
+                only
+              </button>
+            </span>
+            <span
+              bordercolor="#5E6F9E"
+              class="c4 c14"
+            >
+              <label
+                backgroundcolor="rgba(94,111,158,0.5)"
+                class="c15"
+                for="clinvar-track-included-categories-benign"
+              >
+                <input
+                  checked=""
+                  class="c7"
+                  id="clinvar-track-included-categories-benign"
+                  type="checkbox"
+                />
+                <span
+                  aria-hidden="true"
+                  class="c8 c9"
+                >
+                  <img
+                    alt=""
+                    src="test-file-stub"
+                  />
+                </span>
+                <span
+                  class="c10"
+                >
+                  Benign / likely benign
+                </span>
+              </label>
+              <button
+                class="c11"
+              >
+                only
+              </button>
+            </span>
+            <span
+              bordercolor="#bababa"
+              class="c4 c16"
+            >
+              <label
+                backgroundcolor="rgba(186,186,186,0.5)"
+                class="c17"
+                for="clinvar-track-included-categories-other"
+              >
+                <input
+                  checked=""
+                  class="c7"
+                  id="clinvar-track-included-categories-other"
+                  type="checkbox"
+                />
+                <span
+                  aria-hidden="true"
+                  class="c8 c9"
+                >
+                  <img
+                    alt=""
+                    src="test-file-stub"
+                  />
+                </span>
+                <span
+                  class="c10"
+                >
+                  Other
+                </span>
+              </label>
+              <button
+                class="c11"
+              >
+                only
+              </button>
+            </span>
+            <button
+              backgroundcolor="#f8f9fa"
+              bordercolor="#6c757d"
+              class="c18 c19 c20"
+              type="button"
+            >
+              all
+            </button>
+          </div>
+           
+          <button
+            class="c21"
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; white-space: nowrap; width: 1px;"
+            >
+              More information
+            </span>
+          </button>
+        </div>
+      </div>
+      <div
+        class="c2"
+      >
+        <div
+          class="c22"
+        >
+          <div
+            class="c23"
+          >
+            <label
+              class="c24"
+              for="clinvar-track-include-lof"
+            >
+              <input
+                checked=""
+                class="c25"
+                id="clinvar-track-include-lof"
+                type="checkbox"
+              />
+              pLoF
+            </label>
+             
+            <button
+              backgroundcolor="#f8f9fa"
+              bordercolor="#6c757d"
+              class="c19 c26"
+              type="button"
+            >
+              only
+            </button>
+          </div>
+          <div
+            class="c23"
+          >
+            <label
+              class="c24"
+              for="clinvar-track-include-missense"
+            >
+              <input
+                checked=""
+                class="c25"
+                id="clinvar-track-include-missense"
+                type="checkbox"
+              />
+              Missense / Inframe indel
+            </label>
+             
+            <button
+              backgroundcolor="#f8f9fa"
+              bordercolor="#6c757d"
+              class="c19 c26"
+              type="button"
+            >
+              only
+            </button>
+          </div>
+          <div
+            class="c23"
+          >
+            <label
+              class="c24"
+              for="clinvar-track-include-synonymous"
+            >
+              <input
+                checked=""
+                class="c25"
+                id="clinvar-track-include-synonymous"
+                type="checkbox"
+              />
+              Synonymous
+            </label>
+             
+            <button
+              backgroundcolor="#f8f9fa"
+              bordercolor="#6c757d"
+              class="c19 c26"
+              type="button"
+            >
+              only
+            </button>
+          </div>
+          <div
+            class="c23"
+          >
+            <label
+              class="c24"
+              for="clinvar-track-include-other"
+            >
+              <input
+                checked=""
+                class="c25"
+                id="clinvar-track-include-other"
+                type="checkbox"
+              />
+              Other
+            </label>
+             
+            <button
+              backgroundcolor="#f8f9fa"
+              bordercolor="#6c757d"
+              class="c19 c26"
+              type="button"
+            >
+              only
+            </button>
+          </div>
+          <button
+            backgroundcolor="#f8f9fa"
+            bordercolor="#6c757d"
+            class="c19 c26"
+            style="margin-left: 0.5em;"
+            type="button"
+          >
+            all
+          </button>
+        </div>
+        <button
+          backgroundcolor="#f8f9fa"
+          bordercolor="#6c757d"
+          class="c19"
+          style="flex-shrink: 0;"
+          type="button"
+        >
+          Expand to all variants
+        </button>
+      </div>
+      <div
+        class="c27"
+      >
+        <label
+          class="c24"
+          for="clinvar-track-in-gnomad"
+        >
+          <input
+            class="c25"
+            id="clinvar-track-in-gnomad"
+            type="checkbox"
+          />
+          Only show ClinVar variants that are in gnomAD
+        </label>
+        <label
+          for="star-filtering"
+        >
+          Filter by 
+          <a
+            class="c28"
+            href="https://www.ncbi.nlm.nih.gov/clinvar/docs/review_status/"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            review status
+          </a>
+          :  
+          <select
+            id="clinvar-star-filter"
+          >
+            <option
+              value="0"
+            >
+               0-4 Stars 
+            </option>
+            <option
+              value="1"
+            >
+               &gt;=1 Stars 
+            </option>
+            <option
+              value="2"
+            >
+               &gt;=2 Stars 
+            </option>
+            <option
+              value="3"
+            >
+               &gt;=3 Stars 
+            </option>
+            <option
+              value="4"
+            >
+               4 Stars 
+            </option>
+          </select>
+        </label>
+      </div>
+    </div>
+  </div>
+  .c0 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c1 {
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+}
+
+.c2 {
+  display: flex;
+  flex-shrink: 0;
+  flex-direction: column;
+}
+
+.c4 {
+  display: flex;
+  flex-shrink: 0;
+  flex-direction: column;
+}
+
+.c5 {
+  pointer-events: visible;
+  fill: none;
+}
+
+.c5:hover {
+  fill: rgba(0,0,0,0.05);
+}
+
+.c3 {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  height: 100%;
+  padding-right: 20px;
+}
+
+@media (max-width:1200px) {
+
+}
+
+@media (max-width:900px) {
+
+}
+
+@media (max-width:600px) {
+
+}
+
+@media (max-width:600px) {
+
+}
+
+<div
+    class="c0"
+  >
+    <div
+      class="c1"
+    >
+      <div
+        class="c2"
+        style="width: 4px;"
+      >
+        <div
+          class="c3"
+        >
+          ClinVar variants (7)
+        </div>
+      </div>
+      <div
+        class="c4"
+        style="width: 500px;"
+      >
+        <svg
+          height="50"
+          style="overflow: visible;"
+          width="500"
+        >
+          <g>
+            <text
+              dy="0.3em"
+              text-anchor="end"
+              x="-7"
+              y="0"
+            >
+              1
+            </text>
+            <line
+              stroke="#000"
+              stroke-width="1"
+              x1="-5"
+              x2="0"
+              y1="0"
+              y2="0"
+            />
+            <text
+              dy="0.3em"
+              text-anchor="end"
+              x="-7"
+              y="50"
+            >
+              0
+            </text>
+            <line
+              stroke="#000"
+              stroke-width="1"
+              x1="-5"
+              x2="0"
+              y1="50"
+              y2="50"
+            />
+            <line
+              stroke="#000"
+              stroke-width="1"
+              x1="0"
+              x2="0"
+              y1="0"
+              y2="50"
+            />
+          </g>
+          <g>
+            <g
+              transform="translate(1,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(9.064516129032258,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(17.129032258064516,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(25.193548387096776,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(33.25806451612903,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(41.32258064516129,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(49.38709677419355,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(57.45161290322581,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="50"
+                width="6.064516129032258"
+                x="1"
+                y="0"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="0"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="0"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="0"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(65.51612903225806,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(73.58064516129032,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(81.64516129032258,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(89.70967741935483,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(97.7741935483871,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(105.83870967741936,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(113.90322580645162,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="50"
+                width="6.064516129032258"
+                x="1"
+                y="0"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="0"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="0"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="0"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(121.96774193548387,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(130.03225806451613,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(138.09677419354838,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(146.16129032258064,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(154.2258064516129,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(162.29032258064515,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(170.3548387096774,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(178.41935483870967,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="50"
+                width="6.064516129032258"
+                x="1"
+                y="0"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="0"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="0"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(186.48387096774192,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(194.5483870967742,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(202.61290322580646,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(210.67741935483872,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(218.74193548387098,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(226.80645161290323,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(234.8709677419355,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="50"
+                width="6.064516129032258"
+                x="1"
+                y="0"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="0"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="0"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(242.93548387096774,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(251,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(259.06451612903226,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(267.1290322580645,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(275.19354838709677,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(283.258064516129,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(291.3225806451613,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(299.38709677419354,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="50"
+                width="6.064516129032258"
+                x="1"
+                y="0"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="0"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(307.4516129032258,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(315.51612903225805,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(323.5806451612903,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(331.64516129032256,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(339.7096774193548,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(347.7741935483871,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(355.83870967741933,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="50"
+                width="6.064516129032258"
+                x="1"
+                y="0"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="0"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(363.9032258064516,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(371.96774193548384,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(380.0322580645161,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(388.0967741935484,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(396.16129032258067,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(404.2258064516129,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(412.2903225806452,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="50"
+                width="6.064516129032258"
+                x="1"
+                y="0"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(420.35483870967744,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(428.4193548387097,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(436.48387096774195,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(444.5483870967742,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(452.61290322580646,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(460.6774193548387,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(468.741935483871,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(476.80645161290323,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(484.8709677419355,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(492.93548387096774,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+          </g>
+          <line
+            stroke="#000"
+            x1="0"
+            x2="500"
+            y1="50"
+            y2="50"
+          />
+        </svg>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Clinvar Variants Track renders the expanded all-variants plot correctly 1`] = `
+<DocumentFragment>
+  .c19 {
+  box-sizing: border-box;
+  height: calc(2em + 2px);
+  padding: 0.375em 0.75em;
+  border-color: #6c757d;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0.5em;
+  background-color: #f8f9fa;
+  cursor: pointer;
+  font-size: 1em;
+  line-height: 1.25;
+  outline: none;
+  user-select: none;
+}
+
+.c19:active,
+.c19:hover {
+  background-color: #cbd3da;
+}
+
+.c19:disabled {
+  background-color: rgba(248,249,250,0.5);
+  cursor: not-allowed;
+}
+
+.c19:focus {
+  box-shadow: 0 0 0 0.2em rgba(108,117,125,0.5);
+}
+
+.c19 svg {
+  position: relative;
+  top: 0.11em;
+  width: 0.9em;
+  height: 0.9em;
+}
+
+.c24 {
+  user-select: none;
+}
+
+.c25 {
+  margin-right: 0.5em;
+}
+
+.c28 {
+  color: #1173bb;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.c28:visited,
+.c28:active {
+  color: #1173bb;
+}
+
+.c28:focus,
+.c28:hover {
+  text-decoration: underline;
+}
+
+.c11 {
+  box-sizing: border-box;
+  width: 35px;
+  height: 20px;
+  padding: 0;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+  margin-right: 0.75em;
+  background: none;
+  cursor: pointer;
+  user-select: none;
+  line-height: 18px;
+  outline: none;
+}
+
+.c11:active,
+.c11:hover {
+  border-color: #b7b7b7;
+}
+
+.c11:focus {
+  box-shadow: 0 0 0 0.2em rgba(221,221,221,0.5);
+}
+
+.c11 ::-moz-focus-inner {
+  border: 0;
+}
+
+.c9 {
+  position: relative;
+  display: inline-block;
+  box-sizing: border-box;
+  width: 14px;
+  height: 14px;
+  padding: 1px;
+  border-width: 1px;
+  margin: 0 0.7em;
+  border-color: #000;
+  border-radius: 3px;
+  border-style: solid;
+  font-size: 10px;
+}
+
+.c9 >img {
+  position: absolute;
+  top: 1px;
+  left: 1px;
+  width: 10px;
+  height: 10px;
+}
+
+.c7 {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 :focus+.c8 {
+  border-color: #428bca;
+  box-shadow: 0 0 0 0.2em #428bca;
+}
+
+.c5 {
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  overflow: hidden;
+  border-color: #E6573D;
+  border-style: solid;
+  border-width: 1px;
+}
+
+.c5:first-child {
+  border-top-left-radius: 0.5em;
+  border-bottom-left-radius: 0.5em;
+}
+
+.c5:nth-last-child(2) {
+  border-top-right-radius: 0.5em;
+  border-bottom-right-radius: 0.5em;
+}
+
+.c12 {
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  overflow: hidden;
+  border-color: #FAB470;
+  border-style: solid;
+  border-width: 1px;
+}
+
+.c12:first-child {
+  border-top-left-radius: 0.5em;
+  border-bottom-left-radius: 0.5em;
+}
+
+.c12:nth-last-child(2) {
+  border-top-right-radius: 0.5em;
+  border-bottom-right-radius: 0.5em;
+}
+
+.c14 {
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  overflow: hidden;
+  border-color: #5E6F9E;
+  border-style: solid;
+  border-width: 1px;
+}
+
+.c14:first-child {
+  border-top-left-radius: 0.5em;
+  border-bottom-left-radius: 0.5em;
+}
+
+.c14:nth-last-child(2) {
+  border-top-right-radius: 0.5em;
+  border-bottom-right-radius: 0.5em;
+}
+
+.c16 {
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  overflow: hidden;
+  border-color: #bababa;
+  border-style: solid;
+  border-width: 1px;
+}
+
+.c16:first-child {
+  border-top-left-radius: 0.5em;
+  border-bottom-left-radius: 0.5em;
+}
+
+.c16:nth-last-child(2) {
+  border-top-right-radius: 0.5em;
+  border-bottom-right-radius: 0.5em;
+}
+
+.c6 {
+  display: inline-flex;
+  flex-grow: 1;
+  align-items: center;
+  background: linear-gradient(to right, rgba(230,87,61,0.5), rgba(230,87,61,0.5) 2em, rgba(0, 0, 0, 0) 2em, rgba(0, 0, 0, 0));
+  background-repeat: no-repeat;
+  font-size: 14px;
+  user-select: none;
+}
+
+.c13 {
+  display: inline-flex;
+  flex-grow: 1;
+  align-items: center;
+  background: linear-gradient(to right, rgba(250,180,112,0.5), rgba(250,180,112,0.5) 2em, rgba(0, 0, 0, 0) 2em, rgba(0, 0, 0, 0));
+  background-repeat: no-repeat;
+  font-size: 14px;
+  user-select: none;
+}
+
+.c15 {
+  display: inline-flex;
+  flex-grow: 1;
+  align-items: center;
+  background: linear-gradient(to right, rgba(94,111,158,0.5), rgba(94,111,158,0.5) 2em, rgba(0, 0, 0, 0) 2em, rgba(0, 0, 0, 0));
+  background-repeat: no-repeat;
+  font-size: 14px;
+  user-select: none;
+}
+
+.c17 {
+  display: inline-flex;
+  flex-grow: 1;
+  align-items: center;
+  background: linear-gradient(to right, rgba(186,186,186,0.5), rgba(186,186,186,0.5) 2em, rgba(0, 0, 0, 0) 2em, rgba(0, 0, 0, 0));
+  background-repeat: no-repeat;
+  font-size: 14px;
+  user-select: none;
+}
+
+.c10 {
+  padding: 0.375em 0.75em;
+  line-height: 1.15em;
+}
+
+.c20 {
+  width: 35px;
+  height: 20px;
+  padding: 0;
+  border-radius: 5px;
+  margin: 0 0.5em;
+}
+
+.c3 {
+  display: inline-flex;
+  flex-flow: row wrap;
+  align-items: center;
+}
+
+.c21 {
+  display: inline-flex;
+  align-self: center;
+  outline: none;
+  padding: 0 3px;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.c21 img {
+  position: relative;
+  top: 0.13em;
+  width: 14px;
+  height: 14px;
+  border-radius: 7px;
+}
+
+.c21:focus img {
+  box-shadow: 0 0 0 0.2em rgba(70,130,180,0.5);
+}
+
+.c0 {
+  padding: 0 80px 0 115px;
+}
+
+.c1 {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  margin-bottom: 1em;
+}
+
+.c2 {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5em;
+}
+
+.c22 {
+  display: flex;
+  flex-flow: row wrap;
+}
+
+.c22 input[type='checkbox'] {
+  position: relative;
+  top: 2px;
+}
+
+.c22 label {
+  margin-left: 1em;
+}
+
+.c22 label:first-child {
+  margin-left: 0;
+}
+
+.c23 {
+  margin-right: 1ch;
+}
+
+.c26 {
+  width: 35px;
+  height: 20px;
+  padding: 0;
+  border-radius: 5px;
+  line-height: 18px;
+}
+
+.c27 {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+@media (max-width:1200px) {
+  .c3 .c4 {
+    border-radius: 0.5em;
+    margin: 0 0.5em 0.5em 0;
+  }
+
+  .c3 .c18 {
+    margin: 0 0.5em 0.5em;
+  }
+}
+
+@media (max-width:900px) {
+  .c0 {
+    padding: 0;
+  }
+}
+
+@media (max-width:600px) {
+  .c2 {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+
+@media (max-width:600px) {
+  .c22 {
+    margin-bottom: 0.5em;
+  }
+}
+
+<div
+    class="c0"
+  >
+    <div
+      class="c1"
+    >
+      <div
+        class="c2"
+      >
+        <div>
+          <div
+            breakpoint="1200"
+            class="c3"
+            id="clinvar-track-included-categories"
+          >
+            <span
+              bordercolor="#E6573D"
+              class="c4 c5"
+            >
+              <label
+                backgroundcolor="rgba(230,87,61,0.5)"
+                class="c6"
+                for="clinvar-track-included-categories-pathogenic"
+              >
+                <input
+                  checked=""
+                  class="c7"
+                  id="clinvar-track-included-categories-pathogenic"
+                  type="checkbox"
+                />
+                <span
+                  aria-hidden="true"
+                  class="c8 c9"
+                >
+                  <img
+                    alt=""
+                    src="test-file-stub"
+                  />
+                </span>
+                <span
+                  class="c10"
+                >
+                  Pathogenic / likely pathogenic
+                </span>
+              </label>
+              <button
+                class="c11"
+              >
+                only
+              </button>
+            </span>
+            <span
+              bordercolor="#FAB470"
+              class="c4 c12"
+            >
+              <label
+                backgroundcolor="rgba(250,180,112,0.5)"
+                class="c13"
+                for="clinvar-track-included-categories-uncertain"
+              >
+                <input
+                  checked=""
+                  class="c7"
+                  id="clinvar-track-included-categories-uncertain"
+                  type="checkbox"
+                />
+                <span
+                  aria-hidden="true"
+                  class="c8 c9"
+                >
+                  <img
+                    alt=""
+                    src="test-file-stub"
+                  />
+                </span>
+                <span
+                  class="c10"
+                >
+                  Uncertain significance / conflicting
+                </span>
+              </label>
+              <button
+                class="c11"
+              >
+                only
+              </button>
+            </span>
+            <span
+              bordercolor="#5E6F9E"
+              class="c4 c14"
+            >
+              <label
+                backgroundcolor="rgba(94,111,158,0.5)"
+                class="c15"
+                for="clinvar-track-included-categories-benign"
+              >
+                <input
+                  checked=""
+                  class="c7"
+                  id="clinvar-track-included-categories-benign"
+                  type="checkbox"
+                />
+                <span
+                  aria-hidden="true"
+                  class="c8 c9"
+                >
+                  <img
+                    alt=""
+                    src="test-file-stub"
+                  />
+                </span>
+                <span
+                  class="c10"
+                >
+                  Benign / likely benign
+                </span>
+              </label>
+              <button
+                class="c11"
+              >
+                only
+              </button>
+            </span>
+            <span
+              bordercolor="#bababa"
+              class="c4 c16"
+            >
+              <label
+                backgroundcolor="rgba(186,186,186,0.5)"
+                class="c17"
+                for="clinvar-track-included-categories-other"
+              >
+                <input
+                  checked=""
+                  class="c7"
+                  id="clinvar-track-included-categories-other"
+                  type="checkbox"
+                />
+                <span
+                  aria-hidden="true"
+                  class="c8 c9"
+                >
+                  <img
+                    alt=""
+                    src="test-file-stub"
+                  />
+                </span>
+                <span
+                  class="c10"
+                >
+                  Other
+                </span>
+              </label>
+              <button
+                class="c11"
+              >
+                only
+              </button>
+            </span>
+            <button
+              backgroundcolor="#f8f9fa"
+              bordercolor="#6c757d"
+              class="c18 c19 c20"
+              type="button"
+            >
+              all
+            </button>
+          </div>
+           
+          <button
+            class="c21"
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; white-space: nowrap; width: 1px;"
+            >
+              More information
+            </span>
+          </button>
+        </div>
+      </div>
+      <div
+        class="c2"
+      >
+        <div
+          class="c22"
+        >
+          <div
+            class="c23"
+          >
+            <label
+              class="c24"
+              for="clinvar-track-include-lof"
+            >
+              <input
+                checked=""
+                class="c25"
+                id="clinvar-track-include-lof"
+                type="checkbox"
+              />
+              pLoF
+            </label>
+             
+            <button
+              backgroundcolor="#f8f9fa"
+              bordercolor="#6c757d"
+              class="c19 c26"
+              type="button"
+            >
+              only
+            </button>
+          </div>
+          <div
+            class="c23"
+          >
+            <label
+              class="c24"
+              for="clinvar-track-include-missense"
+            >
+              <input
+                checked=""
+                class="c25"
+                id="clinvar-track-include-missense"
+                type="checkbox"
+              />
+              Missense / Inframe indel
+            </label>
+             
+            <button
+              backgroundcolor="#f8f9fa"
+              bordercolor="#6c757d"
+              class="c19 c26"
+              type="button"
+            >
+              only
+            </button>
+          </div>
+          <div
+            class="c23"
+          >
+            <label
+              class="c24"
+              for="clinvar-track-include-synonymous"
+            >
+              <input
+                checked=""
+                class="c25"
+                id="clinvar-track-include-synonymous"
+                type="checkbox"
+              />
+              Synonymous
+            </label>
+             
+            <button
+              backgroundcolor="#f8f9fa"
+              bordercolor="#6c757d"
+              class="c19 c26"
+              type="button"
+            >
+              only
+            </button>
+          </div>
+          <div
+            class="c23"
+          >
+            <label
+              class="c24"
+              for="clinvar-track-include-other"
+            >
+              <input
+                checked=""
+                class="c25"
+                id="clinvar-track-include-other"
+                type="checkbox"
+              />
+              Other
+            </label>
+             
+            <button
+              backgroundcolor="#f8f9fa"
+              bordercolor="#6c757d"
+              class="c19 c26"
+              type="button"
+            >
+              only
+            </button>
+          </div>
+          <button
+            backgroundcolor="#f8f9fa"
+            bordercolor="#6c757d"
+            class="c19 c26"
+            style="margin-left: 0.5em;"
+            type="button"
+          >
+            all
+          </button>
+        </div>
+        <button
+          backgroundcolor="#f8f9fa"
+          bordercolor="#6c757d"
+          class="c19"
+          style="flex-shrink: 0;"
+          type="button"
+        >
+          Collapse to bins
+        </button>
+      </div>
+      <div
+        class="c27"
+      >
+        <label
+          class="c24"
+          for="clinvar-track-in-gnomad"
+        >
+          <input
+            class="c25"
+            id="clinvar-track-in-gnomad"
+            type="checkbox"
+          />
+          Only show ClinVar variants that are in gnomAD
+        </label>
+        <label
+          for="star-filtering"
+        >
+          Filter by 
+          <a
+            class="c28"
+            href="https://www.ncbi.nlm.nih.gov/clinvar/docs/review_status/"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            review status
+          </a>
+          :  
+          <select
+            id="clinvar-star-filter"
+          >
+            <option
+              value="0"
+            >
+               0-4 Stars 
+            </option>
+            <option
+              value="1"
+            >
+               &gt;=1 Stars 
+            </option>
+            <option
+              value="2"
+            >
+               &gt;=2 Stars 
+            </option>
+            <option
+              value="3"
+            >
+               &gt;=3 Stars 
+            </option>
+            <option
+              value="4"
+            >
+               4 Stars 
+            </option>
+          </select>
+        </label>
+      </div>
+    </div>
+  </div>
+  .c0 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c1 {
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+}
+
+.c2 {
+  display: flex;
+  flex-shrink: 0;
+  flex-direction: column;
+}
+
+.c4 {
+  display: flex;
+  flex-shrink: 0;
+  flex-direction: column;
+}
+
+.c3 {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  height: 100%;
+  padding-right: 20px;
+}
+
+@media (max-width:1200px) {
+
+}
+
+@media (max-width:900px) {
+
+}
+
+@media (max-width:600px) {
+
+}
+
+@media (max-width:600px) {
+
+}
+
+<div
+    class="c0"
+  >
+    <div
+      class="c1"
+    >
+      <div
+        class="c2"
+        style="width: 4px;"
+      >
+        <div
+          class="c3"
+        >
+          ClinVar variants (7)
+        </div>
+      </div>
+      <div
+        class="c4"
+        style="width: 500px;"
+      >
+        <svg
+          height="35"
+          width="500"
+        >
+          <g
+            transform="translate(0, 9)"
+          >
+            <g>
+              <line
+                stroke="#333"
+                stroke-width="0.5"
+                x1="0"
+                x2="10"
+                y1="0"
+                y2="0"
+              />
+              <path
+                d="M-4.242640687119286,-1.4142135623730951L-1.4142135623730951,-1.4142135623730951L-1.4142135623730951,-4.242640687119286L1.4142135623730951,-4.242640687119286L1.4142135623730951,-1.4142135623730951L4.242640687119286,-1.4142135623730951L4.242640687119286,1.4142135623730951L1.4142135623730951,1.4142135623730951L1.4142135623730951,4.242640687119286L-1.4142135623730951,4.242640687119286L-1.4142135623730951,1.4142135623730951L-4.242640687119286,1.4142135623730951Z"
+                fill="#333"
+                stroke="none"
+                transform="translate(10,0) rotate(45)"
+              />
+              <text
+                dy="0.3em"
+                font-size="12"
+                x="16"
+              >
+                Frameshift
+              </text>
+            </g>
+            <g
+              transform="translate(86,0)"
+            >
+              <path
+                d="M-4.242640687119286,-1.4142135623730951L-1.4142135623730951,-1.4142135623730951L-1.4142135623730951,-4.242640687119286L1.4142135623730951,-4.242640687119286L1.4142135623730951,-1.4142135623730951L4.242640687119286,-1.4142135623730951L4.242640687119286,1.4142135623730951L1.4142135623730951,1.4142135623730951L1.4142135623730951,4.242640687119286L-1.4142135623730951,4.242640687119286L-1.4142135623730951,1.4142135623730951L-4.242640687119286,1.4142135623730951Z"
+                fill="#333"
+                stroke="none"
+                transform="rotate(45)"
+              />
+              <text
+                dy="0.3em"
+                font-size="12"
+                x="6"
+              >
+                Other pLoF
+              </text>
+            </g>
+            <g
+              transform="translate(165,0)"
+            >
+              <path
+                d="M0,-4.963225915211198L4.298279727294167,2.481612957605599L-4.298279727294167,2.481612957605599Z"
+                fill="#333"
+                stroke="none"
+              />
+              <text
+                dy="0.3em"
+                font-size="12"
+                x="6"
+              >
+                Missense / Inframe indel
+              </text>
+            </g>
+            <g
+              transform="translate(318,0)"
+            >
+              <path
+                d="M0,-5.26429605180997L3.03934274260637,0L0,5.26429605180997L-3.03934274260637,0Z"
+                fill="#333"
+                stroke="none"
+              />
+              <text
+                dy="0.3em"
+                font-size="12"
+                x="6"
+              >
+                Splice region
+              </text>
+            </g>
+            <g
+              transform="translate(406,0)"
+            >
+              <path
+                d="M3.1915382432114616,0A3.1915382432114616,3.1915382432114616,0,1,1,-3.1915382432114616,0A3.1915382432114616,3.1915382432114616,0,1,1,3.1915382432114616,0"
+                fill="#333"
+                stroke="none"
+              />
+              <text
+                dy="0.3em"
+                font-size="12"
+                x="7"
+              >
+                Synonymous / non-coding
+              </text>
+            </g>
+          </g>
+          <g
+            transform="translate(0, 25)"
+          >
+            <g>
+              <rect
+                fill="transparent"
+                height="10"
+                opacity="1"
+                style="cursor: pointer;"
+                width="0"
+                x="59"
+                y="0"
+              />
+              <path
+                d="M-4.242640687119286,-1.4142135623730951L-1.4142135623730951,-1.4142135623730951L-1.4142135623730951,-4.242640687119286L1.4142135623730951,-4.242640687119286L1.4142135623730951,-1.4142135623730951L4.242640687119286,-1.4142135623730951L4.242640687119286,1.4142135623730951L1.4142135623730951,1.4142135623730951L1.4142135623730951,4.242640687119286L-1.4142135623730951,4.242640687119286L-1.4142135623730951,1.4142135623730951L-4.242640687119286,1.4142135623730951Z"
+                fill="#E6573D"
+                opacity="1"
+                stroke="#666"
+                stroke-width="0.5"
+                style="cursor: pointer;"
+                transform="translate(59,5) rotate(45)"
+              />
+            </g>
+            <path
+              d="M-4.242640687119286,-1.4142135623730951L-1.4142135623730951,-1.4142135623730951L-1.4142135623730951,-4.242640687119286L1.4142135623730951,-4.242640687119286L1.4142135623730951,-1.4142135623730951L4.242640687119286,-1.4142135623730951L4.242640687119286,1.4142135623730951L1.4142135623730951,1.4142135623730951L1.4142135623730951,4.242640687119286L-1.4142135623730951,4.242640687119286L-1.4142135623730951,1.4142135623730951L-4.242640687119286,1.4142135623730951Z"
+              fill="#E6573D"
+              opacity="1"
+              stroke="#666"
+              stroke-width="0.5"
+              style="cursor: pointer;"
+              transform="translate(119,5) rotate(45)"
+            />
+            <path
+              d="M0,-4.963225915211198L4.298279727294167,2.481612957605599L-4.298279727294167,2.481612957605599Z"
+              fill="#FAB470"
+              opacity="1"
+              stroke="#666"
+              stroke-width="0.5"
+              style="cursor: pointer;"
+              transform="translate(179,6) rotate(0)"
+            />
+            <path
+              d="M0,-5.26429605180997L3.03934274260637,0L0,5.26429605180997L-3.03934274260637,0Z"
+              fill="#FAB470"
+              opacity="1"
+              stroke="#666"
+              stroke-width="0.5"
+              style="cursor: pointer;"
+              transform="translate(239,5) rotate(0)"
+            />
+            <path
+              d="M3.1915382432114616,0A3.1915382432114616,3.1915382432114616,0,1,1,-3.1915382432114616,0A3.1915382432114616,3.1915382432114616,0,1,1,3.1915382432114616,0"
+              fill="#5E6F9E"
+              opacity="1"
+              stroke="#666"
+              stroke-width="0.5"
+              style="cursor: pointer;"
+              transform="translate(299,5) rotate(0)"
+            />
+            <path
+              d="M0,-4.963225915211198L4.298279727294167,2.481612957605599L-4.298279727294167,2.481612957605599Z"
+              fill="#5E6F9E"
+              opacity="1"
+              stroke="#666"
+              stroke-width="0.5"
+              style="cursor: pointer;"
+              transform="translate(359,6) rotate(0)"
+            />
+            <path
+              d="M3.1915382432114616,0A3.1915382432114616,3.1915382432114616,0,1,1,-3.1915382432114616,0A3.1915382432114616,3.1915382432114616,0,1,1,3.1915382432114616,0"
+              fill="#bababa"
+              opacity="1"
+              stroke="#666"
+              stroke-width="0.5"
+              style="cursor: pointer;"
+              transform="translate(419,5) rotate(0)"
+            />
+          </g>
+          <line
+            stroke="#424242"
+            x1="0"
+            x2="500"
+            y1="35"
+            y2="35"
+          />
+        </svg>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`ClinvarVariants renders the heading, the track and the release date when variants are present 1`] = `
+<DocumentFragment>
+  .c0 {
+  padding: 0 80px 0 115px;
+}
+
+@media (max-width:1200px) {
+
+}
+
+@media (max-width:900px) {
+  .c0 {
+    padding: 0;
+  }
+}
+
+@media (max-width:600px) {
+
+}
+
+@media (max-width:600px) {
+
+}
+
+<div
+    class="c0"
+  >
+    <h2>
+      ClinVar variants
+    </h2>
+  </div>
+  .c19 {
+  box-sizing: border-box;
+  height: calc(2em + 2px);
+  padding: 0.375em 0.75em;
+  border-color: #6c757d;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0.5em;
+  background-color: #f8f9fa;
+  cursor: pointer;
+  font-size: 1em;
+  line-height: 1.25;
+  outline: none;
+  user-select: none;
+}
+
+.c19:active,
+.c19:hover {
+  background-color: #cbd3da;
+}
+
+.c19:disabled {
+  background-color: rgba(248,249,250,0.5);
+  cursor: not-allowed;
+}
+
+.c19:focus {
+  box-shadow: 0 0 0 0.2em rgba(108,117,125,0.5);
+}
+
+.c19 svg {
+  position: relative;
+  top: 0.11em;
+  width: 0.9em;
+  height: 0.9em;
+}
+
+.c24 {
+  user-select: none;
+}
+
+.c25 {
+  margin-right: 0.5em;
+}
+
+.c28 {
+  color: #1173bb;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.c28:visited,
+.c28:active {
+  color: #1173bb;
+}
+
+.c28:focus,
+.c28:hover {
+  text-decoration: underline;
+}
+
+.c11 {
+  box-sizing: border-box;
+  width: 35px;
+  height: 20px;
+  padding: 0;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+  margin-right: 0.75em;
+  background: none;
+  cursor: pointer;
+  user-select: none;
+  line-height: 18px;
+  outline: none;
+}
+
+.c11:active,
+.c11:hover {
+  border-color: #b7b7b7;
+}
+
+.c11:focus {
+  box-shadow: 0 0 0 0.2em rgba(221,221,221,0.5);
+}
+
+.c11 ::-moz-focus-inner {
+  border: 0;
+}
+
+.c9 {
+  position: relative;
+  display: inline-block;
+  box-sizing: border-box;
+  width: 14px;
+  height: 14px;
+  padding: 1px;
+  border-width: 1px;
+  margin: 0 0.7em;
+  border-color: #000;
+  border-radius: 3px;
+  border-style: solid;
+  font-size: 10px;
+}
+
+.c9 >img {
+  position: absolute;
+  top: 1px;
+  left: 1px;
+  width: 10px;
+  height: 10px;
+}
+
+.c7 {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 :focus+.c8 {
+  border-color: #428bca;
+  box-shadow: 0 0 0 0.2em #428bca;
+}
+
+.c5 {
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  overflow: hidden;
+  border-color: #E6573D;
+  border-style: solid;
+  border-width: 1px;
+}
+
+.c5:first-child {
+  border-top-left-radius: 0.5em;
+  border-bottom-left-radius: 0.5em;
+}
+
+.c5:nth-last-child(2) {
+  border-top-right-radius: 0.5em;
+  border-bottom-right-radius: 0.5em;
+}
+
+.c12 {
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  overflow: hidden;
+  border-color: #FAB470;
+  border-style: solid;
+  border-width: 1px;
+}
+
+.c12:first-child {
+  border-top-left-radius: 0.5em;
+  border-bottom-left-radius: 0.5em;
+}
+
+.c12:nth-last-child(2) {
+  border-top-right-radius: 0.5em;
+  border-bottom-right-radius: 0.5em;
+}
+
+.c14 {
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  overflow: hidden;
+  border-color: #5E6F9E;
+  border-style: solid;
+  border-width: 1px;
+}
+
+.c14:first-child {
+  border-top-left-radius: 0.5em;
+  border-bottom-left-radius: 0.5em;
+}
+
+.c14:nth-last-child(2) {
+  border-top-right-radius: 0.5em;
+  border-bottom-right-radius: 0.5em;
+}
+
+.c16 {
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  overflow: hidden;
+  border-color: #bababa;
+  border-style: solid;
+  border-width: 1px;
+}
+
+.c16:first-child {
+  border-top-left-radius: 0.5em;
+  border-bottom-left-radius: 0.5em;
+}
+
+.c16:nth-last-child(2) {
+  border-top-right-radius: 0.5em;
+  border-bottom-right-radius: 0.5em;
+}
+
+.c6 {
+  display: inline-flex;
+  flex-grow: 1;
+  align-items: center;
+  background: linear-gradient(to right, rgba(230,87,61,0.5), rgba(230,87,61,0.5) 2em, rgba(0, 0, 0, 0) 2em, rgba(0, 0, 0, 0));
+  background-repeat: no-repeat;
+  font-size: 14px;
+  user-select: none;
+}
+
+.c13 {
+  display: inline-flex;
+  flex-grow: 1;
+  align-items: center;
+  background: linear-gradient(to right, rgba(250,180,112,0.5), rgba(250,180,112,0.5) 2em, rgba(0, 0, 0, 0) 2em, rgba(0, 0, 0, 0));
+  background-repeat: no-repeat;
+  font-size: 14px;
+  user-select: none;
+}
+
+.c15 {
+  display: inline-flex;
+  flex-grow: 1;
+  align-items: center;
+  background: linear-gradient(to right, rgba(94,111,158,0.5), rgba(94,111,158,0.5) 2em, rgba(0, 0, 0, 0) 2em, rgba(0, 0, 0, 0));
+  background-repeat: no-repeat;
+  font-size: 14px;
+  user-select: none;
+}
+
+.c17 {
+  display: inline-flex;
+  flex-grow: 1;
+  align-items: center;
+  background: linear-gradient(to right, rgba(186,186,186,0.5), rgba(186,186,186,0.5) 2em, rgba(0, 0, 0, 0) 2em, rgba(0, 0, 0, 0));
+  background-repeat: no-repeat;
+  font-size: 14px;
+  user-select: none;
+}
+
+.c10 {
+  padding: 0.375em 0.75em;
+  line-height: 1.15em;
+}
+
+.c20 {
+  width: 35px;
+  height: 20px;
+  padding: 0;
+  border-radius: 5px;
+  margin: 0 0.5em;
+}
+
+.c3 {
+  display: inline-flex;
+  flex-flow: row wrap;
+  align-items: center;
+}
+
+.c21 {
+  display: inline-flex;
+  align-self: center;
+  outline: none;
+  padding: 0 3px;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.c21 img {
+  position: relative;
+  top: 0.13em;
+  width: 14px;
+  height: 14px;
+  border-radius: 7px;
+}
+
+.c21:focus img {
+  box-shadow: 0 0 0 0.2em rgba(70,130,180,0.5);
+}
+
+.c0 {
+  padding: 0 80px 0 115px;
+}
+
+.c1 {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  margin-bottom: 1em;
+}
+
+.c2 {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5em;
+}
+
+.c22 {
+  display: flex;
+  flex-flow: row wrap;
+}
+
+.c22 input[type='checkbox'] {
+  position: relative;
+  top: 2px;
+}
+
+.c22 label {
+  margin-left: 1em;
+}
+
+.c22 label:first-child {
+  margin-left: 0;
+}
+
+.c23 {
+  margin-right: 1ch;
+}
+
+.c26 {
+  width: 35px;
+  height: 20px;
+  padding: 0;
+  border-radius: 5px;
+  line-height: 18px;
+}
+
+.c27 {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+@media (max-width:1200px) {
+  .c3 .c4 {
+    border-radius: 0.5em;
+    margin: 0 0.5em 0.5em 0;
+  }
+
+  .c3 .c18 {
+    margin: 0 0.5em 0.5em;
+  }
+}
+
+@media (max-width:900px) {
+  .c0 {
+    padding: 0;
+  }
+}
+
+@media (max-width:600px) {
+  .c2 {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+
+@media (max-width:600px) {
+  .c22 {
+    margin-bottom: 0.5em;
+  }
+}
+
+<div
+    class="c0"
+  >
+    <div
+      class="c1"
+    >
+      <div
+        class="c2"
+      >
+        <div>
+          <div
+            breakpoint="1200"
+            class="c3"
+            id="clinvar-track-included-categories"
+          >
+            <span
+              bordercolor="#E6573D"
+              class="c4 c5"
+            >
+              <label
+                backgroundcolor="rgba(230,87,61,0.5)"
+                class="c6"
+                for="clinvar-track-included-categories-pathogenic"
+              >
+                <input
+                  checked=""
+                  class="c7"
+                  id="clinvar-track-included-categories-pathogenic"
+                  type="checkbox"
+                />
+                <span
+                  aria-hidden="true"
+                  class="c8 c9"
+                >
+                  <img
+                    alt=""
+                    src="test-file-stub"
+                  />
+                </span>
+                <span
+                  class="c10"
+                >
+                  Pathogenic / likely pathogenic
+                </span>
+              </label>
+              <button
+                class="c11"
+              >
+                only
+              </button>
+            </span>
+            <span
+              bordercolor="#FAB470"
+              class="c4 c12"
+            >
+              <label
+                backgroundcolor="rgba(250,180,112,0.5)"
+                class="c13"
+                for="clinvar-track-included-categories-uncertain"
+              >
+                <input
+                  checked=""
+                  class="c7"
+                  id="clinvar-track-included-categories-uncertain"
+                  type="checkbox"
+                />
+                <span
+                  aria-hidden="true"
+                  class="c8 c9"
+                >
+                  <img
+                    alt=""
+                    src="test-file-stub"
+                  />
+                </span>
+                <span
+                  class="c10"
+                >
+                  Uncertain significance / conflicting
+                </span>
+              </label>
+              <button
+                class="c11"
+              >
+                only
+              </button>
+            </span>
+            <span
+              bordercolor="#5E6F9E"
+              class="c4 c14"
+            >
+              <label
+                backgroundcolor="rgba(94,111,158,0.5)"
+                class="c15"
+                for="clinvar-track-included-categories-benign"
+              >
+                <input
+                  checked=""
+                  class="c7"
+                  id="clinvar-track-included-categories-benign"
+                  type="checkbox"
+                />
+                <span
+                  aria-hidden="true"
+                  class="c8 c9"
+                >
+                  <img
+                    alt=""
+                    src="test-file-stub"
+                  />
+                </span>
+                <span
+                  class="c10"
+                >
+                  Benign / likely benign
+                </span>
+              </label>
+              <button
+                class="c11"
+              >
+                only
+              </button>
+            </span>
+            <span
+              bordercolor="#bababa"
+              class="c4 c16"
+            >
+              <label
+                backgroundcolor="rgba(186,186,186,0.5)"
+                class="c17"
+                for="clinvar-track-included-categories-other"
+              >
+                <input
+                  checked=""
+                  class="c7"
+                  id="clinvar-track-included-categories-other"
+                  type="checkbox"
+                />
+                <span
+                  aria-hidden="true"
+                  class="c8 c9"
+                >
+                  <img
+                    alt=""
+                    src="test-file-stub"
+                  />
+                </span>
+                <span
+                  class="c10"
+                >
+                  Other
+                </span>
+              </label>
+              <button
+                class="c11"
+              >
+                only
+              </button>
+            </span>
+            <button
+              backgroundcolor="#f8f9fa"
+              bordercolor="#6c757d"
+              class="c18 c19 c20"
+              type="button"
+            >
+              all
+            </button>
+          </div>
+           
+          <button
+            class="c21"
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; white-space: nowrap; width: 1px;"
+            >
+              More information
+            </span>
+          </button>
+        </div>
+      </div>
+      <div
+        class="c2"
+      >
+        <div
+          class="c22"
+        >
+          <div
+            class="c23"
+          >
+            <label
+              class="c24"
+              for="clinvar-track-include-lof"
+            >
+              <input
+                checked=""
+                class="c25"
+                id="clinvar-track-include-lof"
+                type="checkbox"
+              />
+              pLoF
+            </label>
+             
+            <button
+              backgroundcolor="#f8f9fa"
+              bordercolor="#6c757d"
+              class="c19 c26"
+              type="button"
+            >
+              only
+            </button>
+          </div>
+          <div
+            class="c23"
+          >
+            <label
+              class="c24"
+              for="clinvar-track-include-missense"
+            >
+              <input
+                checked=""
+                class="c25"
+                id="clinvar-track-include-missense"
+                type="checkbox"
+              />
+              Missense / Inframe indel
+            </label>
+             
+            <button
+              backgroundcolor="#f8f9fa"
+              bordercolor="#6c757d"
+              class="c19 c26"
+              type="button"
+            >
+              only
+            </button>
+          </div>
+          <div
+            class="c23"
+          >
+            <label
+              class="c24"
+              for="clinvar-track-include-synonymous"
+            >
+              <input
+                checked=""
+                class="c25"
+                id="clinvar-track-include-synonymous"
+                type="checkbox"
+              />
+              Synonymous
+            </label>
+             
+            <button
+              backgroundcolor="#f8f9fa"
+              bordercolor="#6c757d"
+              class="c19 c26"
+              type="button"
+            >
+              only
+            </button>
+          </div>
+          <div
+            class="c23"
+          >
+            <label
+              class="c24"
+              for="clinvar-track-include-other"
+            >
+              <input
+                checked=""
+                class="c25"
+                id="clinvar-track-include-other"
+                type="checkbox"
+              />
+              Other
+            </label>
+             
+            <button
+              backgroundcolor="#f8f9fa"
+              bordercolor="#6c757d"
+              class="c19 c26"
+              type="button"
+            >
+              only
+            </button>
+          </div>
+          <button
+            backgroundcolor="#f8f9fa"
+            bordercolor="#6c757d"
+            class="c19 c26"
+            style="margin-left: 0.5em;"
+            type="button"
+          >
+            all
+          </button>
+        </div>
+        <button
+          backgroundcolor="#f8f9fa"
+          bordercolor="#6c757d"
+          class="c19"
+          style="flex-shrink: 0;"
+          type="button"
+        >
+          Expand to all variants
+        </button>
+      </div>
+      <div
+        class="c27"
+      >
+        <label
+          class="c24"
+          for="clinvar-track-in-gnomad"
+        >
+          <input
+            class="c25"
+            id="clinvar-track-in-gnomad"
+            type="checkbox"
+          />
+          Only show ClinVar variants that are in gnomAD
+        </label>
+        <label
+          for="star-filtering"
+        >
+          Filter by 
+          <a
+            class="c28"
+            href="https://www.ncbi.nlm.nih.gov/clinvar/docs/review_status/"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            review status
+          </a>
+          :  
+          <select
+            id="clinvar-star-filter"
+          >
+            <option
+              value="0"
+            >
+               0-4 Stars 
+            </option>
+            <option
+              value="1"
+            >
+               &gt;=1 Stars 
+            </option>
+            <option
+              value="2"
+            >
+               &gt;=2 Stars 
+            </option>
+            <option
+              value="3"
+            >
+               &gt;=3 Stars 
+            </option>
+            <option
+              value="4"
+            >
+               4 Stars 
+            </option>
+          </select>
+        </label>
+      </div>
+    </div>
+  </div>
+  .c0 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c1 {
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+}
+
+.c2 {
+  display: flex;
+  flex-shrink: 0;
+  flex-direction: column;
+}
+
+.c4 {
+  display: flex;
+  flex-shrink: 0;
+  flex-direction: column;
+}
+
+.c5 {
+  pointer-events: visible;
+  fill: none;
+}
+
+.c5:hover {
+  fill: rgba(0,0,0,0.05);
+}
+
+.c3 {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  height: 100%;
+  padding-right: 20px;
+}
+
+@media (max-width:1200px) {
+
+}
+
+@media (max-width:900px) {
+
+}
+
+@media (max-width:600px) {
+
+}
+
+@media (max-width:600px) {
+
+}
+
+<div
+    class="c0"
+  >
+    <div
+      class="c1"
+    >
+      <div
+        class="c2"
+        style="width: 4px;"
+      >
+        <div
+          class="c3"
+        >
+          ClinVar variants (7)
+        </div>
+      </div>
+      <div
+        class="c4"
+        style="width: 500px;"
+      >
+        <svg
+          height="50"
+          style="overflow: visible;"
+          width="500"
+        >
+          <g>
+            <text
+              dy="0.3em"
+              text-anchor="end"
+              x="-7"
+              y="0"
+            >
+              1
+            </text>
+            <line
+              stroke="#000"
+              stroke-width="1"
+              x1="-5"
+              x2="0"
+              y1="0"
+              y2="0"
+            />
+            <text
+              dy="0.3em"
+              text-anchor="end"
+              x="-7"
+              y="50"
+            >
+              0
+            </text>
+            <line
+              stroke="#000"
+              stroke-width="1"
+              x1="-5"
+              x2="0"
+              y1="50"
+              y2="50"
+            />
+            <line
+              stroke="#000"
+              stroke-width="1"
+              x1="0"
+              x2="0"
+              y1="0"
+              y2="50"
+            />
+          </g>
+          <g>
+            <g
+              transform="translate(1,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(9.064516129032258,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(17.129032258064516,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(25.193548387096776,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(33.25806451612903,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(41.32258064516129,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(49.38709677419355,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(57.45161290322581,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="50"
+                width="6.064516129032258"
+                x="1"
+                y="0"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="0"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="0"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="0"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(65.51612903225806,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(73.58064516129032,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(81.64516129032258,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(89.70967741935483,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(97.7741935483871,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(105.83870967741936,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(113.90322580645162,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="50"
+                width="6.064516129032258"
+                x="1"
+                y="0"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="0"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="0"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="0"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(121.96774193548387,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(130.03225806451613,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(138.09677419354838,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(146.16129032258064,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(154.2258064516129,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(162.29032258064515,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(170.3548387096774,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(178.41935483870967,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="50"
+                width="6.064516129032258"
+                x="1"
+                y="0"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="0"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="0"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(186.48387096774192,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(194.5483870967742,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(202.61290322580646,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(210.67741935483872,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(218.74193548387098,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(226.80645161290323,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(234.8709677419355,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="50"
+                width="6.064516129032258"
+                x="1"
+                y="0"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="0"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="0"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(242.93548387096774,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(251,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(259.06451612903226,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(267.1290322580645,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(275.19354838709677,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(283.258064516129,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(291.3225806451613,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(299.38709677419354,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="50"
+                width="6.064516129032258"
+                x="1"
+                y="0"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="0"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(307.4516129032258,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(315.51612903225805,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(323.5806451612903,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(331.64516129032256,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(339.7096774193548,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(347.7741935483871,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(355.83870967741933,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="50"
+                width="6.064516129032258"
+                x="1"
+                y="0"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="0"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(363.9032258064516,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(371.96774193548384,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(380.0322580645161,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(388.0967741935484,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(396.16129032258067,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(404.2258064516129,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(412.2903225806452,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="50"
+                width="6.064516129032258"
+                x="1"
+                y="0"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(420.35483870967744,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(428.4193548387097,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(436.48387096774195,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(444.5483870967742,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(452.61290322580646,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(460.6774193548387,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(468.741935483871,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(476.80645161290323,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(484.8709677419355,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+            <g
+              transform="translate(492.93548387096774,0)"
+            >
+              <rect
+                fill="#E6573D"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#FAB470"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#5E6F9E"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                fill="#bababa"
+                height="0"
+                width="6.064516129032258"
+                x="1"
+                y="50"
+              />
+              <rect
+                class="c5"
+                height="50"
+                width="8.064516129032258"
+                x="0"
+                y="0"
+              />
+            </g>
+          </g>
+          <line
+            stroke="#000"
+            x1="0"
+            x2="500"
+            y1="50"
+            y2="50"
+          />
+        </svg>
+      </div>
+    </div>
+  </div>
+  .c0 {
+  padding: 0 80px 0 115px;
+}
+
+@media (max-width:1200px) {
+
+}
+
+@media (max-width:900px) {
+  .c0 {
+    padding: 0;
+  }
+}
+
+@media (max-width:600px) {
+
+}
+
+@media (max-width:600px) {
+
+}
+
+<p
+    class="c0"
+  >
+    Data displayed here is from ClinVar's March 1, 2023 release.
+  </p>
+</DocumentFragment>
+`;
+
+exports[`ClinvarVariants reports that none were found on a gene page when the list is empty 1`] = `
+<DocumentFragment>
+  .c0 {
+  padding: 0 80px 0 115px;
+}
+
+@media (max-width:900px) {
+  .c0 {
+    padding: 0;
+  }
+}
+
+<div
+    class="c0"
+  >
+    <h2>
+      ClinVar variants
+    </h2>
+  </div>
+  .c0 {
+  padding: 0 80px 0 115px;
+}
+
+@media (max-width:900px) {
+  .c0 {
+    padding: 0;
+  }
+}
+
+<p
+    class="c0"
+  >
+    No ClinVar variants found in this gene.
+  </p>
+</DocumentFragment>
+`;
+
+exports[`ClinvarVariants reports that none were found on a region page when the list is empty 1`] = `
+<DocumentFragment>
+  .c0 {
+  padding: 0 80px 0 115px;
+}
+
+@media (max-width:900px) {
+  .c0 {
+    padding: 0;
+  }
+}
+
+<div
+    class="c0"
+  >
+    <h2>
+      ClinVar variants
+    </h2>
+  </div>
+  .c0 {
+  padding: 0 80px 0 115px;
+}
+
+@media (max-width:900px) {
+  .c0 {
+    padding: 0;
+  }
+}
+
+<p
+    class="c0"
+  >
+    No ClinVar variants found in this region.
+  </p>
+</DocumentFragment>
+`;
+
+exports[`ClinvarVariants reports that none were found on a transcript page when the list is empty 1`] = `
+<DocumentFragment>
+  .c0 {
+  padding: 0 80px 0 115px;
+}
+
+@media (max-width:900px) {
+  .c0 {
+    padding: 0;
+  }
+}
+
+<div
+    class="c0"
+  >
+    <h2>
+      ClinVar variants
+    </h2>
+  </div>
+  .c0 {
+  padding: 0 80px 0 115px;
+}
+
+@media (max-width:900px) {
+  .c0 {
+    padding: 0;
+  }
+}
+
+<p
+    class="c0"
+  >
+    No ClinVar variants found in this transcript.
+  </p>
+</DocumentFragment>
+`;

--- a/browser/src/ClinvarVariantsTrack/formatClinvarDate.spec.ts
+++ b/browser/src/ClinvarVariantsTrack/formatClinvarDate.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from '@jest/globals'
+
+import formatClinvarDate from './formatClinvarDate'
+
+describe('formatClinvarDate', () => {
+  test('formats a well-formed ClinVar date', () => {
+    expect(formatClinvarDate('2023-06-17')).toEqual(
+      new Intl.DateTimeFormat([], { dateStyle: 'long' }).format(new Date(2023, 5, 17))
+    )
+  })
+
+  test.each([
+    ['not-a-date'],
+    [''],
+    ['2023-06'],
+    ['2023-06-17T00:00:00Z'],
+    ['06-17-2023'],
+    ['23-06-17'],
+    ['x-06-17'],
+    ['2023-00-17'],
+    ['2023-13-01'],
+    ['2023-17-00'],
+    ['2023-01-00'],
+    ['2023-01-37'],
+    ['2023-02-29'],
+    ['2023-04-31'],
+  ])('rejects %p rather than rolling it over', (dateString) => {
+    expect(formatClinvarDate(dateString)).toEqual(`Malformed date string: "${dateString}"`)
+  })
+
+  test('accepts a leap day in a leap year', () => {
+    expect(formatClinvarDate('2024-02-29')).toEqual(
+      new Intl.DateTimeFormat([], { dateStyle: 'long' }).format(new Date(2024, 1, 29))
+    )
+  })
+
+  test('accepts unpadded month and day', () => {
+    expect(formatClinvarDate('2023-6-17')).toEqual(formatClinvarDate('2023-06-17'))
+  })
+})

--- a/browser/src/ClinvarVariantsTrack/formatClinvarDate.ts
+++ b/browser/src/ClinvarVariantsTrack/formatClinvarDate.ts
@@ -1,10 +1,30 @@
 const dateFormatter = new Intl.DateTimeFormat([], { dateStyle: 'long' })
 
-// Dates in ClinVar date are formatted YYYY-MM-DD
-const formatClinvarDate = (dateString: any) => {
+const isLeapYear = (year: number): boolean =>
+  (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0
+
+const daysInMonth = (year: number, month: number): number => {
+  const lengths = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+  return month === 2 && isLeapYear(year) ? 29 : lengths[month - 1]
+}
+
+// ClinVar dates are formatted YYYY-MM-DD
+const formatClinvarDate = (dateString: string): string => {
   const [year, month, day] = dateString.split('-').map(Number)
-  const date = new Date(year, month - 1, day)
-  return dateFormatter.format(date)
+
+  const isRealDate =
+    year >= 1000 &&
+    year <= 9999 &&
+    month >= 1 &&
+    month <= 12 &&
+    day >= 1 &&
+    day <= daysInMonth(year, month)
+
+  if (!isRealDate) {
+    return `Malformed date string: "${dateString}"`
+  }
+
+  return dateFormatter.format(new Date(year, month - 1, day))
 }
 
 export default formatClinvarDate

--- a/browser/src/GenePage/MitochondrialVariantsInGene.tsx
+++ b/browser/src/GenePage/MitochondrialVariantsInGene.tsx
@@ -5,13 +5,11 @@ import {
   referenceGenome,
   hasMitochondrialVariants,
 } from '@gnomad/dataset-metadata/metadata'
-import ClinvarVariantTrack from '../ClinvarVariantsTrack/ClinvarVariantTrack'
-import formatClinvarDate from '../ClinvarVariantsTrack/formatClinvarDate'
+import ClinvarVariants from '../ClinvarVariantsTrack/ClinvarVariantTrack'
 import Link from '../Link'
 import Query from '../Query'
 import filterVariantsInZoomRegion from '../RegionViewer/filterVariantsInZoomRegion'
 import StatusMessage from '../StatusMessage'
-import { TrackPageSection } from '../TrackPage'
 import MitochondrialVariants from '../MitochondrialVariantList/MitochondrialVariants'
 import annotateVariantsWithClinvar from '../VariantList/annotateVariantsWithClinvar'
 
@@ -132,24 +130,14 @@ const MitochondrialVariantsInGene = ({ datasetId, gene, zoomRegion, ...rest }: P
 
         return (
           <>
-            <TrackPageSection>
-              <h2>ClinVar variants</h2>
-            </TrackPageSection>
-            {data.gene.clinvar_variants.length > 0 ? (
-              <>
-                <ClinvarVariantTrack
-                  referenceGenome={referenceGenome(datasetId)}
-                  transcripts={gene.transcripts}
-                  variants={filterVariantsInZoomRegion(data.gene.clinvar_variants, zoomRegion)}
-                />
-                <TrackPageSection as="p" style={{ margin: 0 }}>
-                  Data displayed here is from ClinVar&apos;s{' '}
-                  {formatClinvarDate(data.meta.clinvar_release_date)} release.
-                </TrackPageSection>
-              </>
-            ) : (
-              <TrackPageSection as="p">No ClinVar variants found in this gene.</TrackPageSection>
-            )}
+            <ClinvarVariants
+              clinvarVariants={data.gene.clinvar_variants}
+              clinvarReleaseDate={data.meta.clinvar_release_date}
+              referenceGenome={referenceGenome(datasetId)}
+              transcripts={gene.transcripts}
+              zoomRegion={zoomRegion}
+              pageType="gene"
+            />
 
             <MitochondrialVariants
               {...rest}

--- a/browser/src/GenePage/VariantsInGene.tsx
+++ b/browser/src/GenePage/VariantsInGene.tsx
@@ -3,12 +3,10 @@ import React, { useState } from 'react'
 import { Badge, List, ListItem, Modal, TextButton } from '@gnomad/ui'
 
 import { DatasetId, labelForDataset, referenceGenome } from '@gnomad/dataset-metadata/metadata'
-import ClinvarVariantTrack from '../ClinvarVariantsTrack/ClinvarVariantTrack'
-import formatClinvarDate from '../ClinvarVariantsTrack/formatClinvarDate'
+import ClinvarVariants from '../ClinvarVariantsTrack/ClinvarVariantTrack'
 import Link from '../Link'
 import Query from '../Query'
 import filterVariantsInZoomRegion from '../RegionViewer/filterVariantsInZoomRegion'
-import { TrackPageSection } from '../TrackPage'
 import annotateVariantsWithClinvar from '../VariantList/annotateVariantsWithClinvar'
 import Variants from '../VariantList/Variants'
 import { Gene } from './GenePage'
@@ -104,24 +102,14 @@ const VariantsInGene = ({
 
   return (
     <>
-      <TrackPageSection>
-        <h2>ClinVar variants</h2>
-      </TrackPageSection>
-      {clinvarVariants.length > 0 ? (
-        <>
-          <ClinvarVariantTrack
-            referenceGenome={referenceGenome(datasetId)}
-            transcripts={gene.transcripts}
-            variants={filterVariantsInZoomRegion(clinvarVariants, zoomRegion)}
-          />
-          <TrackPageSection as="p">
-            Data displayed here is from ClinVar&apos;s {formatClinvarDate(clinvarReleaseDate)}{' '}
-            release.
-          </TrackPageSection>
-        </>
-      ) : (
-        <TrackPageSection as="p">No ClinVar variants found in this gene.</TrackPageSection>
-      )}
+      <ClinvarVariants
+        clinvarVariants={clinvarVariants}
+        clinvarReleaseDate={clinvarReleaseDate}
+        referenceGenome={referenceGenome(datasetId)}
+        transcripts={gene.transcripts}
+        zoomRegion={zoomRegion}
+        pageType="gene"
+      />
 
       <Variants
         clinvarReleaseDate={clinvarReleaseDate}

--- a/browser/src/GenePage/VariantsInGene.tsx
+++ b/browser/src/GenePage/VariantsInGene.tsx
@@ -9,6 +9,7 @@ import Query from '../Query'
 import filterVariantsInZoomRegion from '../RegionViewer/filterVariantsInZoomRegion'
 import annotateVariantsWithClinvar from '../VariantList/annotateVariantsWithClinvar'
 import Variants from '../VariantList/Variants'
+import { ClinvarVariant } from '../VariantPage/VariantPage'
 import { Gene } from './GenePage'
 
 type TranscriptsModalProps = {
@@ -48,7 +49,7 @@ const TranscriptsModal = ({ gene, onRequestClose }: TranscriptsModalProps) => (
 
 type OwnVariantsInGeneProps = {
   clinvarReleaseDate: string
-  clinvarVariants?: any[]
+  clinvarVariants?: ClinvarVariant[] | null
   datasetId: DatasetId
   gene: {
     gene_id: string

--- a/browser/src/RegionPage/MitochondrialVariantsInRegion.tsx
+++ b/browser/src/RegionPage/MitochondrialVariantsInRegion.tsx
@@ -6,13 +6,11 @@ import {
   DatasetId,
   hasMitochondrialVariants,
 } from '@gnomad/dataset-metadata/metadata'
-import ClinvarVariantTrack from '../ClinvarVariantsTrack/ClinvarVariantTrack'
-import formatClinvarDate from '../ClinvarVariantsTrack/formatClinvarDate'
+import ClinvarVariants from '../ClinvarVariantsTrack/ClinvarVariantTrack'
 import Link from '../Link'
 import Query from '../Query'
 import filterVariantsInZoomRegion from '../RegionViewer/filterVariantsInZoomRegion'
 import StatusMessage from '../StatusMessage'
-import { TrackPageSection } from '../TrackPage'
 import MitochondrialVariants from '../MitochondrialVariantList/MitochondrialVariants'
 import annotateVariantsWithClinvar from '../VariantList/annotateVariantsWithClinvar'
 import { Region } from './RegionPage'
@@ -129,24 +127,14 @@ const MitochondrialVariantsInRegion = ({ datasetId, region, zoomRegion, ...rest 
 
         return (
           <>
-            <TrackPageSection>
-              <h2>ClinVar variants</h2>
-            </TrackPageSection>
-            {data.region.clinvar_variants.length > 0 ? (
-              <>
-                <ClinvarVariantTrack
-                  referenceGenome={referenceGenome(datasetId)}
-                  transcripts={region.genes.flatMap((gene: any) => gene.transcripts)}
-                  variants={filterVariantsInZoomRegion(data.region.clinvar_variants, zoomRegion)}
-                />
-                <TrackPageSection as="p">
-                  Data displayed here is from ClinVar&apos;s{' '}
-                  {formatClinvarDate(data.meta.clinvar_release_date)} release.
-                </TrackPageSection>
-              </>
-            ) : (
-              <TrackPageSection as="p">No ClinVar variants found in this region.</TrackPageSection>
-            )}
+            <ClinvarVariants
+              clinvarVariants={data.region.clinvar_variants}
+              clinvarReleaseDate={data.meta.clinvar_release_date}
+              referenceGenome={referenceGenome(datasetId)}
+              transcripts={region.genes.flatMap((gene: any) => gene.transcripts)}
+              zoomRegion={zoomRegion}
+              pageType="region"
+            />
 
             <MitochondrialVariants
               {...rest}

--- a/browser/src/RegionPage/VariantsInRegion.tsx
+++ b/browser/src/RegionPage/VariantsInRegion.tsx
@@ -1,11 +1,9 @@
 import React from 'react'
 
 import { DatasetId, labelForDataset, referenceGenome } from '@gnomad/dataset-metadata/metadata'
-import ClinvarVariantTrack from '../ClinvarVariantsTrack/ClinvarVariantTrack'
-import formatClinvarDate from '../ClinvarVariantsTrack/formatClinvarDate'
+import ClinvarVariants from '../ClinvarVariantsTrack/ClinvarVariantTrack'
 import Query from '../Query'
 import filterVariantsInZoomRegion from '../RegionViewer/filterVariantsInZoomRegion'
-import { TrackPageSection } from '../TrackPage'
 import annotateVariantsWithClinvar from '../VariantList/annotateVariantsWithClinvar'
 import Variants from '../VariantList/Variants'
 
@@ -44,24 +42,14 @@ const VariantsInRegion = ({
 
   return (
     <>
-      <TrackPageSection>
-        <h2>ClinVar variants</h2>
-      </TrackPageSection>
-      {clinvarVariants.length > 0 ? (
-        <>
-          <ClinvarVariantTrack
-            referenceGenome={referenceGenome(datasetId)}
-            transcripts={region.genes.flatMap((gene: any) => gene.transcripts)}
-            variants={filterVariantsInZoomRegion(clinvarVariants, zoomRegion)}
-          />
-          <TrackPageSection as="p">
-            Data displayed here is from ClinVar&apos;s {formatClinvarDate(clinvarReleaseDate)}{' '}
-            release.
-          </TrackPageSection>
-        </>
-      ) : (
-        <TrackPageSection as="p">No ClinVar variants found in this region.</TrackPageSection>
-      )}
+      <ClinvarVariants
+        clinvarVariants={clinvarVariants}
+        clinvarReleaseDate={clinvarReleaseDate}
+        referenceGenome={referenceGenome(datasetId)}
+        transcripts={region.genes.flatMap((gene: any) => gene.transcripts)}
+        zoomRegion={zoomRegion}
+        pageType="region"
+      />
 
       <Variants
         clinvarReleaseDate={clinvarReleaseDate}

--- a/browser/src/RegionPage/VariantsInRegion.tsx
+++ b/browser/src/RegionPage/VariantsInRegion.tsx
@@ -6,10 +6,11 @@ import Query from '../Query'
 import filterVariantsInZoomRegion from '../RegionViewer/filterVariantsInZoomRegion'
 import annotateVariantsWithClinvar from '../VariantList/annotateVariantsWithClinvar'
 import Variants from '../VariantList/Variants'
+import { ClinvarVariant } from '../VariantPage/VariantPage'
 
 type OwnVariantsInRegionProps = {
   clinvarReleaseDate: string
-  clinvarVariants?: any[]
+  clinvarVariants?: ClinvarVariant[] | null
   datasetId: DatasetId
   region: {
     chrom: string

--- a/browser/src/TrackPage.ts
+++ b/browser/src/TrackPage.ts
@@ -2,6 +2,8 @@ import styled from 'styled-components'
 
 import { Page } from '@gnomad/ui'
 
+export type PageType = 'gene' | 'transcript' | 'region'
+
 export const TrackPage = styled(Page)`
   max-width: none;
 `

--- a/browser/src/TranscriptPage/MitochondrialVariantsInTranscript.tsx
+++ b/browser/src/TranscriptPage/MitochondrialVariantsInTranscript.tsx
@@ -6,13 +6,11 @@ import {
   DatasetId,
   hasMitochondrialVariants,
 } from '@gnomad/dataset-metadata/metadata'
-import ClinvarVariantTrack from '../ClinvarVariantsTrack/ClinvarVariantTrack'
-import formatClinvarDate from '../ClinvarVariantsTrack/formatClinvarDate'
+import ClinvarVariants from '../ClinvarVariantsTrack/ClinvarVariantTrack'
 import Link from '../Link'
 import Query from '../Query'
 import filterVariantsInZoomRegion from '../RegionViewer/filterVariantsInZoomRegion'
 import StatusMessage from '../StatusMessage'
-import { TrackPageSection } from '../TrackPage'
 import MitochondrialVariants from '../MitochondrialVariantList/MitochondrialVariants'
 import annotateVariantsWithClinvar from '../VariantList/annotateVariantsWithClinvar'
 
@@ -134,29 +132,14 @@ const MitochondrialVariantsInTranscript = ({
 
         return (
           <>
-            <TrackPageSection>
-              <h2>ClinVar variants</h2>
-            </TrackPageSection>
-            {data.transcript.clinvar_variants.length > 0 ? (
-              <>
-                <ClinvarVariantTrack
-                  referenceGenome={referenceGenome(datasetId)}
-                  transcripts={[transcript]}
-                  variants={filterVariantsInZoomRegion(
-                    data.transcript.clinvar_variants,
-                    zoomRegion
-                  )}
-                />
-                <TrackPageSection as="p">
-                  Data displayed here is from ClinVar&apos;s{' '}
-                  {formatClinvarDate(data.meta.clinvar_release_date)} release.
-                </TrackPageSection>
-              </>
-            ) : (
-              <TrackPageSection as="p">
-                No ClinVar variants found in this transcript.
-              </TrackPageSection>
-            )}
+            <ClinvarVariants
+              clinvarVariants={data.transcript.clinvar_variants}
+              clinvarReleaseDate={data.meta.clinvar_release_date}
+              referenceGenome={referenceGenome(datasetId)}
+              transcripts={[transcript]}
+              zoomRegion={zoomRegion}
+              pageType="transcript"
+            />
 
             <MitochondrialVariants
               {...rest}

--- a/browser/src/TranscriptPage/VariantsInTranscript.tsx
+++ b/browser/src/TranscriptPage/VariantsInTranscript.tsx
@@ -3,12 +3,10 @@ import React from 'react'
 import { Badge } from '@gnomad/ui'
 
 import { DatasetId, labelForDataset, referenceGenome } from '@gnomad/dataset-metadata/metadata'
-import ClinvarVariantTrack from '../ClinvarVariantsTrack/ClinvarVariantTrack'
-import formatClinvarDate from '../ClinvarVariantsTrack/formatClinvarDate'
+import ClinvarVariants from '../ClinvarVariantsTrack/ClinvarVariantTrack'
 import Link from '../Link'
 import Query from '../Query'
 import filterVariantsInZoomRegion from '../RegionViewer/filterVariantsInZoomRegion'
-import { TrackPageSection } from '../TrackPage'
 import annotateVariantsWithClinvar from '../VariantList/annotateVariantsWithClinvar'
 import Variants from '../VariantList/Variants'
 
@@ -55,24 +53,14 @@ const VariantsInTranscript = ({
 
   return (
     <>
-      <TrackPageSection>
-        <h2>ClinVar variants</h2>
-      </TrackPageSection>
-      {clinvarVariants.length > 0 ? (
-        <>
-          <ClinvarVariantTrack
-            referenceGenome={referenceGenome(datasetId)}
-            transcripts={[transcript]}
-            variants={filterVariantsInZoomRegion(clinvarVariants, zoomRegion)}
-          />
-          <TrackPageSection as="p">
-            Data displayed here is from ClinVar&apos;s {formatClinvarDate(clinvarReleaseDate)}{' '}
-            release.
-          </TrackPageSection>
-        </>
-      ) : (
-        <TrackPageSection as="p">No ClinVar variants found in this transcript.</TrackPageSection>
-      )}
+      <ClinvarVariants
+        clinvarVariants={clinvarVariants}
+        clinvarReleaseDate={clinvarReleaseDate}
+        referenceGenome={referenceGenome(datasetId)}
+        transcripts={[transcript]}
+        zoomRegion={zoomRegion}
+        pageType="transcript"
+      />
 
       <Variants
         clinvarReleaseDate={clinvarReleaseDate}

--- a/browser/src/TranscriptPage/VariantsInTranscript.tsx
+++ b/browser/src/TranscriptPage/VariantsInTranscript.tsx
@@ -9,10 +9,11 @@ import Query from '../Query'
 import filterVariantsInZoomRegion from '../RegionViewer/filterVariantsInZoomRegion'
 import annotateVariantsWithClinvar from '../VariantList/annotateVariantsWithClinvar'
 import Variants from '../VariantList/Variants'
+import { ClinvarVariant } from '../VariantPage/VariantPage'
 
 type OwnVariantsInTranscriptProps = {
   clinvarReleaseDate: string
-  clinvarVariants?: any[]
+  clinvarVariants?: ClinvarVariant[] | null
   datasetId: DatasetId
   includeUTRs: boolean
   transcript: {

--- a/browser/src/VariantList/annotateVariantsWithClinvar.spec.ts
+++ b/browser/src/VariantList/annotateVariantsWithClinvar.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from '@jest/globals'
+
+import clinvarVariantFactory from '../__factories__/ClinvarVariant'
+import { ClinvarVariant } from '../VariantPage/VariantPage'
+import annotateVariantsWithClinvar from './annotateVariantsWithClinvar'
+
+const annotatedVariant = clinvarVariantFactory.build({
+  variant_id: '1-100-A-C',
+  clinical_significance: 'Pathogenic',
+  clinvar_variation_id: '987654',
+})
+
+const variants = [{ variant_id: '1-100-A-C' }, { variant_id: '1-200-G-T' }]
+
+describe('annotateVariantsWithClinvar', () => {
+  test('copies clinical significance and variation id onto matching variants', () => {
+    const [matched] = annotateVariantsWithClinvar(variants, [annotatedVariant])
+
+    expect(matched).toEqual({
+      variant_id: '1-100-A-C',
+      clinical_significance: 'Pathogenic',
+      clinvar_variation_id: '987654',
+    })
+  })
+
+  test('leaves variants with no ClinVar record untouched', () => {
+    const [, unmatched] = annotateVariantsWithClinvar(variants, [annotatedVariant])
+
+    expect(unmatched).toEqual({ variant_id: '1-200-G-T' })
+  })
+
+  test.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['empty', []],
+  ] as [string, ClinvarVariant[] | null | undefined][])(
+    'returns variants unannotated when the ClinVar list is %s',
+    (_label, clinvarVariants) => {
+      expect(annotateVariantsWithClinvar(variants, clinvarVariants)).toEqual(variants)
+    }
+  )
+
+  test('does not mutate its arguments', () => {
+    const clinvarVariants = [annotatedVariant]
+
+    annotateVariantsWithClinvar(variants, clinvarVariants)
+
+    expect(variants).toEqual([{ variant_id: '1-100-A-C' }, { variant_id: '1-200-G-T' }])
+    expect(clinvarVariants).toEqual([annotatedVariant])
+  })
+})

--- a/browser/src/VariantList/annotateVariantsWithClinvar.ts
+++ b/browser/src/VariantList/annotateVariantsWithClinvar.ts
@@ -1,6 +1,20 @@
-const annotateVariantsWithClinvar = (variants: any, clinvarVariants: any) => {
-  const clinvarInfo = new Map()
-  clinvarVariants.forEach((clinvarVariant: any) => {
+import { ClinvarVariant } from '../VariantPage/VariantPage'
+
+type ClinvarAnnotation = {
+  clinical_significance?: string
+  clinvar_variation_id?: string
+}
+
+const annotateVariantsWithClinvar = (
+  variants: any[],
+  clinvarVariants: ClinvarVariant[] | null | undefined
+) => {
+  if (!clinvarVariants) {
+    return variants
+  }
+
+  const clinvarInfo = new Map<string, ClinvarAnnotation>()
+  clinvarVariants.forEach((clinvarVariant) => {
     clinvarInfo.set(clinvarVariant.variant_id, {
       clinical_significance: clinvarVariant.clinical_significance,
       clinvar_variation_id: clinvarVariant.clinvar_variation_id,

--- a/tests/e2e/ClinvarVariantsTrack.playwright.spec.ts
+++ b/tests/e2e/ClinvarVariantsTrack.playwright.spec.ts
@@ -1,0 +1,148 @@
+import { test, expect, type Page, type Route } from '@playwright/test'
+
+const QUERY_TIMEOUT_MS = 30_000
+const RENDER_TIMEOUT_MS = 20_000
+
+// Look for uncaught errors, which are what produce the generic
+// "Something Went Wrong" page.
+const collectUncaughtErrors = (target: Page): Error[] => {
+  const errors: Error[] = []
+  target.on('pageerror', (error) => {
+    errors.push(error)
+  })
+  return errors
+}
+
+const openPcsk9GenePage = async (target: Page) => {
+  await target.goto('/')
+  await target.getByRole('link', { name: 'PCSK9' }).click()
+  await expect(target.getByText('Loading gene')).toHaveCount(0, { timeout: QUERY_TIMEOUT_MS })
+}
+
+const expectNoCrashPage = async (target: Page, uncaughtErrors: Error[]) => {
+  await expect(target.getByRole('heading', { name: 'Something Went Wrong' })).toHaveCount(0)
+  expect(uncaughtErrors.map((error) => error.message)).toEqual([])
+}
+
+const simulateClinvarVariants = (replacement: null | []) => async (route: Route) => {
+  const response = await route.fetch()
+  const body = await response.json()
+
+  ;['gene', 'region', 'transcript'].forEach((feature) => {
+    const featureData = body?.data?.[feature]
+    if (featureData && 'clinvar_variants' in featureData) {
+      featureData.clinvar_variants = replacement
+    }
+  })
+
+  await route.fulfill({ response, json: body })
+}
+
+test.describe('Gene page ClinVar track, real API data', () => {
+  let page: Page
+  let uncaughtErrors: Error[]
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage()
+    uncaughtErrors = collectUncaughtErrors(page)
+    await openPcsk9GenePage(page)
+  })
+
+  test.afterAll(async () => {
+    await page.close()
+  })
+
+  test('renders the ClinVar track', async () => {
+    await expect(page.getByRole('heading', { name: 'ClinVar variants' })).toBeVisible({
+      timeout: QUERY_TIMEOUT_MS,
+    })
+
+    await expect(page.getByText(/ClinVar variants could not be loaded/)).toHaveCount(0)
+    await expect(page.getByText(/No ClinVar variants found in this gene/)).toHaveCount(0)
+    await expect(page.getByText(/Data displayed here is from ClinVar/)).toBeVisible()
+
+    await expectNoCrashPage(page, uncaughtErrors)
+  })
+
+  test('expands to all variants without crashing', async () => {
+    const expandButton = page.getByRole('button', { name: 'Expand to all variants' })
+    await expect(expandButton).toBeVisible({ timeout: RENDER_TIMEOUT_MS })
+
+    await expandButton.click()
+
+    await expect(page.getByRole('button', { name: 'Collapse to bins' })).toBeVisible()
+    await expectNoCrashPage(page, uncaughtErrors)
+  })
+})
+
+test.describe('Gene page ClinVar track, simulated null clinvar_variants', () => {
+  let page: Page
+  let uncaughtErrors: Error[]
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage()
+    uncaughtErrors = collectUncaughtErrors(page)
+    await page.route('**/api/**', simulateClinvarVariants(null))
+    await openPcsk9GenePage(page)
+  })
+
+  test.afterAll(async () => {
+    await page.close()
+  })
+
+  test('reports that ClinVar could not be loaded, and does not crash', async () => {
+    await expect(page.getByRole('heading', { name: 'ClinVar variants' })).toBeVisible({
+      timeout: QUERY_TIMEOUT_MS,
+    })
+    await expect(page.getByText(/ClinVar variants could not be loaded/)).toBeVisible({
+      timeout: QUERY_TIMEOUT_MS,
+    })
+
+    await expect(page.getByText(/No ClinVar variants found in this gene/)).toHaveCount(0)
+
+    await expectNoCrashPage(page, uncaughtErrors)
+  })
+
+  test('still renders the gnomAD variant table', async () => {
+    await expect(page.getByText('Loading variants'))
+      .toHaveCount(0, { timeout: QUERY_TIMEOUT_MS })
+      .catch(() => {
+        throw new Error(`gene page variants query timed out after ${QUERY_TIMEOUT_MS / 1000}s`)
+      })
+
+    await expect(page.getByRole('columnheader', { name: 'Variant ID' })).toBeVisible({
+      timeout: RENDER_TIMEOUT_MS,
+    })
+    await expectNoCrashPage(page, uncaughtErrors)
+  })
+})
+
+test.describe('Gene page ClinVar track, simulated empty clinvar_variants', () => {
+  let page: Page
+  let uncaughtErrors: Error[]
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage()
+    uncaughtErrors = collectUncaughtErrors(page)
+    await page.route('**/api/**', simulateClinvarVariants([]))
+    await openPcsk9GenePage(page)
+  })
+
+  test.afterAll(async () => {
+    await page.close()
+  })
+
+  test('reports that none were found, and does not crash', async () => {
+    await expect(page.getByRole('heading', { name: 'ClinVar variants' })).toBeVisible({
+      timeout: QUERY_TIMEOUT_MS,
+    })
+    await expect(page.getByText('No ClinVar variants found in this gene.')).toBeVisible({
+      timeout: QUERY_TIMEOUT_MS,
+    })
+
+    await expect(page.getByText(/ClinVar variants could not be loaded/)).toHaveCount(0)
+    await expect(page.getByText(/Data displayed here is from ClinVar/)).toHaveCount(0)
+
+    await expectNoCrashPage(page, uncaughtErrors)
+  })
+})


### PR DESCRIPTION
This PR adds additional snapshot and playwright tests surrounding ClinVar, and handles a full page crash on a rare but possible circumstance in production.

It could be reviewed as a single big diff, but I believe commit by commit using GitHub's functionality for that will be a far more clear way to review it, and didn't want to open 4 stacked PRs all around testing ClinVar. Each individual commit is quite small and scoped, could have been a seperate PR if we really want, but I personally find the github option to view a single commit at a time pretty useful, and think these commits are all quite related to each other. 

This is in prep for further changes to local development of the frontend/backend without the need for a tunnel to ES.

- Handle an existing crash where inability to get ClinVar variants (network failure, bad indice) would crash the existing gene page
- minor refactor to reduce duplication of ClinVar section rendering
- Add more snapshot tests to handle ClinVar with better synthetic data, in all of its new possible states (clinvar failed to load, clinvar loaded but no variants, clinvar loaded and has variants)
- Add playwright test to confirm behavior against chosen backend (live api or local backend), not synthetic mocked data, to help with adding confidence when we move clinvar to parquet