### PR TITLE
Isolate render errors on major sections of pages

### DIFF
--- a/browser/src/BugReportControls.tsx
+++ b/browser/src/BugReportControls.tsx
@@ -1,0 +1,59 @@
+import React, { useState } from 'react'
+
+import { ExternalLink, Link as StyledLink } from '@gnomad/ui'
+
+import { buildBugReportBody, buildBugReportUrls, BugReportContext } from './buildBugReportBody'
+
+type Props = {
+  error: Error
+  context: BugReportContext
+}
+
+const BugReportControls = ({ error, context }: Props) => {
+  const [bugDescription, setBugDescription] = useState('')
+
+  const body = buildBugReportBody(error, bugDescription, context)
+  const { issueURL, forumURL, emailURL } = buildBugReportUrls(error, body)
+
+  return (
+    <>
+      <p>
+        Please describe what you were trying to do at the time the page crashed
+        <div>
+          <textarea
+            id="bug-description"
+            name="bug-description"
+            value={bugDescription}
+            onChange={(e) => setBugDescription(e.target.value)}
+            rows={4}
+            cols={50}
+          />
+        </div>
+      </p>
+
+      <p>
+        And submit this bug report as{' '}
+        <ul>
+          <li>
+            <ExternalLink href={issueURL}>an issue on GitHub</ExternalLink> or{' '}
+          </li>
+          <li>
+            <ExternalLink href={forumURL}>a topic on our forum</ExternalLink>
+          </li>
+        </ul>
+        Then
+        <StyledLink href="/">reload the browser</StyledLink>.
+        <br />
+        <br />
+        <br />
+        <p>
+          Alternately, you can <ExternalLink href={emailURL}>email us</ExternalLink>. Please note
+          that we prioritize answering issues on Github and topics on the Forum, so if you choose to
+          email it may take us longer to respond.
+        </p>
+      </p>
+    </>
+  )
+}
+
+export default BugReportControls

--- a/browser/src/ErrorBoundary.spec.tsx
+++ b/browser/src/ErrorBoundary.spec.tsx
@@ -1,0 +1,94 @@
+import React from 'react'
+import { describe, expect, jest, test } from '@jest/globals'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { BrowserRouter } from 'react-router-dom'
+
+import ErrorBoundary from './ErrorBoundary'
+
+const ComponentThatThrows = ({ shouldThrowError }: { shouldThrowError: boolean }) => {
+  if (shouldThrowError) {
+    throw new Error('Kaboom')
+  }
+  return <div>Rendered without error</div>
+}
+
+const withSilencedConsoleError = (fn: () => void) => {
+  const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+  try {
+    fn()
+  } finally {
+    consoleErrorSpy.mockRestore()
+  }
+}
+
+describe('ErrorBoundary', () => {
+  test('renders children when nothing throws', () => {
+    render(
+      <BrowserRouter>
+        <ErrorBoundary>
+          <ComponentThatThrows shouldThrowError={false} />
+        </ErrorBoundary>
+      </BrowserRouter>
+    )
+
+    expect(screen.getByText('Rendered without error')).toBeTruthy()
+    expect(screen.queryByText('Something Went Wrong')).toBeNull()
+  })
+
+  test('renders the full-page fallback instead of the thrown error', () => {
+    withSilencedConsoleError(() => {
+      render(
+        <BrowserRouter>
+          <ErrorBoundary>
+            <ComponentThatThrows shouldThrowError />
+          </ErrorBoundary>
+        </BrowserRouter>
+      )
+    })
+
+    expect(screen.getByText('Something Went Wrong')).toBeTruthy()
+    expect(screen.queryByText('Rendered without error')).toBeNull()
+  })
+
+  test('fallback includes the error message and links to file a report', () => {
+    withSilencedConsoleError(() => {
+      render(
+        <BrowserRouter>
+          <ErrorBoundary>
+            <ComponentThatThrows shouldThrowError />
+          </ErrorBoundary>
+        </BrowserRouter>
+      )
+    })
+
+    const issueLink = screen.getByText('an issue on GitHub').closest('a')
+    const forumLink = screen.getByText('a topic on our forum').closest('a')
+    const emailLink = screen.getByText('email us').closest('a')
+
+    expect(issueLink?.getAttribute('href')).toContain('github.com/broadinstitute/gnomad-browser')
+    expect(issueLink?.getAttribute('href')).toContain(encodeURIComponent('Kaboom'))
+    expect(forumLink?.getAttribute('href')).toContain('discuss.gnomad.broadinstitute.org')
+    expect(emailLink?.getAttribute('href')).toContain('mailto:gnomad@broadinstitute.org')
+  })
+
+  test('includes the user-entered bug description in the filed report', () => {
+    withSilencedConsoleError(() => {
+      render(
+        <BrowserRouter>
+          <ErrorBoundary>
+            <ComponentThatThrows shouldThrowError />
+          </ErrorBoundary>
+        </BrowserRouter>
+      )
+    })
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: 'I clicked the coverage track' },
+    })
+
+    const issueLink = screen.getByText('an issue on GitHub').closest('a')
+    expect(issueLink?.getAttribute('href')).toContain(
+      encodeURIComponent('I clicked the coverage track')
+    )
+  })
+})

--- a/browser/src/ErrorBoundary.tsx
+++ b/browser/src/ErrorBoundary.tsx
@@ -1,8 +1,9 @@
 import React, { ReactNode } from 'react'
 import { withRouter } from 'react-router-dom'
 
-import { ExternalLink, Link as StyledLink, PageHeading } from '@gnomad/ui'
+import { PageHeading } from '@gnomad/ui'
 
+import BugReportControls from './BugReportControls'
 import DocumentTitle from './DocumentTitle'
 import InfoPage from './InfoPage'
 
@@ -14,91 +15,32 @@ type Props = {
   }
 }
 
-type State = any
+type State = {
+  error: Error | null
+}
 
 class ErrorBoundary extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props)
-    this.state = { error: null, bugDescription: '' }
+    this.state = { error: null }
   }
 
-  static getDerivedStateFromError(error: any) {
+  static getDerivedStateFromError(error: Error) {
     return { error }
   }
 
   render() {
     const { children, location } = this.props
-    const { error, bugDescription } = this.state
+    const { error } = this.state
 
     if (error) {
-      const issueBody = `
-**Description**: ${bugDescription}
-
-**Error message**: ${error.message}
-
-**Stack trace**:
-\`\`\`
-${error.stack}
-\`\`\`
-
-**Route**: ${location.pathname}${location.search}
-
-**Browser**: ${navigator.userAgent}
-`
-
-      const issueURL = `https://github.com/broadinstitute/gnomad-browser/issues/new?title=${encodeURIComponent(
-        error.message
-      )}&body=${encodeURIComponent(issueBody)}&labels=Type%3A%20Bug`
-
-      const forumURL = `https://discuss.gnomad.broadinstitute.org/new-topic?title=topic%20${encodeURIComponent(
-        error.message
-      )}&body=${encodeURIComponent(issueBody)}&category=Browser&tags=bug`
-
-      const emailURL = `mailto:gnomad@broadinstitute.org?subject=${encodeURIComponent(
-        'Browser bug report'
-      )}&body=${encodeURIComponent(issueBody.replace(/```\n/g, ''))}`
-
       return (
         <InfoPage>
           <DocumentTitle title="Error" />
           <PageHeading>Something Went Wrong</PageHeading>
           <p>An error prevented this page from being displayed.</p>
           <p>This is a bug.</p>
-          <p>
-            Please describe what you were trying to do at the time the page crashed
-            <div>
-              <textarea
-                id="bug-description"
-                name="bug-description"
-                value={bugDescription}
-                onChange={(e) => this.setState({ bugDescription: e.target.value })}
-                rows={4}
-                cols={50}
-              />
-            </div>
-          </p>
-
-          <p>
-            And submit this bug report as{' '}
-            <ul>
-              <li>
-                <ExternalLink href={issueURL}>an issue on GitHub</ExternalLink> or{' '}
-              </li>
-              <li>
-                <ExternalLink href={forumURL}>a topic on our forum</ExternalLink>
-              </li>
-            </ul>
-            Then
-            <StyledLink href="/">reload the browser</StyledLink>.
-            <br />
-            <br />
-            <br />
-            <p>
-              Alternately, you can <ExternalLink href={emailURL}>email us</ExternalLink>. Please
-              note that we prioritize answering issues on Github and topics on the Forum, so if you
-              choose to email it may take us longer to respond.
-            </p>
-          </p>
+          <BugReportControls error={error} context={{ route: location }} />
         </InfoPage>
       )
     }

--- a/browser/src/GenePage/GenePage.sectionRenderErrorIsolation.spec.tsx
+++ b/browser/src/GenePage/GenePage.sectionRenderErrorIsolation.spec.tsx
@@ -1,0 +1,83 @@
+import React from 'react'
+import { describe, expect, jest, test } from '@jest/globals'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+import { mockQueries } from '../../../tests/__helpers__/queries'
+import Query, { BaseQuery } from '../Query'
+
+import geneFactory from '../__factories__/Gene'
+
+import GenePage from './GenePage'
+
+jest.mock('../Query', () => {
+  const originalModule = jest.requireActual('../Query')
+
+  return {
+    __esModule: true,
+    ...(originalModule as object),
+    default: jest.fn(),
+    BaseQuery: jest.fn(),
+  }
+})
+
+jest.mock('./GeneCoverageTrack', () => ({
+  __esModule: true,
+  default: () => {
+    throw new Error('Forced render-time error in GeneCoverageTrack for regression test')
+  },
+}))
+
+const { resetMockApiCalls, resetMockApiResponses, simulateApiResponse, setMockApiResponses } =
+  mockQueries()
+
+beforeEach(() => {
+  Query.mockImplementation(
+    jest.fn(({ children, operationName, variables, query }) =>
+      simulateApiResponse('Query', query, children, operationName, variables)
+    )
+  )
+  ;(BaseQuery as any).mockImplementation(
+    jest.fn(({ children, operationName, variables, query }) =>
+      simulateApiResponse('BaseQuery', query, children, operationName, variables)
+    )
+  )
+})
+
+afterEach(() => {
+  resetMockApiCalls()
+  resetMockApiResponses()
+})
+
+const withSilencedConsoleError = (fn: () => void) => {
+  const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+  try {
+    fn()
+  } finally {
+    consoleErrorSpy.mockRestore()
+  }
+}
+
+describe('GenePage section render error isolation', () => {
+  test('a render-time throw in one section leaves sibling sections rendered', () => {
+    const gene = geneFactory.build()
+    setMockApiResponses({
+      VariantsInGene: () => ({
+        gene,
+        meta: { clinvar_release_date: '2022-10-31' },
+      }),
+    })
+
+    withSilencedConsoleError(() => {
+      render(
+        <MemoryRouter>
+          <GenePage datasetId="gnomad_r4" gene={gene} geneId={gene.gene_id} />
+        </MemoryRouter>
+      )
+    })
+
+    expect(screen.getByText(/Something went wrong rendering Gene coverage/)).toBeTruthy()
+    expect(screen.queryByText('Something Went Wrong')).toBeNull()
+    expect(screen.getByText('Constraint')).toBeTruthy()
+  })
+})

--- a/browser/src/GenePage/GenePage.tsx
+++ b/browser/src/GenePage/GenePage.tsx
@@ -42,6 +42,7 @@ import RegionalMissenseConstraintTrack, {
 } from '../RegionalMissenseConstraintTrack'
 import RegionCoverageTrack from '../RegionPage/RegionCoverageTrack'
 import RegionViewer from '../RegionViewer/ZoomableRegionViewer'
+import { useSectionErrorBoundary } from '../SectionErrorBoundary'
 import { TrackPage, TrackPageSection } from '../TrackPage'
 import { useWindowSize } from '../windowSize'
 
@@ -359,6 +360,12 @@ const GenePage = ({ datasetId, gene, geneId }: Props) => {
 
   const { preferredTranscriptId, preferredTranscriptDescription } = getPreferredTranscript(gene)
 
+  const wrapWithSectionErrorBoundary = useSectionErrorBoundary(
+    `gene ${gene.symbol} (${gene.gene_id})`,
+    datasetId,
+    [gene.gene_id, datasetId]
+  )
+
   return (
     <TrackPage>
       <TrackPageSection>
@@ -380,17 +387,22 @@ const GenePage = ({ datasetId, gene, geneId }: Props) => {
         </GnomadPageHeading>
         <GeneInfoColumnWrapper>
           <GeneInfoColumn>
-            {/* @ts-expect-error TS(2741) FIXME: Property 'gencode_symbol' is missing in type '{ ge... Remove this comment to see the full error message */}
-            <GeneInfo gene={gene} />
-            <GeneFlags gene={gene} />
-            {gene.short_tandem_repeats && gene.short_tandem_repeats.length > 0 && (
-              <p>
-                <Badge level="info">Note</Badge> Data is available for a{' '}
-                <Link to={`/short-tandem-repeat/${gene.short_tandem_repeats[0].id}`}>
-                  tandem repeat locus
-                </Link>{' '}
-                in this gene.
-              </p>
+            {wrapWithSectionErrorBoundary(
+              'Gene information',
+              <>
+                {/* @ts-expect-error TS(2741) FIXME: Property 'gencode_symbol' is missing in type '{ ge... Remove this comment to see the full error message */}
+                <GeneInfo gene={gene} />
+                <GeneFlags gene={gene} />
+                {gene.short_tandem_repeats && gene.short_tandem_repeats.length > 0 && (
+                  <p>
+                    <Badge level="info">Note</Badge> Data is available for a{' '}
+                    <Link to={`/short-tandem-repeat/${gene.short_tandem_repeats[0].id}`}>
+                      tandem repeat locus
+                    </Link>{' '}
+                    in this gene.
+                  </p>
+                )}
+              </>
             )}
           </GeneInfoColumn>
           <ConstraintOrCooccurrenceColumn>
@@ -413,19 +425,25 @@ const GenePage = ({ datasetId, gene, geneId }: Props) => {
                 Variant co-occurrence <InfoButton topic="variant-cooccurrence-table" />
               </TableSelector>
             </TableSelectorWrapper>
-            {selectedTableName === 'constraint' ? (
-              <ConstraintTable datasetId={datasetId} geneOrTranscript={gene} />
-            ) : (
-              <VariantCooccurrenceCountsTable
-                datasetId={datasetId}
-                heterozygous_variant_cooccurrence_counts={
-                  gene.heterozygous_variant_cooccurrence_counts!
-                }
-                homozygous_variant_cooccurrence_counts={
-                  gene.homozygous_variant_cooccurrence_counts!
-                }
-              />
-            )}
+            {selectedTableName === 'constraint'
+              ? wrapWithSectionErrorBoundary(
+                  'Constraint',
+                  <ConstraintTable datasetId={datasetId} geneOrTranscript={gene} />,
+                  [selectedTableName]
+                )
+              : wrapWithSectionErrorBoundary(
+                  'Variant co-occurrence',
+                  <VariantCooccurrenceCountsTable
+                    datasetId={datasetId}
+                    heterozygous_variant_cooccurrence_counts={
+                      gene.heterozygous_variant_cooccurrence_counts!
+                    }
+                    homozygous_variant_cooccurrence_counts={
+                      gene.homozygous_variant_cooccurrence_counts!
+                    }
+                  />,
+                  [selectedTableName]
+                )}
           </ConstraintOrCooccurrenceColumn>
         </GeneInfoColumnWrapper>
       </TrackPageSection>
@@ -450,24 +468,31 @@ const GenePage = ({ datasetId, gene, geneId }: Props) => {
         onChangeZoomRegion={setZoomRegion}
       >
         {/* eslint-disable-next-line no-nested-ternary */}
-        {!hasExons(datasetId) ? (
-          <RegionCoverageTrack
-            chrom={gene.chrom}
-            datasetId={datasetId}
-            includeExomeCoverage={false}
-            start={gene.start}
-            stop={gene.stop}
-          />
-        ) : gene.chrom === 'M' ? (
-          <MitochondrialGeneCoverageTrack datasetId={datasetId} geneId={geneId} />
-        ) : (
-          <GeneCoverageTrack
-            datasetId={datasetId}
-            geneId={geneId}
-            includeExomeCoverage={genesHaveExomeCoverage(datasetId)}
-            includeGenomeCoverage={genesHaveGenomeCoverage(datasetId)}
-          />
-        )}
+        {!hasExons(datasetId)
+          ? wrapWithSectionErrorBoundary(
+              'Gene coverage',
+              <RegionCoverageTrack
+                chrom={gene.chrom}
+                datasetId={datasetId}
+                includeExomeCoverage={false}
+                start={gene.start}
+                stop={gene.stop}
+              />
+            )
+          : gene.chrom === 'M'
+          ? wrapWithSectionErrorBoundary(
+              'Gene coverage',
+              <MitochondrialGeneCoverageTrack datasetId={datasetId} geneId={geneId} />
+            )
+          : wrapWithSectionErrorBoundary(
+              'Gene coverage',
+              <GeneCoverageTrack
+                datasetId={datasetId}
+                geneId={geneId}
+                includeExomeCoverage={genesHaveExomeCoverage(datasetId)}
+                includeGenomeCoverage={genesHaveGenomeCoverage(datasetId)}
+              />
+            )}
 
         {/* @ts-expect-error TS(2769) FIXME: No overload matches this call. */}
         <ControlPanel marginLeft={100} width={regionViewerWidth - 100 - (isSmallScreen ? 0 : 80)}>
@@ -556,87 +581,118 @@ const GenePage = ({ datasetId, gene, geneId }: Props) => {
               )
             }}
           >
-            {({ scalePosition, width: trackWidth }: any) => (
-              <CompositeTranscriptPlotWrapper>
-                <TranscriptPlot
-                  height={20}
-                  scalePosition={scalePosition}
-                  showNonCodingExons={includeNonCodingTranscripts}
-                  showUTRs={includeUTRs}
-                  transcript={{ exons: gene.exons }}
-                  width={trackWidth}
-                />
-              </CompositeTranscriptPlotWrapper>
-            )}
+            {({ scalePosition, width: trackWidth }: any) =>
+              wrapWithSectionErrorBoundary(
+                'Transcript composite plot',
+                <CompositeTranscriptPlotWrapper>
+                  <TranscriptPlot
+                    height={20}
+                    scalePosition={scalePosition}
+                    showNonCodingExons={includeNonCodingTranscripts}
+                    showUTRs={includeUTRs}
+                    transcript={{ exons: gene.exons }}
+                    width={trackWidth}
+                  />
+                </CompositeTranscriptPlotWrapper>
+              )
+            }
           </Track>
         </TrackWrapper>
 
-        {showTranscripts && (
-          <TrackWrapper>
-            <GeneTranscriptsTrack
-              datasetId={datasetId}
-              isTissueExpressionAvailable={!!gene.pext}
-              gene={gene}
-              includeNonCodingTranscripts={includeNonCodingTranscripts}
-              includeUTRs={includeUTRs}
+        {showTranscripts &&
+          wrapWithSectionErrorBoundary(
+            'Transcripts',
+            <TrackWrapper>
+              <GeneTranscriptsTrack
+                datasetId={datasetId}
+                isTissueExpressionAvailable={!!gene.pext}
+                gene={gene}
+                includeNonCodingTranscripts={includeNonCodingTranscripts}
+                includeUTRs={includeUTRs}
+                preferredTranscriptId={preferredTranscriptId}
+                preferredTranscriptDescription={preferredTranscriptDescription}
+              />
+            </TrackWrapper>,
+            [includeNonCodingTranscripts, includeUTRs]
+          )}
+
+        {gene.chrom.startsWith('M') &&
+          wrapWithSectionErrorBoundary(
+            'Mitochondrial region constraint',
+            <MitochondrialRegionConstraintTrack
+              constraintRegions={gene.mitochondrial_missense_constraint_regions}
+              exons={gene.exons}
+              geneSymbol={gene.symbol}
+            />
+          )}
+
+        {hasCodingExons &&
+          gene.chrom !== 'M' &&
+          gene.pext &&
+          wrapWithSectionErrorBoundary(
+            'Tissue expression',
+            <TissueExpressionTrack
+              exons={cdsCompositeExons}
+              expressionRegions={gene.pext.regions}
+              flags={gene.pext.flags}
+              transcripts={gene.transcripts as TranscriptWithTissueExpression[]} // if a gene has pext, it has gtex
               preferredTranscriptId={preferredTranscriptId}
               preferredTranscriptDescription={preferredTranscriptDescription}
+              topLevelDataset={getTopLevelDataset(datasetId)}
             />
-          </TrackWrapper>
-        )}
+          )}
 
-        {gene.chrom.startsWith('M') && (
-          <MitochondrialRegionConstraintTrack
-            constraintRegions={gene.mitochondrial_missense_constraint_regions}
-            exons={gene.exons}
-            geneSymbol={gene.symbol}
-          />
-        )}
+        {isExac(datasetId) &&
+          gene.exac_regional_missense_constraint_regions &&
+          wrapWithSectionErrorBoundary(
+            'Regional missense constraint (ExAC)',
+            <RegionalConstraintTrack
+              height={15}
+              regions={gene.exac_regional_missense_constraint_regions}
+            />
+          )}
 
-        {hasCodingExons && gene.chrom !== 'M' && gene.pext && (
-          <TissueExpressionTrack
-            exons={cdsCompositeExons}
-            expressionRegions={gene.pext.regions}
-            flags={gene.pext.flags}
-            transcripts={gene.transcripts as TranscriptWithTissueExpression[]} // if a gene has pext, it has gtex
-            preferredTranscriptId={preferredTranscriptId}
-            preferredTranscriptDescription={preferredTranscriptDescription}
-            topLevelDataset={getTopLevelDataset(datasetId)}
-          />
-        )}
-
-        {isExac(datasetId) && gene.exac_regional_missense_constraint_regions && (
-          <RegionalConstraintTrack
-            height={15}
-            regions={gene.exac_regional_missense_constraint_regions}
-          />
-        )}
-
-        {isV2(datasetId) && (
-          <RegionalMissenseConstraintTrack
-            regionalMissenseConstraint={gene.gnomad_v2_regional_missense_constraint}
-            gene={gene}
-          />
-        )}
+        {isV2(datasetId) &&
+          wrapWithSectionErrorBoundary(
+            'Regional missense constraint (gnomAD v2)',
+            <RegionalMissenseConstraintTrack
+              regionalMissenseConstraint={gene.gnomad_v2_regional_missense_constraint}
+              gene={gene}
+            />
+          )}
 
         {/* eslint-disable-next-line no-nested-ternary */}
-        {hasStructuralVariants(datasetId) ? (
-          <StructuralVariantsInGene datasetId={datasetId} gene={gene} zoomRegion={zoomRegion} />
-        ) : // eslint-disable-next-line no-nested-ternary
-        hasCopyNumberVariants(datasetId) ? (
-          <CopyNumberVariantsInGene datasetId={datasetId} gene={gene} zoomRegion={zoomRegion} />
-        ) : gene.chrom === 'M' ? (
-          <MitochondrialVariantsInGene datasetId={datasetId} gene={gene} zoomRegion={zoomRegion} />
-        ) : (
-          <VariantsInGene
-            datasetId={datasetId}
-            gene={gene}
-            includeNonCodingTranscripts={includeNonCodingTranscripts}
-            includeUTRs={includeUTRs}
-            zoomRegion={zoomRegion}
-            hasOnlyNonCodingTranscripts={!hasCodingExons && hasNonCodingTranscripts}
-          />
-        )}
+        {hasStructuralVariants(datasetId)
+          ? wrapWithSectionErrorBoundary(
+              'Variants',
+              <StructuralVariantsInGene datasetId={datasetId} gene={gene} zoomRegion={zoomRegion} />
+            )
+          : // eslint-disable-next-line no-nested-ternary
+          hasCopyNumberVariants(datasetId)
+          ? wrapWithSectionErrorBoundary(
+              'Variants',
+              <CopyNumberVariantsInGene datasetId={datasetId} gene={gene} zoomRegion={zoomRegion} />
+            )
+          : gene.chrom === 'M'
+          ? wrapWithSectionErrorBoundary(
+              'Variants',
+              <MitochondrialVariantsInGene
+                datasetId={datasetId}
+                gene={gene}
+                zoomRegion={zoomRegion}
+              />
+            )
+          : wrapWithSectionErrorBoundary(
+              'Variants',
+              <VariantsInGene
+                datasetId={datasetId}
+                gene={gene}
+                includeNonCodingTranscripts={includeNonCodingTranscripts}
+                includeUTRs={includeUTRs}
+                zoomRegion={zoomRegion}
+                hasOnlyNonCodingTranscripts={!hasCodingExons && hasNonCodingTranscripts}
+              />
+            )}
       </RegionViewer>
     </TrackPage>
   )

--- a/browser/src/RegionPage/RegionPage.sectionRenderErrorIsolation.spec.tsx
+++ b/browser/src/RegionPage/RegionPage.sectionRenderErrorIsolation.spec.tsx
@@ -1,0 +1,92 @@
+import React from 'react'
+import { describe, expect, jest, test } from '@jest/globals'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+import { mockQueries } from '../../../tests/__helpers__/queries'
+import { referenceGenome } from '../../../dataset-metadata/metadata'
+import Query, { BaseQuery } from '../Query'
+
+import RegionPage from './RegionPage'
+
+jest.mock('../Query', () => {
+  const originalModule = jest.requireActual('../Query')
+
+  return {
+    __esModule: true,
+    ...(originalModule as object),
+    default: jest.fn(),
+    BaseQuery: jest.fn(),
+  }
+})
+
+jest.mock('./RegionCoverageTrack', () => ({
+  __esModule: true,
+  default: () => {
+    throw new Error('Forced render-time error in RegionCoverageTrack for regression test')
+  },
+}))
+
+const { resetMockApiCalls, resetMockApiResponses, simulateApiResponse, setMockApiResponses } =
+  mockQueries()
+
+beforeEach(() => {
+  Query.mockImplementation(
+    jest.fn(({ children, operationName, variables, query }) =>
+      simulateApiResponse('Query', query, children, operationName, variables)
+    )
+  )
+  ;(BaseQuery as any).mockImplementation(
+    jest.fn(({ children, operationName, variables, query }) =>
+      simulateApiResponse('BaseQuery', query, children, operationName, variables)
+    )
+  )
+})
+
+afterEach(() => {
+  resetMockApiCalls()
+  resetMockApiResponses()
+})
+
+const withSilencedConsoleError = (fn: () => void) => {
+  const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+  try {
+    fn()
+  } finally {
+    consoleErrorSpy.mockRestore()
+  }
+}
+
+describe('RegionPage section render error isolation', () => {
+  test('a render-time throw in one section leaves sibling sections rendered', () => {
+    const datasetId = 'gnomad_r4'
+    const region = {
+      reference_genome: referenceGenome(datasetId),
+      chrom: '12',
+      start: 345,
+      stop: 456,
+      genes: [],
+      short_tandem_repeats: [],
+      non_coding_constraints: [],
+    }
+
+    setMockApiResponses({
+      VariantInRegion: () => ({
+        meta: { clinvar_release_date: '2022-10-31' },
+        region: { variants: [], clinvar_variants: [] },
+      }),
+    })
+
+    withSilencedConsoleError(() => {
+      render(
+        <MemoryRouter>
+          <RegionPage datasetId={datasetId} region={region} />
+        </MemoryRouter>
+      )
+    })
+
+    expect(screen.getByText(/Something went wrong rendering Region coverage/)).toBeTruthy()
+    expect(screen.queryByText('Something Went Wrong')).toBeNull()
+    expect(screen.getByText(`${region.chrom}-${region.start}-${region.stop}`)).toBeTruthy()
+  })
+})

--- a/browser/src/RegionPage/RegionPage.tsx
+++ b/browser/src/RegionPage/RegionPage.tsx
@@ -17,6 +17,7 @@ import GnomadPageHeading from '../GnomadPageHeading'
 import Link from '../Link'
 import RegionalGenomicConstraintTrack from '../RegionalGenomicConstraintTrack'
 import RegionViewer from '../RegionViewer/RegionViewer'
+import { useSectionErrorBoundary } from '../SectionErrorBoundary'
 import { TrackPage, TrackPageSection } from '../TrackPage'
 import { useWindowSize } from '../windowSize'
 
@@ -105,6 +106,12 @@ const RegionPage = ({ datasetId, region }: RegionPageProps) => {
   // Subtract 30px for padding on Page component
   const regionViewerWidth = windowWidth - 30
 
+  const wrapWithSectionErrorBoundary = useSectionErrorBoundary(
+    `region ${chrom}:${start}-${stop}`,
+    datasetId,
+    [chrom, start, stop, datasetId]
+  )
+
   const nccToRegion = (ncc: NonCodingConstraint) => {
     return {
       start: ncc.start,
@@ -138,15 +145,20 @@ const RegionPage = ({ datasetId, region }: RegionPageProps) => {
         </GnomadPageHeading>
         <RegionInfoColumnWrapper>
           <div>
-            <RegionInfo region={region} />
-            {region.short_tandem_repeats && region.short_tandem_repeats.length > 0 && (
-              <p>
-                <Badge level="info">Note</Badge> Data is available for a{' '}
-                <Link to={`/short-tandem-repeat/${region.short_tandem_repeats[0].id}`}>
-                  tandem repeat locus
-                </Link>{' '}
-                within this region.
-              </p>
+            {wrapWithSectionErrorBoundary(
+              'Region information',
+              <>
+                <RegionInfo region={region} />
+                {region.short_tandem_repeats && region.short_tandem_repeats.length > 0 && (
+                  <p>
+                    <Badge level="info">Note</Badge> Data is available for a{' '}
+                    <Link to={`/short-tandem-repeat/${region.short_tandem_repeats[0].id}`}>
+                      tandem repeat locus
+                    </Link>{' '}
+                    within this region.
+                  </p>
+                )}
+              </>
             )}
           </div>
           <RegionControlsWrapper>
@@ -160,23 +172,31 @@ const RegionPage = ({ datasetId, region }: RegionPageProps) => {
         rightPanelWidth={isSmallScreen ? 0 : 80}
         width={regionViewerWidth}
       >
-        {region.chrom === 'M' ? (
-          <MitochondrialRegionCoverageTrack datasetId={datasetId} start={start} stop={stop} />
-        ) : (
-          <RegionCoverageTrack
-            datasetId={datasetId}
-            chrom={chrom}
-            includeExomeCoverage={regionsHaveExomeCoverage(datasetId)}
-            includeGenomeCoverage={regionsHaveGenomeCoverage(datasetId)}
-            start={start}
-            stop={stop}
-          />
+        {region.chrom === 'M'
+          ? wrapWithSectionErrorBoundary(
+              'Region coverage',
+              <MitochondrialRegionCoverageTrack datasetId={datasetId} start={start} stop={stop} />
+            )
+          : wrapWithSectionErrorBoundary(
+              'Region coverage',
+              <RegionCoverageTrack
+                datasetId={datasetId}
+                chrom={chrom}
+                includeExomeCoverage={regionsHaveExomeCoverage(datasetId)}
+                includeGenomeCoverage={regionsHaveGenomeCoverage(datasetId)}
+                start={start}
+                stop={stop}
+              />
+            )}
+
+        {wrapWithSectionErrorBoundary(
+          'Genes in region',
+          <GenesInRegionTrack genes={region.genes} region={region} />
         )}
 
-        <GenesInRegionTrack genes={region.genes} region={region} />
-
-        {hasNonCodingConstraints(datasetId) && (
-          <>
+        {hasNonCodingConstraints(datasetId) &&
+          wrapWithSectionErrorBoundary(
+            'Regional genomic constraint',
             <RegionalGenomicConstraintTrack
               start={region.start}
               stop={region.stop}
@@ -186,9 +206,8 @@ const RegionPage = ({ datasetId, region }: RegionPageProps) => {
                   : null
               }
             />
-          </>
-        )}
-        {variantsInRegion(datasetId, region)}
+          )}
+        {wrapWithSectionErrorBoundary('Variants', variantsInRegion(datasetId, region))}
       </RegionViewer>
     </TrackPage>
   )

--- a/browser/src/RegionPage/__snapshots__/RegionPage.spec.tsx.snap
+++ b/browser/src/RegionPage/__snapshots__/RegionPage.spec.tsx.snap
@@ -45,19 +45,35 @@ exports[`RegionPage with "exac" dataset has no unexpected changes for a mitochon
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "M",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh37",
-              "short_tandem_repeats": [],
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="exac"
+          entityDescription="region M:345-456"
+          resetKeys={
+            [
+              "M",
+              345,
+              456,
+              "exac",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "M",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh37",
+                  "short_tandem_repeats": [],
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
       </div>
       <RegionPage__RegionControlsWrapper>
         <withRouter()
@@ -94,50 +110,92 @@ exports[`RegionPage with "exac" dataset has no unexpected changes for a mitochon
     rightPanelWidth={80}
     width={994}
   >
-    <MitochondrialRegionCoverageTrack
+    <withRouter(SectionErrorBoundary)
       datasetId="exac"
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "exac",
+        ]
       }
-    />
-    <MitochondrialVariantsInRegion
+      sectionName="Region coverage"
+    >
+      <MitochondrialRegionCoverageTrack
+        datasetId="exac"
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="exac"
-      region={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "exac",
+        ]
       }
-      zoomRegion={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
         }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="exac"
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "exac",
+        ]
       }
-    />
+      sectionName="Variants"
+    >
+      <MitochondrialVariantsInRegion
+        datasetId="exac"
+        region={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+        zoomRegion={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -187,19 +245,35 @@ exports[`RegionPage with "exac" dataset has no unexpected changes for a non-mito
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "12",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh37",
-              "short_tandem_repeats": [],
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="exac"
+          entityDescription="region 12:345-456"
+          resetKeys={
+            [
+              "12",
+              345,
+              456,
+              "exac",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "12",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh37",
+                  "short_tandem_repeats": [],
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
       </div>
       <RegionPage__RegionControlsWrapper>
         <withRouter()
@@ -236,42 +310,84 @@ exports[`RegionPage with "exac" dataset has no unexpected changes for a non-mito
     rightPanelWidth={80}
     width={994}
   >
-    <RegionCoverageTrack
-      chrom="12"
+    <withRouter(SectionErrorBoundary)
       datasetId="exac"
-      includeExomeCoverage={true}
-      includeGenomeCoverage={true}
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "exac",
+        ]
       }
-    />
-    <ConnectedVariantsInRegion
+      sectionName="Region coverage"
+    >
+      <RegionCoverageTrack
+        chrom="12"
+        datasetId="exac"
+        includeExomeCoverage={true}
+        includeGenomeCoverage={true}
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="exac"
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "exac",
+        ]
       }
-    />
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="exac"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "exac",
+        ]
+      }
+      sectionName="Variants"
+    >
+      <ConnectedVariantsInRegion
+        datasetId="exac"
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -321,19 +437,35 @@ exports[`RegionPage with "gnomad_cnv_r4" dataset has no unexpected changes for a
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "M",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh38",
-              "short_tandem_repeats": [],
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_cnv_r4"
+          entityDescription="region M:345-456"
+          resetKeys={
+            [
+              "M",
+              345,
+              456,
+              "gnomad_cnv_r4",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "M",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh38",
+                  "short_tandem_repeats": [],
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
       </div>
       <RegionPage__RegionControlsWrapper>
         <withRouter()
@@ -370,50 +502,92 @@ exports[`RegionPage with "gnomad_cnv_r4" dataset has no unexpected changes for a
     rightPanelWidth={80}
     width={994}
   >
-    <MitochondrialRegionCoverageTrack
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_cnv_r4"
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_cnv_r4",
+        ]
       }
-    />
-    <CopyNumberVariantsInRegion
+      sectionName="Region coverage"
+    >
+      <MitochondrialRegionCoverageTrack
+        datasetId="gnomad_cnv_r4"
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_cnv_r4"
-      region={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_cnv_r4",
+        ]
       }
-      zoomRegion={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
         }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_cnv_r4"
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_cnv_r4",
+        ]
       }
-    />
+      sectionName="Variants"
+    >
+      <CopyNumberVariantsInRegion
+        datasetId="gnomad_cnv_r4"
+        region={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+        zoomRegion={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -463,19 +637,35 @@ exports[`RegionPage with "gnomad_cnv_r4" dataset has no unexpected changes for a
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "12",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh38",
-              "short_tandem_repeats": [],
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_cnv_r4"
+          entityDescription="region 12:345-456"
+          resetKeys={
+            [
+              "12",
+              345,
+              456,
+              "gnomad_cnv_r4",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "12",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh38",
+                  "short_tandem_repeats": [],
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
       </div>
       <RegionPage__RegionControlsWrapper>
         <withRouter()
@@ -512,53 +702,95 @@ exports[`RegionPage with "gnomad_cnv_r4" dataset has no unexpected changes for a
     rightPanelWidth={80}
     width={994}
   >
-    <RegionCoverageTrack
-      chrom="12"
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_cnv_r4"
-      includeExomeCoverage={true}
-      includeGenomeCoverage={false}
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_cnv_r4",
+        ]
       }
-    />
-    <CopyNumberVariantsInRegion
+      sectionName="Region coverage"
+    >
+      <RegionCoverageTrack
+        chrom="12"
+        datasetId="gnomad_cnv_r4"
+        includeExomeCoverage={true}
+        includeGenomeCoverage={false}
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_cnv_r4"
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_cnv_r4",
+        ]
       }
-      zoomRegion={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
         }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_cnv_r4"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_cnv_r4",
+        ]
       }
-    />
+      sectionName="Variants"
+    >
+      <CopyNumberVariantsInRegion
+        datasetId="gnomad_cnv_r4"
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+        zoomRegion={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -608,19 +840,35 @@ exports[`RegionPage with "gnomad_r2_1" dataset has no unexpected changes for a m
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "M",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh37",
-              "short_tandem_repeats": [],
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_r2_1"
+          entityDescription="region M:345-456"
+          resetKeys={
+            [
+              "M",
+              345,
+              456,
+              "gnomad_r2_1",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "M",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh37",
+                  "short_tandem_repeats": [],
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
       </div>
       <RegionPage__RegionControlsWrapper>
         <withRouter()
@@ -657,50 +905,92 @@ exports[`RegionPage with "gnomad_r2_1" dataset has no unexpected changes for a m
     rightPanelWidth={80}
     width={994}
   >
-    <MitochondrialRegionCoverageTrack
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r2_1"
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_r2_1",
+        ]
       }
-    />
-    <MitochondrialVariantsInRegion
+      sectionName="Region coverage"
+    >
+      <MitochondrialRegionCoverageTrack
+        datasetId="gnomad_r2_1"
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r2_1"
-      region={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_r2_1",
+        ]
       }
-      zoomRegion={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
         }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r2_1"
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_r2_1",
+        ]
       }
-    />
+      sectionName="Variants"
+    >
+      <MitochondrialVariantsInRegion
+        datasetId="gnomad_r2_1"
+        region={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+        zoomRegion={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -750,19 +1040,35 @@ exports[`RegionPage with "gnomad_r2_1" dataset has no unexpected changes for a n
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "12",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh37",
-              "short_tandem_repeats": [],
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_r2_1"
+          entityDescription="region 12:345-456"
+          resetKeys={
+            [
+              "12",
+              345,
+              456,
+              "gnomad_r2_1",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "12",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh37",
+                  "short_tandem_repeats": [],
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
       </div>
       <RegionPage__RegionControlsWrapper>
         <withRouter()
@@ -799,42 +1105,84 @@ exports[`RegionPage with "gnomad_r2_1" dataset has no unexpected changes for a n
     rightPanelWidth={80}
     width={994}
   >
-    <RegionCoverageTrack
-      chrom="12"
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r2_1"
-      includeExomeCoverage={true}
-      includeGenomeCoverage={true}
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r2_1",
+        ]
       }
-    />
-    <ConnectedVariantsInRegion
+      sectionName="Region coverage"
+    >
+      <RegionCoverageTrack
+        chrom="12"
+        datasetId="gnomad_r2_1"
+        includeExomeCoverage={true}
+        includeGenomeCoverage={true}
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r2_1"
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r2_1",
+        ]
       }
-    />
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r2_1"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r2_1",
+        ]
+      }
+      sectionName="Variants"
+    >
+      <ConnectedVariantsInRegion
+        datasetId="gnomad_r2_1"
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -884,19 +1232,35 @@ exports[`RegionPage with "gnomad_r2_1_controls" dataset has no unexpected change
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "M",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh37",
-              "short_tandem_repeats": [],
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_r2_1_controls"
+          entityDescription="region M:345-456"
+          resetKeys={
+            [
+              "M",
+              345,
+              456,
+              "gnomad_r2_1_controls",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "M",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh37",
+                  "short_tandem_repeats": [],
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
       </div>
       <RegionPage__RegionControlsWrapper>
         <withRouter()
@@ -933,50 +1297,92 @@ exports[`RegionPage with "gnomad_r2_1_controls" dataset has no unexpected change
     rightPanelWidth={80}
     width={994}
   >
-    <MitochondrialRegionCoverageTrack
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r2_1_controls"
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_r2_1_controls",
+        ]
       }
-    />
-    <MitochondrialVariantsInRegion
+      sectionName="Region coverage"
+    >
+      <MitochondrialRegionCoverageTrack
+        datasetId="gnomad_r2_1_controls"
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r2_1_controls"
-      region={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_r2_1_controls",
+        ]
       }
-      zoomRegion={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
         }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r2_1_controls"
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_r2_1_controls",
+        ]
       }
-    />
+      sectionName="Variants"
+    >
+      <MitochondrialVariantsInRegion
+        datasetId="gnomad_r2_1_controls"
+        region={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+        zoomRegion={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -1026,19 +1432,35 @@ exports[`RegionPage with "gnomad_r2_1_controls" dataset has no unexpected change
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "12",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh37",
-              "short_tandem_repeats": [],
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_r2_1_controls"
+          entityDescription="region 12:345-456"
+          resetKeys={
+            [
+              "12",
+              345,
+              456,
+              "gnomad_r2_1_controls",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "12",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh37",
+                  "short_tandem_repeats": [],
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
       </div>
       <RegionPage__RegionControlsWrapper>
         <withRouter()
@@ -1075,42 +1497,84 @@ exports[`RegionPage with "gnomad_r2_1_controls" dataset has no unexpected change
     rightPanelWidth={80}
     width={994}
   >
-    <RegionCoverageTrack
-      chrom="12"
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r2_1_controls"
-      includeExomeCoverage={true}
-      includeGenomeCoverage={true}
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r2_1_controls",
+        ]
       }
-    />
-    <ConnectedVariantsInRegion
+      sectionName="Region coverage"
+    >
+      <RegionCoverageTrack
+        chrom="12"
+        datasetId="gnomad_r2_1_controls"
+        includeExomeCoverage={true}
+        includeGenomeCoverage={true}
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r2_1_controls"
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r2_1_controls",
+        ]
       }
-    />
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r2_1_controls"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r2_1_controls",
+        ]
+      }
+      sectionName="Variants"
+    >
+      <ConnectedVariantsInRegion
+        datasetId="gnomad_r2_1_controls"
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -1160,19 +1624,35 @@ exports[`RegionPage with "gnomad_r2_1_non_cancer" dataset has no unexpected chan
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "M",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh37",
-              "short_tandem_repeats": [],
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_r2_1_non_cancer"
+          entityDescription="region M:345-456"
+          resetKeys={
+            [
+              "M",
+              345,
+              456,
+              "gnomad_r2_1_non_cancer",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "M",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh37",
+                  "short_tandem_repeats": [],
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
       </div>
       <RegionPage__RegionControlsWrapper>
         <withRouter()
@@ -1209,50 +1689,92 @@ exports[`RegionPage with "gnomad_r2_1_non_cancer" dataset has no unexpected chan
     rightPanelWidth={80}
     width={994}
   >
-    <MitochondrialRegionCoverageTrack
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r2_1_non_cancer"
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_r2_1_non_cancer",
+        ]
       }
-    />
-    <MitochondrialVariantsInRegion
+      sectionName="Region coverage"
+    >
+      <MitochondrialRegionCoverageTrack
+        datasetId="gnomad_r2_1_non_cancer"
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r2_1_non_cancer"
-      region={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_r2_1_non_cancer",
+        ]
       }
-      zoomRegion={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
         }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r2_1_non_cancer"
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_r2_1_non_cancer",
+        ]
       }
-    />
+      sectionName="Variants"
+    >
+      <MitochondrialVariantsInRegion
+        datasetId="gnomad_r2_1_non_cancer"
+        region={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+        zoomRegion={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -1302,19 +1824,35 @@ exports[`RegionPage with "gnomad_r2_1_non_cancer" dataset has no unexpected chan
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "12",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh37",
-              "short_tandem_repeats": [],
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_r2_1_non_cancer"
+          entityDescription="region 12:345-456"
+          resetKeys={
+            [
+              "12",
+              345,
+              456,
+              "gnomad_r2_1_non_cancer",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "12",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh37",
+                  "short_tandem_repeats": [],
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
       </div>
       <RegionPage__RegionControlsWrapper>
         <withRouter()
@@ -1351,42 +1889,84 @@ exports[`RegionPage with "gnomad_r2_1_non_cancer" dataset has no unexpected chan
     rightPanelWidth={80}
     width={994}
   >
-    <RegionCoverageTrack
-      chrom="12"
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r2_1_non_cancer"
-      includeExomeCoverage={true}
-      includeGenomeCoverage={true}
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r2_1_non_cancer",
+        ]
       }
-    />
-    <ConnectedVariantsInRegion
+      sectionName="Region coverage"
+    >
+      <RegionCoverageTrack
+        chrom="12"
+        datasetId="gnomad_r2_1_non_cancer"
+        includeExomeCoverage={true}
+        includeGenomeCoverage={true}
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r2_1_non_cancer"
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r2_1_non_cancer",
+        ]
       }
-    />
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r2_1_non_cancer"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r2_1_non_cancer",
+        ]
+      }
+      sectionName="Variants"
+    >
+      <ConnectedVariantsInRegion
+        datasetId="gnomad_r2_1_non_cancer"
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -1436,19 +2016,35 @@ exports[`RegionPage with "gnomad_r2_1_non_neuro" dataset has no unexpected chang
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "M",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh37",
-              "short_tandem_repeats": [],
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_r2_1_non_neuro"
+          entityDescription="region M:345-456"
+          resetKeys={
+            [
+              "M",
+              345,
+              456,
+              "gnomad_r2_1_non_neuro",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "M",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh37",
+                  "short_tandem_repeats": [],
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
       </div>
       <RegionPage__RegionControlsWrapper>
         <withRouter()
@@ -1485,50 +2081,92 @@ exports[`RegionPage with "gnomad_r2_1_non_neuro" dataset has no unexpected chang
     rightPanelWidth={80}
     width={994}
   >
-    <MitochondrialRegionCoverageTrack
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r2_1_non_neuro"
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_r2_1_non_neuro",
+        ]
       }
-    />
-    <MitochondrialVariantsInRegion
+      sectionName="Region coverage"
+    >
+      <MitochondrialRegionCoverageTrack
+        datasetId="gnomad_r2_1_non_neuro"
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r2_1_non_neuro"
-      region={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_r2_1_non_neuro",
+        ]
       }
-      zoomRegion={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
         }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r2_1_non_neuro"
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_r2_1_non_neuro",
+        ]
       }
-    />
+      sectionName="Variants"
+    >
+      <MitochondrialVariantsInRegion
+        datasetId="gnomad_r2_1_non_neuro"
+        region={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+        zoomRegion={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -1578,19 +2216,35 @@ exports[`RegionPage with "gnomad_r2_1_non_neuro" dataset has no unexpected chang
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "12",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh37",
-              "short_tandem_repeats": [],
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_r2_1_non_neuro"
+          entityDescription="region 12:345-456"
+          resetKeys={
+            [
+              "12",
+              345,
+              456,
+              "gnomad_r2_1_non_neuro",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "12",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh37",
+                  "short_tandem_repeats": [],
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
       </div>
       <RegionPage__RegionControlsWrapper>
         <withRouter()
@@ -1627,42 +2281,84 @@ exports[`RegionPage with "gnomad_r2_1_non_neuro" dataset has no unexpected chang
     rightPanelWidth={80}
     width={994}
   >
-    <RegionCoverageTrack
-      chrom="12"
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r2_1_non_neuro"
-      includeExomeCoverage={true}
-      includeGenomeCoverage={true}
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r2_1_non_neuro",
+        ]
       }
-    />
-    <ConnectedVariantsInRegion
+      sectionName="Region coverage"
+    >
+      <RegionCoverageTrack
+        chrom="12"
+        datasetId="gnomad_r2_1_non_neuro"
+        includeExomeCoverage={true}
+        includeGenomeCoverage={true}
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r2_1_non_neuro"
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r2_1_non_neuro",
+        ]
       }
-    />
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r2_1_non_neuro"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r2_1_non_neuro",
+        ]
+      }
+      sectionName="Variants"
+    >
+      <ConnectedVariantsInRegion
+        datasetId="gnomad_r2_1_non_neuro"
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -1712,19 +2408,35 @@ exports[`RegionPage with "gnomad_r2_1_non_topmed" dataset has no unexpected chan
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "M",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh37",
-              "short_tandem_repeats": [],
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_r2_1_non_topmed"
+          entityDescription="region M:345-456"
+          resetKeys={
+            [
+              "M",
+              345,
+              456,
+              "gnomad_r2_1_non_topmed",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "M",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh37",
+                  "short_tandem_repeats": [],
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
       </div>
       <RegionPage__RegionControlsWrapper>
         <withRouter()
@@ -1761,50 +2473,92 @@ exports[`RegionPage with "gnomad_r2_1_non_topmed" dataset has no unexpected chan
     rightPanelWidth={80}
     width={994}
   >
-    <MitochondrialRegionCoverageTrack
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r2_1_non_topmed"
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_r2_1_non_topmed",
+        ]
       }
-    />
-    <MitochondrialVariantsInRegion
+      sectionName="Region coverage"
+    >
+      <MitochondrialRegionCoverageTrack
+        datasetId="gnomad_r2_1_non_topmed"
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r2_1_non_topmed"
-      region={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_r2_1_non_topmed",
+        ]
       }
-      zoomRegion={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
         }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r2_1_non_topmed"
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_r2_1_non_topmed",
+        ]
       }
-    />
+      sectionName="Variants"
+    >
+      <MitochondrialVariantsInRegion
+        datasetId="gnomad_r2_1_non_topmed"
+        region={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+        zoomRegion={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -1854,19 +2608,35 @@ exports[`RegionPage with "gnomad_r2_1_non_topmed" dataset has no unexpected chan
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "12",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh37",
-              "short_tandem_repeats": [],
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_r2_1_non_topmed"
+          entityDescription="region 12:345-456"
+          resetKeys={
+            [
+              "12",
+              345,
+              456,
+              "gnomad_r2_1_non_topmed",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "12",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh37",
+                  "short_tandem_repeats": [],
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
       </div>
       <RegionPage__RegionControlsWrapper>
         <withRouter()
@@ -1903,42 +2673,84 @@ exports[`RegionPage with "gnomad_r2_1_non_topmed" dataset has no unexpected chan
     rightPanelWidth={80}
     width={994}
   >
-    <RegionCoverageTrack
-      chrom="12"
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r2_1_non_topmed"
-      includeExomeCoverage={true}
-      includeGenomeCoverage={true}
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r2_1_non_topmed",
+        ]
       }
-    />
-    <ConnectedVariantsInRegion
+      sectionName="Region coverage"
+    >
+      <RegionCoverageTrack
+        chrom="12"
+        datasetId="gnomad_r2_1_non_topmed"
+        includeExomeCoverage={true}
+        includeGenomeCoverage={true}
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r2_1_non_topmed"
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r2_1_non_topmed",
+        ]
       }
-    />
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r2_1_non_topmed"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r2_1_non_topmed",
+        ]
+      }
+      sectionName="Variants"
+    >
+      <ConnectedVariantsInRegion
+        datasetId="gnomad_r2_1_non_topmed"
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -1988,19 +2800,35 @@ exports[`RegionPage with "gnomad_r3" dataset has no unexpected changes for a mit
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "M",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh38",
-              "short_tandem_repeats": [],
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_r3"
+          entityDescription="region M:345-456"
+          resetKeys={
+            [
+              "M",
+              345,
+              456,
+              "gnomad_r3",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "M",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh38",
+                  "short_tandem_repeats": [],
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
       </div>
       <RegionPage__RegionControlsWrapper>
         <withRouter()
@@ -2037,58 +2865,112 @@ exports[`RegionPage with "gnomad_r3" dataset has no unexpected changes for a mit
     rightPanelWidth={80}
     width={994}
   >
-    <MitochondrialRegionCoverageTrack
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r3"
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_r3",
+        ]
       }
-    />
-    <React.Fragment>
+      sectionName="Region coverage"
+    >
+      <MitochondrialRegionCoverageTrack
+        datasetId="gnomad_r3"
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r3"
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_r3",
+        ]
+      }
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r3"
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_r3",
+        ]
+      }
+      sectionName="Regional genomic constraint"
+    >
       <RegionalGenomicConstraintTrack
         height={45}
         regions={[]}
         start={345}
         stop={456}
       />
-    </React.Fragment>
-    <MitochondrialVariantsInRegion
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r3"
-      region={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_r3",
+        ]
       }
-      zoomRegion={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
+      sectionName="Variants"
+    >
+      <MitochondrialVariantsInRegion
+        datasetId="gnomad_r3"
+        region={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
         }
-      }
-    />
+        zoomRegion={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -2138,19 +3020,35 @@ exports[`RegionPage with "gnomad_r3" dataset has no unexpected changes for a non
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "12",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh38",
-              "short_tandem_repeats": [],
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_r3"
+          entityDescription="region 12:345-456"
+          resetKeys={
+            [
+              "12",
+              345,
+              456,
+              "gnomad_r3",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "12",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh38",
+                  "short_tandem_repeats": [],
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
       </div>
       <RegionPage__RegionControlsWrapper>
         <withRouter()
@@ -2187,50 +3085,104 @@ exports[`RegionPage with "gnomad_r3" dataset has no unexpected changes for a non
     rightPanelWidth={80}
     width={994}
   >
-    <RegionCoverageTrack
-      chrom="12"
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r3"
-      includeExomeCoverage={false}
-      includeGenomeCoverage={true}
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r3",
+        ]
       }
-    />
-    <React.Fragment>
+      sectionName="Region coverage"
+    >
+      <RegionCoverageTrack
+        chrom="12"
+        datasetId="gnomad_r3"
+        includeExomeCoverage={false}
+        includeGenomeCoverage={true}
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r3"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r3",
+        ]
+      }
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r3"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r3",
+        ]
+      }
+      sectionName="Regional genomic constraint"
+    >
       <RegionalGenomicConstraintTrack
         height={45}
         regions={[]}
         start={345}
         stop={456}
       />
-    </React.Fragment>
-    <ConnectedVariantsInRegion
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r3"
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r3",
+        ]
       }
-    />
+      sectionName="Variants"
+    >
+      <ConnectedVariantsInRegion
+        datasetId="gnomad_r3"
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -2280,19 +3232,35 @@ exports[`RegionPage with "gnomad_r3_controls_and_biobanks" dataset has no unexpe
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "M",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh38",
-              "short_tandem_repeats": [],
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_r3_controls_and_biobanks"
+          entityDescription="region M:345-456"
+          resetKeys={
+            [
+              "M",
+              345,
+              456,
+              "gnomad_r3_controls_and_biobanks",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "M",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh38",
+                  "short_tandem_repeats": [],
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
       </div>
       <RegionPage__RegionControlsWrapper>
         <withRouter()
@@ -2329,58 +3297,112 @@ exports[`RegionPage with "gnomad_r3_controls_and_biobanks" dataset has no unexpe
     rightPanelWidth={80}
     width={994}
   >
-    <MitochondrialRegionCoverageTrack
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r3_controls_and_biobanks"
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_r3_controls_and_biobanks",
+        ]
       }
-    />
-    <React.Fragment>
+      sectionName="Region coverage"
+    >
+      <MitochondrialRegionCoverageTrack
+        datasetId="gnomad_r3_controls_and_biobanks"
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r3_controls_and_biobanks"
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_r3_controls_and_biobanks",
+        ]
+      }
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r3_controls_and_biobanks"
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_r3_controls_and_biobanks",
+        ]
+      }
+      sectionName="Regional genomic constraint"
+    >
       <RegionalGenomicConstraintTrack
         height={45}
         regions={[]}
         start={345}
         stop={456}
       />
-    </React.Fragment>
-    <MitochondrialVariantsInRegion
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r3_controls_and_biobanks"
-      region={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_r3_controls_and_biobanks",
+        ]
       }
-      zoomRegion={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
+      sectionName="Variants"
+    >
+      <MitochondrialVariantsInRegion
+        datasetId="gnomad_r3_controls_and_biobanks"
+        region={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
         }
-      }
-    />
+        zoomRegion={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -2430,19 +3452,35 @@ exports[`RegionPage with "gnomad_r3_controls_and_biobanks" dataset has no unexpe
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "12",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh38",
-              "short_tandem_repeats": [],
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_r3_controls_and_biobanks"
+          entityDescription="region 12:345-456"
+          resetKeys={
+            [
+              "12",
+              345,
+              456,
+              "gnomad_r3_controls_and_biobanks",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "12",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh38",
+                  "short_tandem_repeats": [],
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
       </div>
       <RegionPage__RegionControlsWrapper>
         <withRouter()
@@ -2479,50 +3517,104 @@ exports[`RegionPage with "gnomad_r3_controls_and_biobanks" dataset has no unexpe
     rightPanelWidth={80}
     width={994}
   >
-    <RegionCoverageTrack
-      chrom="12"
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r3_controls_and_biobanks"
-      includeExomeCoverage={false}
-      includeGenomeCoverage={true}
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r3_controls_and_biobanks",
+        ]
       }
-    />
-    <React.Fragment>
+      sectionName="Region coverage"
+    >
+      <RegionCoverageTrack
+        chrom="12"
+        datasetId="gnomad_r3_controls_and_biobanks"
+        includeExomeCoverage={false}
+        includeGenomeCoverage={true}
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r3_controls_and_biobanks"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r3_controls_and_biobanks",
+        ]
+      }
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r3_controls_and_biobanks"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r3_controls_and_biobanks",
+        ]
+      }
+      sectionName="Regional genomic constraint"
+    >
       <RegionalGenomicConstraintTrack
         height={45}
         regions={[]}
         start={345}
         stop={456}
       />
-    </React.Fragment>
-    <ConnectedVariantsInRegion
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r3_controls_and_biobanks"
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r3_controls_and_biobanks",
+        ]
       }
-    />
+      sectionName="Variants"
+    >
+      <ConnectedVariantsInRegion
+        datasetId="gnomad_r3_controls_and_biobanks"
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -2572,19 +3664,35 @@ exports[`RegionPage with "gnomad_r3_non_cancer" dataset has no unexpected change
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "M",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh38",
-              "short_tandem_repeats": [],
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_r3_non_cancer"
+          entityDescription="region M:345-456"
+          resetKeys={
+            [
+              "M",
+              345,
+              456,
+              "gnomad_r3_non_cancer",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "M",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh38",
+                  "short_tandem_repeats": [],
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
       </div>
       <RegionPage__RegionControlsWrapper>
         <withRouter()
@@ -2621,58 +3729,112 @@ exports[`RegionPage with "gnomad_r3_non_cancer" dataset has no unexpected change
     rightPanelWidth={80}
     width={994}
   >
-    <MitochondrialRegionCoverageTrack
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r3_non_cancer"
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_r3_non_cancer",
+        ]
       }
-    />
-    <React.Fragment>
+      sectionName="Region coverage"
+    >
+      <MitochondrialRegionCoverageTrack
+        datasetId="gnomad_r3_non_cancer"
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r3_non_cancer"
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_r3_non_cancer",
+        ]
+      }
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r3_non_cancer"
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_r3_non_cancer",
+        ]
+      }
+      sectionName="Regional genomic constraint"
+    >
       <RegionalGenomicConstraintTrack
         height={45}
         regions={[]}
         start={345}
         stop={456}
       />
-    </React.Fragment>
-    <MitochondrialVariantsInRegion
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r3_non_cancer"
-      region={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_r3_non_cancer",
+        ]
       }
-      zoomRegion={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
+      sectionName="Variants"
+    >
+      <MitochondrialVariantsInRegion
+        datasetId="gnomad_r3_non_cancer"
+        region={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
         }
-      }
-    />
+        zoomRegion={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -2722,19 +3884,35 @@ exports[`RegionPage with "gnomad_r3_non_cancer" dataset has no unexpected change
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "12",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh38",
-              "short_tandem_repeats": [],
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_r3_non_cancer"
+          entityDescription="region 12:345-456"
+          resetKeys={
+            [
+              "12",
+              345,
+              456,
+              "gnomad_r3_non_cancer",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "12",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh38",
+                  "short_tandem_repeats": [],
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
       </div>
       <RegionPage__RegionControlsWrapper>
         <withRouter()
@@ -2771,50 +3949,104 @@ exports[`RegionPage with "gnomad_r3_non_cancer" dataset has no unexpected change
     rightPanelWidth={80}
     width={994}
   >
-    <RegionCoverageTrack
-      chrom="12"
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r3_non_cancer"
-      includeExomeCoverage={false}
-      includeGenomeCoverage={true}
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r3_non_cancer",
+        ]
       }
-    />
-    <React.Fragment>
+      sectionName="Region coverage"
+    >
+      <RegionCoverageTrack
+        chrom="12"
+        datasetId="gnomad_r3_non_cancer"
+        includeExomeCoverage={false}
+        includeGenomeCoverage={true}
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r3_non_cancer"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r3_non_cancer",
+        ]
+      }
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r3_non_cancer"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r3_non_cancer",
+        ]
+      }
+      sectionName="Regional genomic constraint"
+    >
       <RegionalGenomicConstraintTrack
         height={45}
         regions={[]}
         start={345}
         stop={456}
       />
-    </React.Fragment>
-    <ConnectedVariantsInRegion
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r3_non_cancer"
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r3_non_cancer",
+        ]
       }
-    />
+      sectionName="Variants"
+    >
+      <ConnectedVariantsInRegion
+        datasetId="gnomad_r3_non_cancer"
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -2864,19 +4096,35 @@ exports[`RegionPage with "gnomad_r3_non_neuro" dataset has no unexpected changes
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "M",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh38",
-              "short_tandem_repeats": [],
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_r3_non_neuro"
+          entityDescription="region M:345-456"
+          resetKeys={
+            [
+              "M",
+              345,
+              456,
+              "gnomad_r3_non_neuro",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "M",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh38",
+                  "short_tandem_repeats": [],
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
       </div>
       <RegionPage__RegionControlsWrapper>
         <withRouter()
@@ -2913,58 +4161,112 @@ exports[`RegionPage with "gnomad_r3_non_neuro" dataset has no unexpected changes
     rightPanelWidth={80}
     width={994}
   >
-    <MitochondrialRegionCoverageTrack
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r3_non_neuro"
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_r3_non_neuro",
+        ]
       }
-    />
-    <React.Fragment>
+      sectionName="Region coverage"
+    >
+      <MitochondrialRegionCoverageTrack
+        datasetId="gnomad_r3_non_neuro"
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r3_non_neuro"
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_r3_non_neuro",
+        ]
+      }
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r3_non_neuro"
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_r3_non_neuro",
+        ]
+      }
+      sectionName="Regional genomic constraint"
+    >
       <RegionalGenomicConstraintTrack
         height={45}
         regions={[]}
         start={345}
         stop={456}
       />
-    </React.Fragment>
-    <MitochondrialVariantsInRegion
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r3_non_neuro"
-      region={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_r3_non_neuro",
+        ]
       }
-      zoomRegion={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
+      sectionName="Variants"
+    >
+      <MitochondrialVariantsInRegion
+        datasetId="gnomad_r3_non_neuro"
+        region={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
         }
-      }
-    />
+        zoomRegion={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -3014,19 +4316,35 @@ exports[`RegionPage with "gnomad_r3_non_neuro" dataset has no unexpected changes
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "12",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh38",
-              "short_tandem_repeats": [],
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_r3_non_neuro"
+          entityDescription="region 12:345-456"
+          resetKeys={
+            [
+              "12",
+              345,
+              456,
+              "gnomad_r3_non_neuro",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "12",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh38",
+                  "short_tandem_repeats": [],
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
       </div>
       <RegionPage__RegionControlsWrapper>
         <withRouter()
@@ -3063,50 +4381,104 @@ exports[`RegionPage with "gnomad_r3_non_neuro" dataset has no unexpected changes
     rightPanelWidth={80}
     width={994}
   >
-    <RegionCoverageTrack
-      chrom="12"
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r3_non_neuro"
-      includeExomeCoverage={false}
-      includeGenomeCoverage={true}
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r3_non_neuro",
+        ]
       }
-    />
-    <React.Fragment>
+      sectionName="Region coverage"
+    >
+      <RegionCoverageTrack
+        chrom="12"
+        datasetId="gnomad_r3_non_neuro"
+        includeExomeCoverage={false}
+        includeGenomeCoverage={true}
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r3_non_neuro"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r3_non_neuro",
+        ]
+      }
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r3_non_neuro"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r3_non_neuro",
+        ]
+      }
+      sectionName="Regional genomic constraint"
+    >
       <RegionalGenomicConstraintTrack
         height={45}
         regions={[]}
         start={345}
         stop={456}
       />
-    </React.Fragment>
-    <ConnectedVariantsInRegion
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r3_non_neuro"
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r3_non_neuro",
+        ]
       }
-    />
+      sectionName="Variants"
+    >
+      <ConnectedVariantsInRegion
+        datasetId="gnomad_r3_non_neuro"
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -3156,19 +4528,35 @@ exports[`RegionPage with "gnomad_r3_non_topmed" dataset has no unexpected change
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "M",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh38",
-              "short_tandem_repeats": [],
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_r3_non_topmed"
+          entityDescription="region M:345-456"
+          resetKeys={
+            [
+              "M",
+              345,
+              456,
+              "gnomad_r3_non_topmed",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "M",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh38",
+                  "short_tandem_repeats": [],
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
       </div>
       <RegionPage__RegionControlsWrapper>
         <withRouter()
@@ -3205,58 +4593,112 @@ exports[`RegionPage with "gnomad_r3_non_topmed" dataset has no unexpected change
     rightPanelWidth={80}
     width={994}
   >
-    <MitochondrialRegionCoverageTrack
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r3_non_topmed"
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_r3_non_topmed",
+        ]
       }
-    />
-    <React.Fragment>
+      sectionName="Region coverage"
+    >
+      <MitochondrialRegionCoverageTrack
+        datasetId="gnomad_r3_non_topmed"
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r3_non_topmed"
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_r3_non_topmed",
+        ]
+      }
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r3_non_topmed"
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_r3_non_topmed",
+        ]
+      }
+      sectionName="Regional genomic constraint"
+    >
       <RegionalGenomicConstraintTrack
         height={45}
         regions={[]}
         start={345}
         stop={456}
       />
-    </React.Fragment>
-    <MitochondrialVariantsInRegion
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r3_non_topmed"
-      region={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_r3_non_topmed",
+        ]
       }
-      zoomRegion={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
+      sectionName="Variants"
+    >
+      <MitochondrialVariantsInRegion
+        datasetId="gnomad_r3_non_topmed"
+        region={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
         }
-      }
-    />
+        zoomRegion={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -3306,19 +4748,35 @@ exports[`RegionPage with "gnomad_r3_non_topmed" dataset has no unexpected change
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "12",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh38",
-              "short_tandem_repeats": [],
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_r3_non_topmed"
+          entityDescription="region 12:345-456"
+          resetKeys={
+            [
+              "12",
+              345,
+              456,
+              "gnomad_r3_non_topmed",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "12",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh38",
+                  "short_tandem_repeats": [],
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
       </div>
       <RegionPage__RegionControlsWrapper>
         <withRouter()
@@ -3355,50 +4813,104 @@ exports[`RegionPage with "gnomad_r3_non_topmed" dataset has no unexpected change
     rightPanelWidth={80}
     width={994}
   >
-    <RegionCoverageTrack
-      chrom="12"
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r3_non_topmed"
-      includeExomeCoverage={false}
-      includeGenomeCoverage={true}
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r3_non_topmed",
+        ]
       }
-    />
-    <React.Fragment>
+      sectionName="Region coverage"
+    >
+      <RegionCoverageTrack
+        chrom="12"
+        datasetId="gnomad_r3_non_topmed"
+        includeExomeCoverage={false}
+        includeGenomeCoverage={true}
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r3_non_topmed"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r3_non_topmed",
+        ]
+      }
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r3_non_topmed"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r3_non_topmed",
+        ]
+      }
+      sectionName="Regional genomic constraint"
+    >
       <RegionalGenomicConstraintTrack
         height={45}
         regions={[]}
         start={345}
         stop={456}
       />
-    </React.Fragment>
-    <ConnectedVariantsInRegion
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r3_non_topmed"
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r3_non_topmed",
+        ]
       }
-    />
+      sectionName="Variants"
+    >
+      <ConnectedVariantsInRegion
+        datasetId="gnomad_r3_non_topmed"
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -3448,19 +4960,35 @@ exports[`RegionPage with "gnomad_r3_non_v2" dataset has no unexpected changes fo
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "M",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh38",
-              "short_tandem_repeats": [],
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_r3_non_v2"
+          entityDescription="region M:345-456"
+          resetKeys={
+            [
+              "M",
+              345,
+              456,
+              "gnomad_r3_non_v2",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "M",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh38",
+                  "short_tandem_repeats": [],
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
       </div>
       <RegionPage__RegionControlsWrapper>
         <withRouter()
@@ -3497,58 +5025,112 @@ exports[`RegionPage with "gnomad_r3_non_v2" dataset has no unexpected changes fo
     rightPanelWidth={80}
     width={994}
   >
-    <MitochondrialRegionCoverageTrack
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r3_non_v2"
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_r3_non_v2",
+        ]
       }
-    />
-    <React.Fragment>
+      sectionName="Region coverage"
+    >
+      <MitochondrialRegionCoverageTrack
+        datasetId="gnomad_r3_non_v2"
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r3_non_v2"
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_r3_non_v2",
+        ]
+      }
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r3_non_v2"
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_r3_non_v2",
+        ]
+      }
+      sectionName="Regional genomic constraint"
+    >
       <RegionalGenomicConstraintTrack
         height={45}
         regions={[]}
         start={345}
         stop={456}
       />
-    </React.Fragment>
-    <MitochondrialVariantsInRegion
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r3_non_v2"
-      region={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_r3_non_v2",
+        ]
       }
-      zoomRegion={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
+      sectionName="Variants"
+    >
+      <MitochondrialVariantsInRegion
+        datasetId="gnomad_r3_non_v2"
+        region={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
         }
-      }
-    />
+        zoomRegion={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -3598,19 +5180,35 @@ exports[`RegionPage with "gnomad_r3_non_v2" dataset has no unexpected changes fo
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "12",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh38",
-              "short_tandem_repeats": [],
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_r3_non_v2"
+          entityDescription="region 12:345-456"
+          resetKeys={
+            [
+              "12",
+              345,
+              456,
+              "gnomad_r3_non_v2",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "12",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh38",
+                  "short_tandem_repeats": [],
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
       </div>
       <RegionPage__RegionControlsWrapper>
         <withRouter()
@@ -3647,50 +5245,104 @@ exports[`RegionPage with "gnomad_r3_non_v2" dataset has no unexpected changes fo
     rightPanelWidth={80}
     width={994}
   >
-    <RegionCoverageTrack
-      chrom="12"
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r3_non_v2"
-      includeExomeCoverage={false}
-      includeGenomeCoverage={true}
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r3_non_v2",
+        ]
       }
-    />
-    <React.Fragment>
+      sectionName="Region coverage"
+    >
+      <RegionCoverageTrack
+        chrom="12"
+        datasetId="gnomad_r3_non_v2"
+        includeExomeCoverage={false}
+        includeGenomeCoverage={true}
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r3_non_v2"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r3_non_v2",
+        ]
+      }
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r3_non_v2"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r3_non_v2",
+        ]
+      }
+      sectionName="Regional genomic constraint"
+    >
       <RegionalGenomicConstraintTrack
         height={45}
         regions={[]}
         start={345}
         stop={456}
       />
-    </React.Fragment>
-    <ConnectedVariantsInRegion
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r3_non_v2"
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r3_non_v2",
+        ]
       }
-    />
+      sectionName="Variants"
+    >
+      <ConnectedVariantsInRegion
+        datasetId="gnomad_r3_non_v2"
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -3740,19 +5392,35 @@ exports[`RegionPage with "gnomad_r4" dataset has no unexpected changes for a mit
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "M",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh38",
-              "short_tandem_repeats": [],
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_r4"
+          entityDescription="region M:345-456"
+          resetKeys={
+            [
+              "M",
+              345,
+              456,
+              "gnomad_r4",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "M",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh38",
+                  "short_tandem_repeats": [],
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
       </div>
       <RegionPage__RegionControlsWrapper>
         <withRouter()
@@ -3789,58 +5457,112 @@ exports[`RegionPage with "gnomad_r4" dataset has no unexpected changes for a mit
     rightPanelWidth={80}
     width={994}
   >
-    <MitochondrialRegionCoverageTrack
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r4"
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_r4",
+        ]
       }
-    />
-    <React.Fragment>
+      sectionName="Region coverage"
+    >
+      <MitochondrialRegionCoverageTrack
+        datasetId="gnomad_r4"
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r4"
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_r4",
+        ]
+      }
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r4"
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_r4",
+        ]
+      }
+      sectionName="Regional genomic constraint"
+    >
       <RegionalGenomicConstraintTrack
         height={45}
         regions={[]}
         start={345}
         stop={456}
       />
-    </React.Fragment>
-    <MitochondrialVariantsInRegion
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r4"
-      region={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_r4",
+        ]
       }
-      zoomRegion={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
+      sectionName="Variants"
+    >
+      <MitochondrialVariantsInRegion
+        datasetId="gnomad_r4"
+        region={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
         }
-      }
-    />
+        zoomRegion={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -3890,19 +5612,35 @@ exports[`RegionPage with "gnomad_r4" dataset has no unexpected changes for a non
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "12",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh38",
-              "short_tandem_repeats": [],
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_r4"
+          entityDescription="region 12:345-456"
+          resetKeys={
+            [
+              "12",
+              345,
+              456,
+              "gnomad_r4",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "12",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh38",
+                  "short_tandem_repeats": [],
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
       </div>
       <RegionPage__RegionControlsWrapper>
         <withRouter()
@@ -3939,50 +5677,104 @@ exports[`RegionPage with "gnomad_r4" dataset has no unexpected changes for a non
     rightPanelWidth={80}
     width={994}
   >
-    <RegionCoverageTrack
-      chrom="12"
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r4"
-      includeExomeCoverage={true}
-      includeGenomeCoverage={true}
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r4",
+        ]
       }
-    />
-    <React.Fragment>
+      sectionName="Region coverage"
+    >
+      <RegionCoverageTrack
+        chrom="12"
+        datasetId="gnomad_r4"
+        includeExomeCoverage={true}
+        includeGenomeCoverage={true}
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r4"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r4",
+        ]
+      }
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r4"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r4",
+        ]
+      }
+      sectionName="Regional genomic constraint"
+    >
       <RegionalGenomicConstraintTrack
         height={45}
         regions={[]}
         start={345}
         stop={456}
       />
-    </React.Fragment>
-    <ConnectedVariantsInRegion
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r4"
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r4",
+        ]
       }
-    />
+      sectionName="Variants"
+    >
+      <ConnectedVariantsInRegion
+        datasetId="gnomad_r4"
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -4032,19 +5824,35 @@ exports[`RegionPage with "gnomad_r4_non_ukb" dataset has no unexpected changes f
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "M",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh38",
-              "short_tandem_repeats": [],
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_r4_non_ukb"
+          entityDescription="region M:345-456"
+          resetKeys={
+            [
+              "M",
+              345,
+              456,
+              "gnomad_r4_non_ukb",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "M",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh38",
+                  "short_tandem_repeats": [],
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
       </div>
       <RegionPage__RegionControlsWrapper>
         <withRouter()
@@ -4081,58 +5889,112 @@ exports[`RegionPage with "gnomad_r4_non_ukb" dataset has no unexpected changes f
     rightPanelWidth={80}
     width={994}
   >
-    <MitochondrialRegionCoverageTrack
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r4_non_ukb"
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_r4_non_ukb",
+        ]
       }
-    />
-    <React.Fragment>
+      sectionName="Region coverage"
+    >
+      <MitochondrialRegionCoverageTrack
+        datasetId="gnomad_r4_non_ukb"
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r4_non_ukb"
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_r4_non_ukb",
+        ]
+      }
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r4_non_ukb"
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_r4_non_ukb",
+        ]
+      }
+      sectionName="Regional genomic constraint"
+    >
       <RegionalGenomicConstraintTrack
         height={45}
         regions={[]}
         start={345}
         stop={456}
       />
-    </React.Fragment>
-    <MitochondrialVariantsInRegion
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r4_non_ukb"
-      region={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_r4_non_ukb",
+        ]
       }
-      zoomRegion={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
+      sectionName="Variants"
+    >
+      <MitochondrialVariantsInRegion
+        datasetId="gnomad_r4_non_ukb"
+        region={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
         }
-      }
-    />
+        zoomRegion={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -4182,19 +6044,35 @@ exports[`RegionPage with "gnomad_r4_non_ukb" dataset has no unexpected changes f
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "12",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh38",
-              "short_tandem_repeats": [],
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_r4_non_ukb"
+          entityDescription="region 12:345-456"
+          resetKeys={
+            [
+              "12",
+              345,
+              456,
+              "gnomad_r4_non_ukb",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "12",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh38",
+                  "short_tandem_repeats": [],
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
       </div>
       <RegionPage__RegionControlsWrapper>
         <withRouter()
@@ -4231,50 +6109,104 @@ exports[`RegionPage with "gnomad_r4_non_ukb" dataset has no unexpected changes f
     rightPanelWidth={80}
     width={994}
   >
-    <RegionCoverageTrack
-      chrom="12"
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r4_non_ukb"
-      includeExomeCoverage={true}
-      includeGenomeCoverage={true}
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r4_non_ukb",
+        ]
       }
-    />
-    <React.Fragment>
+      sectionName="Region coverage"
+    >
+      <RegionCoverageTrack
+        chrom="12"
+        datasetId="gnomad_r4_non_ukb"
+        includeExomeCoverage={true}
+        includeGenomeCoverage={true}
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r4_non_ukb"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r4_non_ukb",
+        ]
+      }
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r4_non_ukb"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r4_non_ukb",
+        ]
+      }
+      sectionName="Regional genomic constraint"
+    >
       <RegionalGenomicConstraintTrack
         height={45}
         regions={[]}
         start={345}
         stop={456}
       />
-    </React.Fragment>
-    <ConnectedVariantsInRegion
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r4_non_ukb"
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r4_non_ukb",
+        ]
       }
-    />
+      sectionName="Variants"
+    >
+      <ConnectedVariantsInRegion
+        datasetId="gnomad_r4_non_ukb"
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -4324,19 +6256,35 @@ exports[`RegionPage with "gnomad_sv_r2_1" dataset has no unexpected changes for 
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "M",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh37",
-              "short_tandem_repeats": [],
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_sv_r2_1"
+          entityDescription="region M:345-456"
+          resetKeys={
+            [
+              "M",
+              345,
+              456,
+              "gnomad_sv_r2_1",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "M",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh37",
+                  "short_tandem_repeats": [],
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
       </div>
       <RegionPage__RegionControlsWrapper>
         <withRouter()
@@ -4373,50 +6321,92 @@ exports[`RegionPage with "gnomad_sv_r2_1" dataset has no unexpected changes for 
     rightPanelWidth={80}
     width={994}
   >
-    <MitochondrialRegionCoverageTrack
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_sv_r2_1"
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_sv_r2_1",
+        ]
       }
-    />
-    <StructuralVariantsInRegion
+      sectionName="Region coverage"
+    >
+      <MitochondrialRegionCoverageTrack
+        datasetId="gnomad_sv_r2_1"
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_sv_r2_1"
-      region={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_sv_r2_1",
+        ]
       }
-      zoomRegion={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
         }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_sv_r2_1"
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_sv_r2_1",
+        ]
       }
-    />
+      sectionName="Variants"
+    >
+      <StructuralVariantsInRegion
+        datasetId="gnomad_sv_r2_1"
+        region={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+        zoomRegion={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -4466,19 +6456,35 @@ exports[`RegionPage with "gnomad_sv_r2_1" dataset has no unexpected changes for 
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "12",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh37",
-              "short_tandem_repeats": [],
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_sv_r2_1"
+          entityDescription="region 12:345-456"
+          resetKeys={
+            [
+              "12",
+              345,
+              456,
+              "gnomad_sv_r2_1",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "12",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh37",
+                  "short_tandem_repeats": [],
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
       </div>
       <RegionPage__RegionControlsWrapper>
         <withRouter()
@@ -4515,53 +6521,95 @@ exports[`RegionPage with "gnomad_sv_r2_1" dataset has no unexpected changes for 
     rightPanelWidth={80}
     width={994}
   >
-    <RegionCoverageTrack
-      chrom="12"
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_sv_r2_1"
-      includeExomeCoverage={false}
-      includeGenomeCoverage={true}
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_sv_r2_1",
+        ]
       }
-    />
-    <StructuralVariantsInRegion
+      sectionName="Region coverage"
+    >
+      <RegionCoverageTrack
+        chrom="12"
+        datasetId="gnomad_sv_r2_1"
+        includeExomeCoverage={false}
+        includeGenomeCoverage={true}
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_sv_r2_1"
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_sv_r2_1",
+        ]
       }
-      zoomRegion={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
         }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_sv_r2_1"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_sv_r2_1",
+        ]
       }
-    />
+      sectionName="Variants"
+    >
+      <StructuralVariantsInRegion
+        datasetId="gnomad_sv_r2_1"
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+        zoomRegion={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -4611,19 +6659,35 @@ exports[`RegionPage with "gnomad_sv_r2_1_controls" dataset has no unexpected cha
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "M",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh37",
-              "short_tandem_repeats": [],
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_sv_r2_1_controls"
+          entityDescription="region M:345-456"
+          resetKeys={
+            [
+              "M",
+              345,
+              456,
+              "gnomad_sv_r2_1_controls",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "M",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh37",
+                  "short_tandem_repeats": [],
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
       </div>
       <RegionPage__RegionControlsWrapper>
         <withRouter()
@@ -4660,50 +6724,92 @@ exports[`RegionPage with "gnomad_sv_r2_1_controls" dataset has no unexpected cha
     rightPanelWidth={80}
     width={994}
   >
-    <MitochondrialRegionCoverageTrack
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_sv_r2_1_controls"
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_sv_r2_1_controls",
+        ]
       }
-    />
-    <StructuralVariantsInRegion
+      sectionName="Region coverage"
+    >
+      <MitochondrialRegionCoverageTrack
+        datasetId="gnomad_sv_r2_1_controls"
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_sv_r2_1_controls"
-      region={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_sv_r2_1_controls",
+        ]
       }
-      zoomRegion={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
         }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_sv_r2_1_controls"
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_sv_r2_1_controls",
+        ]
       }
-    />
+      sectionName="Variants"
+    >
+      <StructuralVariantsInRegion
+        datasetId="gnomad_sv_r2_1_controls"
+        region={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+        zoomRegion={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -4753,19 +6859,35 @@ exports[`RegionPage with "gnomad_sv_r2_1_controls" dataset has no unexpected cha
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "12",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh37",
-              "short_tandem_repeats": [],
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_sv_r2_1_controls"
+          entityDescription="region 12:345-456"
+          resetKeys={
+            [
+              "12",
+              345,
+              456,
+              "gnomad_sv_r2_1_controls",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "12",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh37",
+                  "short_tandem_repeats": [],
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
       </div>
       <RegionPage__RegionControlsWrapper>
         <withRouter()
@@ -4802,53 +6924,95 @@ exports[`RegionPage with "gnomad_sv_r2_1_controls" dataset has no unexpected cha
     rightPanelWidth={80}
     width={994}
   >
-    <RegionCoverageTrack
-      chrom="12"
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_sv_r2_1_controls"
-      includeExomeCoverage={false}
-      includeGenomeCoverage={true}
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_sv_r2_1_controls",
+        ]
       }
-    />
-    <StructuralVariantsInRegion
+      sectionName="Region coverage"
+    >
+      <RegionCoverageTrack
+        chrom="12"
+        datasetId="gnomad_sv_r2_1_controls"
+        includeExomeCoverage={false}
+        includeGenomeCoverage={true}
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_sv_r2_1_controls"
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_sv_r2_1_controls",
+        ]
       }
-      zoomRegion={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
         }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_sv_r2_1_controls"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_sv_r2_1_controls",
+        ]
       }
-    />
+      sectionName="Variants"
+    >
+      <StructuralVariantsInRegion
+        datasetId="gnomad_sv_r2_1_controls"
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+        zoomRegion={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -4898,19 +7062,35 @@ exports[`RegionPage with "gnomad_sv_r2_1_non_neuro" dataset has no unexpected ch
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "M",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh37",
-              "short_tandem_repeats": [],
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_sv_r2_1_non_neuro"
+          entityDescription="region M:345-456"
+          resetKeys={
+            [
+              "M",
+              345,
+              456,
+              "gnomad_sv_r2_1_non_neuro",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "M",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh37",
+                  "short_tandem_repeats": [],
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
       </div>
       <RegionPage__RegionControlsWrapper>
         <withRouter()
@@ -4947,50 +7127,92 @@ exports[`RegionPage with "gnomad_sv_r2_1_non_neuro" dataset has no unexpected ch
     rightPanelWidth={80}
     width={994}
   >
-    <MitochondrialRegionCoverageTrack
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_sv_r2_1_non_neuro"
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_sv_r2_1_non_neuro",
+        ]
       }
-    />
-    <StructuralVariantsInRegion
+      sectionName="Region coverage"
+    >
+      <MitochondrialRegionCoverageTrack
+        datasetId="gnomad_sv_r2_1_non_neuro"
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_sv_r2_1_non_neuro"
-      region={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_sv_r2_1_non_neuro",
+        ]
       }
-      zoomRegion={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
         }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_sv_r2_1_non_neuro"
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_sv_r2_1_non_neuro",
+        ]
       }
-    />
+      sectionName="Variants"
+    >
+      <StructuralVariantsInRegion
+        datasetId="gnomad_sv_r2_1_non_neuro"
+        region={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+        zoomRegion={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -5040,19 +7262,35 @@ exports[`RegionPage with "gnomad_sv_r2_1_non_neuro" dataset has no unexpected ch
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "12",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh37",
-              "short_tandem_repeats": [],
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_sv_r2_1_non_neuro"
+          entityDescription="region 12:345-456"
+          resetKeys={
+            [
+              "12",
+              345,
+              456,
+              "gnomad_sv_r2_1_non_neuro",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "12",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh37",
+                  "short_tandem_repeats": [],
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
       </div>
       <RegionPage__RegionControlsWrapper>
         <withRouter()
@@ -5089,53 +7327,95 @@ exports[`RegionPage with "gnomad_sv_r2_1_non_neuro" dataset has no unexpected ch
     rightPanelWidth={80}
     width={994}
   >
-    <RegionCoverageTrack
-      chrom="12"
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_sv_r2_1_non_neuro"
-      includeExomeCoverage={false}
-      includeGenomeCoverage={true}
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_sv_r2_1_non_neuro",
+        ]
       }
-    />
-    <StructuralVariantsInRegion
+      sectionName="Region coverage"
+    >
+      <RegionCoverageTrack
+        chrom="12"
+        datasetId="gnomad_sv_r2_1_non_neuro"
+        includeExomeCoverage={false}
+        includeGenomeCoverage={true}
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_sv_r2_1_non_neuro"
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_sv_r2_1_non_neuro",
+        ]
       }
-      zoomRegion={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
         }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_sv_r2_1_non_neuro"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_sv_r2_1_non_neuro",
+        ]
       }
-    />
+      sectionName="Variants"
+    >
+      <StructuralVariantsInRegion
+        datasetId="gnomad_sv_r2_1_non_neuro"
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+        zoomRegion={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -5185,19 +7465,35 @@ exports[`RegionPage with "gnomad_sv_r4" dataset has no unexpected changes for a 
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "M",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh38",
-              "short_tandem_repeats": [],
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_sv_r4"
+          entityDescription="region M:345-456"
+          resetKeys={
+            [
+              "M",
+              345,
+              456,
+              "gnomad_sv_r4",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "M",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh38",
+                  "short_tandem_repeats": [],
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
       </div>
       <RegionPage__RegionControlsWrapper>
         <withRouter()
@@ -5234,58 +7530,112 @@ exports[`RegionPage with "gnomad_sv_r4" dataset has no unexpected changes for a 
     rightPanelWidth={80}
     width={994}
   >
-    <MitochondrialRegionCoverageTrack
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_sv_r4"
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_sv_r4",
+        ]
       }
-    />
-    <React.Fragment>
+      sectionName="Region coverage"
+    >
+      <MitochondrialRegionCoverageTrack
+        datasetId="gnomad_sv_r4"
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_sv_r4"
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_sv_r4",
+        ]
+      }
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_sv_r4"
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_sv_r4",
+        ]
+      }
+      sectionName="Regional genomic constraint"
+    >
       <RegionalGenomicConstraintTrack
         height={45}
         regions={[]}
         start={345}
         stop={456}
       />
-    </React.Fragment>
-    <StructuralVariantsInRegion
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_sv_r4"
-      region={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region M:345-456"
+      resetKeys={
+        [
+          "M",
+          345,
+          456,
+          "gnomad_sv_r4",
+        ]
       }
-      zoomRegion={
-        {
-          "chrom": "M",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
+      sectionName="Variants"
+    >
+      <StructuralVariantsInRegion
+        datasetId="gnomad_sv_r4"
+        region={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
         }
-      }
-    />
+        zoomRegion={
+          {
+            "chrom": "M",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -5335,19 +7685,35 @@ exports[`RegionPage with "gnomad_sv_r4" dataset has no unexpected changes for a 
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "12",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh38",
-              "short_tandem_repeats": [],
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_sv_r4"
+          entityDescription="region 12:345-456"
+          resetKeys={
+            [
+              "12",
+              345,
+              456,
+              "gnomad_sv_r4",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "12",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh38",
+                  "short_tandem_repeats": [],
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
       </div>
       <RegionPage__RegionControlsWrapper>
         <withRouter()
@@ -5384,61 +7750,115 @@ exports[`RegionPage with "gnomad_sv_r4" dataset has no unexpected changes for a 
     rightPanelWidth={80}
     width={994}
   >
-    <RegionCoverageTrack
-      chrom="12"
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_sv_r4"
-      includeExomeCoverage={false}
-      includeGenomeCoverage={true}
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_sv_r4",
+        ]
       }
-    />
-    <React.Fragment>
+      sectionName="Region coverage"
+    >
+      <RegionCoverageTrack
+        chrom="12"
+        datasetId="gnomad_sv_r4"
+        includeExomeCoverage={false}
+        includeGenomeCoverage={true}
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_sv_r4"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_sv_r4",
+        ]
+      }
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_sv_r4"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_sv_r4",
+        ]
+      }
+      sectionName="Regional genomic constraint"
+    >
       <RegionalGenomicConstraintTrack
         height={45}
         regions={[]}
         start={345}
         stop={456}
       />
-    </React.Fragment>
-    <StructuralVariantsInRegion
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_sv_r4"
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_sv_r4",
+        ]
       }
-      zoomRegion={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": [],
-          "start": 345,
-          "stop": 456,
+      sectionName="Variants"
+    >
+      <StructuralVariantsInRegion
+        datasetId="gnomad_sv_r4"
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
         }
-      }
-    />
+        zoomRegion={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": [],
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;

--- a/browser/src/SectionErrorBoundary.spec.tsx
+++ b/browser/src/SectionErrorBoundary.spec.tsx
@@ -1,0 +1,155 @@
+import React, { useState } from 'react'
+import { describe, expect, jest, test } from '@jest/globals'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { BrowserRouter } from 'react-router-dom'
+
+import SectionErrorBoundary from './SectionErrorBoundary'
+
+const ComponentThatThrows = ({ shouldThrowError }: { shouldThrowError: boolean }) => {
+  if (shouldThrowError) {
+    throw new Error('Kaboom')
+  }
+  return <div>Rendered without error</div>
+}
+
+const withSilencedConsoleError = (fn: () => void) => {
+  const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+  try {
+    fn()
+  } finally {
+    consoleErrorSpy.mockRestore()
+  }
+}
+
+const SectionWithResettableKey = () => {
+  const [geneId, setGeneId] = useState('ENSG00000012048')
+
+  return (
+    <>
+      <button type="button" onClick={() => setGeneId('ENSG00000139618')}>
+        Navigate to a different gene
+      </button>
+      <SectionErrorBoundary
+        sectionName="Gene coverage"
+        datasetId="gnomad_r4"
+        entityDescription={`gene ${geneId}`}
+        resetKeys={[geneId]}
+      >
+        <ComponentThatThrows shouldThrowError={geneId === 'ENSG00000012048'} />
+      </SectionErrorBoundary>
+    </>
+  )
+}
+
+describe('SectionErrorBoundary', () => {
+  test('renders children when nothing throws', () => {
+    render(
+      <BrowserRouter>
+        <SectionErrorBoundary
+          sectionName="Gene coverage"
+          datasetId="gnomad_r4"
+          entityDescription="gene BRCA1 (ENSG00000012048)"
+          resetKeys={['ENSG00000012048', 'gnomad_r4']}
+        >
+          <ComponentThatThrows shouldThrowError={false} />
+        </SectionErrorBoundary>
+      </BrowserRouter>
+    )
+
+    expect(screen.getByText('Rendered without error')).toBeTruthy()
+  })
+
+  test('renders an inline, section-scoped fallback instead of the thrown error', () => {
+    withSilencedConsoleError(() => {
+      render(
+        <BrowserRouter>
+          <div>
+            <div>Sibling section content</div>
+            <SectionErrorBoundary
+              sectionName="Gene coverage"
+              datasetId="gnomad_r4"
+              entityDescription="gene BRCA1 (ENSG00000012048)"
+              resetKeys={['ENSG00000012048', 'gnomad_r4']}
+            >
+              <ComponentThatThrows shouldThrowError />
+            </SectionErrorBoundary>
+          </div>
+        </BrowserRouter>
+      )
+    })
+
+    expect(screen.getByText('Sibling section content')).toBeTruthy()
+    expect(screen.getByText(/Something went wrong rendering Gene coverage/)).toBeTruthy()
+    expect(screen.queryByText('Rendered without error')).toBeNull()
+  })
+
+  test('does not render the bug report form until the fallback button is clicked', () => {
+    withSilencedConsoleError(() => {
+      render(
+        <BrowserRouter>
+          <SectionErrorBoundary
+            sectionName="Gene coverage"
+            datasetId="gnomad_r4"
+            entityDescription="gene BRCA1 (ENSG00000012048)"
+            resetKeys={['ENSG00000012048', 'gnomad_r4']}
+          >
+            <ComponentThatThrows shouldThrowError />
+          </SectionErrorBoundary>
+        </BrowserRouter>
+      )
+    })
+
+    expect(screen.queryByText('an issue on GitHub')).toBeNull()
+
+    fireEvent.click(screen.getByText('Report this issue'))
+
+    expect(screen.getByText('an issue on GitHub')).toBeTruthy()
+  })
+
+  test('bug report modal includes section name and entity description, and can be closed', () => {
+    withSilencedConsoleError(() => {
+      render(
+        <BrowserRouter>
+          <SectionErrorBoundary
+            sectionName="Gene coverage"
+            datasetId="gnomad_r4"
+            entityDescription="gene BRCA1 (ENSG00000012048)"
+            resetKeys={['ENSG00000012048', 'gnomad_r4']}
+          >
+            <ComponentThatThrows shouldThrowError />
+          </SectionErrorBoundary>
+        </BrowserRouter>
+      )
+    })
+
+    fireEvent.click(screen.getByText('Report this issue'))
+
+    const issueLink = screen.getByText('an issue on GitHub').closest('a')
+    const decodedBody = decodeURIComponent(issueLink?.getAttribute('href') ?? '')
+
+    expect(decodedBody).toContain('**Section**: Gene coverage')
+    expect(decodedBody).toContain('gene BRCA1 (ENSG00000012048)')
+    expect(decodedBody).toContain('dataset: gnomad_r4')
+
+    fireEvent.click(screen.getByLabelText('Close'))
+
+    expect(screen.queryByText('an issue on GitHub')).toBeNull()
+  })
+
+  test('attempts to render children again after resetKeys change', () => {
+    render(
+      <BrowserRouter>
+        <SectionWithResettableKey />
+      </BrowserRouter>
+    )
+
+    withSilencedConsoleError(() => {
+      expect(screen.getByText(/Something went wrong rendering Gene coverage/)).toBeTruthy()
+    })
+
+    fireEvent.click(screen.getByText('Navigate to a different gene'))
+
+    expect(screen.getByText('Rendered without error')).toBeTruthy()
+    expect(screen.queryByText(/Something went wrong rendering Gene coverage/)).toBeNull()
+  })
+})

--- a/browser/src/SectionErrorBoundary.tsx
+++ b/browser/src/SectionErrorBoundary.tsx
@@ -82,4 +82,22 @@ class SectionErrorBoundary extends React.Component<Props, State> {
   }
 }
 
-export default withRouter<Props, typeof SectionErrorBoundary>(SectionErrorBoundary)
+const RoutedSectionErrorBoundary = withRouter<Props, typeof SectionErrorBoundary>(
+  SectionErrorBoundary
+)
+
+export const useSectionErrorBoundary =
+  (entityDescription: string, datasetId: DatasetId, baseResetKeys: unknown[]) =>
+  (sectionName: string, children: ReactNode, extraResetKeys: unknown[] = []) =>
+    (
+      <RoutedSectionErrorBoundary
+        sectionName={sectionName}
+        datasetId={datasetId}
+        entityDescription={entityDescription}
+        resetKeys={[...baseResetKeys, ...extraResetKeys]}
+      >
+        {children}
+      </RoutedSectionErrorBoundary>
+    )
+
+export default RoutedSectionErrorBoundary

--- a/browser/src/SectionErrorBoundary.tsx
+++ b/browser/src/SectionErrorBoundary.tsx
@@ -1,0 +1,85 @@
+import React, { ReactNode } from 'react'
+import { withRouter, RouteComponentProps } from 'react-router-dom'
+
+import { Modal, TextButton } from '@gnomad/ui'
+import { DatasetId } from '@gnomad/dataset-metadata/metadata'
+
+import BugReportControls from './BugReportControls'
+import StatusMessage from './StatusMessage'
+
+type SectionErrorBoundaryProps = {
+  children: ReactNode
+  sectionName: string
+  datasetId: DatasetId
+  entityDescription: string
+  resetKeys: unknown[]
+}
+
+type Props = SectionErrorBoundaryProps & RouteComponentProps
+
+type State = {
+  error: Error | null
+  isReportModalOpen: boolean
+}
+
+class SectionErrorBoundary extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props)
+    this.state = { error: null, isReportModalOpen: false }
+  }
+
+  static getDerivedStateFromError(error: Error) {
+    return { error }
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    const { error } = this.state
+    const { resetKeys } = this.props
+
+    if (
+      error &&
+      (resetKeys.length !== prevProps.resetKeys.length ||
+        resetKeys.some((key, index) => key !== prevProps.resetKeys[index]))
+    ) {
+      this.setState({ error: null })
+    }
+  }
+
+  render() {
+    const { children, sectionName, datasetId, entityDescription, location } = this.props
+    const { error, isReportModalOpen } = this.state
+
+    if (error) {
+      return (
+        <StatusMessage>
+          <div>Something went wrong rendering {sectionName}.</div>
+          <div style={{ marginTop: '0.5em' }}>
+            <TextButton onClick={() => this.setState({ isReportModalOpen: true })}>
+              Report this issue
+            </TextButton>
+            .
+          </div>
+          {isReportModalOpen && (
+            <Modal
+              onRequestClose={() => this.setState({ isReportModalOpen: false })}
+              title={`Report a problem: ${sectionName}`}
+              size="large"
+            >
+              <BugReportControls
+                error={error}
+                context={{
+                  route: location,
+                  section: { sectionName, datasetId, entityDescription },
+                }}
+              />
+            </Modal>
+          )}
+        </StatusMessage>
+      )
+    }
+
+    return children
+  }
+}
+
+export default withRouter<Props, typeof SectionErrorBoundary>(SectionErrorBoundary)

--- a/browser/src/TranscriptPage/TranscriptPage.sectionRenderErrorIsolation.spec.tsx
+++ b/browser/src/TranscriptPage/TranscriptPage.sectionRenderErrorIsolation.spec.tsx
@@ -1,0 +1,85 @@
+import React from 'react'
+import { describe, expect, jest, test } from '@jest/globals'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+import { mockQueries } from '../../../tests/__helpers__/queries'
+import Query, { BaseQuery } from '../Query'
+
+import transcriptFactory from '../__factories__/Transcript'
+
+import TranscriptPage from './TranscriptPage'
+
+jest.mock('../Query', () => {
+  const originalModule = jest.requireActual('../Query')
+
+  return {
+    __esModule: true,
+    ...(originalModule as object),
+    default: jest.fn(),
+    BaseQuery: jest.fn(),
+  }
+})
+
+jest.mock('./TranscriptCoverageTrack', () => ({
+  __esModule: true,
+  default: () => {
+    throw new Error('Forced render-time error in TranscriptCoverageTrack for regression test')
+  },
+}))
+
+const { resetMockApiCalls, resetMockApiResponses, simulateApiResponse, setMockApiResponses } =
+  mockQueries()
+
+beforeEach(() => {
+  Query.mockImplementation(
+    jest.fn(({ children, operationName, variables, query }) =>
+      simulateApiResponse('Query', query, children, operationName, variables)
+    )
+  )
+  ;(BaseQuery as any).mockImplementation(
+    jest.fn(({ children, operationName, variables, query }) =>
+      simulateApiResponse('BaseQuery', query, children, operationName, variables)
+    )
+  )
+})
+
+afterEach(() => {
+  resetMockApiCalls()
+  resetMockApiResponses()
+})
+
+const withSilencedConsoleError = (fn: () => void) => {
+  const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+  try {
+    fn()
+  } finally {
+    consoleErrorSpy.mockRestore()
+  }
+}
+
+describe('TranscriptPage section render error isolation', () => {
+  test('a render-time throw in one section leaves sibling sections rendered', () => {
+    const transcript = transcriptFactory.build()
+    setMockApiResponses({
+      VariantsInTranscript: () => ({
+        meta: { clinvar_release_date: '2022-10-31' },
+        transcript: { variants: [], clinvar_variants: [] },
+      }),
+    })
+
+    withSilencedConsoleError(() => {
+      render(
+        <MemoryRouter>
+          <TranscriptPage datasetId="gnomad_r4" transcript={transcript} />
+        </MemoryRouter>
+      )
+    })
+
+    expect(screen.getByText(/Something went wrong rendering Transcript coverage/)).toBeTruthy()
+    expect(screen.queryByText('Something Went Wrong')).toBeNull()
+    expect(
+      screen.getByText(`Transcript: ${transcript.transcript_id}.${transcript.transcript_version}`)
+    ).toBeTruthy()
+  })
+})

--- a/browser/src/TranscriptPage/TranscriptPage.tsx
+++ b/browser/src/TranscriptPage/TranscriptPage.tsx
@@ -17,6 +17,7 @@ import GeneFlags from '../GenePage/GeneFlags'
 import GnomadPageHeading from '../GnomadPageHeading'
 import InfoButton from '../help/InfoButton'
 import RegionViewer from '../RegionViewer/ZoomableRegionViewer'
+import { useSectionErrorBoundary } from '../SectionErrorBoundary'
 import { TrackPage, TrackPageSection } from '../TrackPage'
 import { useWindowSize } from '../windowSize'
 
@@ -131,6 +132,12 @@ const TranscriptPage = ({ datasetId, transcript }: Props) => {
 
   const [zoomRegion, setZoomRegion] = useState(null)
 
+  const wrapWithSectionErrorBoundary = useSectionErrorBoundary(
+    `transcript ${transcript.transcript_id}.${transcript.transcript_version}`,
+    datasetId,
+    [transcript.transcript_id, datasetId]
+  )
+
   return (
     <TrackPage>
       <TrackPageSection>
@@ -151,12 +158,20 @@ const TranscriptPage = ({ datasetId, transcript }: Props) => {
         </GnomadPageHeading>
         <TranscriptInfoColumnWrapper>
           <div style={{ maxWidth: '50%' }}>
-            <TranscriptInfo transcript={transcript} />
-            <GeneFlags gene={transcript.gene} />
+            {wrapWithSectionErrorBoundary(
+              'Transcript information',
+              <>
+                <TranscriptInfo transcript={transcript} />
+                <GeneFlags gene={transcript.gene} />
+              </>
+            )}
           </div>
           <div>
             <h2>Constraint {transcript.chrom !== 'M' && <InfoButton topic="constraint" />}</h2>
-            <ConstraintTable datasetId={datasetId} geneOrTranscript={transcript} />
+            {wrapWithSectionErrorBoundary(
+              'Constraint',
+              <ConstraintTable datasetId={datasetId} geneOrTranscript={transcript} />
+            )}
           </div>
         </TranscriptInfoColumnWrapper>
       </TrackPageSection>
@@ -179,18 +194,22 @@ const TranscriptPage = ({ datasetId, transcript }: Props) => {
         zoomRegion={zoomRegion}
         onChangeZoomRegion={setZoomRegion}
       >
-        {transcript.chrom === 'M' ? (
-          <MitochondrialTranscriptCoverageTrack
-            datasetId={datasetId}
-            transcriptId={transcript.transcript_id}
-          />
-        ) : (
-          <TranscriptCoverageTrack
-            datasetId={datasetId}
-            transcriptId={transcript.transcript_id}
-            includeExomeCoverage={transcriptsHaveExomeCoverage(datasetId)}
-          />
-        )}
+        {transcript.chrom === 'M'
+          ? wrapWithSectionErrorBoundary(
+              'Transcript coverage',
+              <MitochondrialTranscriptCoverageTrack
+                datasetId={datasetId}
+                transcriptId={transcript.transcript_id}
+              />
+            )
+          : wrapWithSectionErrorBoundary(
+              'Transcript coverage',
+              <TranscriptCoverageTrack
+                datasetId={datasetId}
+                transcriptId={transcript.transcript_id}
+                includeExomeCoverage={transcriptsHaveExomeCoverage(datasetId)}
+              />
+            )}
 
         {/* @ts-expect-error TS(2769) FIXME: No overload matches this call. */}
         <ControlPanel marginLeft={100} width={regionViewerWidth - 100 - (isSmallScreen ? 0 : 80)}>
@@ -251,25 +270,32 @@ const TranscriptPage = ({ datasetId, transcript }: Props) => {
           </Legend>
         </ControlPanel>
 
-        <div style={{ margin: '1em 0' }}>
-          <TranscriptTrack transcript={transcript} showUTRs={includeUTRs} />
-        </div>
-
-        {transcript.chrom === 'M' ? (
-          <MitochondrialVariantsInTranscript
-            datasetId={datasetId}
-            transcript={transcript}
-            zoomRegion={zoomRegion}
-          />
-        ) : (
-          <VariantsInTranscript
-            datasetId={datasetId}
-            // @ts-expect-error TS(2322) FIXME: Type '{ datasetId: string; includeUTRs: boolean; t... Remove this comment to see the full error message
-            includeUTRs={includeUTRs}
-            transcript={transcript}
-            zoomRegion={zoomRegion}
-          />
+        {wrapWithSectionErrorBoundary(
+          'Transcript track',
+          <div style={{ margin: '1em 0' }}>
+            <TranscriptTrack transcript={transcript} showUTRs={includeUTRs} />
+          </div>
         )}
+
+        {transcript.chrom === 'M'
+          ? wrapWithSectionErrorBoundary(
+              'Variants',
+              <MitochondrialVariantsInTranscript
+                datasetId={datasetId}
+                transcript={transcript}
+                zoomRegion={zoomRegion}
+              />
+            )
+          : wrapWithSectionErrorBoundary(
+              'Variants',
+              <VariantsInTranscript
+                datasetId={datasetId}
+                // @ts-expect-error TS(2322) FIXME: Type '{ datasetId: string; includeUTRs: boolean; t... Remove this comment to see the full error message
+                includeUTRs={includeUTRs}
+                transcript={transcript}
+                zoomRegion={zoomRegion}
+              />
+            )}
       </RegionViewer>
     </TrackPage>
   )

--- a/browser/src/buildBugReportBody.ts
+++ b/browser/src/buildBugReportBody.ts
@@ -1,0 +1,52 @@
+export type BugReportContext = {
+  route: {
+    pathname?: string
+    search?: string
+  }
+  section?: {
+    sectionName: string
+    datasetId: string
+    entityDescription: string
+  }
+}
+
+export const buildBugReportBody = (
+  error: Error,
+  bugDescription: string,
+  context: BugReportContext
+): string => {
+  const sectionContextBlock = context.section
+    ? `\n**Section**: ${context.section.sectionName}\n\n**Context**: ${context.section.entityDescription} (dataset: ${context.section.datasetId})\n`
+    : ''
+
+  return `
+**Description**: ${bugDescription}
+${sectionContextBlock}
+**Error message**: ${error.message}
+
+**Stack trace**:
+\`\`\`
+${error.stack}
+\`\`\`
+
+**Route**: ${context.route.pathname}${context.route.search}
+
+**Browser**: ${navigator.userAgent}
+`
+}
+
+export const buildBugReportUrls = (error: Error, body: string) => {
+  const issueURL = `https://github.com/broadinstitute/gnomad-browser/issues/new?title=${encodeURIComponent(
+    error.message
+  )}&body=${encodeURIComponent(body)}&labels=Type%3A%20Bug`
+
+  const forumURL = `https://discuss.gnomad.broadinstitute.org/new-topic?title=topic%20${encodeURIComponent(
+    error.message
+  )}&body=${encodeURIComponent(body)}&category=Browser&tags=bug`
+
+  const emailURL = `mailto:gnomad@broadinstitute.org?subject=${encodeURIComponent(
+    'Browser bug report'
+  )}&body=${encodeURIComponent(body.replace(/```\n/g, ''))}`
+
+  return { issueURL, forumURL, emailURL }
+}


### PR DESCRIPTION
This is working towards more pleasant and workable local dev, and also represents better user experience, imo.

Add per 'section' level error boundaries, e.g. for each major track on the Gene Page (i.e. Coverage, Gene Info, Variants) so that a render time error on a single section doesn't cause the an entire page crash with the "something went wrong" error boundary page. 

This is stacked on top of the ClinVar testing improvement (and bugfix). 

Like that one, this PR is made up of several logical commits, each one is pretty well isolated and would make for a good review experience, imo, reviewing the entire diff is not awful, but not recommended. Github's UI has good support for viewing a single commit at a time when reviewing.

If a given section has a render error, it's caught and an error message is displayed (screenshot below). Clicking the error message opens a modal letting the user submit an issue on Github, Email, etc. Parts of the template are pre-filled, and having it be section level crashing with some automatic info filled out in a template in the form of section, dataset, etc (hopefully) gives us a bit more information about what the issue is (rather than just having a report come in that the gene page crashed *somewhere*).

---

<img width="2604" height="1684" alt="Screenshot 2026-08-27 at 17 37 28" src="https://github.com/user-attachments/assets/2994bf75-a460-4318-90f7-6a90ae9efb6f" />


