### PR TITLE
feat: add allele number (AN) and callrate metrics to coverage track

### DIFF
--- a/browser/help/topics/allele-number.md
+++ b/browser/help/topics/allele-number.md
@@ -1,0 +1,10 @@
+---
+id: allele-number
+title: Allele number (AN)
+---
+
+The number of alleles with a realized genotype call<sup>1</sup> at a site. Each person contributes one count per called allele, so a diploid call adds 2 and a haploid call adds 1. Note that allele number (AN) is a count and not a rate.
+
+Because this is an absolute count, it scales with the number of samples and is not comparable between data types of different size. To compare callability across sites or between exomes and genomes, use [Callrate (Allele Number %)](/help/callrate), which divides by the maximum allele number attainable at the site.
+
+<sup>1</sup>A call is counted when it meets gnomAD's "adj" (high-quality) criteria: genotype quality (GQ) ≥ 20, depth (DP) ≥ 10, and, for heterozygous calls, an allele balance ≥ 0.2. In v5, homozygous reference calls from All of Us are published only at GQ ≥ 20 and carry no DP, so all homozygous reference calls are counted; the full adj criteria apply to calls at variant sites.

--- a/browser/help/topics/callrate.md
+++ b/browser/help/topics/callrate.md
@@ -1,0 +1,14 @@
+---
+id: callrate
+title: Callrate (Allele Number %)
+---
+
+The fraction of people with a realized genotype call at a site, shown as a percentage of the total possible allele number.
+
+Callrate is the total number of alleles called across all samples divided by the maximum number of alleles attainable in the dataset. For example, if an autosomal locus has 5 high-quality<sup>1</sup> genotypes in a dataset containing 10 samples, the callrate would be:
+
+5 genotypes \* 2 alleles per person / 20 maximum alleles = 0.50
+
+This metric accounts for ploidy: two alleles are counted per person in autosomal and pseudoautosomal (PAR) regions, two alleles are counted per XX individual in non-pseudoautosomal (non-PAR) regions of chromosome X, one allele is counted per XY individual in non-PAR regions of chromosomes X and Y, and only alleles from XY individuals are counted in non-PAR regions of chromosome Y.
+
+<sup>1</sup>A call is counted when it meets gnomAD's "adj" (high-quality) criteria: genotype quality (GQ) ≥ 20, depth (DP) ≥ 10, and, for heterozygous calls, an allele balance ≥ 0.2. In v5, homozygous reference calls from All of Us are published only at GQ ≥ 20 and carry no DP, so all homozygous reference calls are counted; the full adj criteria apply to calls at variant sites.

--- a/browser/src/CoverageTrack.spec.tsx
+++ b/browser/src/CoverageTrack.spec.tsx
@@ -1,0 +1,219 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { createRenderer } from 'react-test-renderer/shallow'
+
+import { describe, expect, test } from '@jest/globals'
+
+import CoverageTrack, { MetricOptions } from './CoverageTrack'
+
+// Two buckets are enough: the AN axis ceiling is derived from the data, so the
+// assertions below only need a known maximum.
+const coverageBuckets = [
+  { pos: 100, mean: 30, median: 30, over_1: 1, over_20: 0.97 },
+  { pos: 200, mean: 32, median: 31, over_1: 1, over_20: 0.98 },
+]
+
+// Shaped exactly as the allele_number query returns: flat per-bucket values, the
+// same shape as the coverage buckets above.
+const anBuckets = [
+  { pos: 100, an: 800, an_percent: 99.5 },
+  { pos: 200, an: 900, an_percent: 99.9 },
+]
+
+// Global exome AN reaches ~1.46M (v4.1 exomes are 730,947 samples), which is what
+// escalates the axis unit to M. With `anBuckets` above and `midANBuckets` below,
+// the three fixtures sit in each of the formatter's bands.
+const largeANBuckets = [
+  { pos: 100, an: 1400000, an_percent: 95.8 },
+  { pos: 200, an: 1461894, an_percent: 100 },
+]
+
+// A ceiling that straddles the 1e4 abbreviation cutoff, e.g. a ~7,350-sample
+// callset. This is the only band where per-tick and per-axis unit selection
+// disagree, so it is what the "not per tick" assertion needs.
+const midANBuckets = [
+  { pos: 100, an: 14000, an_percent: 95.2 },
+  { pos: 200, an: 14700, an_percent: 100 },
+]
+
+const coverageDatasets = [{ buckets: coverageBuckets, color: 'green', name: 'genome' }]
+const anDatasets = [{ buckets: anBuckets, color: 'green', name: 'genome' }]
+const midANDatasets = [{ buckets: midANBuckets, color: 'green', name: 'genome' }]
+const largeANDatasets = [{ buckets: largeANBuckets, color: 'green', name: 'genome' }]
+
+const renderShallow = (props: any) => {
+  const shallowRenderer = createRenderer()
+  shallowRenderer.render(<CoverageTrack datasetId="gnomad_r4" {...props} />)
+  return shallowRenderer.getRenderOutput() as any
+}
+
+/** Left panel content for a given metric, via the Track's render prop. */
+const leftPanel = (props: any) => renderShallow(props).props.renderLeftPanel()
+
+/** Top panel (legend + selectors) for a given metric, via the Track's render prop. */
+const topPanel = (props: any) => renderShallow(props).props.renderTopPanel()
+
+/**
+ * Every text node in a full render, in document order.
+ *
+ * The axis ceiling and the tick formatter only run inside the Track's render
+ * prop, which a shallow render never invokes -- so the assertions that cover
+ * them have to read the mounted tree.
+ */
+const renderedText = (props: any): string[] => {
+  const out: string[] = []
+  const walk = (node: any) => {
+    if (node === null || node === undefined) {
+      return
+    }
+    if (Array.isArray(node)) {
+      node.forEach(walk)
+    } else if (typeof node === 'string' || typeof node === 'number') {
+      out.push(String(node))
+    } else if (node.children) {
+      node.children.forEach(walk)
+    }
+  }
+  walk(renderer.create(<CoverageTrack datasetId="gnomad_r4" {...props} />).toJSON())
+  return out
+}
+
+describe('CoverageTrack', () => {
+  test('has no unexpected changes', () => {
+    const tree = renderer.create(
+      <CoverageTrack datasetId="gnomad_r4" datasets={coverageDatasets} />
+    )
+    expect(tree).toMatchSnapshot()
+  })
+
+  test('has no unexpected changes with AN datasets', () => {
+    const tree = renderer.create(
+      <CoverageTrack
+        datasetId="gnomad_r4"
+        datasets={coverageDatasets}
+        anDatasets={anDatasets}
+        metric={MetricOptions.an_percent}
+      />
+    )
+    expect(tree).toMatchSnapshot()
+  })
+})
+
+describe('CoverageTrack metric selector', () => {
+  test('omits the allele number options when no AN data is supplied', () => {
+    const tree = renderer.create(topPanel({ datasets: coverageDatasets })).toJSON()
+    expect(JSON.stringify(tree)).not.toContain('an_percent')
+  })
+
+  test('offers the allele number options when AN data is supplied', () => {
+    const rendered = JSON.stringify(
+      renderer.create(topPanel({ datasets: coverageDatasets, anDatasets })).toJSON()
+    )
+    expect(rendered).toContain('an_percent')
+    expect(rendered).toContain('Callrate')
+  })
+})
+
+describe('CoverageTrack track title', () => {
+  test.each([
+    [MetricOptions.mean, 'Per-base mean depth of coverage'],
+    [MetricOptions.over_20, 'Fraction of individuals with coverage over 20'],
+    [MetricOptions.an_percent, 'Callrate (Allele Number %)'],
+    [MetricOptions.an, 'Allele number (AN)'],
+  ])('names the metric for %s', (metric, expected) => {
+    const rendered = JSON.stringify(
+      renderer.create(leftPanel({ datasets: coverageDatasets, anDatasets, metric })).toJSON()
+    )
+    expect(rendered).toContain(expected)
+  })
+})
+
+describe('CoverageTrack allele number axis', () => {
+  const axisTicks = (datasets: any) =>
+    renderedText({
+      datasets: coverageDatasets,
+      anDatasets: datasets,
+      metric: MetricOptions.an,
+    }).filter((text) => /^[\d,.]+[kM]?$/.test(text))
+
+  test('scales the ceiling to the AN actually on screen', () => {
+    // Raw AN scales with sample count, so a constant ceiling would clip one
+    // series or flatten the other; the axis has to follow the data.
+    const small = axisTicks(anDatasets)
+    const large = axisTicks(largeANDatasets)
+
+    expect(small.length).toBeGreaterThan(0)
+    expect(large.length).toBeGreaterThan(0)
+
+    const asNumber = (tick: string) => {
+      let scale = 1
+      if (tick.endsWith('M')) {
+        scale = 1e6
+      } else if (tick.endsWith('k')) {
+        scale = 1e3
+      }
+      return parseFloat(tick.replace(/,/g, '')) * scale
+    }
+    const highest = (ticks: string[]) => Math.max(...ticks.map(asNumber))
+
+    // 900 -> ceiling 945; 1,461,894 -> ceiling ~1.53M. Three orders of magnitude
+    // apart, which a constant domain could not produce.
+    expect(highest(small)).toBeLessThanOrEqual(945)
+    expect(highest(large)).toBeGreaterThan(1e6)
+  })
+
+  test('picks the tick unit from the ceiling, not per tick', () => {
+    // Per-tick formatting printed small ticks as "0k" and mixed "5,000" with
+    // "10k" on a single axis. A ceiling of ~15.4k puts ticks on both sides of the
+    // 1e4 cutoff, so a per-tick unit shows up as a mixed axis here.
+    const mid = axisTicks(midANDatasets)
+    expect(mid.length).toBeGreaterThan(0)
+    expect(mid.filter((tick) => /[kM]$/.test(tick))).toEqual(mid)
+
+    // Below the cutoff nothing is abbreviated; above 1e6 the unit escalates to M.
+    expect(axisTicks(anDatasets).every((tick) => !/[kM]$/.test(tick))).toBe(true)
+    expect(axisTicks(largeANDatasets).some((tick) => tick.endsWith('M'))).toBe(true)
+  })
+
+  test('suffixes the percent axis and leaves depth axes alone', () => {
+    const percentTicks = renderedText({
+      datasets: coverageDatasets,
+      anDatasets,
+      metric: MetricOptions.an_percent,
+    }).filter((text) => /^\d+%$/.test(text))
+    expect(percentTicks.length).toBeGreaterThan(0)
+    expect(percentTicks).toContain('100%')
+
+    const meanTicks = renderedText({
+      datasets: coverageDatasets,
+      anDatasets,
+      metric: MetricOptions.mean,
+    })
+    expect(meanTicks.some((text) => /[kM]$/.test(text) || /%$/.test(text))).toBe(false)
+  })
+})
+
+describe('CoverageTrack help topic', () => {
+  // Regression guard: both AN metrics once pointed at the `callrate` topic, so
+  // selecting raw AN opened a modal describing a rate with a denominator.
+  const topicFor = (metric: MetricOptions) => {
+    const panel = leftPanel({ datasets: coverageDatasets, anDatasets, metric })
+    const infoButton = React.Children.toArray(panel.props.children).find(
+      (child: any) => child && child.props && typeof child.props.topic === 'string'
+    ) as any
+    return infoButton ? infoButton.props.topic : null
+  }
+
+  test('uses the callrate topic for AN percent', () => {
+    expect(topicFor(MetricOptions.an_percent)).toBe('callrate')
+  })
+
+  test('uses the allele-number topic for raw AN', () => {
+    expect(topicFor(MetricOptions.an)).toBe('allele-number')
+  })
+
+  test('has no help button for depth metrics', () => {
+    expect(topicFor(MetricOptions.mean)).toBeNull()
+    expect(topicFor(MetricOptions.over_20)).toBeNull()
+  })
+})

--- a/browser/src/CoverageTrack.tsx
+++ b/browser/src/CoverageTrack.tsx
@@ -7,6 +7,7 @@ import { AxisLeft } from '@visx/axis'
 import { Track } from '@gnomad/region-viewer'
 import { Button, Select } from '@gnomad/ui'
 import { DatasetId, isV4 } from '@gnomad/dataset-metadata/metadata'
+import InfoButton from './help/InfoButton'
 
 const TopPanel = styled.div`
   display: flex;
@@ -85,7 +86,28 @@ export enum MetricOptions {
   over_30 = 'over_30',
   over_50 = 'over_50',
   over_100 = 'over_100',
+  // Allele number. AoU reference blocks carry no DP, so for v5 genomes the
+  // depth-based metrics above are not meaningful and AN is the callability
+  // signal instead.
+  //
+  // an_percent is AN%, gnomAD's existing published term for AN/2N -- "percent of
+  // total possible AN observed at site". Already used in the Low exome coverage
+  // gene flag (median AN% > 90%) and in constraint.md (AN percent >= 20), so the
+  // axis is a percent to match those thresholds.
+  //
+  // Named an_percent internally but surfaced as "Callrate", which is the term
+  // readers of a coverage track expect. The two are not strictly synonymous --
+  // gnomad_methods describes AN only as a *proxy* for call rate, and AN% is
+  // adj-filtered, allele-level rather than sample-level, and assumes diploid --
+  // so the axis label keeps "(Allele Number %)" and the help topic states the
+  // adj thresholds that define it.
+  an_percent = 'an_percent',
+  an = 'an',
 }
+
+const AN_METRICS: MetricOptions[] = [MetricOptions.an_percent, MetricOptions.an]
+
+const isANMetric = (metric: MetricOptions) => AN_METRICS.includes(metric)
 
 type OwnCoverageTrackProps = {
   datasets: {
@@ -93,11 +115,19 @@ type OwnCoverageTrackProps = {
       pos: number
       mean?: number
       median?: number
+      an?: number
+      an_percent?: number
     }[]
     color: string
     name: string
     opacity?: number
   }[]
+  // AN series, supplied separately from the coverage series. They are NOT
+  // merged into `datasets`: AN and coverage are bucketed independently (and
+  // exome AN covers a different base set than exome coverage), so a merge
+  // would require aligning two bucket grids that need not line up. Passing
+  // this prop is also what enables the AN metrics in the selector.
+  anDatasets?: OwnCoverageTrackProps['datasets']
   coverageOverThresholds?: number[]
   filenameForExport?: (...args: any[]) => any
   height?: number
@@ -121,13 +151,57 @@ class CoverageTrack extends Component<CoverageTrackProps, CoverageTrackState> {
 
   constructor(props: CoverageTrackProps) {
     super(props)
+    let selectedMetric
     if (this.props.metric) {
-      this.state = { selectedMetric: this.props.metric }
+      selectedMetric = this.props.metric
     } else if (isV4(this.props.datasetId)) {
-      this.state = { selectedMetric: MetricOptions.over_20 }
+      selectedMetric = MetricOptions.over_20
     } else {
-      this.state = { selectedMetric: MetricOptions.mean }
+      selectedMetric = MetricOptions.mean
     }
+    this.state = { selectedMetric }
+  }
+
+  /** The series to draw: AN series under an AN metric, coverage series otherwise. */
+  activeDatasets = () => {
+    const { anDatasets, datasets } = this.props
+    return isANMetric(this.state.selectedMetric) && anDatasets ? anDatasets : datasets
+  }
+
+  /**
+   * Resolve the plotted value for a bucket under the current metric.
+   *
+   * Every metric reads straight off the bucket -- the AN series is shaped like the
+   * coverage series. Absent values are normalised to null rather than undefined so
+   * the existing null-filtering in renderBars and renderArea still applies; the API
+   * returns null for a bucket with no data, and `an_percent` is null where the
+   * attainable AN is zero.
+   */
+  metricValue = (bucket: any) => {
+    const value = bucket[this.state.selectedMetric]
+    return value === undefined ? null : value
+  }
+
+  /**
+   * Axis ceiling for raw AN, derived from the data actually on screen.
+   *
+   * Raw AN has no natural ceiling: it scales with sample count, so it differs by
+   * an order of magnitude between series (v4.1 exomes 2N ~ 1.46M vs v4.1 genomes
+   * 2N ~ 152k) and again between releases. A constant would clip one series or
+   * flatten the other, so the axis follows the data on screen. This is why AN% is
+   * the better default -- it is already normalised.
+   */
+  anAxisMax = () => {
+    let max = 0
+    this.activeDatasets().forEach((dataset: any) => {
+      dataset.buckets.forEach((bucket: any) => {
+        const value = this.metricValue(bucket)
+        if (typeof value === 'number' && Number.isFinite(value) && value > max) {
+          max = value
+        }
+      })
+    })
+    return max > 0 ? max * 1.05 : 1
   }
 
   plotRef = (el: any) => {
@@ -157,14 +231,17 @@ class CoverageTrack extends Component<CoverageTrackProps, CoverageTrackState> {
   }
 
   renderArea({ scaleCoverageMetric, scalePosition }: any) {
-    const { datasets, height } = this.props
-    const { selectedMetric } = this.state
+    const { height } = this.props
+    const datasets = this.activeDatasets()
 
     const pathGenerator = area()
+      .defined((bucket) => {
+        const value = this.metricValue(bucket)
+        return value !== undefined && value !== null
+      })
       .x((bucket) => scalePosition((bucket as any).pos))
       .y0(height)
-      // @ts-expect-error TS(7015) FIXME: Element implicitly has an 'any' type because index... Remove this comment to see the full error message
-      .y1((bucket) => scaleCoverageMetric(bucket[selectedMetric]))
+      .y1((bucket) => scaleCoverageMetric(this.metricValue(bucket)))
 
     return datasets.map((dataset) => (
       <g key={dataset.name}>
@@ -179,22 +256,20 @@ class CoverageTrack extends Component<CoverageTrackProps, CoverageTrackState> {
   }
 
   renderBars({ isPositionDefined, scaleCoverageMetric, scalePosition, totalBases, width }: any) {
-    const { datasets, height } = this.props
-    const { selectedMetric } = this.state
+    const { height } = this.props
+    const datasets = this.activeDatasets()
 
     const barWidth = width / totalBases - 1
 
     return datasets.map((dataset: any) => (
       <g key={dataset.name}>
         {dataset.buckets
-          .filter(
-            (bucket: any) =>
-              bucket[selectedMetric] !== undefined &&
-              bucket[selectedMetric] !== null &&
-              isPositionDefined(bucket.pos)
-          )
+          .filter((bucket: any) => {
+            const value = this.metricValue(bucket)
+            return value !== undefined && value !== null && isPositionDefined(bucket.pos)
+          })
           .map((bucket: any) => {
-            const barHeight = height - scaleCoverageMetric(bucket[selectedMetric])
+            const barHeight = height - scaleCoverageMetric(this.metricValue(bucket))
             const x = scalePosition(bucket.pos)
             return (
               <rect
@@ -236,17 +311,43 @@ class CoverageTrack extends Component<CoverageTrackProps, CoverageTrackState> {
   }
 
   render() {
-    const { coverageOverThresholds, datasets, height, maxCoverage } = this.props
+    const { anDatasets, coverageOverThresholds, height, maxCoverage } = this.props
     const { selectedMetric } = this.state
+    const datasets = this.activeDatasets()
+    // Once per render: drives both the axis domain and the tick unit.
+    const anMax = selectedMetric === MetricOptions.an ? this.anAxisMax() : 0
 
-    const trackTitle =
-      selectedMetric === 'mean' || selectedMetric === 'median'
-        ? `Per-base ${selectedMetric} depth of coverage`
-        : `Fraction of individuals with coverage over ${selectedMetric.slice(5)}`
+    const showANMetrics = Boolean(anDatasets)
+
+    let trackTitle: string
+    if (selectedMetric === MetricOptions.mean || selectedMetric === MetricOptions.median) {
+      trackTitle = `Per-base ${selectedMetric} depth of coverage`
+    } else if (selectedMetric === MetricOptions.an_percent) {
+      trackTitle = 'Callrate (Allele Number %)'
+    } else if (selectedMetric === MetricOptions.an) {
+      trackTitle = 'Allele number (AN)'
+    } else {
+      trackTitle = `Fraction of individuals with coverage over ${selectedMetric.slice(5)}`
+    }
+    // Help topic per metric. Raw AN is an absolute count; Callrate is a rate with a
+    // ploidy-aware denominator -- pointing both at one topic described the wrong thing.
+    let titleHelpTopic: string | null = null
+    if (selectedMetric === MetricOptions.an_percent) {
+      titleHelpTopic = 'callrate'
+    } else if (selectedMetric === MetricOptions.an) {
+      titleHelpTopic = 'allele-number'
+    }
 
     return (
       <Track
-        renderLeftPanel={() => <TitlePanel>{trackTitle}</TitlePanel>}
+        renderLeftPanel={() => (
+          <TitlePanel>
+            {trackTitle}
+            {/* Click-to-open help, same pattern as RegionalConstraintTrack. Copy lives
+                in browser/help/topics/{callrate,allele-number}.md. */}
+            {titleHelpTopic && <InfoButton topic={titleHelpTopic} />}
+          </TitlePanel>
+        )}
         renderTopPanel={() => (
           <TopPanel>
             <Legend datasets={datasets} />
@@ -273,6 +374,12 @@ class CoverageTrack extends Component<CoverageTrackProps, CoverageTrackState> {
                     ))}
                   </optgroup>
                 )}
+                {showANMetrics && (
+                  <optgroup label="Allele number">
+                    <option value={MetricOptions.an_percent}>Callrate</option>
+                    <option value={MetricOptions.an}>Allele number (AN)</option>
+                  </optgroup>
+                )}
               </Select>
             </label>
             <Button style={{ marginLeft: '1em' }} onClick={() => this.exportPlot()}>
@@ -282,11 +389,21 @@ class CoverageTrack extends Component<CoverageTrackProps, CoverageTrackState> {
         )}
       >
         {({ isPositionDefined, regions, scalePosition, width }: any) => {
-          const scaleCoverageMetric = scaleLinear()
-            .domain(
-              selectedMetric === 'mean' || selectedMetric === 'median' ? [0, maxCoverage] : [0, 1]
-            )
-            .range([height, 7])
+          // AN% runs 0-100 (matching the documented >90% / >=20 thresholds), raw
+          // AN is an absolute count, over_X is a 0-1 fraction.
+          let domain
+          if (selectedMetric === MetricOptions.mean || selectedMetric === MetricOptions.median) {
+            domain = [0, maxCoverage]
+          } else if (selectedMetric === MetricOptions.an) {
+            // Follows the data on screen; see anAxisMax. `|| 1` guards an
+            // all-null series, which would otherwise give a zero-width domain.
+            domain = [0, anMax || 1]
+          } else if (selectedMetric === MetricOptions.an_percent) {
+            domain = [0, 100]
+          } else {
+            domain = [0, 1]
+          }
+          const scaleCoverageMetric = scaleLinear().domain(domain).range([height, 7])
 
           const axisWidth = 60
           return (
@@ -302,6 +419,27 @@ class CoverageTrack extends Component<CoverageTrackProps, CoverageTrackState> {
                     fontSize: 10,
                     textAnchor: 'end',
                   })}
+                  // Raw AN reaches ~10^6 (v4.1 exomes are 730,947 samples, so
+                  // 2N ~ 1.46M); the default formatter overflows the 60px axis
+                  // gutter, so abbreviate to k / M.
+                  tickFormat={
+                    // eslint-disable-next-line no-nested-ternary
+                    selectedMetric === MetricOptions.an
+                      ? (value: any) => {
+                          // Unit chosen from the axis ceiling, not per tick: the axis
+                          // follows the data and spans ~152k (v4.1 genomes 2N) to
+                          // ~1.46M (v4.1 exomes 2N), and less on a short region.
+                          // Per-tick formatting printed small ticks as "0k" and
+                          // mixed "5,000" with "10k" on one axis.
+                          const n = Number(value)
+                          if (anMax < 1e4) return n.toLocaleString()
+                          if (n >= 1e6) return `${(n / 1e6).toFixed(1)}M`
+                          return `${Math.round(n / 1000).toLocaleString()}k`
+                        }
+                      : selectedMetric === MetricOptions.an_percent
+                      ? (value: any) => `${Number(value)}%`
+                      : undefined
+                  }
                   scale={scaleCoverageMetric}
                   stroke="#333"
                 />

--- a/browser/src/GenePage/GeneCoverageTrack.tsx
+++ b/browser/src/GenePage/GeneCoverageTrack.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
 
 import { referenceGenome, isExac, coverageDatasetId } from '@gnomad/dataset-metadata/metadata'
-import { coverageConfigClassic, coverageConfigNew } from '../coverageStyles'
+import { anConfig, coverageConfigClassic, coverageConfigNew } from '../coverageStyles'
 import CoverageTrack from '../CoverageTrack'
-import Query from '../Query'
+import Query, { BaseQuery } from '../Query'
 
 const operationName = 'GeneCoverage'
 const coverageQuery = `
@@ -42,6 +42,34 @@ query ${operationName}($geneId: String!, $datasetId: DatasetId!, $referenceGenom
   }
 }
 `
+
+// Allele number is requested separately, and deliberately not folded into the
+// coverage query above. A single document would make the coverage track fail
+// outright against an API that predates the `allele_number` field -- an unknown
+// field is a query validation error, not a null -- so the browser could not be
+// deployed ahead of the API. Fetched through BaseQuery rather than Query because
+// BaseQuery renders its children regardless of loading or error state, which is
+// what lets the coverage track draw normally when AN is unavailable.
+const alleleNumberOperationName = 'GeneAlleleNumber'
+const alleleNumberQuery = `
+query ${alleleNumberOperationName}($geneId: String!, $datasetId: DatasetId!, $referenceGenome: ReferenceGenomeId!, $includeExomeCoverage: Boolean!, $includeGenomeCoverage: Boolean!) {
+  gene(gene_id: $geneId, reference_genome: $referenceGenome) {
+    allele_number(dataset: $datasetId) {
+      exome @include(if: $includeExomeCoverage) {
+        pos
+        an
+        an_percent
+      }
+      genome @include(if: $includeGenomeCoverage) {
+        pos
+        an
+        an_percent
+      }
+    }
+  }
+}
+`
+
 type OwnProps = {
   datasetId: string
   geneId: string
@@ -59,48 +87,69 @@ const GeneCoverageTrack = ({
   includeExomeCoverage,
   includeGenomeCoverage,
 }: Props) => {
+  const variables = {
+    geneId,
+    datasetId: coverageDatasetId(datasetId),
+    referenceGenome: referenceGenome(coverageDatasetId(datasetId)),
+    includeExomeCoverage,
+    includeGenomeCoverage,
+  }
+
   return (
-    <Query
-      operationName={operationName}
-      query={coverageQuery}
-      variables={{
-        geneId,
-        datasetId: coverageDatasetId(datasetId),
-        referenceGenome: referenceGenome(coverageDatasetId(datasetId)),
-        includeExomeCoverage,
-        includeGenomeCoverage,
-      }}
-      loadingMessage="Loading coverage"
-      loadingPlaceholderHeight={220}
-      errorMessage="Unable to load coverage"
-      success={(data: any) => {
-        if (!data.gene || !data.gene.coverage) {
-          return false
-        }
-        const exomeCoverage = includeExomeCoverage ? data.gene.coverage.exome : true
-        const genomeCoverage = includeGenomeCoverage ? data.gene.coverage.genome : true
-        return exomeCoverage || genomeCoverage
-      }}
+    <BaseQuery
+      operationName={alleleNumberOperationName}
+      query={alleleNumberQuery}
+      variables={variables}
     >
-      {({ data }: any) => {
-        const exomeCoverage = includeExomeCoverage ? data.gene.coverage.exome : null
-        const genomeCoverage = includeGenomeCoverage ? data.gene.coverage.genome : null
+      {({ data: alleleNumberData }: any) => (
+        <Query
+          operationName={operationName}
+          query={coverageQuery}
+          variables={variables}
+          loadingMessage="Loading coverage"
+          loadingPlaceholderHeight={220}
+          errorMessage="Unable to load coverage"
+          success={(data: any) => {
+            if (!data.gene || !data.gene.coverage) {
+              return false
+            }
+            const exomeCoverage = includeExomeCoverage ? data.gene.coverage.exome : true
+            const genomeCoverage = includeGenomeCoverage ? data.gene.coverage.genome : true
+            return exomeCoverage || genomeCoverage
+          }}
+        >
+          {({ data }: any) => {
+            const exomeCoverage = includeExomeCoverage ? data.gene.coverage.exome : null
+            const genomeCoverage = includeGenomeCoverage ? data.gene.coverage.genome : null
 
-        const coverageConfig = isExac(datasetId)
-          ? coverageConfigClassic(exomeCoverage, genomeCoverage)
-          : coverageConfigNew(exomeCoverage, genomeCoverage)
+            const coverageConfig = isExac(datasetId)
+              ? coverageConfigClassic(exomeCoverage, genomeCoverage)
+              : coverageConfigNew(exomeCoverage, genomeCoverage)
 
-        return (
-          <CoverageTrack
-            coverageOverThresholds={[1, 5, 10, 15, 20, 25, 30, 50, 100]}
-            datasets={coverageConfig}
-            filenameForExport={() => `${geneId}_coverage`}
-            height={190}
-            datasetId={datasetId}
-          />
-        )
-      }}
-    </Query>
+            // Absent for a dataset with no AN index, an API without the field, or
+            // while the request is still in flight. Empty arrays are normalised to
+            // null because anConfig treats any truthy value as a series to draw, so
+            // `[]` would add a legend entry for a series with no data.
+            const alleleNumber = alleleNumberData?.gene?.allele_number
+            const exomeAN =
+              includeExomeCoverage && alleleNumber?.exome?.length ? alleleNumber.exome : null
+            const genomeAN =
+              includeGenomeCoverage && alleleNumber?.genome?.length ? alleleNumber.genome : null
+
+            return (
+              <CoverageTrack
+                coverageOverThresholds={[1, 5, 10, 15, 20, 25, 30, 50, 100]}
+                datasets={coverageConfig}
+                anDatasets={exomeAN || genomeAN ? anConfig(exomeAN, genomeAN) : undefined}
+                filenameForExport={() => `${geneId}_coverage`}
+                height={190}
+                datasetId={datasetId}
+              />
+            )
+          }}
+        </Query>
+      )}
+    </BaseQuery>
   )
 }
 

--- a/browser/src/GenePage/GenePage.spec.tsx
+++ b/browser/src/GenePage/GenePage.spec.tsx
@@ -71,6 +71,11 @@ forDatasetsNotMatching(svRegexp, 'GenePage with non-SV dataset "%s"', (datasetId
           coverage: {},
         },
       }),
+      GeneAlleleNumber: () => ({
+        gene: {
+          allele_number: {},
+        },
+      }),
       CopyNumberVariantsInGene: () => ({
         gene: { copy_number_variants: [] },
       }),
@@ -154,6 +159,11 @@ forDatasetsMatching(cnvRegexp, 'GenePage with CNV dataset "%s"', (datasetId) => 
           coverage: {},
         },
       }),
+      GeneAlleleNumber: () => ({
+        gene: {
+          allele_number: {},
+        },
+      }),
     })
     const tree = renderer.create(
       <MemoryRouter>
@@ -172,6 +182,11 @@ forDatasetsMatching(cnvRegexp, 'GenePage with CNV dataset "%s"', (datasetId) => 
       GeneCoverage: () => ({
         gene: {
           coverage: {},
+        },
+      }),
+      GeneAlleleNumber: () => ({
+        gene: {
+          allele_number: {},
         },
       }),
     })
@@ -215,6 +230,11 @@ describe.each([
       GeneCoverage: () => ({
         gene: {
           coverage: {},
+        },
+      }),
+      GeneAlleleNumber: () => ({
+        gene: {
+          allele_number: {},
         },
       }),
       CopyNumberVariantsInGene: () => ({

--- a/browser/src/__snapshots__/CoverageTrack.spec.tsx.snap
+++ b/browser/src/__snapshots__/CoverageTrack.spec.tsx.snap
@@ -1,0 +1,1191 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CoverageTrack has no unexpected changes 1`] = `
+<div
+  className="sc-ggWZvA faMivF"
+>
+  <div
+    className="sc-jwTyAe cTLZpt"
+    style={
+      {
+        "marginLeft": 100,
+        "marginRight": 160,
+        "width": 1440,
+      }
+    }
+  >
+    <div
+      className="CoverageTrack__TopPanel-sc-1kumbsx-0 cLbDZX"
+    >
+      <ul
+        className="CoverageTrack__LegendWrapper-sc-1kumbsx-1 jLTtQ"
+      >
+        <li
+          className="CoverageTrack__LegendItem-sc-1kumbsx-2 iyLhwF"
+        >
+          <span
+            className="CoverageTrack__LegendSwatch-sc-1kumbsx-3 oLsXH"
+            color="green"
+          />
+          genome
+        </li>
+      </ul>
+      <label
+        htmlFor="coverage-metric"
+      >
+        Metric:
+         
+        <select
+          className="Select-sc-1lkyg9e-0 iPbHsk"
+          id="coverage-metric"
+          onChange={[Function]}
+          value="over_20"
+        >
+          <optgroup
+            label="Per-base depth of coverage"
+          >
+            <option
+              value="mean"
+            >
+              Mean
+            </option>
+            <option
+              value="median"
+            >
+              Median
+            </option>
+          </optgroup>
+        </select>
+      </label>
+      <button
+        backgroundColor="#f8f9fa"
+        borderColor="#6c757d"
+        className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 VaScf"
+        onClick={[Function]}
+        style={
+          {
+            "marginLeft": "1em",
+          }
+        }
+        type="button"
+      >
+        Save plot
+      </button>
+    </div>
+  </div>
+  <div
+    className="sc-dTvVRJ ejoLSV"
+  >
+    <div
+      className="sc-hjsuWn ccbdKG"
+      style={
+        {
+          "width": 100,
+        }
+      }
+    >
+      <div
+        className="CoverageTrack__TitlePanel-sc-1kumbsx-4 kxMCgi"
+      >
+        Fraction of individuals with coverage over 20
+      </div>
+    </div>
+    <div
+      className="sc-jJLAfE KfhrV"
+      style={
+        {
+          "width": 1440,
+        }
+      }
+    >
+      <div
+        style={
+          {
+            "marginLeft": -60,
+          }
+        }
+      >
+        <svg
+          height={190}
+          width={1500}
+        >
+          <g
+            className="visx-group visx-axis visx-axis-left"
+            transform="translate(60, 0)"
+          >
+            <g
+              className="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                className="visx-line"
+                fill="transparent"
+                shapeRendering="crispEdges"
+                stroke="#222"
+                strokeLinecap="square"
+                strokeWidth={1}
+                x1={0}
+                x2={-8}
+                y1={171.7}
+                y2={171.7}
+              />
+              <svg
+                fontSize={10}
+                style={
+                  {
+                    "overflow": "visible",
+                  }
+                }
+                x="-0.25em"
+                y="0.25em"
+              >
+                <text
+                  fill="#000"
+                  fontSize={10}
+                  textAnchor="end"
+                  transform=""
+                  x={-8}
+                  y={171.7}
+                >
+                  <tspan
+                    dy="0em"
+                    x={-8}
+                  >
+                    0.1
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              className="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                className="visx-line"
+                fill="transparent"
+                shapeRendering="crispEdges"
+                stroke="#222"
+                strokeLinecap="square"
+                strokeWidth={1}
+                x1={0}
+                x2={-8}
+                y1={153.4}
+                y2={153.4}
+              />
+              <svg
+                fontSize={10}
+                style={
+                  {
+                    "overflow": "visible",
+                  }
+                }
+                x="-0.25em"
+                y="0.25em"
+              >
+                <text
+                  fill="#000"
+                  fontSize={10}
+                  textAnchor="end"
+                  transform=""
+                  x={-8}
+                  y={153.4}
+                >
+                  <tspan
+                    dy="0em"
+                    x={-8}
+                  >
+                    0.2
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              className="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                className="visx-line"
+                fill="transparent"
+                shapeRendering="crispEdges"
+                stroke="#222"
+                strokeLinecap="square"
+                strokeWidth={1}
+                x1={0}
+                x2={-8}
+                y1={135.1}
+                y2={135.1}
+              />
+              <svg
+                fontSize={10}
+                style={
+                  {
+                    "overflow": "visible",
+                  }
+                }
+                x="-0.25em"
+                y="0.25em"
+              >
+                <text
+                  fill="#000"
+                  fontSize={10}
+                  textAnchor="end"
+                  transform=""
+                  x={-8}
+                  y={135.1}
+                >
+                  <tspan
+                    dy="0em"
+                    x={-8}
+                  >
+                    0.3
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              className="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                className="visx-line"
+                fill="transparent"
+                shapeRendering="crispEdges"
+                stroke="#222"
+                strokeLinecap="square"
+                strokeWidth={1}
+                x1={0}
+                x2={-8}
+                y1={116.8}
+                y2={116.8}
+              />
+              <svg
+                fontSize={10}
+                style={
+                  {
+                    "overflow": "visible",
+                  }
+                }
+                x="-0.25em"
+                y="0.25em"
+              >
+                <text
+                  fill="#000"
+                  fontSize={10}
+                  textAnchor="end"
+                  transform=""
+                  x={-8}
+                  y={116.8}
+                >
+                  <tspan
+                    dy="0em"
+                    x={-8}
+                  >
+                    0.4
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              className="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                className="visx-line"
+                fill="transparent"
+                shapeRendering="crispEdges"
+                stroke="#222"
+                strokeLinecap="square"
+                strokeWidth={1}
+                x1={0}
+                x2={-8}
+                y1={98.5}
+                y2={98.5}
+              />
+              <svg
+                fontSize={10}
+                style={
+                  {
+                    "overflow": "visible",
+                  }
+                }
+                x="-0.25em"
+                y="0.25em"
+              >
+                <text
+                  fill="#000"
+                  fontSize={10}
+                  textAnchor="end"
+                  transform=""
+                  x={-8}
+                  y={98.5}
+                >
+                  <tspan
+                    dy="0em"
+                    x={-8}
+                  >
+                    0.5
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              className="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                className="visx-line"
+                fill="transparent"
+                shapeRendering="crispEdges"
+                stroke="#222"
+                strokeLinecap="square"
+                strokeWidth={1}
+                x1={0}
+                x2={-8}
+                y1={80.2}
+                y2={80.2}
+              />
+              <svg
+                fontSize={10}
+                style={
+                  {
+                    "overflow": "visible",
+                  }
+                }
+                x="-0.25em"
+                y="0.25em"
+              >
+                <text
+                  fill="#000"
+                  fontSize={10}
+                  textAnchor="end"
+                  transform=""
+                  x={-8}
+                  y={80.2}
+                >
+                  <tspan
+                    dy="0em"
+                    x={-8}
+                  >
+                    0.6
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              className="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                className="visx-line"
+                fill="transparent"
+                shapeRendering="crispEdges"
+                stroke="#222"
+                strokeLinecap="square"
+                strokeWidth={1}
+                x1={0}
+                x2={-8}
+                y1={61.900000000000006}
+                y2={61.900000000000006}
+              />
+              <svg
+                fontSize={10}
+                style={
+                  {
+                    "overflow": "visible",
+                  }
+                }
+                x="-0.25em"
+                y="0.25em"
+              >
+                <text
+                  fill="#000"
+                  fontSize={10}
+                  textAnchor="end"
+                  transform=""
+                  x={-8}
+                  y={61.900000000000006}
+                >
+                  <tspan
+                    dy="0em"
+                    x={-8}
+                  >
+                    0.7
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              className="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                className="visx-line"
+                fill="transparent"
+                shapeRendering="crispEdges"
+                stroke="#222"
+                strokeLinecap="square"
+                strokeWidth={1}
+                x1={0}
+                x2={-8}
+                y1={43.599999999999994}
+                y2={43.599999999999994}
+              />
+              <svg
+                fontSize={10}
+                style={
+                  {
+                    "overflow": "visible",
+                  }
+                }
+                x="-0.25em"
+                y="0.25em"
+              >
+                <text
+                  fill="#000"
+                  fontSize={10}
+                  textAnchor="end"
+                  transform=""
+                  x={-8}
+                  y={43.599999999999994}
+                >
+                  <tspan
+                    dy="0em"
+                    x={-8}
+                  >
+                    0.8
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              className="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                className="visx-line"
+                fill="transparent"
+                shapeRendering="crispEdges"
+                stroke="#222"
+                strokeLinecap="square"
+                strokeWidth={1}
+                x1={0}
+                x2={-8}
+                y1={25.299999999999997}
+                y2={25.299999999999997}
+              />
+              <svg
+                fontSize={10}
+                style={
+                  {
+                    "overflow": "visible",
+                  }
+                }
+                x="-0.25em"
+                y="0.25em"
+              >
+                <text
+                  fill="#000"
+                  fontSize={10}
+                  textAnchor="end"
+                  transform=""
+                  x={-8}
+                  y={25.299999999999997}
+                >
+                  <tspan
+                    dy="0em"
+                    x={-8}
+                  >
+                    0.9
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              className="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                className="visx-line"
+                fill="transparent"
+                shapeRendering="crispEdges"
+                stroke="#222"
+                strokeLinecap="square"
+                strokeWidth={1}
+                x1={0}
+                x2={-8}
+                y1={7}
+                y2={7}
+              />
+              <svg
+                fontSize={10}
+                style={
+                  {
+                    "overflow": "visible",
+                  }
+                }
+                x="-0.25em"
+                y="0.25em"
+              >
+                <text
+                  fill="#000"
+                  fontSize={10}
+                  textAnchor="end"
+                  transform=""
+                  x={-8}
+                  y={7}
+                >
+                  <tspan
+                    dy="0em"
+                    x={-8}
+                  >
+                    1.0
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <line
+              className="visx-line visx-axis-line"
+              fill="transparent"
+              shapeRendering="crispEdges"
+              stroke="#333"
+              strokeWidth={1}
+              x1={0}
+              x2={0}
+              y1={190.5}
+              y2={7.5}
+            />
+          </g>
+          <g
+            transform="translate(60,0)"
+          >
+            <g />
+            <line
+              stroke="#333"
+              x1={0}
+              x2={1440}
+              y1={190}
+              y2={190}
+            />
+          </g>
+        </svg>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`CoverageTrack has no unexpected changes with AN datasets 1`] = `
+<div
+  className="sc-ggWZvA faMivF"
+>
+  <div
+    className="sc-jwTyAe cTLZpt"
+    style={
+      {
+        "marginLeft": 100,
+        "marginRight": 160,
+        "width": 1440,
+      }
+    }
+  >
+    <div
+      className="CoverageTrack__TopPanel-sc-1kumbsx-0 cLbDZX"
+    >
+      <ul
+        className="CoverageTrack__LegendWrapper-sc-1kumbsx-1 jLTtQ"
+      >
+        <li
+          className="CoverageTrack__LegendItem-sc-1kumbsx-2 iyLhwF"
+        >
+          <span
+            className="CoverageTrack__LegendSwatch-sc-1kumbsx-3 oLsXH"
+            color="green"
+          />
+          genome
+        </li>
+      </ul>
+      <label
+        htmlFor="coverage-metric"
+      >
+        Metric:
+         
+        <select
+          className="Select-sc-1lkyg9e-0 iPbHsk"
+          id="coverage-metric"
+          onChange={[Function]}
+          value="an_percent"
+        >
+          <optgroup
+            label="Per-base depth of coverage"
+          >
+            <option
+              value="mean"
+            >
+              Mean
+            </option>
+            <option
+              value="median"
+            >
+              Median
+            </option>
+          </optgroup>
+          <optgroup
+            label="Allele number"
+          >
+            <option
+              value="an_percent"
+            >
+              Callrate
+            </option>
+            <option
+              value="an"
+            >
+              Allele number (AN)
+            </option>
+          </optgroup>
+        </select>
+      </label>
+      <button
+        backgroundColor="#f8f9fa"
+        borderColor="#6c757d"
+        className="Button__BaseButton-sc-1eobygi-0 Button-sc-1eobygi-1 VaScf"
+        onClick={[Function]}
+        style={
+          {
+            "marginLeft": "1em",
+          }
+        }
+        type="button"
+      >
+        Save plot
+      </button>
+    </div>
+  </div>
+  <div
+    className="sc-dTvVRJ ejoLSV"
+  >
+    <div
+      className="sc-hjsuWn ccbdKG"
+      style={
+        {
+          "width": 100,
+        }
+      }
+    >
+      <div
+        className="CoverageTrack__TitlePanel-sc-1kumbsx-4 kxMCgi"
+      >
+        Callrate (Allele Number %)
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+          >
+            More information
+          </span>
+        </button>
+      </div>
+    </div>
+    <div
+      className="sc-jJLAfE KfhrV"
+      style={
+        {
+          "width": 1440,
+        }
+      }
+    >
+      <div
+        style={
+          {
+            "marginLeft": -60,
+          }
+        }
+      >
+        <svg
+          height={190}
+          width={1500}
+        >
+          <g
+            className="visx-group visx-axis visx-axis-left"
+            transform="translate(60, 0)"
+          >
+            <g
+              className="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                className="visx-line"
+                fill="transparent"
+                shapeRendering="crispEdges"
+                stroke="#222"
+                strokeLinecap="square"
+                strokeWidth={1}
+                x1={0}
+                x2={-8}
+                y1={171.7}
+                y2={171.7}
+              />
+              <svg
+                fontSize={10}
+                style={
+                  {
+                    "overflow": "visible",
+                  }
+                }
+                x="-0.25em"
+                y="0.25em"
+              >
+                <text
+                  fill="#000"
+                  fontSize={10}
+                  textAnchor="end"
+                  transform=""
+                  x={-8}
+                  y={171.7}
+                >
+                  <tspan
+                    dy="0em"
+                    x={-8}
+                  >
+                    10%
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              className="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                className="visx-line"
+                fill="transparent"
+                shapeRendering="crispEdges"
+                stroke="#222"
+                strokeLinecap="square"
+                strokeWidth={1}
+                x1={0}
+                x2={-8}
+                y1={153.4}
+                y2={153.4}
+              />
+              <svg
+                fontSize={10}
+                style={
+                  {
+                    "overflow": "visible",
+                  }
+                }
+                x="-0.25em"
+                y="0.25em"
+              >
+                <text
+                  fill="#000"
+                  fontSize={10}
+                  textAnchor="end"
+                  transform=""
+                  x={-8}
+                  y={153.4}
+                >
+                  <tspan
+                    dy="0em"
+                    x={-8}
+                  >
+                    20%
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              className="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                className="visx-line"
+                fill="transparent"
+                shapeRendering="crispEdges"
+                stroke="#222"
+                strokeLinecap="square"
+                strokeWidth={1}
+                x1={0}
+                x2={-8}
+                y1={135.1}
+                y2={135.1}
+              />
+              <svg
+                fontSize={10}
+                style={
+                  {
+                    "overflow": "visible",
+                  }
+                }
+                x="-0.25em"
+                y="0.25em"
+              >
+                <text
+                  fill="#000"
+                  fontSize={10}
+                  textAnchor="end"
+                  transform=""
+                  x={-8}
+                  y={135.1}
+                >
+                  <tspan
+                    dy="0em"
+                    x={-8}
+                  >
+                    30%
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              className="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                className="visx-line"
+                fill="transparent"
+                shapeRendering="crispEdges"
+                stroke="#222"
+                strokeLinecap="square"
+                strokeWidth={1}
+                x1={0}
+                x2={-8}
+                y1={116.8}
+                y2={116.8}
+              />
+              <svg
+                fontSize={10}
+                style={
+                  {
+                    "overflow": "visible",
+                  }
+                }
+                x="-0.25em"
+                y="0.25em"
+              >
+                <text
+                  fill="#000"
+                  fontSize={10}
+                  textAnchor="end"
+                  transform=""
+                  x={-8}
+                  y={116.8}
+                >
+                  <tspan
+                    dy="0em"
+                    x={-8}
+                  >
+                    40%
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              className="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                className="visx-line"
+                fill="transparent"
+                shapeRendering="crispEdges"
+                stroke="#222"
+                strokeLinecap="square"
+                strokeWidth={1}
+                x1={0}
+                x2={-8}
+                y1={98.5}
+                y2={98.5}
+              />
+              <svg
+                fontSize={10}
+                style={
+                  {
+                    "overflow": "visible",
+                  }
+                }
+                x="-0.25em"
+                y="0.25em"
+              >
+                <text
+                  fill="#000"
+                  fontSize={10}
+                  textAnchor="end"
+                  transform=""
+                  x={-8}
+                  y={98.5}
+                >
+                  <tspan
+                    dy="0em"
+                    x={-8}
+                  >
+                    50%
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              className="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                className="visx-line"
+                fill="transparent"
+                shapeRendering="crispEdges"
+                stroke="#222"
+                strokeLinecap="square"
+                strokeWidth={1}
+                x1={0}
+                x2={-8}
+                y1={80.2}
+                y2={80.2}
+              />
+              <svg
+                fontSize={10}
+                style={
+                  {
+                    "overflow": "visible",
+                  }
+                }
+                x="-0.25em"
+                y="0.25em"
+              >
+                <text
+                  fill="#000"
+                  fontSize={10}
+                  textAnchor="end"
+                  transform=""
+                  x={-8}
+                  y={80.2}
+                >
+                  <tspan
+                    dy="0em"
+                    x={-8}
+                  >
+                    60%
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              className="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                className="visx-line"
+                fill="transparent"
+                shapeRendering="crispEdges"
+                stroke="#222"
+                strokeLinecap="square"
+                strokeWidth={1}
+                x1={0}
+                x2={-8}
+                y1={61.900000000000006}
+                y2={61.900000000000006}
+              />
+              <svg
+                fontSize={10}
+                style={
+                  {
+                    "overflow": "visible",
+                  }
+                }
+                x="-0.25em"
+                y="0.25em"
+              >
+                <text
+                  fill="#000"
+                  fontSize={10}
+                  textAnchor="end"
+                  transform=""
+                  x={-8}
+                  y={61.900000000000006}
+                >
+                  <tspan
+                    dy="0em"
+                    x={-8}
+                  >
+                    70%
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              className="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                className="visx-line"
+                fill="transparent"
+                shapeRendering="crispEdges"
+                stroke="#222"
+                strokeLinecap="square"
+                strokeWidth={1}
+                x1={0}
+                x2={-8}
+                y1={43.599999999999994}
+                y2={43.599999999999994}
+              />
+              <svg
+                fontSize={10}
+                style={
+                  {
+                    "overflow": "visible",
+                  }
+                }
+                x="-0.25em"
+                y="0.25em"
+              >
+                <text
+                  fill="#000"
+                  fontSize={10}
+                  textAnchor="end"
+                  transform=""
+                  x={-8}
+                  y={43.599999999999994}
+                >
+                  <tspan
+                    dy="0em"
+                    x={-8}
+                  >
+                    80%
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              className="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                className="visx-line"
+                fill="transparent"
+                shapeRendering="crispEdges"
+                stroke="#222"
+                strokeLinecap="square"
+                strokeWidth={1}
+                x1={0}
+                x2={-8}
+                y1={25.299999999999997}
+                y2={25.299999999999997}
+              />
+              <svg
+                fontSize={10}
+                style={
+                  {
+                    "overflow": "visible",
+                  }
+                }
+                x="-0.25em"
+                y="0.25em"
+              >
+                <text
+                  fill="#000"
+                  fontSize={10}
+                  textAnchor="end"
+                  transform=""
+                  x={-8}
+                  y={25.299999999999997}
+                >
+                  <tspan
+                    dy="0em"
+                    x={-8}
+                  >
+                    90%
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              className="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                className="visx-line"
+                fill="transparent"
+                shapeRendering="crispEdges"
+                stroke="#222"
+                strokeLinecap="square"
+                strokeWidth={1}
+                x1={0}
+                x2={-8}
+                y1={7}
+                y2={7}
+              />
+              <svg
+                fontSize={10}
+                style={
+                  {
+                    "overflow": "visible",
+                  }
+                }
+                x="-0.25em"
+                y="0.25em"
+              >
+                <text
+                  fill="#000"
+                  fontSize={10}
+                  textAnchor="end"
+                  transform=""
+                  x={-8}
+                  y={7}
+                >
+                  <tspan
+                    dy="0em"
+                    x={-8}
+                  >
+                    100%
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <line
+              className="visx-line visx-axis-line"
+              fill="transparent"
+              shapeRendering="crispEdges"
+              stroke="#333"
+              strokeWidth={1}
+              x1={0}
+              x2={0}
+              y1={190.5}
+              y2={7.5}
+            />
+          </g>
+          <g
+            transform="translate(60,0)"
+          >
+            <g />
+            <line
+              stroke="#333"
+              x1={0}
+              x2={1440}
+              y1={190}
+              y2={190}
+            />
+          </g>
+        </svg>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/browser/src/coverageStyles.ts
+++ b/browser/src/coverageStyles.ts
@@ -1,3 +1,17 @@
+/**
+ * Shared exome/genome series appearance.
+ *
+ * The AN configs and the coverage configs draw the same two data types, so they
+ * must not drift apart: a reader switching metrics should see the same exome
+ * blue and genome green at the same weights. Kept here rather than inlined so
+ * there is one place to change them.
+ */
+const EXOME_COLOR = 'rgb(70, 130, 180)'
+const GENOME_COLOR = 'rgb(115, 171, 61)'
+// Exome sits on top of genome and is the narrower series, so it is the more opaque.
+const EXOME_OPACITY = 0.7
+const GENOME_OPACITY = 0.5
+
 export const coverageConfigClassic = (exomeCoverage: any, genomeCoverage: any) => {
   const coverage = []
   if (exomeCoverage) {
@@ -17,22 +31,52 @@ export const coverageConfigClassic = (exomeCoverage: any, genomeCoverage: any) =
   return coverage
 }
 
+/**
+ * Dataset config for the allele-number metrics.
+ *
+ * Deliberately reuses the exome-blue / genome-green pairing of the coverage
+ * configs below: on a gene page the AN metrics are an alternate view of the
+ * same two data types, so recoloring them would imply they are different
+ * series. Genome AN is drawn under exome AN (exome AN exists only over the
+ * capture target, so it reads as islands on top of a continuous genome track).
+ */
+export const anConfig = (exomeAN: any, genomeAN: any) => {
+  const an = []
+  if (genomeAN) {
+    an.push({
+      color: GENOME_COLOR,
+      buckets: genomeAN,
+      name: 'genome',
+      opacity: GENOME_OPACITY,
+    })
+  }
+  if (exomeAN) {
+    an.push({
+      color: EXOME_COLOR,
+      buckets: exomeAN,
+      name: 'exome',
+      opacity: EXOME_OPACITY,
+    })
+  }
+  return an
+}
+
 export const coverageConfigNew = (exomeCoverage: any, genomeCoverage: any) => {
   const coverage = []
   if (exomeCoverage) {
     coverage.push({
-      color: 'rgb(70, 130, 180)',
+      color: EXOME_COLOR,
       buckets: exomeCoverage,
       name: 'exome',
-      opacity: 0.7,
+      opacity: EXOME_OPACITY,
     })
   }
   if (genomeCoverage) {
     coverage.push({
-      color: 'rgb(115, 171, 61)',
+      color: GENOME_COLOR,
       buckets: genomeCoverage,
       name: 'genome',
-      opacity: 0.5,
+      opacity: GENOME_OPACITY,
     })
   }
   return coverage

--- a/data-pipeline/src/data_pipeline/data_types/allele_number.py
+++ b/data-pipeline/src/data_pipeline/data_types/allele_number.py
@@ -1,0 +1,88 @@
+from typing import Dict, List, Optional
+
+import hail as hl
+
+from data_pipeline.data_types.locus import x_position
+
+
+def _stratum_index(strata_meta: List[Dict[str, str]], keys: Dict[str, str]) -> int:
+    """Index into the AN array of the stratum described exactly by ``keys``.
+
+    ``AN`` is an array parallel to the ``strata_meta`` / ``strata_sample_count``
+    globals, so a stratum is addressed by position. Matching on equality rather
+    than a subset is deliberate: ``{"group": "adj"}`` is a prefix of every
+    ancestry- and sex-stratified entry, so a subset match would pick the first of
+    hundreds.
+    """
+    matches = [index for index, meta in enumerate(strata_meta) if meta == keys]
+    if len(matches) != 1:
+        raise ValueError(f"Expected exactly one stratum matching {keys}, found {len(matches)}")
+    return matches[0]
+
+
+def prepare_allele_number(allele_number_path: str, filter_intervals: Optional[List[str]] = None):
+    """Prepare an all-sites allele number table for the browser's AN track.
+
+    Emits, per base, the allele number and the percentage of the attainable
+    allele number that represents. AN% is what makes the track comparable across
+    data types and releases -- raw AN scales with sample count, so an exome and a
+    genome series drawn on one axis are not otherwise on the same footing.
+    """
+    ht = hl.read_table(allele_number_path)
+
+    strata = hl.eval(hl.struct(meta=ht.strata_meta, counts=ht.strata_sample_count))
+    strata_meta = [dict(meta) for meta in strata.meta]
+
+    # adj, not raw. A call contributes to AN only when GQ >= 20, DP >= 10 and,
+    # for heterozygous calls, allele balance >= 0.2 -- the thresholds gnomAD
+    # applies when reporting allele counts, so the track agrees with the variant
+    # tables. (In v5, All of Us hom-ref calls carry no DP and are published only
+    # at GQ >= 20, so every hom-ref call is adj; variant sites use the full rule.)
+    global_index = _stratum_index(strata_meta, {"group": "adj"})
+    xx_index = _stratum_index(strata_meta, {"group": "adj", "sex": "XX"})
+    xy_index = _stratum_index(strata_meta, {"group": "adj", "sex": "XY"})
+
+    n_total = strata.counts[global_index]
+    n_xx = strata.counts[xx_index]
+    n_xy = strata.counts[xy_index]
+
+    # The sex strata partition the callset, so this is an identity, not a
+    # tolerance check. If it ever fails the denominators below are wrong.
+    if n_xx + n_xy != n_total:
+        raise ValueError(
+            f"XX ({n_xx:,}) + XY ({n_xy:,}) != total ({n_total:,}); "
+            "the ploidy-aware denominator needs both karyotype counts"
+        )
+
+    # Attainable AN depends on ploidy, so it is not a flat 2N: on chrX outside the
+    # pseudoautosomal regions XY samples are haploid, and on chrY only XY samples
+    # contribute at all. Autosomes and chrX PAR fall through to 2N.
+    max_an = (
+        hl.case()
+        .when(ht.locus.in_x_nonpar(), 2 * n_xx + n_xy)
+        .when(ht.locus.in_y_nonpar(), n_xy)
+        # chrY PAR is masked in the release tables (PAR calls are assigned to
+        # chrX), so this branch matches no rows today. It is here so that the
+        # expression is total rather than silently falling through to 2N, which
+        # would be wrong by a factor of ~2 if those rows ever appear.
+        .when(ht.locus.in_y_par(), 2 * n_xy)
+        .default(2 * n_total)
+    )
+
+    an = ht.AN[global_index]
+
+    ht = ht.select(
+        xpos=x_position(ht.locus),
+        an=an,
+        # Guarded because chrY denominators are zero in an all-XX callset.
+        an_percent=hl.if_else(max_an > 0, 100 * an / max_an, hl.missing(hl.tfloat64)),
+    )
+
+    # The strata globals describe hundreds of strata this table no longer carries.
+    ht = ht.select_globals()
+
+    if filter_intervals:
+        intervals = [hl.parse_locus_interval(interval, reference_genome="GRCh38") for interval in filter_intervals]
+        ht = hl.filter_intervals(ht, intervals)
+
+    return ht

--- a/data-pipeline/src/data_pipeline/helpers/datasets_config.py
+++ b/data-pipeline/src/data_pipeline/helpers/datasets_config.py
@@ -27,6 +27,7 @@ from data_pipeline.pipelines.gnomad_v3_mitochondrial_coverage import (
 from data_pipeline.pipelines.gnomad_v3_short_tandem_repeats import pipeline as gnomad_v3_short_tandem_repeats_pipeline
 from data_pipeline.pipelines.gnomad_v4_variants import pipeline as gnomad_v4_variants_pipeline
 from data_pipeline.pipelines.gnomad_v4_coverage import pipeline as gnomad_v4_coverage_pipeline
+from data_pipeline.pipelines.gnomad_v4_allele_number import pipeline as gnomad_v4_allele_number_pipeline
 from data_pipeline.pipelines.gnomad_v4_cnvs import pipeline as gnomad_v4_cnvs_pipeline
 from data_pipeline.pipelines.gnomad_v4_lof_curation_results import pipeline as gnomad_v4_lof_curation_results_pipeline
 from data_pipeline.data_types.variant import compressed_variant_id
@@ -132,6 +133,28 @@ DATASETS_CONFIG = {
     #     ),
     #     "args": {"index": "gnomad_v4_genome_coverage", "id_field": "xpos", "num_shards": 2, "block_size": 10_000},
     # },
+    "gnomad_v4_exome_allele_number": {
+        "get_table": lambda: subset_table(
+            hl.read_table(gnomad_v4_allele_number_pipeline.get_output("exome_allele_number").get_output_path())
+        ),
+        "args": {
+            "index": "gnomad_v4_exome_allele_number",
+            "id_field": "xpos",
+            "num_shards": 48,
+            "block_size": 10_000,
+        },
+    },
+    "gnomad_v4_genome_allele_number": {
+        "get_table": lambda: subset_table(
+            hl.read_table(gnomad_v4_allele_number_pipeline.get_output("genome_allele_number").get_output_path())
+        ),
+        "args": {
+            "index": "gnomad_v4_genome_allele_number",
+            "id_field": "xpos",
+            "num_shards": 48,
+            "block_size": 10_000,
+        },
+    },
     "gnomad_v4_lof_curation_results": {
         "get_table": lambda: add_variant_document_id(
             hl.read_table(gnomad_v4_lof_curation_results_pipeline.get_output("lof_curation_results").get_output_path())

--- a/data-pipeline/src/data_pipeline/pipelines/gnomad_v4_allele_number.py
+++ b/data-pipeline/src/data_pipeline/pipelines/gnomad_v4_allele_number.py
@@ -1,0 +1,45 @@
+from data_pipeline.pipeline import Pipeline, run_pipeline
+
+from data_pipeline.data_types.allele_number import prepare_allele_number
+
+output_sub_dir = "gnomad_v4_allele_number"
+
+pipeline = Pipeline()
+
+pipeline.add_task(
+    name="prepare_gnomad_v4_exome_allele_number",
+    task_function=prepare_allele_number,
+    output_path=f"/{output_sub_dir}/gnomad_v4_exome_allele_number.ht",
+    inputs={
+        "allele_number_path": "gs://gcp-public-data--gnomad/release/4.1/ht/exomes/gnomad.exomes.v4.1.allele_number_all_sites.ht",
+    },
+)
+
+pipeline.add_task(
+    name="prepare_gnomad_v4_genome_allele_number",
+    task_function=prepare_allele_number,
+    output_path=f"/{output_sub_dir}/gnomad_v4_genome_allele_number.ht",
+    # Unlike genome coverage -- which v4 inherits from v3.0.1 -- allele number is
+    # published for v4.1 genomes directly (N=76,215).
+    inputs={
+        "allele_number_path": "gs://gcp-public-data--gnomad/release/4.1/ht/genomes/gnomad.genomes.v4.1.allele_number_all_sites.ht",
+    },
+)
+
+###############################################
+# Outputs
+###############################################
+
+pipeline.set_outputs(
+    {
+        "exome_allele_number": "prepare_gnomad_v4_exome_allele_number",
+        "genome_allele_number": "prepare_gnomad_v4_genome_allele_number",
+    }
+)
+
+###############################################
+# Run
+###############################################
+
+if __name__ == "__main__":
+    run_pipeline(pipeline)

--- a/graphql-api/src/graphql/resolvers/allele-number.ts
+++ b/graphql-api/src/graphql/resolvers/allele-number.ts
@@ -1,0 +1,44 @@
+import { UserVisibleError } from '../../errors'
+import {
+  fetchExomeAlleleNumberForRegion,
+  fetchGenomeAlleleNumberForRegion,
+  fetchAlleleNumberForGene,
+  fetchAlleleNumberForTranscript,
+} from '../../queries/allele-number-queries'
+
+const resolveExomeAlleleNumberInRegion = (obj: any, _args: any, ctx: any) =>
+  fetchExomeAlleleNumberForRegion(ctx.esClient, obj.dataset, obj)
+
+const resolveGenomeAlleleNumberInRegion = (obj: any, _args: any, ctx: any) =>
+  fetchGenomeAlleleNumberForRegion(ctx.esClient, obj.dataset, obj)
+
+const resolveAlleleNumberInGene = (obj: any, args: any, ctx: any) =>
+  fetchAlleleNumberForGene(ctx.esClient, args.dataset, obj)
+
+const resolveAlleleNumberInTranscript = (obj: any, args: any, ctx: any) =>
+  fetchAlleleNumberForTranscript(ctx.esClient, args.dataset, obj)
+
+const resolvers = {
+  Region: {
+    allele_number: (obj: any, args: any) => {
+      if (obj.stop - obj.start >= 2.5e6) {
+        throw new UserVisibleError('Allele number is not available for a region this large')
+      }
+
+      // Forward region and dataset argument to exome/genome allele number resolvers.
+      return { ...obj, dataset: args.dataset }
+    },
+  },
+  RegionAlleleNumber: {
+    exome: resolveExomeAlleleNumberInRegion,
+    genome: resolveGenomeAlleleNumberInRegion,
+  },
+  Gene: {
+    allele_number: resolveAlleleNumberInGene,
+  },
+  Transcript: {
+    allele_number: resolveAlleleNumberInTranscript,
+  },
+}
+
+export default resolvers

--- a/graphql-api/src/graphql/schema.ts
+++ b/graphql-api/src/graphql/schema.ts
@@ -4,6 +4,7 @@ import { mergeTypeDefs, mergeResolvers } from '@graphql-tools/merge'
 import { makeExecutableSchema } from '@graphql-tools/schema'
 
 import aliasResolvers from './resolvers/aliases'
+import alleleNumberResolvers from './resolvers/allele-number'
 import browserMetadataResolvers from './resolvers/browser-metadata'
 import clinVarVariantResolvers from './resolvers/clinvar-variants'
 import clinVarVariantFieldResolvers from './resolvers/clinvar-variant-fields'
@@ -33,6 +34,7 @@ const typeDefs = mergeTypeDefs([
 
 const resolvers = mergeResolvers([
   aliasResolvers,
+  alleleNumberResolvers,
   browserMetadataResolvers,
   clinVarVariantResolvers,
   clinVarVariantFieldResolvers,

--- a/graphql-api/src/graphql/types/allele-number.graphql
+++ b/graphql-api/src/graphql/types/allele-number.graphql
@@ -1,0 +1,10 @@
+type AlleleNumberBin {
+  pos: Int!
+  an: Float
+  an_percent: Float
+}
+
+type FeatureAlleleNumber {
+  exome: [AlleleNumberBin!]!
+  genome: [AlleleNumberBin!]!
+}

--- a/graphql-api/src/graphql/types/gene.graphql
+++ b/graphql-api/src/graphql/types/gene.graphql
@@ -79,6 +79,7 @@ type Gene {
   clinvar_variants: [ClinVarVariant!] @cost(value: 10)
 
   coverage(dataset: DatasetId): FeatureCoverage! @cost(value: 5)
+  allele_number(dataset: DatasetId): FeatureAlleleNumber! @cost(value: 5)
   mitochondrial_coverage(dataset: DatasetId!): [MitochondrialCoverageBin!] @cost(value: 5)
   cnv_track_callable_coverage(dataset: CopyNumberVariantDatasetId!): [CNVTrackCallableCoverageBin!]
     @cost(value: 5)

--- a/graphql-api/src/graphql/types/region.graphql
+++ b/graphql-api/src/graphql/types/region.graphql
@@ -19,6 +19,11 @@ type RegionCoverage {
   genome: [CoverageBin!]! @cost(value: 5)
 }
 
+type RegionAlleleNumber {
+  exome: [AlleleNumberBin!]! @cost(value: 5)
+  genome: [AlleleNumberBin!]! @cost(value: 5)
+}
+
 type Region {
   reference_genome: ReferenceGenomeId!
   chrom: String!
@@ -36,6 +41,7 @@ type Region {
   clinvar_variants: [ClinVarVariant!] @cost(value: 10)
 
   coverage(dataset: DatasetId!): RegionCoverage!
+  allele_number(dataset: DatasetId!): RegionAlleleNumber!
   mitochondrial_coverage(dataset: DatasetId!): [MitochondrialCoverageBin!] @cost(value: 5)
 
   short_tandem_repeats(dataset: DatasetId!): [ShortTandemRepeat!]! @cost(value: 5)

--- a/graphql-api/src/graphql/types/transcript.graphql
+++ b/graphql-api/src/graphql/types/transcript.graphql
@@ -49,5 +49,6 @@ type Transcript {
   clinvar_variants: [ClinVarVariant!] @cost(value: 10)
 
   coverage(dataset: DatasetId): FeatureCoverage! @cost(value: 5)
+  allele_number(dataset: DatasetId): FeatureAlleleNumber! @cost(value: 5)
   mitochondrial_coverage(dataset: DatasetId!): [MitochondrialCoverageBin!] @cost(value: 5)
 }

--- a/graphql-api/src/queries/allele-number-queries.spec.ts
+++ b/graphql-api/src/queries/allele-number-queries.spec.ts
@@ -1,0 +1,109 @@
+import { jest, describe, expect, test } from '@jest/globals'
+
+// The module under test imports withCache, which pulls in config.ts and its
+// required ELASTICSEARCH_URL. The tests exercise the uncached `_fetch*` export, so
+// the cache is stubbed rather than adding a jest setup file that fakes API config
+// for every graphql-api suite.
+jest.mock('../cache', () => ({
+  withCache: (fn: any) => fn,
+}))
+
+// eslint-disable-next-line import/first
+import { _fetchAlleleNumberForGene } from './allele-number-queries'
+
+const gene = {
+  gene_id: 'ENSG00000169174',
+  reference_genome: 'GRCh38',
+  chrom: '1',
+  exons: [{ start: 55039447, stop: 55039747, feature_type: 'CDS' }],
+}
+
+/** Records the searches it is asked to run and replays canned aggregation buckets. */
+const stubEsClient = (bucketsByIndex: { [index: string]: any[] }) => {
+  const searches: any[] = []
+  return {
+    searches,
+    client: {
+      search: async (params: any) => {
+        searches.push(params)
+        return {
+          body: {
+            aggregations: {
+              allele_number: { buckets: bucketsByIndex[params.index] ?? [] },
+            },
+          },
+        }
+      },
+    },
+  }
+}
+
+const bucket = (key: number, an: number | null, anPercent: number | null) => ({
+  key,
+  an: { value: an },
+  an_percent: { value: anPercent },
+})
+
+describe('fetchAlleleNumberForGene', () => {
+  test('queries the v4 exome and genome indices', async () => {
+    const { searches, client } = stubEsClient({})
+    await _fetchAlleleNumberForGene(client, 'gnomad_r4', gene)
+
+    expect(searches.map((s) => s.index)).toEqual([
+      'gnomad_v4_exome_allele_number',
+      'gnomad_v4_genome_allele_number',
+    ])
+    // GRCh38 datasets are indexed with a chr prefix.
+    expect(searches[0].body.query.bool.filter[0]).toEqual({ term: { 'locus.contig': 'chr1' } })
+  })
+
+  test('returns empty series for a dataset with no allele number index', async () => {
+    const { searches, client } = stubEsClient({})
+    // v2 and ExAC have no AN release. Returning empty rather than throwing is what
+    // lets the browser hide the AN metrics instead of failing the whole page.
+    const results = await Promise.all(
+      (['gnomad_r2_1', 'exac', 'gnomad_r3'] as const).map((datasetId) =>
+        _fetchAlleleNumberForGene(client, datasetId, {
+          ...gene,
+          reference_genome: datasetId === 'gnomad_r3' ? 'GRCh38' : 'GRCh37',
+        })
+      )
+    )
+    results.forEach((result) => expect(result).toEqual({ exome: [], genome: [] }))
+    expect(searches).toHaveLength(0)
+  })
+
+  test('rounds AN to a whole count and AN% to three decimals', async () => {
+    const { client } = stubEsClient({
+      gnomad_v4_exome_allele_number: [bucket(55039447, 1460123.6, 99.87654321)],
+      gnomad_v4_genome_allele_number: [bucket(55039447, 152345.2, 99.9191919)],
+    })
+    const result = await _fetchAlleleNumberForGene(client, 'gnomad_r4', gene)
+
+    // AN is a count of alleles, so a fractional bucket average is not meaningful.
+    expect(result.exome).toEqual([{ pos: 55039447, an: 1460124, an_percent: 99.877 }])
+    expect(result.genome).toEqual([{ pos: 55039447, an: 152345, an_percent: 99.919 }])
+  })
+
+  test('preserves nulls instead of coercing them to zero', async () => {
+    const { client } = stubEsClient({
+      gnomad_v4_exome_allele_number: [bucket(55039447, null, null)],
+    })
+    const result = await _fetchAlleleNumberForGene(client, 'gnomad_r4', gene)
+
+    // A bucket with no documents is not the same as a bucket where nobody was
+    // called. Zero would draw a callability cliff that is not in the data -- the
+    // coverage track's `|| 0` has exactly that failure mode.
+    expect(result.exome).toEqual([{ pos: 55039447, an: null, an_percent: null }])
+  })
+
+  test('rejects subsets, which have no allele number release', async () => {
+    const { client } = stubEsClient({})
+    await expect(
+      _fetchAlleleNumberForGene(client, 'gnomad_r2_1_controls', {
+        ...gene,
+        reference_genome: 'GRCh37',
+      })
+    ).rejects.toThrow('Allele number is not available for subsets')
+  })
+})

--- a/graphql-api/src/queries/allele-number-queries.ts
+++ b/graphql-api/src/queries/allele-number-queries.ts
@@ -1,0 +1,221 @@
+import { withCache } from '../cache'
+import { UserVisibleError } from '../errors'
+
+import { extendRegions, mergeOverlappingRegions, totalRegionSize } from './helpers/region-helpers'
+
+import { assertDatasetAndReferenceGenomeMatch } from './helpers/validation-helpers'
+
+// Allele number is published for v4.1 exomes and v4.1 genomes. Note the genome
+// index is genuinely v4.1, unlike genome coverage, which v4 inherits from v3.0.1.
+// Datasets absent from this map have no AN track; the browser hides the metrics
+// rather than drawing an empty series.
+const ALLELE_NUMBER_INDICES = {
+  gnomad_r4: {
+    exome: 'gnomad_v4_exome_allele_number',
+    genome: 'gnomad_v4_genome_allele_number',
+  },
+}
+
+const indicesForDataset = (datasetId: string) =>
+  // @ts-expect-error TS(7053) datasetId is a union wider than this map's keys.
+  ALLELE_NUMBER_INDICES[datasetId] || { exome: null, genome: null }
+
+// ================================================================================================
+// Base query
+// ================================================================================================
+
+const fetchAlleleNumber = async (esClient: any, { index, contig, regions, bucketSize }: any) => {
+  try {
+    const response = await esClient.search({
+      index,
+      type: '_doc',
+      size: 0,
+      body: {
+        query: {
+          bool: {
+            filter: [
+              { term: { 'locus.contig': contig } },
+              {
+                bool: {
+                  should: regions.map(({ start, stop }: any) => ({
+                    range: { 'locus.position': { gte: start, lte: stop } },
+                  })),
+                },
+              },
+            ],
+          },
+        },
+        aggregations: {
+          allele_number: {
+            histogram: {
+              field: 'locus.position',
+              interval: bucketSize,
+            },
+            aggregations: {
+              an: { avg: { field: 'an' } },
+              an_percent: { avg: { field: 'an_percent' } },
+            },
+          },
+        },
+      },
+    })
+
+    return response.body.aggregations.allele_number.buckets.map((bucket: any) => ({
+      pos: bucket.key,
+      // Averaging the per-base percentage rather than recomputing it from summed
+      // AN is exact wherever the attainable AN is constant across the bucket,
+      // which is everywhere except the three PAR boundaries, and matches how the
+      // coverage track already aggregates its over_x fractions.
+      an: bucket.an.value === null ? null : Math.round(bucket.an.value),
+      an_percent:
+        bucket.an_percent.value === null ? null : Math.round(bucket.an_percent.value * 1000) / 1000,
+    }))
+  } catch (error) {
+    throw new Error(`Couldn't fetch allele number, ${error}`)
+  }
+}
+
+// ================================================================================================
+// Region queries
+// ================================================================================================
+
+const fetchAlleleNumberForRegion = (
+  esClient: any,
+  datasetId: any,
+  region: any,
+  sequencingType: 'exome' | 'genome'
+) => {
+  assertDatasetAndReferenceGenomeMatch(datasetId, region.reference_genome)
+
+  if (datasetId.startsWith('gnomad_r2_1_') || datasetId.startsWith('gnomad_r3_')) {
+    throw new UserVisibleError('Allele number is not available for subsets')
+  }
+
+  const index = indicesForDataset(datasetId)[sequencingType]
+
+  const regionSize = region.stop - region.start + 150
+  const bucketSize = Math.max(Math.floor(regionSize / 500), 1)
+
+  return index
+    ? fetchAlleleNumber(esClient, {
+        index,
+        contig: region.reference_genome === 'GRCh38' ? `chr${region.chrom}` : region.chrom,
+        regions: [{ start: region.start - 75, stop: region.stop + 75 }],
+        bucketSize,
+      })
+    : []
+}
+
+export const fetchExomeAlleleNumberForRegion = (esClient: any, datasetId: any, region: any) =>
+  fetchAlleleNumberForRegion(esClient, datasetId, region, 'exome')
+
+export const fetchGenomeAlleleNumberForRegion = (esClient: any, datasetId: any, region: any) =>
+  fetchAlleleNumberForRegion(esClient, datasetId, region, 'genome')
+
+// ================================================================================================
+// Gene query
+// ================================================================================================
+
+export const _fetchAlleleNumberForGene = async (esClient: any, datasetId: any, gene: any) => {
+  assertDatasetAndReferenceGenomeMatch(datasetId, gene.reference_genome)
+
+  if (datasetId.startsWith('gnomad_r2_1_') || datasetId.startsWith('gnomad_r3_')) {
+    throw new UserVisibleError('Allele number is not available for subsets')
+  }
+
+  const paddedExons = extendRegions(75, gene.exons)
+  const mergedExons = mergeOverlappingRegions(
+    paddedExons.sort((a: any, b: any) => a.start - b.start)
+  )
+  const totalIntervalSize = totalRegionSize(mergedExons)
+  const bucketSize = Math.max(Math.floor(totalIntervalSize / 500), 1)
+
+  const { exome: exomeIndex, genome: genomeIndex } = indicesForDataset(datasetId)
+  const contig = gene.reference_genome === 'GRCh38' ? `chr${gene.chrom}` : gene.chrom
+
+  const exomeAlleleNumber = exomeIndex
+    ? await fetchAlleleNumber(esClient, {
+        index: exomeIndex,
+        contig,
+        regions: mergedExons,
+        bucketSize,
+      })
+    : []
+
+  const genomeAlleleNumber = genomeIndex
+    ? await fetchAlleleNumber(esClient, {
+        index: genomeIndex,
+        contig,
+        regions: mergedExons,
+        bucketSize,
+      })
+    : []
+
+  return {
+    exome: exomeAlleleNumber,
+    genome: genomeAlleleNumber,
+  }
+}
+
+export const fetchAlleleNumberForGene = withCache(
+  _fetchAlleleNumberForGene,
+  (_: any, datasetId: any, gene: any) => `allele_number:${datasetId}:gene:${gene.gene_id}`,
+  { expiration: 604800 }
+)
+
+// ================================================================================================
+// Transcript query
+// ================================================================================================
+
+export const _fetchAlleleNumberForTranscript = async (
+  esClient: any,
+  datasetId: any,
+  transcript: any
+) => {
+  assertDatasetAndReferenceGenomeMatch(datasetId, transcript.reference_genome)
+
+  if (datasetId.startsWith('gnomad_r2_1_') || datasetId.startsWith('gnomad_r3_')) {
+    throw new UserVisibleError('Allele number is not available for subsets')
+  }
+
+  const paddedExons = extendRegions(75, transcript.exons)
+  const mergedExons = mergeOverlappingRegions(
+    paddedExons.sort((a: any, b: any) => a.start - b.start)
+  )
+  const totalIntervalSize = totalRegionSize(mergedExons)
+  const bucketSize = Math.max(Math.floor(totalIntervalSize / 500), 1)
+
+  const { exome: exomeIndex, genome: genomeIndex } = indicesForDataset(datasetId)
+  const contig =
+    transcript.reference_genome === 'GRCh38' ? `chr${transcript.chrom}` : transcript.chrom
+
+  const exomeAlleleNumber = exomeIndex
+    ? await fetchAlleleNumber(esClient, {
+        index: exomeIndex,
+        contig,
+        regions: mergedExons,
+        bucketSize,
+      })
+    : []
+
+  const genomeAlleleNumber = genomeIndex
+    ? await fetchAlleleNumber(esClient, {
+        index: genomeIndex,
+        contig,
+        regions: mergedExons,
+        bucketSize,
+      })
+    : []
+
+  return {
+    exome: exomeAlleleNumber,
+    genome: genomeAlleleNumber,
+  }
+}
+
+export const fetchAlleleNumberForTranscript = withCache(
+  _fetchAlleleNumberForTranscript,
+  (_: any, datasetId: any, transcript: any) =>
+    `allele_number:${datasetId}:transcript:${transcript.transcript_id}`,
+  { expiration: 604800 }
+)


### PR DESCRIPTION
Adds a per-base allele number track for gnomAD v4.1 exomes and genomes, end to end: data pipeline, GraphQL API, and the gene page coverage track.

Pipeline: prepares the released v4.1 all-sites allele number tables, emitting per base the adj allele number and the percentage of the attainable allele number it represents. The denominator is ploidy-aware rather than a flat 2N: on chrX outside the pseudoautosomal regions XY samples are haploid, and on chrY only XY samples contribute. Verified against the released genome table, where the implied denominator is exact at every locus tested and no base exceeds 100%.

API: adds an `allele_number` field to Gene, Transcript and Region, resolved from the gnomad_v4_{exome,genome}_allele_number indices with the same bucketing the coverage resolver uses. Datasets with no AN release resolve to empty series rather than throwing, and bucket values keep null rather than coercing to zero. The indices do not exist yet; until the pipeline is run and loaded, the field resolves empty.

Browser: adds Callrate (AN%) and raw AN to the coverage track's metric selector, offered only when AN data is supplied. The gene page requests AN in a separate query so the browser can be deployed ahead of the API; against an API without the field, coverage renders unaffected and the AN metrics are absent. Each metric has its own help topic stating the adj criteria: GQ >= 20, DP >= 10 and, for heterozygous calls, allele balance >= 0.2; in v5, All of Us hom-ref calls carry no DP and are published only at GQ >= 20, so all hom-ref calls are counted.

Tests: CoverageTrack.spec.tsx covers metric selection, the AN axis ceiling and tick units, and that AN metrics are hidden without data. allele-number-queries.spec.ts covers index selection per dataset, empty series for datasets without AN, rounding, null preservation, and subset rejection. GenePage.spec.tsx mocks the new query. The pipeline's prepare_allele_number has no unit test; the ploidy denominator was verified by hand against the released genome table as described above.

Screenshots of new tracks
<img width="1023" height="802" alt="Screenshot 2026-09-03 at 2 25 13 PM" src="https://github.com/user-attachments/assets/97e5d7d9-4f4a-4b2f-b9f0-16244fe6bf86" />

<img width="1016" height="522" alt="Screenshot 2026-09-03 at 2 25 51 PM" src="https://github.com/user-attachments/assets/4fdef27b-989b-4d7e-8b59-dab5ea0b5d6b" />
Screenshots are from a local build using v4.1 allele number for PCSK9 generated by this pipeline. That fixture is not part of the PR.


Resolves: #1943
Assisted-by: ClaudeCode:claude-fable-5-1