### PR TITLE
Allow `null` region level tandem repeat data

### DIFF
--- a/browser/src/GenePage/GenePage.spec.tsx
+++ b/browser/src/GenePage/GenePage.spec.tsx
@@ -310,3 +310,66 @@ describe('gene page for a mitochondrial gene', () => {
     expect(tree).toMatchSnapshot()
   })
 })
+
+describe('gene page tandem repeat banner', () => {
+  beforeEach(() =>
+    setMockApiResponses({
+      VariantsInGene: () => ({
+        gene: geneFactory.build(),
+        meta: { clinvar_release_date: '2022-10-31' },
+      }),
+      GeneCoverage: () => ({
+        gene: {
+          coverage: {},
+        },
+      }),
+      CopyNumberVariantsInGene: () => ({
+        gene: { copy_number_variants: [] },
+      }),
+    })
+  )
+
+  test('warns that tandem repeat data is unavailable when the field is null', () => {
+    const gene = geneFactory.build({ short_tandem_repeats: null })
+    render(
+      <MemoryRouter>
+        <GenePage datasetId="gnomad_r4" gene={gene} geneId={gene.gene_id} />
+      </MemoryRouter>
+    )
+    expect(
+      screen.queryByText(
+        'Unable to determine whether tandem repeat data is available for this gene.'
+      )
+    ).not.toBeNull()
+  })
+
+  test('shows no banner when the gene has no tandem repeat loci', () => {
+    const gene = geneFactory.build({ short_tandem_repeats: [] })
+    render(
+      <MemoryRouter>
+        <GenePage datasetId="gnomad_r4" gene={gene} geneId={gene.gene_id} />
+      </MemoryRouter>
+    )
+    expect(
+      screen.queryByText(
+        'Unable to determine whether tandem repeat data is available for this gene.'
+      )
+    ).toBeNull()
+    expect(screen.queryByText('tandem repeat locus')).toBeNull()
+  })
+
+  test('links to the tandem repeat locus when the gene has one', () => {
+    const gene = geneFactory.build({ short_tandem_repeats: [{ id: 'FMR1' }] })
+    render(
+      <MemoryRouter>
+        <GenePage datasetId="gnomad_r4" gene={gene} geneId={gene.gene_id} />
+      </MemoryRouter>
+    )
+    expect(
+      screen.queryByText(
+        'Unable to determine whether tandem repeat data is available for this gene.'
+      )
+    ).toBeNull()
+    expect(screen.queryByText('tandem repeat locus')).not.toBeNull()
+  })
+})

--- a/browser/src/GenePage/GenePage.tsx
+++ b/browser/src/GenePage/GenePage.tsx
@@ -404,6 +404,12 @@ const GenePage = ({ datasetId, gene, geneId }: Props) => {
                 )}
               </>
             )}
+            {gene.short_tandem_repeats === null && (
+              <p>
+                <Badge level="warning">Warning</Badge> Unable to determine whether tandem repeat
+                data is available for this gene.
+              </p>
+            )}
           </GeneInfoColumn>
           <ConstraintOrCooccurrenceColumn>
             <TableSelectorWrapper>

--- a/browser/src/GenePage/__snapshots__/GenePage.spec.tsx.snap
+++ b/browser/src/GenePage/__snapshots__/GenePage.spec.tsx.snap
@@ -649,6 +649,15 @@ exports[`GenePage with CNV dataset "gnomad_cnv_r4" has no unexpected changes 1`]
             </dd>
           </div>
         </dl>
+        <p>
+          <span
+            className="Badge__BadgeWrapper-sc-j4izdp-1 iRTsMe"
+            level="warning"
+          >
+            Warning
+          </span>
+           Unable to determine whether tandem repeat data is available for this gene.
+        </p>
       </div>
       <div
         className="GenePage__ConstraintOrCooccurrenceColumn-sc-rcxzgc-3 jkKjua"
@@ -2187,6 +2196,15 @@ exports[`GenePage with SV dataset "gnomad_sv_r2_1" has no unexpected changes 1`]
             </dd>
           </div>
         </dl>
+        <p>
+          <span
+            className="Badge__BadgeWrapper-sc-j4izdp-1 iRTsMe"
+            level="warning"
+          >
+            Warning
+          </span>
+           Unable to determine whether tandem repeat data is available for this gene.
+        </p>
       </div>
       <div
         className="GenePage__ConstraintOrCooccurrenceColumn-sc-rcxzgc-3 jkKjua"
@@ -3712,6 +3730,15 @@ exports[`GenePage with SV dataset "gnomad_sv_r2_1_controls" has no unexpected ch
             </dd>
           </div>
         </dl>
+        <p>
+          <span
+            className="Badge__BadgeWrapper-sc-j4izdp-1 iRTsMe"
+            level="warning"
+          >
+            Warning
+          </span>
+           Unable to determine whether tandem repeat data is available for this gene.
+        </p>
       </div>
       <div
         className="GenePage__ConstraintOrCooccurrenceColumn-sc-rcxzgc-3 jkKjua"
@@ -5237,6 +5264,15 @@ exports[`GenePage with SV dataset "gnomad_sv_r2_1_non_neuro" has no unexpected c
             </dd>
           </div>
         </dl>
+        <p>
+          <span
+            className="Badge__BadgeWrapper-sc-j4izdp-1 iRTsMe"
+            level="warning"
+          >
+            Warning
+          </span>
+           Unable to determine whether tandem repeat data is available for this gene.
+        </p>
       </div>
       <div
         className="GenePage__ConstraintOrCooccurrenceColumn-sc-rcxzgc-3 jkKjua"
@@ -6762,6 +6798,15 @@ exports[`GenePage with SV dataset "gnomad_sv_r4" has no unexpected changes 1`] =
             </dd>
           </div>
         </dl>
+        <p>
+          <span
+            className="Badge__BadgeWrapper-sc-j4izdp-1 iRTsMe"
+            level="warning"
+          >
+            Warning
+          </span>
+           Unable to determine whether tandem repeat data is available for this gene.
+        </p>
       </div>
       <div
         className="GenePage__ConstraintOrCooccurrenceColumn-sc-rcxzgc-3 jkKjua"
@@ -8287,6 +8332,15 @@ exports[`GenePage with non-SV dataset "exac" has no unexpected changes 1`] = `
             </dd>
           </div>
         </dl>
+        <p>
+          <span
+            className="Badge__BadgeWrapper-sc-j4izdp-1 iRTsMe"
+            level="warning"
+          >
+            Warning
+          </span>
+           Unable to determine whether tandem repeat data is available for this gene.
+        </p>
       </div>
       <div
         className="GenePage__ConstraintOrCooccurrenceColumn-sc-rcxzgc-3 jkKjua"
@@ -9848,6 +9902,15 @@ exports[`GenePage with non-SV dataset "gnomad_cnv_r4" has no unexpected changes 
             </dd>
           </div>
         </dl>
+        <p>
+          <span
+            className="Badge__BadgeWrapper-sc-j4izdp-1 iRTsMe"
+            level="warning"
+          >
+            Warning
+          </span>
+           Unable to determine whether tandem repeat data is available for this gene.
+        </p>
       </div>
       <div
         className="GenePage__ConstraintOrCooccurrenceColumn-sc-rcxzgc-3 jkKjua"
@@ -11386,6 +11449,15 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1" has no unexpected changes 1`
             </dd>
           </div>
         </dl>
+        <p>
+          <span
+            className="Badge__BadgeWrapper-sc-j4izdp-1 iRTsMe"
+            level="warning"
+          >
+            Warning
+          </span>
+           Unable to determine whether tandem repeat data is available for this gene.
+        </p>
       </div>
       <div
         className="GenePage__ConstraintOrCooccurrenceColumn-sc-rcxzgc-3 jkKjua"
@@ -13042,6 +13114,15 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_controls" has no unexpected c
             </dd>
           </div>
         </dl>
+        <p>
+          <span
+            className="Badge__BadgeWrapper-sc-j4izdp-1 iRTsMe"
+            level="warning"
+          >
+            Warning
+          </span>
+           Unable to determine whether tandem repeat data is available for this gene.
+        </p>
       </div>
       <div
         className="GenePage__ConstraintOrCooccurrenceColumn-sc-rcxzgc-3 jkKjua"
@@ -14698,6 +14779,15 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_non_cancer" has no unexpected
             </dd>
           </div>
         </dl>
+        <p>
+          <span
+            className="Badge__BadgeWrapper-sc-j4izdp-1 iRTsMe"
+            level="warning"
+          >
+            Warning
+          </span>
+           Unable to determine whether tandem repeat data is available for this gene.
+        </p>
       </div>
       <div
         className="GenePage__ConstraintOrCooccurrenceColumn-sc-rcxzgc-3 jkKjua"
@@ -16354,6 +16444,15 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_non_neuro" has no unexpected 
             </dd>
           </div>
         </dl>
+        <p>
+          <span
+            className="Badge__BadgeWrapper-sc-j4izdp-1 iRTsMe"
+            level="warning"
+          >
+            Warning
+          </span>
+           Unable to determine whether tandem repeat data is available for this gene.
+        </p>
       </div>
       <div
         className="GenePage__ConstraintOrCooccurrenceColumn-sc-rcxzgc-3 jkKjua"
@@ -18010,6 +18109,15 @@ exports[`GenePage with non-SV dataset "gnomad_r2_1_non_topmed" has no unexpected
             </dd>
           </div>
         </dl>
+        <p>
+          <span
+            className="Badge__BadgeWrapper-sc-j4izdp-1 iRTsMe"
+            level="warning"
+          >
+            Warning
+          </span>
+           Unable to determine whether tandem repeat data is available for this gene.
+        </p>
       </div>
       <div
         className="GenePage__ConstraintOrCooccurrenceColumn-sc-rcxzgc-3 jkKjua"
@@ -19666,6 +19774,15 @@ exports[`GenePage with non-SV dataset "gnomad_r3" has no unexpected changes 1`] 
             </dd>
           </div>
         </dl>
+        <p>
+          <span
+            className="Badge__BadgeWrapper-sc-j4izdp-1 iRTsMe"
+            level="warning"
+          >
+            Warning
+          </span>
+           Unable to determine whether tandem repeat data is available for this gene.
+        </p>
       </div>
       <div
         className="GenePage__ConstraintOrCooccurrenceColumn-sc-rcxzgc-3 jkKjua"
@@ -21227,6 +21344,15 @@ exports[`GenePage with non-SV dataset "gnomad_r3_controls_and_biobanks" has no u
             </dd>
           </div>
         </dl>
+        <p>
+          <span
+            className="Badge__BadgeWrapper-sc-j4izdp-1 iRTsMe"
+            level="warning"
+          >
+            Warning
+          </span>
+           Unable to determine whether tandem repeat data is available for this gene.
+        </p>
       </div>
       <div
         className="GenePage__ConstraintOrCooccurrenceColumn-sc-rcxzgc-3 jkKjua"
@@ -22788,6 +22914,15 @@ exports[`GenePage with non-SV dataset "gnomad_r3_non_cancer" has no unexpected c
             </dd>
           </div>
         </dl>
+        <p>
+          <span
+            className="Badge__BadgeWrapper-sc-j4izdp-1 iRTsMe"
+            level="warning"
+          >
+            Warning
+          </span>
+           Unable to determine whether tandem repeat data is available for this gene.
+        </p>
       </div>
       <div
         className="GenePage__ConstraintOrCooccurrenceColumn-sc-rcxzgc-3 jkKjua"
@@ -24349,6 +24484,15 @@ exports[`GenePage with non-SV dataset "gnomad_r3_non_neuro" has no unexpected ch
             </dd>
           </div>
         </dl>
+        <p>
+          <span
+            className="Badge__BadgeWrapper-sc-j4izdp-1 iRTsMe"
+            level="warning"
+          >
+            Warning
+          </span>
+           Unable to determine whether tandem repeat data is available for this gene.
+        </p>
       </div>
       <div
         className="GenePage__ConstraintOrCooccurrenceColumn-sc-rcxzgc-3 jkKjua"
@@ -25910,6 +26054,15 @@ exports[`GenePage with non-SV dataset "gnomad_r3_non_topmed" has no unexpected c
             </dd>
           </div>
         </dl>
+        <p>
+          <span
+            className="Badge__BadgeWrapper-sc-j4izdp-1 iRTsMe"
+            level="warning"
+          >
+            Warning
+          </span>
+           Unable to determine whether tandem repeat data is available for this gene.
+        </p>
       </div>
       <div
         className="GenePage__ConstraintOrCooccurrenceColumn-sc-rcxzgc-3 jkKjua"
@@ -27471,6 +27624,15 @@ exports[`GenePage with non-SV dataset "gnomad_r3_non_v2" has no unexpected chang
             </dd>
           </div>
         </dl>
+        <p>
+          <span
+            className="Badge__BadgeWrapper-sc-j4izdp-1 iRTsMe"
+            level="warning"
+          >
+            Warning
+          </span>
+           Unable to determine whether tandem repeat data is available for this gene.
+        </p>
       </div>
       <div
         className="GenePage__ConstraintOrCooccurrenceColumn-sc-rcxzgc-3 jkKjua"
@@ -29032,6 +29194,15 @@ exports[`GenePage with non-SV dataset "gnomad_r4" has no unexpected changes 1`] 
             </dd>
           </div>
         </dl>
+        <p>
+          <span
+            className="Badge__BadgeWrapper-sc-j4izdp-1 iRTsMe"
+            level="warning"
+          >
+            Warning
+          </span>
+           Unable to determine whether tandem repeat data is available for this gene.
+        </p>
       </div>
       <div
         className="GenePage__ConstraintOrCooccurrenceColumn-sc-rcxzgc-3 jkKjua"
@@ -30593,6 +30764,15 @@ exports[`GenePage with non-SV dataset "gnomad_r4_non_ukb" has no unexpected chan
             </dd>
           </div>
         </dl>
+        <p>
+          <span
+            className="Badge__BadgeWrapper-sc-j4izdp-1 iRTsMe"
+            level="warning"
+          >
+            Warning
+          </span>
+           Unable to determine whether tandem repeat data is available for this gene.
+        </p>
       </div>
       <div
         className="GenePage__ConstraintOrCooccurrenceColumn-sc-rcxzgc-3 jkKjua"
@@ -31960,6 +32140,15 @@ exports[`gene page for a mitochondrial gene doesn't include a show-transcripts b
             </dd>
           </div>
         </dl>
+        <p>
+          <span
+            className="Badge__BadgeWrapper-sc-j4izdp-1 iRTsMe"
+            level="warning"
+          >
+            Warning
+          </span>
+           Unable to determine whether tandem repeat data is available for this gene.
+        </p>
       </div>
       <div
         className="GenePage__ConstraintOrCooccurrenceColumn-sc-rcxzgc-3 jkKjua"

--- a/browser/src/RegionPage/MitochondrialVariantsInRegion.spec.tsx
+++ b/browser/src/RegionPage/MitochondrialVariantsInRegion.spec.tsx
@@ -62,6 +62,7 @@ const region: Region = {
   start: 123,
   stop: 456,
   genes: [],
+  short_tandem_repeats: null,
   non_coding_constraints: null,
 }
 

--- a/browser/src/RegionPage/RegionPage.spec.tsx
+++ b/browser/src/RegionPage/RegionPage.spec.tsx
@@ -38,4 +38,20 @@ forAllDatasets('RegionPage with "%s" dataset', (datasetId) => {
     renderer.render(<RegionPage datasetId={datasetId} region={region} />)
     expect(renderer.getRenderOutput()).toMatchSnapshot()
   })
+
+  test('warns that tandem repeat data is unavailable when the field is null', () => {
+    const region = {
+      reference_genome: referenceGenome(datasetId),
+      chrom: '12',
+      start: 345,
+      stop: 456,
+      genes: [],
+      short_tandem_repeats: null,
+      non_coding_constraints: [],
+    }
+
+    const renderer = createRenderer()
+    renderer.render(<RegionPage datasetId={datasetId} region={region} />)
+    expect(renderer.getRenderOutput()).toMatchSnapshot()
+  })
 })

--- a/browser/src/RegionPage/RegionPage.tsx
+++ b/browser/src/RegionPage/RegionPage.tsx
@@ -68,9 +68,11 @@ export type Region = {
   start: number
   stop: number
   genes: any[]
-  short_tandem_repeats?: {
-    id: string
-  }[]
+  short_tandem_repeats:
+    | {
+        id: string
+      }[]
+    | null
   non_coding_constraints: NonCodingConstraint[] | null
 }
 
@@ -159,6 +161,12 @@ const RegionPage = ({ datasetId, region }: RegionPageProps) => {
                   </p>
                 )}
               </>
+            )}
+            {region.short_tandem_repeats === null && (
+              <p>
+                <Badge level="warning">Warning</Badge> Unable to determine whether tandem repeat
+                data is available for this region.
+              </p>
             )}
           </div>
           <RegionControlsWrapper>

--- a/browser/src/RegionPage/__snapshots__/RegionPage.spec.tsx.snap
+++ b/browser/src/RegionPage/__snapshots__/RegionPage.spec.tsx.snap
@@ -392,6 +392,148 @@ exports[`RegionPage with "exac" dataset has no unexpected changes for a non-mito
 </TrackPage>
 `;
 
+exports[`RegionPage with "exac" dataset warns that tandem repeat data is unavailable when the field is null 1`] = `
+<TrackPage>
+  <TrackPage__TrackPageSection>
+    <DocumentTitle
+      title="12-345-456 | ExAC"
+    />
+    <GnomadPageHeading
+      datasetOptions={
+        {
+          "includeCopyNumberVariants": true,
+          "includeExac": true,
+          "includeGnomad2": true,
+          "includeGnomad3": false,
+          "includeGnomad3Subsets": true,
+          "includeGnomad4Subsets": true,
+          "includeShortVariants": true,
+          "includeStructuralVariants": true,
+        }
+      }
+      extra={
+        <withRouter()
+          initialRegion={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh37",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+          style={
+            {
+              "marginLeft": "1em",
+            }
+          }
+        />
+      }
+      selectedDataset="exac"
+    >
+      12-345-456
+    </GnomadPageHeading>
+    <RegionPage__RegionInfoColumnWrapper>
+      <div>
+        <RegionInfo
+          region={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh37",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+        />
+        <p>
+          <Badge
+            level="warning"
+          >
+            Warning
+          </Badge>
+           Unable to determine whether tandem repeat data is available for this region.
+        </p>
+      </div>
+      <RegionPage__RegionControlsWrapper>
+        <withRouter()
+          region={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh37",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+        />
+      </RegionPage__RegionControlsWrapper>
+    </RegionPage__RegionInfoColumnWrapper>
+  </TrackPage__TrackPageSection>
+  <GnomadRegionViewer
+    leftPanelWidth={115}
+    regions={
+      [
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh37",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        },
+      ]
+    }
+    rightPanelWidth={80}
+    width={994}
+  >
+    <RegionCoverageTrack
+      chrom="12"
+      datasetId="exac"
+      includeExomeCoverage={true}
+      includeGenomeCoverage={true}
+      start={345}
+      stop={456}
+    />
+    <GenesInRegionTrack
+      genes={[]}
+      region={
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh37",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        }
+      }
+    />
+    <ConnectedVariantsInRegion
+      datasetId="exac"
+      region={
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh37",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        }
+      }
+    />
+  </GnomadRegionViewer>
+</TrackPage>
+`;
+
 exports[`RegionPage with "gnomad_cnv_r4" dataset has no unexpected changes for a mitochondrial region 1`] = `
 <TrackPage>
   <TrackPage__TrackPageSection>
@@ -795,6 +937,159 @@ exports[`RegionPage with "gnomad_cnv_r4" dataset has no unexpected changes for a
 </TrackPage>
 `;
 
+exports[`RegionPage with "gnomad_cnv_r4" dataset warns that tandem repeat data is unavailable when the field is null 1`] = `
+<TrackPage>
+  <TrackPage__TrackPageSection>
+    <DocumentTitle
+      title="12-345-456 | gnomAD CNVs v4.1.0"
+    />
+    <GnomadPageHeading
+      datasetOptions={
+        {
+          "includeCopyNumberVariants": true,
+          "includeExac": false,
+          "includeGnomad2": false,
+          "includeGnomad3": true,
+          "includeGnomad3Subsets": true,
+          "includeGnomad4Subsets": true,
+          "includeShortVariants": true,
+          "includeStructuralVariants": true,
+        }
+      }
+      extra={
+        <withRouter()
+          initialRegion={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh38",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+          style={
+            {
+              "marginLeft": "1em",
+            }
+          }
+        />
+      }
+      selectedDataset="gnomad_cnv_r4"
+    >
+      12-345-456
+    </GnomadPageHeading>
+    <RegionPage__RegionInfoColumnWrapper>
+      <div>
+        <RegionInfo
+          region={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh38",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+        />
+        <p>
+          <Badge
+            level="warning"
+          >
+            Warning
+          </Badge>
+           Unable to determine whether tandem repeat data is available for this region.
+        </p>
+      </div>
+      <RegionPage__RegionControlsWrapper>
+        <withRouter()
+          region={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh38",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+        />
+      </RegionPage__RegionControlsWrapper>
+    </RegionPage__RegionInfoColumnWrapper>
+  </TrackPage__TrackPageSection>
+  <GnomadRegionViewer
+    leftPanelWidth={115}
+    regions={
+      [
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh38",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        },
+      ]
+    }
+    rightPanelWidth={80}
+    width={994}
+  >
+    <RegionCoverageTrack
+      chrom="12"
+      datasetId="gnomad_cnv_r4"
+      includeExomeCoverage={true}
+      includeGenomeCoverage={false}
+      start={345}
+      stop={456}
+    />
+    <GenesInRegionTrack
+      genes={[]}
+      region={
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh38",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        }
+      }
+    />
+    <CopyNumberVariantsInRegion
+      datasetId="gnomad_cnv_r4"
+      region={
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh38",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        }
+      }
+      zoomRegion={
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh38",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        }
+      }
+    />
+  </GnomadRegionViewer>
+</TrackPage>
+`;
+
 exports[`RegionPage with "gnomad_r2_1" dataset has no unexpected changes for a mitochondrial region 1`] = `
 <TrackPage>
   <TrackPage__TrackPageSection>
@@ -1183,6 +1478,148 @@ exports[`RegionPage with "gnomad_r2_1" dataset has no unexpected changes for a n
         }
       />
     </withRouter(SectionErrorBoundary)>
+  </GnomadRegionViewer>
+</TrackPage>
+`;
+
+exports[`RegionPage with "gnomad_r2_1" dataset warns that tandem repeat data is unavailable when the field is null 1`] = `
+<TrackPage>
+  <TrackPage__TrackPageSection>
+    <DocumentTitle
+      title="12-345-456 | gnomAD v2.1.1"
+    />
+    <GnomadPageHeading
+      datasetOptions={
+        {
+          "includeCopyNumberVariants": true,
+          "includeExac": true,
+          "includeGnomad2": true,
+          "includeGnomad3": false,
+          "includeGnomad3Subsets": true,
+          "includeGnomad4Subsets": true,
+          "includeShortVariants": true,
+          "includeStructuralVariants": true,
+        }
+      }
+      extra={
+        <withRouter()
+          initialRegion={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh37",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+          style={
+            {
+              "marginLeft": "1em",
+            }
+          }
+        />
+      }
+      selectedDataset="gnomad_r2_1"
+    >
+      12-345-456
+    </GnomadPageHeading>
+    <RegionPage__RegionInfoColumnWrapper>
+      <div>
+        <RegionInfo
+          region={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh37",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+        />
+        <p>
+          <Badge
+            level="warning"
+          >
+            Warning
+          </Badge>
+           Unable to determine whether tandem repeat data is available for this region.
+        </p>
+      </div>
+      <RegionPage__RegionControlsWrapper>
+        <withRouter()
+          region={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh37",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+        />
+      </RegionPage__RegionControlsWrapper>
+    </RegionPage__RegionInfoColumnWrapper>
+  </TrackPage__TrackPageSection>
+  <GnomadRegionViewer
+    leftPanelWidth={115}
+    regions={
+      [
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh37",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        },
+      ]
+    }
+    rightPanelWidth={80}
+    width={994}
+  >
+    <RegionCoverageTrack
+      chrom="12"
+      datasetId="gnomad_r2_1"
+      includeExomeCoverage={true}
+      includeGenomeCoverage={true}
+      start={345}
+      stop={456}
+    />
+    <GenesInRegionTrack
+      genes={[]}
+      region={
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh37",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        }
+      }
+    />
+    <ConnectedVariantsInRegion
+      datasetId="gnomad_r2_1"
+      region={
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh37",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        }
+      }
+    />
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -1579,6 +2016,148 @@ exports[`RegionPage with "gnomad_r2_1_controls" dataset has no unexpected change
 </TrackPage>
 `;
 
+exports[`RegionPage with "gnomad_r2_1_controls" dataset warns that tandem repeat data is unavailable when the field is null 1`] = `
+<TrackPage>
+  <TrackPage__TrackPageSection>
+    <DocumentTitle
+      title="12-345-456 | gnomAD v2.1.1 (controls)"
+    />
+    <GnomadPageHeading
+      datasetOptions={
+        {
+          "includeCopyNumberVariants": true,
+          "includeExac": true,
+          "includeGnomad2": true,
+          "includeGnomad3": false,
+          "includeGnomad3Subsets": true,
+          "includeGnomad4Subsets": true,
+          "includeShortVariants": true,
+          "includeStructuralVariants": true,
+        }
+      }
+      extra={
+        <withRouter()
+          initialRegion={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh37",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+          style={
+            {
+              "marginLeft": "1em",
+            }
+          }
+        />
+      }
+      selectedDataset="gnomad_r2_1_controls"
+    >
+      12-345-456
+    </GnomadPageHeading>
+    <RegionPage__RegionInfoColumnWrapper>
+      <div>
+        <RegionInfo
+          region={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh37",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+        />
+        <p>
+          <Badge
+            level="warning"
+          >
+            Warning
+          </Badge>
+           Unable to determine whether tandem repeat data is available for this region.
+        </p>
+      </div>
+      <RegionPage__RegionControlsWrapper>
+        <withRouter()
+          region={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh37",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+        />
+      </RegionPage__RegionControlsWrapper>
+    </RegionPage__RegionInfoColumnWrapper>
+  </TrackPage__TrackPageSection>
+  <GnomadRegionViewer
+    leftPanelWidth={115}
+    regions={
+      [
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh37",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        },
+      ]
+    }
+    rightPanelWidth={80}
+    width={994}
+  >
+    <RegionCoverageTrack
+      chrom="12"
+      datasetId="gnomad_r2_1_controls"
+      includeExomeCoverage={true}
+      includeGenomeCoverage={true}
+      start={345}
+      stop={456}
+    />
+    <GenesInRegionTrack
+      genes={[]}
+      region={
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh37",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        }
+      }
+    />
+    <ConnectedVariantsInRegion
+      datasetId="gnomad_r2_1_controls"
+      region={
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh37",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        }
+      }
+    />
+  </GnomadRegionViewer>
+</TrackPage>
+`;
+
 exports[`RegionPage with "gnomad_r2_1_non_cancer" dataset has no unexpected changes for a mitochondrial region 1`] = `
 <TrackPage>
   <TrackPage__TrackPageSection>
@@ -1967,6 +2546,148 @@ exports[`RegionPage with "gnomad_r2_1_non_cancer" dataset has no unexpected chan
         }
       />
     </withRouter(SectionErrorBoundary)>
+  </GnomadRegionViewer>
+</TrackPage>
+`;
+
+exports[`RegionPage with "gnomad_r2_1_non_cancer" dataset warns that tandem repeat data is unavailable when the field is null 1`] = `
+<TrackPage>
+  <TrackPage__TrackPageSection>
+    <DocumentTitle
+      title="12-345-456 | gnomAD v2.1.1 (non-cancer)"
+    />
+    <GnomadPageHeading
+      datasetOptions={
+        {
+          "includeCopyNumberVariants": true,
+          "includeExac": true,
+          "includeGnomad2": true,
+          "includeGnomad3": false,
+          "includeGnomad3Subsets": true,
+          "includeGnomad4Subsets": true,
+          "includeShortVariants": true,
+          "includeStructuralVariants": true,
+        }
+      }
+      extra={
+        <withRouter()
+          initialRegion={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh37",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+          style={
+            {
+              "marginLeft": "1em",
+            }
+          }
+        />
+      }
+      selectedDataset="gnomad_r2_1_non_cancer"
+    >
+      12-345-456
+    </GnomadPageHeading>
+    <RegionPage__RegionInfoColumnWrapper>
+      <div>
+        <RegionInfo
+          region={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh37",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+        />
+        <p>
+          <Badge
+            level="warning"
+          >
+            Warning
+          </Badge>
+           Unable to determine whether tandem repeat data is available for this region.
+        </p>
+      </div>
+      <RegionPage__RegionControlsWrapper>
+        <withRouter()
+          region={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh37",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+        />
+      </RegionPage__RegionControlsWrapper>
+    </RegionPage__RegionInfoColumnWrapper>
+  </TrackPage__TrackPageSection>
+  <GnomadRegionViewer
+    leftPanelWidth={115}
+    regions={
+      [
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh37",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        },
+      ]
+    }
+    rightPanelWidth={80}
+    width={994}
+  >
+    <RegionCoverageTrack
+      chrom="12"
+      datasetId="gnomad_r2_1_non_cancer"
+      includeExomeCoverage={true}
+      includeGenomeCoverage={true}
+      start={345}
+      stop={456}
+    />
+    <GenesInRegionTrack
+      genes={[]}
+      region={
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh37",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        }
+      }
+    />
+    <ConnectedVariantsInRegion
+      datasetId="gnomad_r2_1_non_cancer"
+      region={
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh37",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        }
+      }
+    />
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -2363,6 +3084,148 @@ exports[`RegionPage with "gnomad_r2_1_non_neuro" dataset has no unexpected chang
 </TrackPage>
 `;
 
+exports[`RegionPage with "gnomad_r2_1_non_neuro" dataset warns that tandem repeat data is unavailable when the field is null 1`] = `
+<TrackPage>
+  <TrackPage__TrackPageSection>
+    <DocumentTitle
+      title="12-345-456 | gnomAD v2.1.1 (non-neuro)"
+    />
+    <GnomadPageHeading
+      datasetOptions={
+        {
+          "includeCopyNumberVariants": true,
+          "includeExac": true,
+          "includeGnomad2": true,
+          "includeGnomad3": false,
+          "includeGnomad3Subsets": true,
+          "includeGnomad4Subsets": true,
+          "includeShortVariants": true,
+          "includeStructuralVariants": true,
+        }
+      }
+      extra={
+        <withRouter()
+          initialRegion={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh37",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+          style={
+            {
+              "marginLeft": "1em",
+            }
+          }
+        />
+      }
+      selectedDataset="gnomad_r2_1_non_neuro"
+    >
+      12-345-456
+    </GnomadPageHeading>
+    <RegionPage__RegionInfoColumnWrapper>
+      <div>
+        <RegionInfo
+          region={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh37",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+        />
+        <p>
+          <Badge
+            level="warning"
+          >
+            Warning
+          </Badge>
+           Unable to determine whether tandem repeat data is available for this region.
+        </p>
+      </div>
+      <RegionPage__RegionControlsWrapper>
+        <withRouter()
+          region={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh37",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+        />
+      </RegionPage__RegionControlsWrapper>
+    </RegionPage__RegionInfoColumnWrapper>
+  </TrackPage__TrackPageSection>
+  <GnomadRegionViewer
+    leftPanelWidth={115}
+    regions={
+      [
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh37",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        },
+      ]
+    }
+    rightPanelWidth={80}
+    width={994}
+  >
+    <RegionCoverageTrack
+      chrom="12"
+      datasetId="gnomad_r2_1_non_neuro"
+      includeExomeCoverage={true}
+      includeGenomeCoverage={true}
+      start={345}
+      stop={456}
+    />
+    <GenesInRegionTrack
+      genes={[]}
+      region={
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh37",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        }
+      }
+    />
+    <ConnectedVariantsInRegion
+      datasetId="gnomad_r2_1_non_neuro"
+      region={
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh37",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        }
+      }
+    />
+  </GnomadRegionViewer>
+</TrackPage>
+`;
+
 exports[`RegionPage with "gnomad_r2_1_non_topmed" dataset has no unexpected changes for a mitochondrial region 1`] = `
 <TrackPage>
   <TrackPage__TrackPageSection>
@@ -2751,6 +3614,148 @@ exports[`RegionPage with "gnomad_r2_1_non_topmed" dataset has no unexpected chan
         }
       />
     </withRouter(SectionErrorBoundary)>
+  </GnomadRegionViewer>
+</TrackPage>
+`;
+
+exports[`RegionPage with "gnomad_r2_1_non_topmed" dataset warns that tandem repeat data is unavailable when the field is null 1`] = `
+<TrackPage>
+  <TrackPage__TrackPageSection>
+    <DocumentTitle
+      title="12-345-456 | gnomAD v2.1.1 (non-TOPMed)"
+    />
+    <GnomadPageHeading
+      datasetOptions={
+        {
+          "includeCopyNumberVariants": true,
+          "includeExac": true,
+          "includeGnomad2": true,
+          "includeGnomad3": false,
+          "includeGnomad3Subsets": true,
+          "includeGnomad4Subsets": true,
+          "includeShortVariants": true,
+          "includeStructuralVariants": true,
+        }
+      }
+      extra={
+        <withRouter()
+          initialRegion={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh37",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+          style={
+            {
+              "marginLeft": "1em",
+            }
+          }
+        />
+      }
+      selectedDataset="gnomad_r2_1_non_topmed"
+    >
+      12-345-456
+    </GnomadPageHeading>
+    <RegionPage__RegionInfoColumnWrapper>
+      <div>
+        <RegionInfo
+          region={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh37",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+        />
+        <p>
+          <Badge
+            level="warning"
+          >
+            Warning
+          </Badge>
+           Unable to determine whether tandem repeat data is available for this region.
+        </p>
+      </div>
+      <RegionPage__RegionControlsWrapper>
+        <withRouter()
+          region={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh37",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+        />
+      </RegionPage__RegionControlsWrapper>
+    </RegionPage__RegionInfoColumnWrapper>
+  </TrackPage__TrackPageSection>
+  <GnomadRegionViewer
+    leftPanelWidth={115}
+    regions={
+      [
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh37",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        },
+      ]
+    }
+    rightPanelWidth={80}
+    width={994}
+  >
+    <RegionCoverageTrack
+      chrom="12"
+      datasetId="gnomad_r2_1_non_topmed"
+      includeExomeCoverage={true}
+      includeGenomeCoverage={true}
+      start={345}
+      stop={456}
+    />
+    <GenesInRegionTrack
+      genes={[]}
+      region={
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh37",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        }
+      }
+    />
+    <ConnectedVariantsInRegion
+      datasetId="gnomad_r2_1_non_topmed"
+      region={
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh37",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        }
+      }
+    />
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -3187,6 +4192,156 @@ exports[`RegionPage with "gnomad_r3" dataset has no unexpected changes for a non
 </TrackPage>
 `;
 
+exports[`RegionPage with "gnomad_r3" dataset warns that tandem repeat data is unavailable when the field is null 1`] = `
+<TrackPage>
+  <TrackPage__TrackPageSection>
+    <DocumentTitle
+      title="12-345-456 | gnomAD v3.1.2"
+    />
+    <GnomadPageHeading
+      datasetOptions={
+        {
+          "includeCopyNumberVariants": true,
+          "includeExac": false,
+          "includeGnomad2": false,
+          "includeGnomad3": true,
+          "includeGnomad3Subsets": true,
+          "includeGnomad4Subsets": true,
+          "includeShortVariants": true,
+          "includeStructuralVariants": true,
+        }
+      }
+      extra={
+        <withRouter()
+          initialRegion={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh38",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+          style={
+            {
+              "marginLeft": "1em",
+            }
+          }
+        />
+      }
+      selectedDataset="gnomad_r3"
+    >
+      12-345-456
+    </GnomadPageHeading>
+    <RegionPage__RegionInfoColumnWrapper>
+      <div>
+        <RegionInfo
+          region={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh38",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+        />
+        <p>
+          <Badge
+            level="warning"
+          >
+            Warning
+          </Badge>
+           Unable to determine whether tandem repeat data is available for this region.
+        </p>
+      </div>
+      <RegionPage__RegionControlsWrapper>
+        <withRouter()
+          region={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh38",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+        />
+      </RegionPage__RegionControlsWrapper>
+    </RegionPage__RegionInfoColumnWrapper>
+  </TrackPage__TrackPageSection>
+  <GnomadRegionViewer
+    leftPanelWidth={115}
+    regions={
+      [
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh38",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        },
+      ]
+    }
+    rightPanelWidth={80}
+    width={994}
+  >
+    <RegionCoverageTrack
+      chrom="12"
+      datasetId="gnomad_r3"
+      includeExomeCoverage={false}
+      includeGenomeCoverage={true}
+      start={345}
+      stop={456}
+    />
+    <GenesInRegionTrack
+      genes={[]}
+      region={
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh38",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        }
+      }
+    />
+    <React.Fragment>
+      <RegionalGenomicConstraintTrack
+        height={45}
+        regions={[]}
+        start={345}
+        stop={456}
+      />
+    </React.Fragment>
+    <ConnectedVariantsInRegion
+      datasetId="gnomad_r3"
+      region={
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh38",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        }
+      }
+    />
+  </GnomadRegionViewer>
+</TrackPage>
+`;
+
 exports[`RegionPage with "gnomad_r3_controls_and_biobanks" dataset has no unexpected changes for a mitochondrial region 1`] = `
 <TrackPage>
   <TrackPage__TrackPageSection>
@@ -3615,6 +4770,156 @@ exports[`RegionPage with "gnomad_r3_controls_and_biobanks" dataset has no unexpe
         }
       />
     </withRouter(SectionErrorBoundary)>
+  </GnomadRegionViewer>
+</TrackPage>
+`;
+
+exports[`RegionPage with "gnomad_r3_controls_and_biobanks" dataset warns that tandem repeat data is unavailable when the field is null 1`] = `
+<TrackPage>
+  <TrackPage__TrackPageSection>
+    <DocumentTitle
+      title="12-345-456 | gnomAD v3.1.2 (controls/biobanks)"
+    />
+    <GnomadPageHeading
+      datasetOptions={
+        {
+          "includeCopyNumberVariants": true,
+          "includeExac": false,
+          "includeGnomad2": false,
+          "includeGnomad3": true,
+          "includeGnomad3Subsets": true,
+          "includeGnomad4Subsets": true,
+          "includeShortVariants": true,
+          "includeStructuralVariants": true,
+        }
+      }
+      extra={
+        <withRouter()
+          initialRegion={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh38",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+          style={
+            {
+              "marginLeft": "1em",
+            }
+          }
+        />
+      }
+      selectedDataset="gnomad_r3_controls_and_biobanks"
+    >
+      12-345-456
+    </GnomadPageHeading>
+    <RegionPage__RegionInfoColumnWrapper>
+      <div>
+        <RegionInfo
+          region={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh38",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+        />
+        <p>
+          <Badge
+            level="warning"
+          >
+            Warning
+          </Badge>
+           Unable to determine whether tandem repeat data is available for this region.
+        </p>
+      </div>
+      <RegionPage__RegionControlsWrapper>
+        <withRouter()
+          region={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh38",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+        />
+      </RegionPage__RegionControlsWrapper>
+    </RegionPage__RegionInfoColumnWrapper>
+  </TrackPage__TrackPageSection>
+  <GnomadRegionViewer
+    leftPanelWidth={115}
+    regions={
+      [
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh38",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        },
+      ]
+    }
+    rightPanelWidth={80}
+    width={994}
+  >
+    <RegionCoverageTrack
+      chrom="12"
+      datasetId="gnomad_r3_controls_and_biobanks"
+      includeExomeCoverage={false}
+      includeGenomeCoverage={true}
+      start={345}
+      stop={456}
+    />
+    <GenesInRegionTrack
+      genes={[]}
+      region={
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh38",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        }
+      }
+    />
+    <React.Fragment>
+      <RegionalGenomicConstraintTrack
+        height={45}
+        regions={[]}
+        start={345}
+        stop={456}
+      />
+    </React.Fragment>
+    <ConnectedVariantsInRegion
+      datasetId="gnomad_r3_controls_and_biobanks"
+      region={
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh38",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        }
+      }
+    />
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -4051,6 +5356,156 @@ exports[`RegionPage with "gnomad_r3_non_cancer" dataset has no unexpected change
 </TrackPage>
 `;
 
+exports[`RegionPage with "gnomad_r3_non_cancer" dataset warns that tandem repeat data is unavailable when the field is null 1`] = `
+<TrackPage>
+  <TrackPage__TrackPageSection>
+    <DocumentTitle
+      title="12-345-456 | gnomAD v3.1.2 (non-cancer)"
+    />
+    <GnomadPageHeading
+      datasetOptions={
+        {
+          "includeCopyNumberVariants": true,
+          "includeExac": false,
+          "includeGnomad2": false,
+          "includeGnomad3": true,
+          "includeGnomad3Subsets": true,
+          "includeGnomad4Subsets": true,
+          "includeShortVariants": true,
+          "includeStructuralVariants": true,
+        }
+      }
+      extra={
+        <withRouter()
+          initialRegion={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh38",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+          style={
+            {
+              "marginLeft": "1em",
+            }
+          }
+        />
+      }
+      selectedDataset="gnomad_r3_non_cancer"
+    >
+      12-345-456
+    </GnomadPageHeading>
+    <RegionPage__RegionInfoColumnWrapper>
+      <div>
+        <RegionInfo
+          region={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh38",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+        />
+        <p>
+          <Badge
+            level="warning"
+          >
+            Warning
+          </Badge>
+           Unable to determine whether tandem repeat data is available for this region.
+        </p>
+      </div>
+      <RegionPage__RegionControlsWrapper>
+        <withRouter()
+          region={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh38",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+        />
+      </RegionPage__RegionControlsWrapper>
+    </RegionPage__RegionInfoColumnWrapper>
+  </TrackPage__TrackPageSection>
+  <GnomadRegionViewer
+    leftPanelWidth={115}
+    regions={
+      [
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh38",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        },
+      ]
+    }
+    rightPanelWidth={80}
+    width={994}
+  >
+    <RegionCoverageTrack
+      chrom="12"
+      datasetId="gnomad_r3_non_cancer"
+      includeExomeCoverage={false}
+      includeGenomeCoverage={true}
+      start={345}
+      stop={456}
+    />
+    <GenesInRegionTrack
+      genes={[]}
+      region={
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh38",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        }
+      }
+    />
+    <React.Fragment>
+      <RegionalGenomicConstraintTrack
+        height={45}
+        regions={[]}
+        start={345}
+        stop={456}
+      />
+    </React.Fragment>
+    <ConnectedVariantsInRegion
+      datasetId="gnomad_r3_non_cancer"
+      region={
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh38",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        }
+      }
+    />
+  </GnomadRegionViewer>
+</TrackPage>
+`;
+
 exports[`RegionPage with "gnomad_r3_non_neuro" dataset has no unexpected changes for a mitochondrial region 1`] = `
 <TrackPage>
   <TrackPage__TrackPageSection>
@@ -4479,6 +5934,156 @@ exports[`RegionPage with "gnomad_r3_non_neuro" dataset has no unexpected changes
         }
       />
     </withRouter(SectionErrorBoundary)>
+  </GnomadRegionViewer>
+</TrackPage>
+`;
+
+exports[`RegionPage with "gnomad_r3_non_neuro" dataset warns that tandem repeat data is unavailable when the field is null 1`] = `
+<TrackPage>
+  <TrackPage__TrackPageSection>
+    <DocumentTitle
+      title="12-345-456 | gnomAD v3.1.2 (non-neuro)"
+    />
+    <GnomadPageHeading
+      datasetOptions={
+        {
+          "includeCopyNumberVariants": true,
+          "includeExac": false,
+          "includeGnomad2": false,
+          "includeGnomad3": true,
+          "includeGnomad3Subsets": true,
+          "includeGnomad4Subsets": true,
+          "includeShortVariants": true,
+          "includeStructuralVariants": true,
+        }
+      }
+      extra={
+        <withRouter()
+          initialRegion={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh38",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+          style={
+            {
+              "marginLeft": "1em",
+            }
+          }
+        />
+      }
+      selectedDataset="gnomad_r3_non_neuro"
+    >
+      12-345-456
+    </GnomadPageHeading>
+    <RegionPage__RegionInfoColumnWrapper>
+      <div>
+        <RegionInfo
+          region={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh38",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+        />
+        <p>
+          <Badge
+            level="warning"
+          >
+            Warning
+          </Badge>
+           Unable to determine whether tandem repeat data is available for this region.
+        </p>
+      </div>
+      <RegionPage__RegionControlsWrapper>
+        <withRouter()
+          region={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh38",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+        />
+      </RegionPage__RegionControlsWrapper>
+    </RegionPage__RegionInfoColumnWrapper>
+  </TrackPage__TrackPageSection>
+  <GnomadRegionViewer
+    leftPanelWidth={115}
+    regions={
+      [
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh38",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        },
+      ]
+    }
+    rightPanelWidth={80}
+    width={994}
+  >
+    <RegionCoverageTrack
+      chrom="12"
+      datasetId="gnomad_r3_non_neuro"
+      includeExomeCoverage={false}
+      includeGenomeCoverage={true}
+      start={345}
+      stop={456}
+    />
+    <GenesInRegionTrack
+      genes={[]}
+      region={
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh38",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        }
+      }
+    />
+    <React.Fragment>
+      <RegionalGenomicConstraintTrack
+        height={45}
+        regions={[]}
+        start={345}
+        stop={456}
+      />
+    </React.Fragment>
+    <ConnectedVariantsInRegion
+      datasetId="gnomad_r3_non_neuro"
+      region={
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh38",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        }
+      }
+    />
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -4915,6 +6520,156 @@ exports[`RegionPage with "gnomad_r3_non_topmed" dataset has no unexpected change
 </TrackPage>
 `;
 
+exports[`RegionPage with "gnomad_r3_non_topmed" dataset warns that tandem repeat data is unavailable when the field is null 1`] = `
+<TrackPage>
+  <TrackPage__TrackPageSection>
+    <DocumentTitle
+      title="12-345-456 | gnomAD v3.1.2 (non-TOPMed)"
+    />
+    <GnomadPageHeading
+      datasetOptions={
+        {
+          "includeCopyNumberVariants": true,
+          "includeExac": false,
+          "includeGnomad2": false,
+          "includeGnomad3": true,
+          "includeGnomad3Subsets": true,
+          "includeGnomad4Subsets": true,
+          "includeShortVariants": true,
+          "includeStructuralVariants": true,
+        }
+      }
+      extra={
+        <withRouter()
+          initialRegion={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh38",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+          style={
+            {
+              "marginLeft": "1em",
+            }
+          }
+        />
+      }
+      selectedDataset="gnomad_r3_non_topmed"
+    >
+      12-345-456
+    </GnomadPageHeading>
+    <RegionPage__RegionInfoColumnWrapper>
+      <div>
+        <RegionInfo
+          region={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh38",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+        />
+        <p>
+          <Badge
+            level="warning"
+          >
+            Warning
+          </Badge>
+           Unable to determine whether tandem repeat data is available for this region.
+        </p>
+      </div>
+      <RegionPage__RegionControlsWrapper>
+        <withRouter()
+          region={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh38",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+        />
+      </RegionPage__RegionControlsWrapper>
+    </RegionPage__RegionInfoColumnWrapper>
+  </TrackPage__TrackPageSection>
+  <GnomadRegionViewer
+    leftPanelWidth={115}
+    regions={
+      [
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh38",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        },
+      ]
+    }
+    rightPanelWidth={80}
+    width={994}
+  >
+    <RegionCoverageTrack
+      chrom="12"
+      datasetId="gnomad_r3_non_topmed"
+      includeExomeCoverage={false}
+      includeGenomeCoverage={true}
+      start={345}
+      stop={456}
+    />
+    <GenesInRegionTrack
+      genes={[]}
+      region={
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh38",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        }
+      }
+    />
+    <React.Fragment>
+      <RegionalGenomicConstraintTrack
+        height={45}
+        regions={[]}
+        start={345}
+        stop={456}
+      />
+    </React.Fragment>
+    <ConnectedVariantsInRegion
+      datasetId="gnomad_r3_non_topmed"
+      region={
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh38",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        }
+      }
+    />
+  </GnomadRegionViewer>
+</TrackPage>
+`;
+
 exports[`RegionPage with "gnomad_r3_non_v2" dataset has no unexpected changes for a mitochondrial region 1`] = `
 <TrackPage>
   <TrackPage__TrackPageSection>
@@ -5343,6 +7098,156 @@ exports[`RegionPage with "gnomad_r3_non_v2" dataset has no unexpected changes fo
         }
       />
     </withRouter(SectionErrorBoundary)>
+  </GnomadRegionViewer>
+</TrackPage>
+`;
+
+exports[`RegionPage with "gnomad_r3_non_v2" dataset warns that tandem repeat data is unavailable when the field is null 1`] = `
+<TrackPage>
+  <TrackPage__TrackPageSection>
+    <DocumentTitle
+      title="12-345-456 | gnomAD v3.1.2 (non-v2)"
+    />
+    <GnomadPageHeading
+      datasetOptions={
+        {
+          "includeCopyNumberVariants": true,
+          "includeExac": false,
+          "includeGnomad2": false,
+          "includeGnomad3": true,
+          "includeGnomad3Subsets": true,
+          "includeGnomad4Subsets": true,
+          "includeShortVariants": true,
+          "includeStructuralVariants": true,
+        }
+      }
+      extra={
+        <withRouter()
+          initialRegion={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh38",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+          style={
+            {
+              "marginLeft": "1em",
+            }
+          }
+        />
+      }
+      selectedDataset="gnomad_r3_non_v2"
+    >
+      12-345-456
+    </GnomadPageHeading>
+    <RegionPage__RegionInfoColumnWrapper>
+      <div>
+        <RegionInfo
+          region={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh38",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+        />
+        <p>
+          <Badge
+            level="warning"
+          >
+            Warning
+          </Badge>
+           Unable to determine whether tandem repeat data is available for this region.
+        </p>
+      </div>
+      <RegionPage__RegionControlsWrapper>
+        <withRouter()
+          region={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh38",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+        />
+      </RegionPage__RegionControlsWrapper>
+    </RegionPage__RegionInfoColumnWrapper>
+  </TrackPage__TrackPageSection>
+  <GnomadRegionViewer
+    leftPanelWidth={115}
+    regions={
+      [
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh38",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        },
+      ]
+    }
+    rightPanelWidth={80}
+    width={994}
+  >
+    <RegionCoverageTrack
+      chrom="12"
+      datasetId="gnomad_r3_non_v2"
+      includeExomeCoverage={false}
+      includeGenomeCoverage={true}
+      start={345}
+      stop={456}
+    />
+    <GenesInRegionTrack
+      genes={[]}
+      region={
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh38",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        }
+      }
+    />
+    <React.Fragment>
+      <RegionalGenomicConstraintTrack
+        height={45}
+        regions={[]}
+        start={345}
+        stop={456}
+      />
+    </React.Fragment>
+    <ConnectedVariantsInRegion
+      datasetId="gnomad_r3_non_v2"
+      region={
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh38",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        }
+      }
+    />
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -5779,6 +7684,156 @@ exports[`RegionPage with "gnomad_r4" dataset has no unexpected changes for a non
 </TrackPage>
 `;
 
+exports[`RegionPage with "gnomad_r4" dataset warns that tandem repeat data is unavailable when the field is null 1`] = `
+<TrackPage>
+  <TrackPage__TrackPageSection>
+    <DocumentTitle
+      title="12-345-456 | gnomAD v4.1.1"
+    />
+    <GnomadPageHeading
+      datasetOptions={
+        {
+          "includeCopyNumberVariants": true,
+          "includeExac": false,
+          "includeGnomad2": false,
+          "includeGnomad3": true,
+          "includeGnomad3Subsets": true,
+          "includeGnomad4Subsets": true,
+          "includeShortVariants": true,
+          "includeStructuralVariants": true,
+        }
+      }
+      extra={
+        <withRouter()
+          initialRegion={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh38",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+          style={
+            {
+              "marginLeft": "1em",
+            }
+          }
+        />
+      }
+      selectedDataset="gnomad_r4"
+    >
+      12-345-456
+    </GnomadPageHeading>
+    <RegionPage__RegionInfoColumnWrapper>
+      <div>
+        <RegionInfo
+          region={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh38",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+        />
+        <p>
+          <Badge
+            level="warning"
+          >
+            Warning
+          </Badge>
+           Unable to determine whether tandem repeat data is available for this region.
+        </p>
+      </div>
+      <RegionPage__RegionControlsWrapper>
+        <withRouter()
+          region={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh38",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+        />
+      </RegionPage__RegionControlsWrapper>
+    </RegionPage__RegionInfoColumnWrapper>
+  </TrackPage__TrackPageSection>
+  <GnomadRegionViewer
+    leftPanelWidth={115}
+    regions={
+      [
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh38",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        },
+      ]
+    }
+    rightPanelWidth={80}
+    width={994}
+  >
+    <RegionCoverageTrack
+      chrom="12"
+      datasetId="gnomad_r4"
+      includeExomeCoverage={true}
+      includeGenomeCoverage={true}
+      start={345}
+      stop={456}
+    />
+    <GenesInRegionTrack
+      genes={[]}
+      region={
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh38",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        }
+      }
+    />
+    <React.Fragment>
+      <RegionalGenomicConstraintTrack
+        height={45}
+        regions={[]}
+        start={345}
+        stop={456}
+      />
+    </React.Fragment>
+    <ConnectedVariantsInRegion
+      datasetId="gnomad_r4"
+      region={
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh38",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        }
+      }
+    />
+  </GnomadRegionViewer>
+</TrackPage>
+`;
+
 exports[`RegionPage with "gnomad_r4_non_ukb" dataset has no unexpected changes for a mitochondrial region 1`] = `
 <TrackPage>
   <TrackPage__TrackPageSection>
@@ -6211,6 +8266,156 @@ exports[`RegionPage with "gnomad_r4_non_ukb" dataset has no unexpected changes f
 </TrackPage>
 `;
 
+exports[`RegionPage with "gnomad_r4_non_ukb" dataset warns that tandem repeat data is unavailable when the field is null 1`] = `
+<TrackPage>
+  <TrackPage__TrackPageSection>
+    <DocumentTitle
+      title="12-345-456 | gnomAD v4.1.1 (non-UKB)"
+    />
+    <GnomadPageHeading
+      datasetOptions={
+        {
+          "includeCopyNumberVariants": true,
+          "includeExac": false,
+          "includeGnomad2": false,
+          "includeGnomad3": true,
+          "includeGnomad3Subsets": true,
+          "includeGnomad4Subsets": true,
+          "includeShortVariants": true,
+          "includeStructuralVariants": true,
+        }
+      }
+      extra={
+        <withRouter()
+          initialRegion={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh38",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+          style={
+            {
+              "marginLeft": "1em",
+            }
+          }
+        />
+      }
+      selectedDataset="gnomad_r4_non_ukb"
+    >
+      12-345-456
+    </GnomadPageHeading>
+    <RegionPage__RegionInfoColumnWrapper>
+      <div>
+        <RegionInfo
+          region={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh38",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+        />
+        <p>
+          <Badge
+            level="warning"
+          >
+            Warning
+          </Badge>
+           Unable to determine whether tandem repeat data is available for this region.
+        </p>
+      </div>
+      <RegionPage__RegionControlsWrapper>
+        <withRouter()
+          region={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh38",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+        />
+      </RegionPage__RegionControlsWrapper>
+    </RegionPage__RegionInfoColumnWrapper>
+  </TrackPage__TrackPageSection>
+  <GnomadRegionViewer
+    leftPanelWidth={115}
+    regions={
+      [
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh38",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        },
+      ]
+    }
+    rightPanelWidth={80}
+    width={994}
+  >
+    <RegionCoverageTrack
+      chrom="12"
+      datasetId="gnomad_r4_non_ukb"
+      includeExomeCoverage={true}
+      includeGenomeCoverage={true}
+      start={345}
+      stop={456}
+    />
+    <GenesInRegionTrack
+      genes={[]}
+      region={
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh38",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        }
+      }
+    />
+    <React.Fragment>
+      <RegionalGenomicConstraintTrack
+        height={45}
+        regions={[]}
+        start={345}
+        stop={456}
+      />
+    </React.Fragment>
+    <ConnectedVariantsInRegion
+      datasetId="gnomad_r4_non_ukb"
+      region={
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh38",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        }
+      }
+    />
+  </GnomadRegionViewer>
+</TrackPage>
+`;
+
 exports[`RegionPage with "gnomad_sv_r2_1" dataset has no unexpected changes for a mitochondrial region 1`] = `
 <TrackPage>
   <TrackPage__TrackPageSection>
@@ -6610,6 +8815,159 @@ exports[`RegionPage with "gnomad_sv_r2_1" dataset has no unexpected changes for 
         }
       />
     </withRouter(SectionErrorBoundary)>
+  </GnomadRegionViewer>
+</TrackPage>
+`;
+
+exports[`RegionPage with "gnomad_sv_r2_1" dataset warns that tandem repeat data is unavailable when the field is null 1`] = `
+<TrackPage>
+  <TrackPage__TrackPageSection>
+    <DocumentTitle
+      title="12-345-456 | gnomAD SVs v2.1"
+    />
+    <GnomadPageHeading
+      datasetOptions={
+        {
+          "includeCopyNumberVariants": true,
+          "includeExac": true,
+          "includeGnomad2": true,
+          "includeGnomad3": false,
+          "includeGnomad3Subsets": true,
+          "includeGnomad4Subsets": true,
+          "includeShortVariants": true,
+          "includeStructuralVariants": true,
+        }
+      }
+      extra={
+        <withRouter()
+          initialRegion={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh37",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+          style={
+            {
+              "marginLeft": "1em",
+            }
+          }
+        />
+      }
+      selectedDataset="gnomad_sv_r2_1"
+    >
+      12-345-456
+    </GnomadPageHeading>
+    <RegionPage__RegionInfoColumnWrapper>
+      <div>
+        <RegionInfo
+          region={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh37",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+        />
+        <p>
+          <Badge
+            level="warning"
+          >
+            Warning
+          </Badge>
+           Unable to determine whether tandem repeat data is available for this region.
+        </p>
+      </div>
+      <RegionPage__RegionControlsWrapper>
+        <withRouter()
+          region={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh37",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+        />
+      </RegionPage__RegionControlsWrapper>
+    </RegionPage__RegionInfoColumnWrapper>
+  </TrackPage__TrackPageSection>
+  <GnomadRegionViewer
+    leftPanelWidth={115}
+    regions={
+      [
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh37",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        },
+      ]
+    }
+    rightPanelWidth={80}
+    width={994}
+  >
+    <RegionCoverageTrack
+      chrom="12"
+      datasetId="gnomad_sv_r2_1"
+      includeExomeCoverage={false}
+      includeGenomeCoverage={true}
+      start={345}
+      stop={456}
+    />
+    <GenesInRegionTrack
+      genes={[]}
+      region={
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh37",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        }
+      }
+    />
+    <StructuralVariantsInRegion
+      datasetId="gnomad_sv_r2_1"
+      region={
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh37",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        }
+      }
+      zoomRegion={
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh37",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        }
+      }
+    />
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -7017,6 +9375,159 @@ exports[`RegionPage with "gnomad_sv_r2_1_controls" dataset has no unexpected cha
 </TrackPage>
 `;
 
+exports[`RegionPage with "gnomad_sv_r2_1_controls" dataset warns that tandem repeat data is unavailable when the field is null 1`] = `
+<TrackPage>
+  <TrackPage__TrackPageSection>
+    <DocumentTitle
+      title="12-345-456 | gnomAD SVs v2.1 (controls)"
+    />
+    <GnomadPageHeading
+      datasetOptions={
+        {
+          "includeCopyNumberVariants": true,
+          "includeExac": true,
+          "includeGnomad2": true,
+          "includeGnomad3": false,
+          "includeGnomad3Subsets": true,
+          "includeGnomad4Subsets": true,
+          "includeShortVariants": true,
+          "includeStructuralVariants": true,
+        }
+      }
+      extra={
+        <withRouter()
+          initialRegion={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh37",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+          style={
+            {
+              "marginLeft": "1em",
+            }
+          }
+        />
+      }
+      selectedDataset="gnomad_sv_r2_1_controls"
+    >
+      12-345-456
+    </GnomadPageHeading>
+    <RegionPage__RegionInfoColumnWrapper>
+      <div>
+        <RegionInfo
+          region={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh37",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+        />
+        <p>
+          <Badge
+            level="warning"
+          >
+            Warning
+          </Badge>
+           Unable to determine whether tandem repeat data is available for this region.
+        </p>
+      </div>
+      <RegionPage__RegionControlsWrapper>
+        <withRouter()
+          region={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh37",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+        />
+      </RegionPage__RegionControlsWrapper>
+    </RegionPage__RegionInfoColumnWrapper>
+  </TrackPage__TrackPageSection>
+  <GnomadRegionViewer
+    leftPanelWidth={115}
+    regions={
+      [
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh37",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        },
+      ]
+    }
+    rightPanelWidth={80}
+    width={994}
+  >
+    <RegionCoverageTrack
+      chrom="12"
+      datasetId="gnomad_sv_r2_1_controls"
+      includeExomeCoverage={false}
+      includeGenomeCoverage={true}
+      start={345}
+      stop={456}
+    />
+    <GenesInRegionTrack
+      genes={[]}
+      region={
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh37",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        }
+      }
+    />
+    <StructuralVariantsInRegion
+      datasetId="gnomad_sv_r2_1_controls"
+      region={
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh37",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        }
+      }
+      zoomRegion={
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh37",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        }
+      }
+    />
+  </GnomadRegionViewer>
+</TrackPage>
+`;
+
 exports[`RegionPage with "gnomad_sv_r2_1_non_neuro" dataset has no unexpected changes for a mitochondrial region 1`] = `
 <TrackPage>
   <TrackPage__TrackPageSection>
@@ -7416,6 +9927,159 @@ exports[`RegionPage with "gnomad_sv_r2_1_non_neuro" dataset has no unexpected ch
         }
       />
     </withRouter(SectionErrorBoundary)>
+  </GnomadRegionViewer>
+</TrackPage>
+`;
+
+exports[`RegionPage with "gnomad_sv_r2_1_non_neuro" dataset warns that tandem repeat data is unavailable when the field is null 1`] = `
+<TrackPage>
+  <TrackPage__TrackPageSection>
+    <DocumentTitle
+      title="12-345-456 | gnomAD SVs v2.1 (non-neuro)"
+    />
+    <GnomadPageHeading
+      datasetOptions={
+        {
+          "includeCopyNumberVariants": true,
+          "includeExac": true,
+          "includeGnomad2": true,
+          "includeGnomad3": false,
+          "includeGnomad3Subsets": true,
+          "includeGnomad4Subsets": true,
+          "includeShortVariants": true,
+          "includeStructuralVariants": true,
+        }
+      }
+      extra={
+        <withRouter()
+          initialRegion={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh37",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+          style={
+            {
+              "marginLeft": "1em",
+            }
+          }
+        />
+      }
+      selectedDataset="gnomad_sv_r2_1_non_neuro"
+    >
+      12-345-456
+    </GnomadPageHeading>
+    <RegionPage__RegionInfoColumnWrapper>
+      <div>
+        <RegionInfo
+          region={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh37",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+        />
+        <p>
+          <Badge
+            level="warning"
+          >
+            Warning
+          </Badge>
+           Unable to determine whether tandem repeat data is available for this region.
+        </p>
+      </div>
+      <RegionPage__RegionControlsWrapper>
+        <withRouter()
+          region={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh37",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+        />
+      </RegionPage__RegionControlsWrapper>
+    </RegionPage__RegionInfoColumnWrapper>
+  </TrackPage__TrackPageSection>
+  <GnomadRegionViewer
+    leftPanelWidth={115}
+    regions={
+      [
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh37",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        },
+      ]
+    }
+    rightPanelWidth={80}
+    width={994}
+  >
+    <RegionCoverageTrack
+      chrom="12"
+      datasetId="gnomad_sv_r2_1_non_neuro"
+      includeExomeCoverage={false}
+      includeGenomeCoverage={true}
+      start={345}
+      stop={456}
+    />
+    <GenesInRegionTrack
+      genes={[]}
+      region={
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh37",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        }
+      }
+    />
+    <StructuralVariantsInRegion
+      datasetId="gnomad_sv_r2_1_non_neuro"
+      region={
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh37",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        }
+      }
+      zoomRegion={
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh37",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        }
+      }
+    />
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -7859,6 +10523,167 @@ exports[`RegionPage with "gnomad_sv_r4" dataset has no unexpected changes for a 
         }
       />
     </withRouter(SectionErrorBoundary)>
+  </GnomadRegionViewer>
+</TrackPage>
+`;
+
+exports[`RegionPage with "gnomad_sv_r4" dataset warns that tandem repeat data is unavailable when the field is null 1`] = `
+<TrackPage>
+  <TrackPage__TrackPageSection>
+    <DocumentTitle
+      title="12-345-456 | gnomAD SVs v4.1.0"
+    />
+    <GnomadPageHeading
+      datasetOptions={
+        {
+          "includeCopyNumberVariants": true,
+          "includeExac": false,
+          "includeGnomad2": false,
+          "includeGnomad3": true,
+          "includeGnomad3Subsets": true,
+          "includeGnomad4Subsets": true,
+          "includeShortVariants": true,
+          "includeStructuralVariants": true,
+        }
+      }
+      extra={
+        <withRouter()
+          initialRegion={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh38",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+          style={
+            {
+              "marginLeft": "1em",
+            }
+          }
+        />
+      }
+      selectedDataset="gnomad_sv_r4"
+    >
+      12-345-456
+    </GnomadPageHeading>
+    <RegionPage__RegionInfoColumnWrapper>
+      <div>
+        <RegionInfo
+          region={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh38",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+        />
+        <p>
+          <Badge
+            level="warning"
+          >
+            Warning
+          </Badge>
+           Unable to determine whether tandem repeat data is available for this region.
+        </p>
+      </div>
+      <RegionPage__RegionControlsWrapper>
+        <withRouter()
+          region={
+            {
+              "chrom": "12",
+              "genes": [],
+              "non_coding_constraints": [],
+              "reference_genome": "GRCh38",
+              "short_tandem_repeats": null,
+              "start": 345,
+              "stop": 456,
+            }
+          }
+        />
+      </RegionPage__RegionControlsWrapper>
+    </RegionPage__RegionInfoColumnWrapper>
+  </TrackPage__TrackPageSection>
+  <GnomadRegionViewer
+    leftPanelWidth={115}
+    regions={
+      [
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh38",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        },
+      ]
+    }
+    rightPanelWidth={80}
+    width={994}
+  >
+    <RegionCoverageTrack
+      chrom="12"
+      datasetId="gnomad_sv_r4"
+      includeExomeCoverage={false}
+      includeGenomeCoverage={true}
+      start={345}
+      stop={456}
+    />
+    <GenesInRegionTrack
+      genes={[]}
+      region={
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh38",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        }
+      }
+    />
+    <React.Fragment>
+      <RegionalGenomicConstraintTrack
+        height={45}
+        regions={[]}
+        start={345}
+        stop={456}
+      />
+    </React.Fragment>
+    <StructuralVariantsInRegion
+      datasetId="gnomad_sv_r4"
+      region={
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh38",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        }
+      }
+      zoomRegion={
+        {
+          "chrom": "12",
+          "genes": [],
+          "non_coding_constraints": [],
+          "reference_genome": "GRCh38",
+          "short_tandem_repeats": null,
+          "start": 345,
+          "stop": 456,
+        }
+      }
+    />
   </GnomadRegionViewer>
 </TrackPage>
 `;

--- a/browser/src/RegionPage/__snapshots__/RegionPage.spec.tsx.snap
+++ b/browser/src/RegionPage/__snapshots__/RegionPage.spec.tsx.snap
@@ -437,19 +437,35 @@ exports[`RegionPage with "exac" dataset warns that tandem repeat data is unavail
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "12",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh37",
-              "short_tandem_repeats": null,
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="exac"
+          entityDescription="region 12:345-456"
+          resetKeys={
+            [
+              "12",
+              345,
+              456,
+              "exac",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "12",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh37",
+                  "short_tandem_repeats": null,
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
         <p>
           <Badge
             level="warning"
@@ -494,42 +510,84 @@ exports[`RegionPage with "exac" dataset warns that tandem repeat data is unavail
     rightPanelWidth={80}
     width={994}
   >
-    <RegionCoverageTrack
-      chrom="12"
+    <withRouter(SectionErrorBoundary)
       datasetId="exac"
-      includeExomeCoverage={true}
-      includeGenomeCoverage={true}
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": null,
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "exac",
+        ]
       }
-    />
-    <ConnectedVariantsInRegion
+      sectionName="Region coverage"
+    >
+      <RegionCoverageTrack
+        chrom="12"
+        datasetId="exac"
+        includeExomeCoverage={true}
+        includeGenomeCoverage={true}
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="exac"
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": null,
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "exac",
+        ]
       }
-    />
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": null,
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="exac"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "exac",
+        ]
+      }
+      sectionName="Variants"
+    >
+      <ConnectedVariantsInRegion
+        datasetId="exac"
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": null,
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -982,19 +1040,35 @@ exports[`RegionPage with "gnomad_cnv_r4" dataset warns that tandem repeat data i
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "12",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh38",
-              "short_tandem_repeats": null,
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_cnv_r4"
+          entityDescription="region 12:345-456"
+          resetKeys={
+            [
+              "12",
+              345,
+              456,
+              "gnomad_cnv_r4",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "12",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh38",
+                  "short_tandem_repeats": null,
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
         <p>
           <Badge
             level="warning"
@@ -1039,53 +1113,95 @@ exports[`RegionPage with "gnomad_cnv_r4" dataset warns that tandem repeat data i
     rightPanelWidth={80}
     width={994}
   >
-    <RegionCoverageTrack
-      chrom="12"
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_cnv_r4"
-      includeExomeCoverage={true}
-      includeGenomeCoverage={false}
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": null,
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_cnv_r4",
+        ]
       }
-    />
-    <CopyNumberVariantsInRegion
+      sectionName="Region coverage"
+    >
+      <RegionCoverageTrack
+        chrom="12"
+        datasetId="gnomad_cnv_r4"
+        includeExomeCoverage={true}
+        includeGenomeCoverage={false}
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_cnv_r4"
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": null,
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_cnv_r4",
+        ]
       }
-      zoomRegion={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": null,
-          "start": 345,
-          "stop": 456,
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": null,
+            "start": 345,
+            "stop": 456,
+          }
         }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_cnv_r4"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_cnv_r4",
+        ]
       }
-    />
+      sectionName="Variants"
+    >
+      <CopyNumberVariantsInRegion
+        datasetId="gnomad_cnv_r4"
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": null,
+            "start": 345,
+            "stop": 456,
+          }
+        }
+        zoomRegion={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": null,
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -1527,19 +1643,35 @@ exports[`RegionPage with "gnomad_r2_1" dataset warns that tandem repeat data is 
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "12",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh37",
-              "short_tandem_repeats": null,
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_r2_1"
+          entityDescription="region 12:345-456"
+          resetKeys={
+            [
+              "12",
+              345,
+              456,
+              "gnomad_r2_1",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "12",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh37",
+                  "short_tandem_repeats": null,
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
         <p>
           <Badge
             level="warning"
@@ -1584,42 +1716,84 @@ exports[`RegionPage with "gnomad_r2_1" dataset warns that tandem repeat data is 
     rightPanelWidth={80}
     width={994}
   >
-    <RegionCoverageTrack
-      chrom="12"
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r2_1"
-      includeExomeCoverage={true}
-      includeGenomeCoverage={true}
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": null,
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r2_1",
+        ]
       }
-    />
-    <ConnectedVariantsInRegion
+      sectionName="Region coverage"
+    >
+      <RegionCoverageTrack
+        chrom="12"
+        datasetId="gnomad_r2_1"
+        includeExomeCoverage={true}
+        includeGenomeCoverage={true}
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r2_1"
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": null,
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r2_1",
+        ]
       }
-    />
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": null,
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r2_1"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r2_1",
+        ]
+      }
+      sectionName="Variants"
+    >
+      <ConnectedVariantsInRegion
+        datasetId="gnomad_r2_1"
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": null,
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -2061,19 +2235,35 @@ exports[`RegionPage with "gnomad_r2_1_controls" dataset warns that tandem repeat
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "12",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh37",
-              "short_tandem_repeats": null,
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_r2_1_controls"
+          entityDescription="region 12:345-456"
+          resetKeys={
+            [
+              "12",
+              345,
+              456,
+              "gnomad_r2_1_controls",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "12",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh37",
+                  "short_tandem_repeats": null,
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
         <p>
           <Badge
             level="warning"
@@ -2118,42 +2308,84 @@ exports[`RegionPage with "gnomad_r2_1_controls" dataset warns that tandem repeat
     rightPanelWidth={80}
     width={994}
   >
-    <RegionCoverageTrack
-      chrom="12"
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r2_1_controls"
-      includeExomeCoverage={true}
-      includeGenomeCoverage={true}
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": null,
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r2_1_controls",
+        ]
       }
-    />
-    <ConnectedVariantsInRegion
+      sectionName="Region coverage"
+    >
+      <RegionCoverageTrack
+        chrom="12"
+        datasetId="gnomad_r2_1_controls"
+        includeExomeCoverage={true}
+        includeGenomeCoverage={true}
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r2_1_controls"
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": null,
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r2_1_controls",
+        ]
       }
-    />
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": null,
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r2_1_controls"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r2_1_controls",
+        ]
+      }
+      sectionName="Variants"
+    >
+      <ConnectedVariantsInRegion
+        datasetId="gnomad_r2_1_controls"
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": null,
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -2595,19 +2827,35 @@ exports[`RegionPage with "gnomad_r2_1_non_cancer" dataset warns that tandem repe
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "12",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh37",
-              "short_tandem_repeats": null,
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_r2_1_non_cancer"
+          entityDescription="region 12:345-456"
+          resetKeys={
+            [
+              "12",
+              345,
+              456,
+              "gnomad_r2_1_non_cancer",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "12",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh37",
+                  "short_tandem_repeats": null,
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
         <p>
           <Badge
             level="warning"
@@ -2652,42 +2900,84 @@ exports[`RegionPage with "gnomad_r2_1_non_cancer" dataset warns that tandem repe
     rightPanelWidth={80}
     width={994}
   >
-    <RegionCoverageTrack
-      chrom="12"
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r2_1_non_cancer"
-      includeExomeCoverage={true}
-      includeGenomeCoverage={true}
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": null,
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r2_1_non_cancer",
+        ]
       }
-    />
-    <ConnectedVariantsInRegion
+      sectionName="Region coverage"
+    >
+      <RegionCoverageTrack
+        chrom="12"
+        datasetId="gnomad_r2_1_non_cancer"
+        includeExomeCoverage={true}
+        includeGenomeCoverage={true}
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r2_1_non_cancer"
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": null,
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r2_1_non_cancer",
+        ]
       }
-    />
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": null,
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r2_1_non_cancer"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r2_1_non_cancer",
+        ]
+      }
+      sectionName="Variants"
+    >
+      <ConnectedVariantsInRegion
+        datasetId="gnomad_r2_1_non_cancer"
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": null,
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -3129,19 +3419,35 @@ exports[`RegionPage with "gnomad_r2_1_non_neuro" dataset warns that tandem repea
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "12",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh37",
-              "short_tandem_repeats": null,
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_r2_1_non_neuro"
+          entityDescription="region 12:345-456"
+          resetKeys={
+            [
+              "12",
+              345,
+              456,
+              "gnomad_r2_1_non_neuro",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "12",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh37",
+                  "short_tandem_repeats": null,
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
         <p>
           <Badge
             level="warning"
@@ -3186,42 +3492,84 @@ exports[`RegionPage with "gnomad_r2_1_non_neuro" dataset warns that tandem repea
     rightPanelWidth={80}
     width={994}
   >
-    <RegionCoverageTrack
-      chrom="12"
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r2_1_non_neuro"
-      includeExomeCoverage={true}
-      includeGenomeCoverage={true}
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": null,
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r2_1_non_neuro",
+        ]
       }
-    />
-    <ConnectedVariantsInRegion
+      sectionName="Region coverage"
+    >
+      <RegionCoverageTrack
+        chrom="12"
+        datasetId="gnomad_r2_1_non_neuro"
+        includeExomeCoverage={true}
+        includeGenomeCoverage={true}
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r2_1_non_neuro"
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": null,
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r2_1_non_neuro",
+        ]
       }
-    />
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": null,
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r2_1_non_neuro"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r2_1_non_neuro",
+        ]
+      }
+      sectionName="Variants"
+    >
+      <ConnectedVariantsInRegion
+        datasetId="gnomad_r2_1_non_neuro"
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": null,
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -3663,19 +4011,35 @@ exports[`RegionPage with "gnomad_r2_1_non_topmed" dataset warns that tandem repe
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "12",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh37",
-              "short_tandem_repeats": null,
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_r2_1_non_topmed"
+          entityDescription="region 12:345-456"
+          resetKeys={
+            [
+              "12",
+              345,
+              456,
+              "gnomad_r2_1_non_topmed",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "12",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh37",
+                  "short_tandem_repeats": null,
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
         <p>
           <Badge
             level="warning"
@@ -3720,42 +4084,84 @@ exports[`RegionPage with "gnomad_r2_1_non_topmed" dataset warns that tandem repe
     rightPanelWidth={80}
     width={994}
   >
-    <RegionCoverageTrack
-      chrom="12"
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r2_1_non_topmed"
-      includeExomeCoverage={true}
-      includeGenomeCoverage={true}
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": null,
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r2_1_non_topmed",
+        ]
       }
-    />
-    <ConnectedVariantsInRegion
+      sectionName="Region coverage"
+    >
+      <RegionCoverageTrack
+        chrom="12"
+        datasetId="gnomad_r2_1_non_topmed"
+        includeExomeCoverage={true}
+        includeGenomeCoverage={true}
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r2_1_non_topmed"
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": null,
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r2_1_non_topmed",
+        ]
       }
-    />
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": null,
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r2_1_non_topmed"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r2_1_non_topmed",
+        ]
+      }
+      sectionName="Variants"
+    >
+      <ConnectedVariantsInRegion
+        datasetId="gnomad_r2_1_non_topmed"
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": null,
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -4237,19 +4643,35 @@ exports[`RegionPage with "gnomad_r3" dataset warns that tandem repeat data is un
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "12",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh38",
-              "short_tandem_repeats": null,
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_r3"
+          entityDescription="region 12:345-456"
+          resetKeys={
+            [
+              "12",
+              345,
+              456,
+              "gnomad_r3",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "12",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh38",
+                  "short_tandem_repeats": null,
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
         <p>
           <Badge
             level="warning"
@@ -4294,50 +4716,104 @@ exports[`RegionPage with "gnomad_r3" dataset warns that tandem repeat data is un
     rightPanelWidth={80}
     width={994}
   >
-    <RegionCoverageTrack
-      chrom="12"
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r3"
-      includeExomeCoverage={false}
-      includeGenomeCoverage={true}
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": null,
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r3",
+        ]
       }
-    />
-    <React.Fragment>
+      sectionName="Region coverage"
+    >
+      <RegionCoverageTrack
+        chrom="12"
+        datasetId="gnomad_r3"
+        includeExomeCoverage={false}
+        includeGenomeCoverage={true}
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r3"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r3",
+        ]
+      }
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": null,
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r3"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r3",
+        ]
+      }
+      sectionName="Regional genomic constraint"
+    >
       <RegionalGenomicConstraintTrack
         height={45}
         regions={[]}
         start={345}
         stop={456}
       />
-    </React.Fragment>
-    <ConnectedVariantsInRegion
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r3"
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": null,
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r3",
+        ]
       }
-    />
+      sectionName="Variants"
+    >
+      <ConnectedVariantsInRegion
+        datasetId="gnomad_r3"
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": null,
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -4819,19 +5295,35 @@ exports[`RegionPage with "gnomad_r3_controls_and_biobanks" dataset warns that ta
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "12",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh38",
-              "short_tandem_repeats": null,
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_r3_controls_and_biobanks"
+          entityDescription="region 12:345-456"
+          resetKeys={
+            [
+              "12",
+              345,
+              456,
+              "gnomad_r3_controls_and_biobanks",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "12",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh38",
+                  "short_tandem_repeats": null,
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
         <p>
           <Badge
             level="warning"
@@ -4876,50 +5368,104 @@ exports[`RegionPage with "gnomad_r3_controls_and_biobanks" dataset warns that ta
     rightPanelWidth={80}
     width={994}
   >
-    <RegionCoverageTrack
-      chrom="12"
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r3_controls_and_biobanks"
-      includeExomeCoverage={false}
-      includeGenomeCoverage={true}
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": null,
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r3_controls_and_biobanks",
+        ]
       }
-    />
-    <React.Fragment>
+      sectionName="Region coverage"
+    >
+      <RegionCoverageTrack
+        chrom="12"
+        datasetId="gnomad_r3_controls_and_biobanks"
+        includeExomeCoverage={false}
+        includeGenomeCoverage={true}
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r3_controls_and_biobanks"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r3_controls_and_biobanks",
+        ]
+      }
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": null,
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r3_controls_and_biobanks"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r3_controls_and_biobanks",
+        ]
+      }
+      sectionName="Regional genomic constraint"
+    >
       <RegionalGenomicConstraintTrack
         height={45}
         regions={[]}
         start={345}
         stop={456}
       />
-    </React.Fragment>
-    <ConnectedVariantsInRegion
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r3_controls_and_biobanks"
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": null,
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r3_controls_and_biobanks",
+        ]
       }
-    />
+      sectionName="Variants"
+    >
+      <ConnectedVariantsInRegion
+        datasetId="gnomad_r3_controls_and_biobanks"
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": null,
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -5401,19 +5947,35 @@ exports[`RegionPage with "gnomad_r3_non_cancer" dataset warns that tandem repeat
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "12",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh38",
-              "short_tandem_repeats": null,
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_r3_non_cancer"
+          entityDescription="region 12:345-456"
+          resetKeys={
+            [
+              "12",
+              345,
+              456,
+              "gnomad_r3_non_cancer",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "12",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh38",
+                  "short_tandem_repeats": null,
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
         <p>
           <Badge
             level="warning"
@@ -5458,50 +6020,104 @@ exports[`RegionPage with "gnomad_r3_non_cancer" dataset warns that tandem repeat
     rightPanelWidth={80}
     width={994}
   >
-    <RegionCoverageTrack
-      chrom="12"
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r3_non_cancer"
-      includeExomeCoverage={false}
-      includeGenomeCoverage={true}
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": null,
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r3_non_cancer",
+        ]
       }
-    />
-    <React.Fragment>
+      sectionName="Region coverage"
+    >
+      <RegionCoverageTrack
+        chrom="12"
+        datasetId="gnomad_r3_non_cancer"
+        includeExomeCoverage={false}
+        includeGenomeCoverage={true}
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r3_non_cancer"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r3_non_cancer",
+        ]
+      }
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": null,
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r3_non_cancer"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r3_non_cancer",
+        ]
+      }
+      sectionName="Regional genomic constraint"
+    >
       <RegionalGenomicConstraintTrack
         height={45}
         regions={[]}
         start={345}
         stop={456}
       />
-    </React.Fragment>
-    <ConnectedVariantsInRegion
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r3_non_cancer"
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": null,
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r3_non_cancer",
+        ]
       }
-    />
+      sectionName="Variants"
+    >
+      <ConnectedVariantsInRegion
+        datasetId="gnomad_r3_non_cancer"
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": null,
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -5983,19 +6599,35 @@ exports[`RegionPage with "gnomad_r3_non_neuro" dataset warns that tandem repeat 
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "12",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh38",
-              "short_tandem_repeats": null,
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_r3_non_neuro"
+          entityDescription="region 12:345-456"
+          resetKeys={
+            [
+              "12",
+              345,
+              456,
+              "gnomad_r3_non_neuro",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "12",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh38",
+                  "short_tandem_repeats": null,
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
         <p>
           <Badge
             level="warning"
@@ -6040,50 +6672,104 @@ exports[`RegionPage with "gnomad_r3_non_neuro" dataset warns that tandem repeat 
     rightPanelWidth={80}
     width={994}
   >
-    <RegionCoverageTrack
-      chrom="12"
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r3_non_neuro"
-      includeExomeCoverage={false}
-      includeGenomeCoverage={true}
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": null,
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r3_non_neuro",
+        ]
       }
-    />
-    <React.Fragment>
+      sectionName="Region coverage"
+    >
+      <RegionCoverageTrack
+        chrom="12"
+        datasetId="gnomad_r3_non_neuro"
+        includeExomeCoverage={false}
+        includeGenomeCoverage={true}
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r3_non_neuro"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r3_non_neuro",
+        ]
+      }
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": null,
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r3_non_neuro"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r3_non_neuro",
+        ]
+      }
+      sectionName="Regional genomic constraint"
+    >
       <RegionalGenomicConstraintTrack
         height={45}
         regions={[]}
         start={345}
         stop={456}
       />
-    </React.Fragment>
-    <ConnectedVariantsInRegion
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r3_non_neuro"
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": null,
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r3_non_neuro",
+        ]
       }
-    />
+      sectionName="Variants"
+    >
+      <ConnectedVariantsInRegion
+        datasetId="gnomad_r3_non_neuro"
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": null,
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -6565,19 +7251,35 @@ exports[`RegionPage with "gnomad_r3_non_topmed" dataset warns that tandem repeat
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "12",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh38",
-              "short_tandem_repeats": null,
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_r3_non_topmed"
+          entityDescription="region 12:345-456"
+          resetKeys={
+            [
+              "12",
+              345,
+              456,
+              "gnomad_r3_non_topmed",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "12",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh38",
+                  "short_tandem_repeats": null,
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
         <p>
           <Badge
             level="warning"
@@ -6622,50 +7324,104 @@ exports[`RegionPage with "gnomad_r3_non_topmed" dataset warns that tandem repeat
     rightPanelWidth={80}
     width={994}
   >
-    <RegionCoverageTrack
-      chrom="12"
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r3_non_topmed"
-      includeExomeCoverage={false}
-      includeGenomeCoverage={true}
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": null,
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r3_non_topmed",
+        ]
       }
-    />
-    <React.Fragment>
+      sectionName="Region coverage"
+    >
+      <RegionCoverageTrack
+        chrom="12"
+        datasetId="gnomad_r3_non_topmed"
+        includeExomeCoverage={false}
+        includeGenomeCoverage={true}
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r3_non_topmed"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r3_non_topmed",
+        ]
+      }
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": null,
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r3_non_topmed"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r3_non_topmed",
+        ]
+      }
+      sectionName="Regional genomic constraint"
+    >
       <RegionalGenomicConstraintTrack
         height={45}
         regions={[]}
         start={345}
         stop={456}
       />
-    </React.Fragment>
-    <ConnectedVariantsInRegion
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r3_non_topmed"
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": null,
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r3_non_topmed",
+        ]
       }
-    />
+      sectionName="Variants"
+    >
+      <ConnectedVariantsInRegion
+        datasetId="gnomad_r3_non_topmed"
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": null,
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -7147,19 +7903,35 @@ exports[`RegionPage with "gnomad_r3_non_v2" dataset warns that tandem repeat dat
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "12",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh38",
-              "short_tandem_repeats": null,
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_r3_non_v2"
+          entityDescription="region 12:345-456"
+          resetKeys={
+            [
+              "12",
+              345,
+              456,
+              "gnomad_r3_non_v2",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "12",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh38",
+                  "short_tandem_repeats": null,
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
         <p>
           <Badge
             level="warning"
@@ -7204,50 +7976,104 @@ exports[`RegionPage with "gnomad_r3_non_v2" dataset warns that tandem repeat dat
     rightPanelWidth={80}
     width={994}
   >
-    <RegionCoverageTrack
-      chrom="12"
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r3_non_v2"
-      includeExomeCoverage={false}
-      includeGenomeCoverage={true}
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": null,
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r3_non_v2",
+        ]
       }
-    />
-    <React.Fragment>
+      sectionName="Region coverage"
+    >
+      <RegionCoverageTrack
+        chrom="12"
+        datasetId="gnomad_r3_non_v2"
+        includeExomeCoverage={false}
+        includeGenomeCoverage={true}
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r3_non_v2"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r3_non_v2",
+        ]
+      }
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": null,
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r3_non_v2"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r3_non_v2",
+        ]
+      }
+      sectionName="Regional genomic constraint"
+    >
       <RegionalGenomicConstraintTrack
         height={45}
         regions={[]}
         start={345}
         stop={456}
       />
-    </React.Fragment>
-    <ConnectedVariantsInRegion
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r3_non_v2"
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": null,
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r3_non_v2",
+        ]
       }
-    />
+      sectionName="Variants"
+    >
+      <ConnectedVariantsInRegion
+        datasetId="gnomad_r3_non_v2"
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": null,
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -7729,19 +8555,35 @@ exports[`RegionPage with "gnomad_r4" dataset warns that tandem repeat data is un
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "12",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh38",
-              "short_tandem_repeats": null,
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_r4"
+          entityDescription="region 12:345-456"
+          resetKeys={
+            [
+              "12",
+              345,
+              456,
+              "gnomad_r4",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "12",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh38",
+                  "short_tandem_repeats": null,
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
         <p>
           <Badge
             level="warning"
@@ -7786,50 +8628,104 @@ exports[`RegionPage with "gnomad_r4" dataset warns that tandem repeat data is un
     rightPanelWidth={80}
     width={994}
   >
-    <RegionCoverageTrack
-      chrom="12"
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r4"
-      includeExomeCoverage={true}
-      includeGenomeCoverage={true}
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": null,
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r4",
+        ]
       }
-    />
-    <React.Fragment>
+      sectionName="Region coverage"
+    >
+      <RegionCoverageTrack
+        chrom="12"
+        datasetId="gnomad_r4"
+        includeExomeCoverage={true}
+        includeGenomeCoverage={true}
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r4"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r4",
+        ]
+      }
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": null,
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r4"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r4",
+        ]
+      }
+      sectionName="Regional genomic constraint"
+    >
       <RegionalGenomicConstraintTrack
         height={45}
         regions={[]}
         start={345}
         stop={456}
       />
-    </React.Fragment>
-    <ConnectedVariantsInRegion
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r4"
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": null,
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r4",
+        ]
       }
-    />
+      sectionName="Variants"
+    >
+      <ConnectedVariantsInRegion
+        datasetId="gnomad_r4"
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": null,
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -8311,19 +9207,35 @@ exports[`RegionPage with "gnomad_r4_non_ukb" dataset warns that tandem repeat da
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "12",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh38",
-              "short_tandem_repeats": null,
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_r4_non_ukb"
+          entityDescription="region 12:345-456"
+          resetKeys={
+            [
+              "12",
+              345,
+              456,
+              "gnomad_r4_non_ukb",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "12",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh38",
+                  "short_tandem_repeats": null,
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
         <p>
           <Badge
             level="warning"
@@ -8368,50 +9280,104 @@ exports[`RegionPage with "gnomad_r4_non_ukb" dataset warns that tandem repeat da
     rightPanelWidth={80}
     width={994}
   >
-    <RegionCoverageTrack
-      chrom="12"
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r4_non_ukb"
-      includeExomeCoverage={true}
-      includeGenomeCoverage={true}
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": null,
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r4_non_ukb",
+        ]
       }
-    />
-    <React.Fragment>
+      sectionName="Region coverage"
+    >
+      <RegionCoverageTrack
+        chrom="12"
+        datasetId="gnomad_r4_non_ukb"
+        includeExomeCoverage={true}
+        includeGenomeCoverage={true}
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r4_non_ukb"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r4_non_ukb",
+        ]
+      }
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": null,
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_r4_non_ukb"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r4_non_ukb",
+        ]
+      }
+      sectionName="Regional genomic constraint"
+    >
       <RegionalGenomicConstraintTrack
         height={45}
         regions={[]}
         start={345}
         stop={456}
       />
-    </React.Fragment>
-    <ConnectedVariantsInRegion
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_r4_non_ukb"
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": null,
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_r4_non_ukb",
+        ]
       }
-    />
+      sectionName="Variants"
+    >
+      <ConnectedVariantsInRegion
+        datasetId="gnomad_r4_non_ukb"
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": null,
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -8864,19 +9830,35 @@ exports[`RegionPage with "gnomad_sv_r2_1" dataset warns that tandem repeat data 
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "12",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh37",
-              "short_tandem_repeats": null,
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_sv_r2_1"
+          entityDescription="region 12:345-456"
+          resetKeys={
+            [
+              "12",
+              345,
+              456,
+              "gnomad_sv_r2_1",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "12",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh37",
+                  "short_tandem_repeats": null,
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
         <p>
           <Badge
             level="warning"
@@ -8921,53 +9903,95 @@ exports[`RegionPage with "gnomad_sv_r2_1" dataset warns that tandem repeat data 
     rightPanelWidth={80}
     width={994}
   >
-    <RegionCoverageTrack
-      chrom="12"
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_sv_r2_1"
-      includeExomeCoverage={false}
-      includeGenomeCoverage={true}
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": null,
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_sv_r2_1",
+        ]
       }
-    />
-    <StructuralVariantsInRegion
+      sectionName="Region coverage"
+    >
+      <RegionCoverageTrack
+        chrom="12"
+        datasetId="gnomad_sv_r2_1"
+        includeExomeCoverage={false}
+        includeGenomeCoverage={true}
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_sv_r2_1"
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": null,
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_sv_r2_1",
+        ]
       }
-      zoomRegion={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": null,
-          "start": 345,
-          "stop": 456,
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": null,
+            "start": 345,
+            "stop": 456,
+          }
         }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_sv_r2_1"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_sv_r2_1",
+        ]
       }
-    />
+      sectionName="Variants"
+    >
+      <StructuralVariantsInRegion
+        datasetId="gnomad_sv_r2_1"
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": null,
+            "start": 345,
+            "stop": 456,
+          }
+        }
+        zoomRegion={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": null,
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -9420,19 +10444,35 @@ exports[`RegionPage with "gnomad_sv_r2_1_controls" dataset warns that tandem rep
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "12",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh37",
-              "short_tandem_repeats": null,
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_sv_r2_1_controls"
+          entityDescription="region 12:345-456"
+          resetKeys={
+            [
+              "12",
+              345,
+              456,
+              "gnomad_sv_r2_1_controls",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "12",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh37",
+                  "short_tandem_repeats": null,
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
         <p>
           <Badge
             level="warning"
@@ -9477,53 +10517,95 @@ exports[`RegionPage with "gnomad_sv_r2_1_controls" dataset warns that tandem rep
     rightPanelWidth={80}
     width={994}
   >
-    <RegionCoverageTrack
-      chrom="12"
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_sv_r2_1_controls"
-      includeExomeCoverage={false}
-      includeGenomeCoverage={true}
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": null,
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_sv_r2_1_controls",
+        ]
       }
-    />
-    <StructuralVariantsInRegion
+      sectionName="Region coverage"
+    >
+      <RegionCoverageTrack
+        chrom="12"
+        datasetId="gnomad_sv_r2_1_controls"
+        includeExomeCoverage={false}
+        includeGenomeCoverage={true}
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_sv_r2_1_controls"
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": null,
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_sv_r2_1_controls",
+        ]
       }
-      zoomRegion={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": null,
-          "start": 345,
-          "stop": 456,
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": null,
+            "start": 345,
+            "stop": 456,
+          }
         }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_sv_r2_1_controls"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_sv_r2_1_controls",
+        ]
       }
-    />
+      sectionName="Variants"
+    >
+      <StructuralVariantsInRegion
+        datasetId="gnomad_sv_r2_1_controls"
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": null,
+            "start": 345,
+            "stop": 456,
+          }
+        }
+        zoomRegion={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": null,
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -9976,19 +11058,35 @@ exports[`RegionPage with "gnomad_sv_r2_1_non_neuro" dataset warns that tandem re
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "12",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh37",
-              "short_tandem_repeats": null,
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_sv_r2_1_non_neuro"
+          entityDescription="region 12:345-456"
+          resetKeys={
+            [
+              "12",
+              345,
+              456,
+              "gnomad_sv_r2_1_non_neuro",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "12",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh37",
+                  "short_tandem_repeats": null,
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
         <p>
           <Badge
             level="warning"
@@ -10033,53 +11131,95 @@ exports[`RegionPage with "gnomad_sv_r2_1_non_neuro" dataset warns that tandem re
     rightPanelWidth={80}
     width={994}
   >
-    <RegionCoverageTrack
-      chrom="12"
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_sv_r2_1_non_neuro"
-      includeExomeCoverage={false}
-      includeGenomeCoverage={true}
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": null,
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_sv_r2_1_non_neuro",
+        ]
       }
-    />
-    <StructuralVariantsInRegion
+      sectionName="Region coverage"
+    >
+      <RegionCoverageTrack
+        chrom="12"
+        datasetId="gnomad_sv_r2_1_non_neuro"
+        includeExomeCoverage={false}
+        includeGenomeCoverage={true}
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_sv_r2_1_non_neuro"
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": null,
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_sv_r2_1_non_neuro",
+        ]
       }
-      zoomRegion={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh37",
-          "short_tandem_repeats": null,
-          "start": 345,
-          "stop": 456,
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": null,
+            "start": 345,
+            "stop": 456,
+          }
         }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_sv_r2_1_non_neuro"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_sv_r2_1_non_neuro",
+        ]
       }
-    />
+      sectionName="Variants"
+    >
+      <StructuralVariantsInRegion
+        datasetId="gnomad_sv_r2_1_non_neuro"
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": null,
+            "start": 345,
+            "stop": 456,
+          }
+        }
+        zoomRegion={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh37",
+            "short_tandem_repeats": null,
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;
@@ -10572,19 +11712,35 @@ exports[`RegionPage with "gnomad_sv_r4" dataset warns that tandem repeat data is
     </GnomadPageHeading>
     <RegionPage__RegionInfoColumnWrapper>
       <div>
-        <RegionInfo
-          region={
-            {
-              "chrom": "12",
-              "genes": [],
-              "non_coding_constraints": [],
-              "reference_genome": "GRCh38",
-              "short_tandem_repeats": null,
-              "start": 345,
-              "stop": 456,
-            }
+        <withRouter(SectionErrorBoundary)
+          datasetId="gnomad_sv_r4"
+          entityDescription="region 12:345-456"
+          resetKeys={
+            [
+              "12",
+              345,
+              456,
+              "gnomad_sv_r4",
+            ]
           }
-        />
+          sectionName="Region information"
+        >
+          <React.Fragment>
+            <RegionInfo
+              region={
+                {
+                  "chrom": "12",
+                  "genes": [],
+                  "non_coding_constraints": [],
+                  "reference_genome": "GRCh38",
+                  "short_tandem_repeats": null,
+                  "start": 345,
+                  "stop": 456,
+                }
+              }
+            />
+          </React.Fragment>
+        </withRouter(SectionErrorBoundary)>
         <p>
           <Badge
             level="warning"
@@ -10629,61 +11785,115 @@ exports[`RegionPage with "gnomad_sv_r4" dataset warns that tandem repeat data is
     rightPanelWidth={80}
     width={994}
   >
-    <RegionCoverageTrack
-      chrom="12"
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_sv_r4"
-      includeExomeCoverage={false}
-      includeGenomeCoverage={true}
-      start={345}
-      stop={456}
-    />
-    <GenesInRegionTrack
-      genes={[]}
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": null,
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_sv_r4",
+        ]
       }
-    />
-    <React.Fragment>
+      sectionName="Region coverage"
+    >
+      <RegionCoverageTrack
+        chrom="12"
+        datasetId="gnomad_sv_r4"
+        includeExomeCoverage={false}
+        includeGenomeCoverage={true}
+        start={345}
+        stop={456}
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_sv_r4"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_sv_r4",
+        ]
+      }
+      sectionName="Genes in region"
+    >
+      <GenesInRegionTrack
+        genes={[]}
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": null,
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
+      datasetId="gnomad_sv_r4"
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_sv_r4",
+        ]
+      }
+      sectionName="Regional genomic constraint"
+    >
       <RegionalGenomicConstraintTrack
         height={45}
         regions={[]}
         start={345}
         stop={456}
       />
-    </React.Fragment>
-    <StructuralVariantsInRegion
+    </withRouter(SectionErrorBoundary)>
+    <withRouter(SectionErrorBoundary)
       datasetId="gnomad_sv_r4"
-      region={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": null,
-          "start": 345,
-          "stop": 456,
-        }
+      entityDescription="region 12:345-456"
+      resetKeys={
+        [
+          "12",
+          345,
+          456,
+          "gnomad_sv_r4",
+        ]
       }
-      zoomRegion={
-        {
-          "chrom": "12",
-          "genes": [],
-          "non_coding_constraints": [],
-          "reference_genome": "GRCh38",
-          "short_tandem_repeats": null,
-          "start": 345,
-          "stop": 456,
+      sectionName="Variants"
+    >
+      <StructuralVariantsInRegion
+        datasetId="gnomad_sv_r4"
+        region={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": null,
+            "start": 345,
+            "stop": 456,
+          }
         }
-      }
-    />
+        zoomRegion={
+          {
+            "chrom": "12",
+            "genes": [],
+            "non_coding_constraints": [],
+            "reference_genome": "GRCh38",
+            "short_tandem_repeats": null,
+            "start": 345,
+            "stop": 456,
+          }
+        }
+      />
+    </withRouter(SectionErrorBoundary)>
   </GnomadRegionViewer>
 </TrackPage>
 `;

--- a/graphql-api/src/graphql/resolvers/short-tandem-repeats.spec.ts
+++ b/graphql-api/src/graphql/resolvers/short-tandem-repeats.spec.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test, jest } from '@jest/globals'
+
+jest.mock('../../queries/short-tandem-repeat-queries', () => ({
+  fetchShortTandemRepeatsByGene: jest.fn(),
+  fetchShortTandemRepeatsByRegion: jest.fn(),
+}))
+
+// eslint-disable-next-line import/first
+import {
+  fetchShortTandemRepeatsByGene,
+  fetchShortTandemRepeatsByRegion,
+} from '../../queries/short-tandem-repeat-queries'
+// eslint-disable-next-line import/first
+import resolvers from './short-tandem-repeats'
+// eslint-disable-next-line import/first
+import { UserVisibleError } from '../../errors'
+
+const mockFetchShortTandemRepeatsByGene = fetchShortTandemRepeatsByGene as jest.MockedFunction<
+  (esClient: any, dataset: any, geneId: any) => Promise<any>
+>
+const mockFetchShortTandemRepeatsByRegion = fetchShortTandemRepeatsByRegion as jest.MockedFunction<
+  (esClient: any, dataset: any, region: any) => Promise<any>
+>
+
+const resolveShortTandemRepeatsInGene = (resolvers as any).Gene.short_tandem_repeats
+const resolveShortTandemRepeatsInRegion = (resolvers as any).Region.short_tandem_repeats
+
+const gene = { gene_id: 'ENSG00000102081' }
+const region = { chrom: '1', start: 1, stop: 100 }
+const args = { dataset: 'gnomad_r4' }
+const ctx = { esClient: {} }
+
+describe('Gene.short_tandem_repeats', () => {
+  test('resolves to the fetched short tandem repeats', async () => {
+    const shortTandemRepeats = [{ id: 'FMR1' }]
+    mockFetchShortTandemRepeatsByGene.mockResolvedValueOnce(shortTandemRepeats)
+
+    expect(await resolveShortTandemRepeatsInGene(gene, args, ctx)).toBe(shortTandemRepeats)
+  })
+
+  test('resolves to null, instead of rejecting, when Elasticsearch fails', async () => {
+    mockFetchShortTandemRepeatsByGene.mockRejectedValueOnce(
+      new Error('connect ECONNREFUSED 127.0.0.1:9200')
+    )
+
+    await expect(resolveShortTandemRepeatsInGene(gene, args, ctx)).resolves.toBeNull()
+  })
+
+  test('still rejects with a UserVisibleError, e.g. for an unsupported dataset', async () => {
+    mockFetchShortTandemRepeatsByGene.mockRejectedValueOnce(
+      new UserVisibleError('Tandem repeat data is not available for this dataset')
+    )
+
+    await expect(resolveShortTandemRepeatsInGene(gene, args, ctx)).rejects.toThrow(UserVisibleError)
+  })
+})
+
+describe('Region.short_tandem_repeats', () => {
+  test('resolves to the fetched short tandem repeats', async () => {
+    const shortTandemRepeats = [{ id: 'FMR1' }]
+    mockFetchShortTandemRepeatsByRegion.mockResolvedValueOnce(shortTandemRepeats)
+
+    expect(await resolveShortTandemRepeatsInRegion(region, args, ctx)).toBe(shortTandemRepeats)
+  })
+
+  test('resolves to null, instead of rejecting, when Elasticsearch fails', async () => {
+    mockFetchShortTandemRepeatsByRegion.mockRejectedValueOnce(
+      new Error('connect ECONNREFUSED 127.0.0.1:9200')
+    )
+
+    await expect(resolveShortTandemRepeatsInRegion(region, args, ctx)).resolves.toBeNull()
+  })
+
+  test('still rejects with a UserVisibleError, e.g. for an unsupported dataset', async () => {
+    mockFetchShortTandemRepeatsByRegion.mockRejectedValueOnce(
+      new UserVisibleError('Tandem repeat data is not available for this dataset')
+    )
+
+    await expect(resolveShortTandemRepeatsInRegion(region, args, ctx)).rejects.toThrow(
+      UserVisibleError
+    )
+  })
+})

--- a/graphql-api/src/graphql/resolvers/short-tandem-repeats.ts
+++ b/graphql-api/src/graphql/resolvers/short-tandem-repeats.ts
@@ -1,4 +1,5 @@
 import { UserVisibleError } from '../../errors'
+import logger from '../../logger'
 import {
   fetchAllShortTandemRepeats,
   fetchShortTandemRepeatById,
@@ -20,12 +21,34 @@ const resolveShortTandemRepeat = async (_obj: any, args: any, ctx: any) => {
   return shortTandemRepeat
 }
 
-const resolveShortTandemRepeatsInGene = (obj: any, args: any, ctx: any) => {
-  return fetchShortTandemRepeatsByGene(ctx.esClient, args.dataset, obj.gene_id)
+const resolveShortTandemRepeatsInGene = async (obj: any, args: any, ctx: any) => {
+  try {
+    return await fetchShortTandemRepeatsByGene(ctx.esClient, args.dataset, obj.gene_id)
+  } catch (error) {
+    if (error instanceof UserVisibleError) {
+      throw error
+    }
+    logger.warn({
+      message: `Unable to fetch short tandem repeats for gene "${obj.gene_id}"`,
+      error,
+    })
+    return null
+  }
 }
 
-const resolveShortTandemRepeatsInRegion = (obj: any, args: any, ctx: any) => {
-  return fetchShortTandemRepeatsByRegion(ctx.esClient, args.dataset, obj)
+const resolveShortTandemRepeatsInRegion = async (obj: any, args: any, ctx: any) => {
+  try {
+    return await fetchShortTandemRepeatsByRegion(ctx.esClient, args.dataset, obj)
+  } catch (error) {
+    if (error instanceof UserVisibleError) {
+      throw error
+    }
+    logger.warn({
+      message: `Unable to fetch short tandem repeats for region "${obj.chrom}-${obj.start}-${obj.stop}"`,
+      error,
+    })
+    return null
+  }
 }
 
 const resolvers = {

--- a/graphql-api/src/graphql/types/gene.graphql
+++ b/graphql-api/src/graphql/types/gene.graphql
@@ -83,7 +83,7 @@ type Gene {
   cnv_track_callable_coverage(dataset: CopyNumberVariantDatasetId!): [CNVTrackCallableCoverageBin!]
     @cost(value: 5)
 
-  short_tandem_repeats(dataset: DatasetId!): [ShortTandemRepeat!]! @cost(value: 5)
+  short_tandem_repeats(dataset: DatasetId!): [ShortTandemRepeat!] @cost(value: 5)
   heterozygous_variant_cooccurrence_counts: [HeterozygousVariantCooccurrenceCounts!]!
     @cost(value: 5)
   homozygous_variant_cooccurrence_counts: [HomozygousVariantCooccurrenceCounts!]! @cost(value: 5)

--- a/graphql-api/src/graphql/types/region.graphql
+++ b/graphql-api/src/graphql/types/region.graphql
@@ -38,5 +38,5 @@ type Region {
   coverage(dataset: DatasetId!): RegionCoverage!
   mitochondrial_coverage(dataset: DatasetId!): [MitochondrialCoverageBin!] @cost(value: 5)
 
-  short_tandem_repeats(dataset: DatasetId!): [ShortTandemRepeat!]! @cost(value: 5)
+  short_tandem_repeats(dataset: DatasetId!): [ShortTandemRepeat!] @cost(value: 5)
 }


### PR DESCRIPTION
Stacked on #1935, very similar changes as there, just a different field.

Just a failing STR index in ES would result in a null value for STRs in regions and genes in our GraphQL API, which then nulls the entire response. Allow this to be nullable on the backend and frontend, and log appropriate warning on frontend if the STR data is found to be null. 

