### PR TITLE
Prepare v4 all-sites allele number for the browser

### DIFF
--- a/data-pipeline/src/data_pipeline/data_types/allele_number.py
+++ b/data-pipeline/src/data_pipeline/data_types/allele_number.py
@@ -1,0 +1,125 @@
+from typing import Dict, List, Optional
+
+import hail as hl
+
+from data_pipeline.data_types.locus import x_position
+
+# Classes of contig that differ in how many alleles a sample can contribute.
+# Anything not called out here is diploid in every sample: the autosomes, and
+# the pseudoautosomal regions of chrX.
+AUTOSOMAL = "autosomal"
+X_NON_PAR = "X_non_par"
+Y_NON_PAR = "Y_non_par"
+Y_PAR = "Y_par"
+MITOCHONDRIAL = "mitochondrial"
+
+
+def max_allele_number(contig_class: str, n_xx: int, n_xy: int) -> int:
+    """The allele number a site would have if every sample were called there.
+
+    This is the denominator of the call rate. It depends on ploidy: XY samples
+    are haploid outside the pseudoautosomal regions of chrX and chrY, only XY
+    samples contribute anything on chrY, and the mitochondrion is haploid in
+    everyone.
+    """
+    if contig_class == AUTOSOMAL:
+        return 2 * (n_xx + n_xy)
+    if contig_class == X_NON_PAR:
+        return 2 * n_xx + n_xy
+    if contig_class == Y_NON_PAR:
+        return n_xy
+    if contig_class == Y_PAR:
+        return 2 * n_xy
+    if contig_class == MITOCHONDRIAL:
+        return n_xx + n_xy
+    raise ValueError(f"Unknown contig class {contig_class}")
+
+
+def _stratum_index(strata_meta: List[Dict[str, str]], keys: Dict[str, str]) -> int:
+    """The position of the stratum described exactly by ``keys``.
+
+    ``AN`` is an array parallel to the ``strata_meta`` global, so a stratum is
+    addressed by position. Matching on equality rather than containment matters:
+    ``{"group": "adj"}`` is contained in every ancestry- and sex-stratified
+    entry, so a containment match would return the first of hundreds of strata
+    instead of the whole-callset one.
+    """
+    matches = [index for index, meta in enumerate(strata_meta) if meta == keys]
+    if len(matches) != 1:
+        raise ValueError(f"Expected exactly one stratum matching {keys}, found {len(matches)}")
+    return matches[0]
+
+
+def prepare_allele_number(allele_number_path: str, filter_intervals: Optional[List[str]] = None):
+    """Prepare an all-sites allele number table for the browser's call rate track.
+
+    Emits, for every base in the release, the adj allele number (``an``) and that
+    allele number as a percentage of the attainable allele number
+    (``an_percent``). The percentage is what the track plots: raw allele number
+    scales with sample count, so exome and genome series drawn against one axis
+    are only comparable once both are normalised.
+    """
+    ds = hl.read_table(allele_number_path)
+
+    strata_meta, strata_sample_count = hl.eval((ds.strata_meta, ds.strata_sample_count))
+    strata_meta = [dict(meta) for meta in strata_meta]
+
+    if len(strata_meta) != len(strata_sample_count):
+        raise ValueError(
+            f"strata_meta ({len(strata_meta)}) and strata_sample_count ({len(strata_sample_count)}) "
+            "have different lengths, but are indexed in parallel"
+        )
+
+    # adj, not raw. A genotype contributes to AN only when it passes gnomAD's
+    # quality thresholds (GQ >= 20, DP >= 10 and, for heterozygous calls, an
+    # allele balance >= 0.2), so the track agrees with the allele counts shown
+    # in the variant tables.
+    adj_index = _stratum_index(strata_meta, {"group": "adj"})
+    n_total = strata_sample_count[adj_index]
+    n_xx = strata_sample_count[_stratum_index(strata_meta, {"group": "adj", "sex": "XX"})]
+    n_xy = strata_sample_count[_stratum_index(strata_meta, {"group": "adj", "sex": "XY"})]
+
+    # The sex strata partition the callset, so this is an identity rather than a
+    # tolerance check. If it does not hold, every denominator below is wrong.
+    if n_xx + n_xy != n_total:
+        raise ValueError(
+            f"XX ({n_xx:,}) + XY ({n_xy:,}) != total ({n_total:,}); "
+            "the ploidy-aware denominators need both karyotype counts"
+        )
+
+    an = ds.AN[adj_index]
+
+    # The default branch is the diploid case, which covers the autosomes and the
+    # pseudoautosomal regions of chrX. Every contig class that is *not* diploid
+    # is matched explicitly above it, so no haploid site can quietly take a
+    # diploid denominator and report half its true call rate.
+    max_an = (
+        hl.case()
+        .when(ds.locus.in_x_nonpar(), max_allele_number(X_NON_PAR, n_xx, n_xy))
+        .when(ds.locus.in_y_nonpar(), max_allele_number(Y_NON_PAR, n_xx, n_xy))
+        # chrY PAR calls are assigned to chrX in the release tables, so this
+        # branch matches nothing today. It is here so that the expression stays
+        # correct if those rows ever appear.
+        .when(ds.locus.in_y_par(), max_allele_number(Y_PAR, n_xx, n_xy))
+        .when(ds.locus.in_mito(), max_allele_number(MITOCHONDRIAL, n_xx, n_xy))
+        .default(max_allele_number(AUTOSOMAL, n_xx, n_xy))
+    )
+
+    ds = ds.select(
+        xpos=x_position(ds.locus),
+        an=an,
+        # chrY denominators are zero in an all-XX callset. A site where no
+        # sample could have been called has no meaningful call rate, so leave it
+        # missing rather than reporting 0%.
+        an_percent=hl.if_else(max_an > 0, 100 * (an / max_an), hl.missing(hl.tfloat64)),
+    )
+
+    # strata_meta and strata_sample_count describe hundreds of strata that this
+    # table no longer carries; drop them rather than passing them downstream.
+    ds = ds.select_globals()
+
+    if filter_intervals:
+        intervals = [hl.parse_locus_interval(interval, reference_genome="GRCh38") for interval in filter_intervals]
+        ds = hl.filter_intervals(ds, intervals)
+
+    return ds

--- a/data-pipeline/src/data_pipeline/helpers/datasets_config.py
+++ b/data-pipeline/src/data_pipeline/helpers/datasets_config.py
@@ -27,6 +27,7 @@ from data_pipeline.pipelines.gnomad_v3_mitochondrial_coverage import (
 from data_pipeline.pipelines.gnomad_v3_short_tandem_repeats import pipeline as gnomad_v3_short_tandem_repeats_pipeline
 from data_pipeline.pipelines.gnomad_v4_variants import pipeline as gnomad_v4_variants_pipeline
 from data_pipeline.pipelines.gnomad_v4_coverage import pipeline as gnomad_v4_coverage_pipeline
+from data_pipeline.pipelines.gnomad_v4_allele_number import pipeline as gnomad_v4_allele_number_pipeline
 from data_pipeline.pipelines.gnomad_v4_cnvs import pipeline as gnomad_v4_cnvs_pipeline
 from data_pipeline.pipelines.gnomad_v4_lof_curation_results import pipeline as gnomad_v4_lof_curation_results_pipeline
 from data_pipeline.data_types.variant import compressed_variant_id
@@ -132,6 +133,21 @@ DATASETS_CONFIG = {
     #     ),
     #     "args": {"index": "gnomad_v4_genome_coverage", "id_field": "xpos", "num_shards": 2, "block_size": 10_000},
     # },
+    # Both allele number indices carry one document per base of the release, the
+    # same shape and scale as the coverage indices, so they are sharded the same
+    # way as gnomad_v4_exome_coverage and gnomad_v3_genome_coverage.
+    "gnomad_v4_exome_allele_number": {
+        "get_table": lambda: subset_table(
+            hl.read_table(gnomad_v4_allele_number_pipeline.get_output("exome_allele_number").get_output_path())
+        ),
+        "args": {"index": "gnomad_v4_exome_allele_number", "id_field": "xpos", "num_shards": 48, "block_size": 10_000},
+    },
+    "gnomad_v4_genome_allele_number": {
+        "get_table": lambda: subset_table(
+            hl.read_table(gnomad_v4_allele_number_pipeline.get_output("genome_allele_number").get_output_path())
+        ),
+        "args": {"index": "gnomad_v4_genome_allele_number", "id_field": "xpos", "num_shards": 48, "block_size": 10_000},
+    },
     "gnomad_v4_lof_curation_results": {
         "get_table": lambda: add_variant_document_id(
             hl.read_table(gnomad_v4_lof_curation_results_pipeline.get_output("lof_curation_results").get_output_path())

--- a/data-pipeline/src/data_pipeline/pipelines/gnomad_v4_allele_number.py
+++ b/data-pipeline/src/data_pipeline/pipelines/gnomad_v4_allele_number.py
@@ -1,0 +1,47 @@
+from data_pipeline.pipeline import Pipeline, run_pipeline
+
+from data_pipeline.data_types.allele_number import prepare_allele_number
+
+output_sub_dir = "gnomad_v4_allele_number"
+
+pipeline = Pipeline()
+
+pipeline.add_task(
+    name="prepare_gnomad_v4_exome_allele_number",
+    task_function=prepare_allele_number,
+    output_path=f"/{output_sub_dir}/gnomad_v4_exome_allele_number.ht",
+    inputs={
+        "allele_number_path": "gs://gcp-public-data--gnomad/release/4.1/ht/exomes/gnomad.exomes.v4.1.allele_number_all_sites.ht",
+    },
+    # params={"filter_intervals": ["chr1:55039447-55064852"]},
+)
+
+# Unlike genome coverage, which v4 still inherits from v3.0.1, allele number is
+# published for v4.1 genomes directly.
+pipeline.add_task(
+    name="prepare_gnomad_v4_genome_allele_number",
+    task_function=prepare_allele_number,
+    output_path=f"/{output_sub_dir}/gnomad_v4_genome_allele_number.ht",
+    inputs={
+        "allele_number_path": "gs://gcp-public-data--gnomad/release/4.1/ht/genomes/gnomad.genomes.v4.1.allele_number_all_sites.ht",
+    },
+    # params={"filter_intervals": ["chr1:55039447-55064852"]},
+)
+
+###############################################
+# Outputs
+###############################################
+
+pipeline.set_outputs(
+    {
+        "exome_allele_number": "prepare_gnomad_v4_exome_allele_number",
+        "genome_allele_number": "prepare_gnomad_v4_genome_allele_number",
+    }
+)
+
+###############################################
+# Run
+###############################################
+
+if __name__ == "__main__":
+    run_pipeline(pipeline)

--- a/data-pipeline/tests/pipeline/test_allele_number.py
+++ b/data-pipeline/tests/pipeline/test_allele_number.py
@@ -1,0 +1,69 @@
+import pytest
+
+from data_pipeline.data_types.allele_number import (
+    AUTOSOMAL,
+    MITOCHONDRIAL,
+    X_NON_PAR,
+    Y_NON_PAR,
+    Y_PAR,
+    _stratum_index,
+    max_allele_number,
+)
+
+# Roughly the v4.1 exome karyotype split, so the numbers below are the ones the
+# pipeline actually divides by.
+N_XX = 399_053
+N_XY = 330_947
+
+
+def test_max_allele_number_is_diploid_off_the_sex_chromosomes():
+    assert max_allele_number(AUTOSOMAL, N_XX, N_XY) == 2 * (N_XX + N_XY)
+
+
+def test_max_allele_number_accounts_for_haploid_sex_chromosomes():
+    # XY samples carry one chrX outside the PAR, and no sample other than an XY
+    # sample carries a chrY at all.
+    assert max_allele_number(X_NON_PAR, N_XX, N_XY) == 2 * N_XX + N_XY
+    assert max_allele_number(Y_NON_PAR, N_XX, N_XY) == N_XY
+    assert max_allele_number(Y_PAR, N_XX, N_XY) == 2 * N_XY
+
+
+def test_max_allele_number_treats_the_mitochondrion_as_haploid():
+    # The diploid default would report half the true call rate here.
+    assert max_allele_number(MITOCHONDRIAL, N_XX, N_XY) == N_XX + N_XY
+
+
+def test_max_allele_number_rejects_an_unknown_contig_class():
+    with pytest.raises(ValueError):
+        max_allele_number("chr1", N_XX, N_XY)
+
+
+def test_stratum_index_finds_an_exact_match():
+    strata = [
+        {"group": "adj"},
+        {"group": "adj", "sex": "XX"},
+        {"group": "adj", "sex": "XY"},
+        {"group": "adj", "gen_anc": "afr", "sex": "XX"},
+    ]
+    assert _stratum_index(strata, {"group": "adj"}) == 0
+    assert _stratum_index(strata, {"group": "adj", "sex": "XX"}) == 1
+    assert _stratum_index(strata, {"group": "adj", "sex": "XY"}) == 2
+
+
+def test_stratum_index_does_not_accept_a_containment_match():
+    # {"group": "adj"} is contained in both entries below, and in every
+    # stratified entry of a real table. A containment match would return index 0
+    # for almost any query; failing is the only safe answer.
+    strata = [
+        {"group": "adj", "gen_anc": "afr"},
+        {"group": "adj", "gen_anc": "amr"},
+    ]
+    with pytest.raises(ValueError):
+        _stratum_index(strata, {"group": "adj"})
+
+
+def test_stratum_index_rejects_missing_and_duplicate_strata():
+    with pytest.raises(ValueError):
+        _stratum_index([{"group": "adj"}], {"group": "raw"})
+    with pytest.raises(ValueError):
+        _stratum_index([{"group": "adj"}, {"group": "adj"}], {"group": "adj"})


### PR DESCRIPTION
Part of #1943. Refactor of #1944.

First of three stacked PRs adding a **Call rate (AN%)** metric to the coverage track
(#1943). This one only produces the data; nothing user-visible changes until the third PR.

## What this does

Reads the released gnomAD v4.1 all-sites allele number tables (exomes and genomes) and
emits, for every base, two fields for Elasticsearch:

| field | meaning |
|---|---|
| `an` | adj allele number at that base |
| `an_percent` | `an` as a percentage of the allele number attainable there |

`an_percent` is what the track plots. Raw allele number scales with sample count, so an
exome series (~730k samples) and a genome series (~76k) drawn against one axis are only
comparable once both are normalised.

## Review notes

**The denominator is ploidy-aware, and the non-diploid cases are explicit.**
`max_allele_number` is a plain function, so the arithmetic is unit-tested without a Hail
context. chrX outside the PAR is `2·XX + XY`, chrY is `XY`, the mitochondrion is `XX + XY`,
and everything else — autosomes and the chrX PAR — is diploid. The diploid case is the
`.default()` branch, so a haploid contig can only get a diploid denominator if someone
adds a new one and forgets; that would report half the true call rate, which is why every
non-diploid class is matched explicitly rather than left to fall through.

**Two things fail loudly rather than quietly returning a wrong number.**

- Strata are matched on *equality*, not containment. `{"group": "adj"}` is contained in
  every ancestry- and sex-stratified entry, so a containment match would silently return
  the first of hundreds of strata instead of the whole-callset one.
- `XX + XY` must equal the callset total. The sex strata partition the callset, so this is
  an identity; if it ever fails, both sex-chromosome denominators are wrong.

**Sharding matches the coverage indices.** These tables are one document per base, the same
shape and scale as coverage, so `gnomad_v4_{exome,genome}_allele_number` reuse the 48 shards
/ 10k block size of `gnomad_v4_exome_coverage` and `gnomad_v3_genome_coverage`. (The `2`
on the commented-out `gnomad_v4_genome_coverage` entry is not a live value.)

**Genome input is genuinely v4.1.** Unlike genome coverage, which v4 still inherits from
v3.0.1, allele number is published for v4.1 genomes directly. This is called out in the
help copy in PR 3, since it means the genome series differs between metrics.

## Verification

```bash
uv run ruff format --check . && uv run ruff check .
```

```bash
uv run pytest data-pipeline/tests/pipeline/test_allele_number.py
```

**Not yet run against the real tables.** Two things a reviewer with cluster access should
confirm before this is trusted:

1. The two `gs://gcp-public-data--gnomad/release/4.1/ht/{exomes,genomes}/...allele_number_all_sites.ht`
   paths resolve.
2. The globals really are named `strata_meta` / `strata_sample_count`, with `group` and
   `sex` keys. If they are not, `_stratum_index` raises rather than picking a wrong stratum,
   so this fails visibly rather than producing bad numbers.

A useful smoke test is to uncomment the `filter_intervals` param on either task (it is
already there, pointed at PCSK9) and check that `an_percent` sits near 100 across the
coding exons.
