### PR TITLE
Serve allele number for genes, transcripts and regions

### DIFF
--- a/data-pipeline/src/data_pipeline/data_types/allele_number.py
+++ b/data-pipeline/src/data_pipeline/data_types/allele_number.py
@@ -1,0 +1,125 @@
+from typing import Dict, List, Optional
+
+import hail as hl
+
+from data_pipeline.data_types.locus import x_position
+
+# Classes of contig that differ in how many alleles a sample can contribute.
+# Anything not called out here is diploid in every sample: the autosomes, and
+# the pseudoautosomal regions of chrX.
+AUTOSOMAL = "autosomal"
+X_NON_PAR = "X_non_par"
+Y_NON_PAR = "Y_non_par"
+Y_PAR = "Y_par"
+MITOCHONDRIAL = "mitochondrial"
+
+
+def max_allele_number(contig_class: str, n_xx: int, n_xy: int) -> int:
+    """The allele number a site would have if every sample were called there.
+
+    This is the denominator of the call rate. It depends on ploidy: XY samples
+    are haploid outside the pseudoautosomal regions of chrX and chrY, only XY
+    samples contribute anything on chrY, and the mitochondrion is haploid in
+    everyone.
+    """
+    if contig_class == AUTOSOMAL:
+        return 2 * (n_xx + n_xy)
+    if contig_class == X_NON_PAR:
+        return 2 * n_xx + n_xy
+    if contig_class == Y_NON_PAR:
+        return n_xy
+    if contig_class == Y_PAR:
+        return 2 * n_xy
+    if contig_class == MITOCHONDRIAL:
+        return n_xx + n_xy
+    raise ValueError(f"Unknown contig class {contig_class}")
+
+
+def _stratum_index(strata_meta: List[Dict[str, str]], keys: Dict[str, str]) -> int:
+    """The position of the stratum described exactly by ``keys``.
+
+    ``AN`` is an array parallel to the ``strata_meta`` global, so a stratum is
+    addressed by position. Matching on equality rather than containment matters:
+    ``{"group": "adj"}`` is contained in every ancestry- and sex-stratified
+    entry, so a containment match would return the first of hundreds of strata
+    instead of the whole-callset one.
+    """
+    matches = [index for index, meta in enumerate(strata_meta) if meta == keys]
+    if len(matches) != 1:
+        raise ValueError(f"Expected exactly one stratum matching {keys}, found {len(matches)}")
+    return matches[0]
+
+
+def prepare_allele_number(allele_number_path: str, filter_intervals: Optional[List[str]] = None):
+    """Prepare an all-sites allele number table for the browser's call rate track.
+
+    Emits, for every base in the release, the adj allele number (``an``) and that
+    allele number as a percentage of the attainable allele number
+    (``an_percent``). The percentage is what the track plots: raw allele number
+    scales with sample count, so exome and genome series drawn against one axis
+    are only comparable once both are normalised.
+    """
+    ds = hl.read_table(allele_number_path)
+
+    strata_meta, strata_sample_count = hl.eval((ds.strata_meta, ds.strata_sample_count))
+    strata_meta = [dict(meta) for meta in strata_meta]
+
+    if len(strata_meta) != len(strata_sample_count):
+        raise ValueError(
+            f"strata_meta ({len(strata_meta)}) and strata_sample_count ({len(strata_sample_count)}) "
+            "have different lengths, but are indexed in parallel"
+        )
+
+    # adj, not raw. A genotype contributes to AN only when it passes gnomAD's
+    # quality thresholds (GQ >= 20, DP >= 10 and, for heterozygous calls, an
+    # allele balance >= 0.2), so the track agrees with the allele counts shown
+    # in the variant tables.
+    adj_index = _stratum_index(strata_meta, {"group": "adj"})
+    n_total = strata_sample_count[adj_index]
+    n_xx = strata_sample_count[_stratum_index(strata_meta, {"group": "adj", "sex": "XX"})]
+    n_xy = strata_sample_count[_stratum_index(strata_meta, {"group": "adj", "sex": "XY"})]
+
+    # The sex strata partition the callset, so this is an identity rather than a
+    # tolerance check. If it does not hold, every denominator below is wrong.
+    if n_xx + n_xy != n_total:
+        raise ValueError(
+            f"XX ({n_xx:,}) + XY ({n_xy:,}) != total ({n_total:,}); "
+            "the ploidy-aware denominators need both karyotype counts"
+        )
+
+    an = ds.AN[adj_index]
+
+    # The default branch is the diploid case, which covers the autosomes and the
+    # pseudoautosomal regions of chrX. Every contig class that is *not* diploid
+    # is matched explicitly above it, so no haploid site can quietly take a
+    # diploid denominator and report half its true call rate.
+    max_an = (
+        hl.case()
+        .when(ds.locus.in_x_nonpar(), max_allele_number(X_NON_PAR, n_xx, n_xy))
+        .when(ds.locus.in_y_nonpar(), max_allele_number(Y_NON_PAR, n_xx, n_xy))
+        # chrY PAR calls are assigned to chrX in the release tables, so this
+        # branch matches nothing today. It is here so that the expression stays
+        # correct if those rows ever appear.
+        .when(ds.locus.in_y_par(), max_allele_number(Y_PAR, n_xx, n_xy))
+        .when(ds.locus.in_mito(), max_allele_number(MITOCHONDRIAL, n_xx, n_xy))
+        .default(max_allele_number(AUTOSOMAL, n_xx, n_xy))
+    )
+
+    ds = ds.select(
+        xpos=x_position(ds.locus),
+        an=an,
+        # chrY denominators are zero in an all-XX callset. A site where no
+        # sample could have been called has no meaningful call rate, so leave it
+        # missing rather than reporting 0%.
+        an_percent=hl.if_else(max_an > 0, 100 * (an / max_an), hl.missing(hl.tfloat64)),
+    )
+
+    # strata_meta and strata_sample_count describe hundreds of strata that this
+    # table no longer carries; drop them rather than passing them downstream.
+    ds = ds.select_globals()
+
+    if filter_intervals:
+        intervals = [hl.parse_locus_interval(interval, reference_genome="GRCh38") for interval in filter_intervals]
+        ds = hl.filter_intervals(ds, intervals)
+
+    return ds

--- a/data-pipeline/src/data_pipeline/helpers/datasets_config.py
+++ b/data-pipeline/src/data_pipeline/helpers/datasets_config.py
@@ -27,6 +27,7 @@ from data_pipeline.pipelines.gnomad_v3_mitochondrial_coverage import (
 from data_pipeline.pipelines.gnomad_v3_short_tandem_repeats import pipeline as gnomad_v3_short_tandem_repeats_pipeline
 from data_pipeline.pipelines.gnomad_v4_variants import pipeline as gnomad_v4_variants_pipeline
 from data_pipeline.pipelines.gnomad_v4_coverage import pipeline as gnomad_v4_coverage_pipeline
+from data_pipeline.pipelines.gnomad_v4_allele_number import pipeline as gnomad_v4_allele_number_pipeline
 from data_pipeline.pipelines.gnomad_v4_cnvs import pipeline as gnomad_v4_cnvs_pipeline
 from data_pipeline.pipelines.gnomad_v4_lof_curation_results import pipeline as gnomad_v4_lof_curation_results_pipeline
 from data_pipeline.data_types.variant import compressed_variant_id
@@ -132,6 +133,21 @@ DATASETS_CONFIG = {
     #     ),
     #     "args": {"index": "gnomad_v4_genome_coverage", "id_field": "xpos", "num_shards": 2, "block_size": 10_000},
     # },
+    # Both allele number indices carry one document per base of the release, the
+    # same shape and scale as the coverage indices, so they are sharded the same
+    # way as gnomad_v4_exome_coverage and gnomad_v3_genome_coverage.
+    "gnomad_v4_exome_allele_number": {
+        "get_table": lambda: subset_table(
+            hl.read_table(gnomad_v4_allele_number_pipeline.get_output("exome_allele_number").get_output_path())
+        ),
+        "args": {"index": "gnomad_v4_exome_allele_number", "id_field": "xpos", "num_shards": 48, "block_size": 10_000},
+    },
+    "gnomad_v4_genome_allele_number": {
+        "get_table": lambda: subset_table(
+            hl.read_table(gnomad_v4_allele_number_pipeline.get_output("genome_allele_number").get_output_path())
+        ),
+        "args": {"index": "gnomad_v4_genome_allele_number", "id_field": "xpos", "num_shards": 48, "block_size": 10_000},
+    },
     "gnomad_v4_lof_curation_results": {
         "get_table": lambda: add_variant_document_id(
             hl.read_table(gnomad_v4_lof_curation_results_pipeline.get_output("lof_curation_results").get_output_path())

--- a/data-pipeline/src/data_pipeline/pipelines/gnomad_v4_allele_number.py
+++ b/data-pipeline/src/data_pipeline/pipelines/gnomad_v4_allele_number.py
@@ -1,0 +1,47 @@
+from data_pipeline.pipeline import Pipeline, run_pipeline
+
+from data_pipeline.data_types.allele_number import prepare_allele_number
+
+output_sub_dir = "gnomad_v4_allele_number"
+
+pipeline = Pipeline()
+
+pipeline.add_task(
+    name="prepare_gnomad_v4_exome_allele_number",
+    task_function=prepare_allele_number,
+    output_path=f"/{output_sub_dir}/gnomad_v4_exome_allele_number.ht",
+    inputs={
+        "allele_number_path": "gs://gcp-public-data--gnomad/release/4.1/ht/exomes/gnomad.exomes.v4.1.allele_number_all_sites.ht",
+    },
+    # params={"filter_intervals": ["chr1:55039447-55064852"]},
+)
+
+# Unlike genome coverage, which v4 still inherits from v3.0.1, allele number is
+# published for v4.1 genomes directly.
+pipeline.add_task(
+    name="prepare_gnomad_v4_genome_allele_number",
+    task_function=prepare_allele_number,
+    output_path=f"/{output_sub_dir}/gnomad_v4_genome_allele_number.ht",
+    inputs={
+        "allele_number_path": "gs://gcp-public-data--gnomad/release/4.1/ht/genomes/gnomad.genomes.v4.1.allele_number_all_sites.ht",
+    },
+    # params={"filter_intervals": ["chr1:55039447-55064852"]},
+)
+
+###############################################
+# Outputs
+###############################################
+
+pipeline.set_outputs(
+    {
+        "exome_allele_number": "prepare_gnomad_v4_exome_allele_number",
+        "genome_allele_number": "prepare_gnomad_v4_genome_allele_number",
+    }
+)
+
+###############################################
+# Run
+###############################################
+
+if __name__ == "__main__":
+    run_pipeline(pipeline)

--- a/data-pipeline/tests/pipeline/test_allele_number.py
+++ b/data-pipeline/tests/pipeline/test_allele_number.py
@@ -1,0 +1,69 @@
+import pytest
+
+from data_pipeline.data_types.allele_number import (
+    AUTOSOMAL,
+    MITOCHONDRIAL,
+    X_NON_PAR,
+    Y_NON_PAR,
+    Y_PAR,
+    _stratum_index,
+    max_allele_number,
+)
+
+# Roughly the v4.1 exome karyotype split, so the numbers below are the ones the
+# pipeline actually divides by.
+N_XX = 399_053
+N_XY = 330_947
+
+
+def test_max_allele_number_is_diploid_off_the_sex_chromosomes():
+    assert max_allele_number(AUTOSOMAL, N_XX, N_XY) == 2 * (N_XX + N_XY)
+
+
+def test_max_allele_number_accounts_for_haploid_sex_chromosomes():
+    # XY samples carry one chrX outside the PAR, and no sample other than an XY
+    # sample carries a chrY at all.
+    assert max_allele_number(X_NON_PAR, N_XX, N_XY) == 2 * N_XX + N_XY
+    assert max_allele_number(Y_NON_PAR, N_XX, N_XY) == N_XY
+    assert max_allele_number(Y_PAR, N_XX, N_XY) == 2 * N_XY
+
+
+def test_max_allele_number_treats_the_mitochondrion_as_haploid():
+    # The diploid default would report half the true call rate here.
+    assert max_allele_number(MITOCHONDRIAL, N_XX, N_XY) == N_XX + N_XY
+
+
+def test_max_allele_number_rejects_an_unknown_contig_class():
+    with pytest.raises(ValueError):
+        max_allele_number("chr1", N_XX, N_XY)
+
+
+def test_stratum_index_finds_an_exact_match():
+    strata = [
+        {"group": "adj"},
+        {"group": "adj", "sex": "XX"},
+        {"group": "adj", "sex": "XY"},
+        {"group": "adj", "gen_anc": "afr", "sex": "XX"},
+    ]
+    assert _stratum_index(strata, {"group": "adj"}) == 0
+    assert _stratum_index(strata, {"group": "adj", "sex": "XX"}) == 1
+    assert _stratum_index(strata, {"group": "adj", "sex": "XY"}) == 2
+
+
+def test_stratum_index_does_not_accept_a_containment_match():
+    # {"group": "adj"} is contained in both entries below, and in every
+    # stratified entry of a real table. A containment match would return index 0
+    # for almost any query; failing is the only safe answer.
+    strata = [
+        {"group": "adj", "gen_anc": "afr"},
+        {"group": "adj", "gen_anc": "amr"},
+    ]
+    with pytest.raises(ValueError):
+        _stratum_index(strata, {"group": "adj"})
+
+
+def test_stratum_index_rejects_missing_and_duplicate_strata():
+    with pytest.raises(ValueError):
+        _stratum_index([{"group": "adj"}], {"group": "raw"})
+    with pytest.raises(ValueError):
+        _stratum_index([{"group": "adj"}, {"group": "adj"}], {"group": "adj"})

--- a/graphql-api/src/graphql/resolvers/allele-number.ts
+++ b/graphql-api/src/graphql/resolvers/allele-number.ts
@@ -1,0 +1,41 @@
+import { UserVisibleError } from '../../errors'
+import {
+  fetchExomeAlleleNumberForRegion,
+  fetchGenomeAlleleNumberForRegion,
+  fetchAlleleNumberForGene,
+  fetchAlleleNumberForTranscript,
+} from '../../queries/allele-number-queries'
+
+// The same limit the coverage resolver applies. Allele number is indexed one
+// document per base, so an unbounded region would ask Elasticsearch to
+// aggregate over most of a chromosome.
+const MAX_REGION_SIZE = 2.5e6
+
+const resolvers = {
+  Region: {
+    allele_number: (obj: any, args: any) => {
+      if (obj.stop - obj.start >= MAX_REGION_SIZE) {
+        throw new UserVisibleError('Allele number is not available for a region this large')
+      }
+
+      // Forward region and dataset argument to exome/genome allele number resolvers.
+      return { ...obj, dataset: args.dataset }
+    },
+  },
+  RegionAlleleNumber: {
+    exome: (obj: any, _args: any, ctx: any) =>
+      fetchExomeAlleleNumberForRegion(ctx.esClient, obj.dataset, obj),
+    genome: (obj: any, _args: any, ctx: any) =>
+      fetchGenomeAlleleNumberForRegion(ctx.esClient, obj.dataset, obj),
+  },
+  Gene: {
+    allele_number: (obj: any, args: any, ctx: any) =>
+      fetchAlleleNumberForGene(ctx.esClient, args.dataset, obj),
+  },
+  Transcript: {
+    allele_number: (obj: any, args: any, ctx: any) =>
+      fetchAlleleNumberForTranscript(ctx.esClient, args.dataset, obj),
+  },
+}
+
+export default resolvers

--- a/graphql-api/src/graphql/schema.ts
+++ b/graphql-api/src/graphql/schema.ts
@@ -4,6 +4,7 @@ import { mergeTypeDefs, mergeResolvers } from '@graphql-tools/merge'
 import { makeExecutableSchema } from '@graphql-tools/schema'
 
 import aliasResolvers from './resolvers/aliases'
+import alleleNumberResolvers from './resolvers/allele-number'
 import browserMetadataResolvers from './resolvers/browser-metadata'
 import clinVarVariantResolvers from './resolvers/clinvar-variants'
 import clinVarVariantFieldResolvers from './resolvers/clinvar-variant-fields'
@@ -33,6 +34,7 @@ const typeDefs = mergeTypeDefs([
 
 const resolvers = mergeResolvers([
   aliasResolvers,
+  alleleNumberResolvers,
   browserMetadataResolvers,
   clinVarVariantResolvers,
   clinVarVariantFieldResolvers,

--- a/graphql-api/src/graphql/types/allele-number.graphql
+++ b/graphql-api/src/graphql/types/allele-number.graphql
@@ -1,0 +1,10 @@
+type AlleleNumberBin {
+  pos: Int!
+  an: Int
+  an_percent: Float
+}
+
+type FeatureAlleleNumber {
+  exome: [AlleleNumberBin!]!
+  genome: [AlleleNumberBin!]!
+}

--- a/graphql-api/src/graphql/types/gene.graphql
+++ b/graphql-api/src/graphql/types/gene.graphql
@@ -79,6 +79,7 @@ type Gene {
   clinvar_variants: [ClinVarVariant!] @cost(value: 10)
 
   coverage(dataset: DatasetId): FeatureCoverage! @cost(value: 5)
+  allele_number(dataset: DatasetId): FeatureAlleleNumber! @cost(value: 5)
   mitochondrial_coverage(dataset: DatasetId!): [MitochondrialCoverageBin!] @cost(value: 5)
   cnv_track_callable_coverage(dataset: CopyNumberVariantDatasetId!): [CNVTrackCallableCoverageBin!]
     @cost(value: 5)

--- a/graphql-api/src/graphql/types/region.graphql
+++ b/graphql-api/src/graphql/types/region.graphql
@@ -19,6 +19,11 @@ type RegionCoverage {
   genome: [CoverageBin!]! @cost(value: 5)
 }
 
+type RegionAlleleNumber {
+  exome: [AlleleNumberBin!]! @cost(value: 5)
+  genome: [AlleleNumberBin!]! @cost(value: 5)
+}
+
 type Region {
   reference_genome: ReferenceGenomeId!
   chrom: String!
@@ -36,6 +41,7 @@ type Region {
   clinvar_variants: [ClinVarVariant!] @cost(value: 10)
 
   coverage(dataset: DatasetId!): RegionCoverage!
+  allele_number(dataset: DatasetId!): RegionAlleleNumber!
   mitochondrial_coverage(dataset: DatasetId!): [MitochondrialCoverageBin!] @cost(value: 5)
 
   short_tandem_repeats(dataset: DatasetId!): [ShortTandemRepeat!]! @cost(value: 5)

--- a/graphql-api/src/graphql/types/transcript.graphql
+++ b/graphql-api/src/graphql/types/transcript.graphql
@@ -49,5 +49,6 @@ type Transcript {
   clinvar_variants: [ClinVarVariant!] @cost(value: 10)
 
   coverage(dataset: DatasetId): FeatureCoverage! @cost(value: 5)
+  allele_number(dataset: DatasetId): FeatureAlleleNumber! @cost(value: 5)
   mitochondrial_coverage(dataset: DatasetId!): [MitochondrialCoverageBin!] @cost(value: 5)
 }

--- a/graphql-api/src/queries/allele-number-queries.spec.ts
+++ b/graphql-api/src/queries/allele-number-queries.spec.ts
@@ -1,0 +1,231 @@
+import { beforeEach, describe, expect, jest, test } from '@jest/globals'
+
+import {
+  fetchAlleleNumberForGene,
+  fetchAlleleNumberForTranscript,
+  fetchExomeAlleleNumberForRegion,
+  fetchGenomeAlleleNumberForRegion,
+} from './allele-number-queries'
+
+/**
+ * A cache double that actually memoizes.
+ *
+ * The real cache module cannot be loaded here: it pulls in the API config,
+ * which requires ELASTICSEARCH_URL, and it would talk to Redis. Memoizing
+ * rather than passing calls straight through is deliberate -- it lets
+ * "an empty result is never cached" below be a real test.
+ */
+jest.mock('../cache', () => {
+  const entries = new Map<string, any>()
+  return {
+    clearTestCache: () => entries.clear(),
+    withCache: (fn: any, keyFn: any) => async (...args: any[]) => {
+      const key = keyFn(...args)
+      if (!entries.has(key)) {
+        entries.set(key, await fn(...args))
+      }
+      return entries.get(key)
+    },
+  }
+})
+
+const { clearTestCache } = jest.requireMock('../cache') as any
+
+beforeEach(() => clearTestCache())
+
+// Two PCSK9 exons 101 bases apart. Padding each side by 75 makes them overlap,
+// so they merge into the single interval 55039372-55090165 (50793 bases, and
+// therefore a bucket size of floor(50793 / 500) = 101).
+const gene = {
+  gene_id: 'ENSG00000169174',
+  reference_genome: 'GRCh38',
+  chrom: '1',
+  exons: [
+    { feature_type: 'CDS', start: 55039447, stop: 55039666, xstart: 1055039447, xstop: 1055039666 },
+    { feature_type: 'CDS', start: 55039767, stop: 55090090, xstart: 1055039767, xstop: 1055090090 },
+  ],
+}
+
+const transcript = { ...gene, transcript_id: 'ENST00000302118' }
+
+const region = { reference_genome: 'GRCh38', chrom: '1', start: 55039447, stop: 55064852 }
+
+/** An Elasticsearch double that records every search it is asked to run. */
+const stubEsClient = (bucketsByIndex: { [index: string]: any[] } = {}) => {
+  const searches: any[] = []
+  return {
+    searches,
+    client: {
+      search: async (params: any) => {
+        searches.push(params)
+        return {
+          body: {
+            aggregations: { allele_number: { buckets: bucketsByIndex[params.index] ?? [] } },
+          },
+        }
+      },
+    },
+  }
+}
+
+const failingEsClient = (error: any) => ({
+  search: async () => {
+    throw error
+  },
+})
+
+const indexNotFoundError = {
+  meta: { statusCode: 404, body: { error: { type: 'index_not_found_exception' } } },
+}
+
+const bucket = (key: number, an: number | null, anPercent: number | null) => ({
+  key,
+  an: { value: an },
+  an_percent: { value: anPercent },
+})
+
+describe('fetchAlleleNumberForGene', () => {
+  test('queries the v4 exome and genome indices', async () => {
+    const { searches, client } = stubEsClient()
+    await fetchAlleleNumberForGene(client, 'gnomad_r4', gene)
+
+    expect(searches.map((search) => search.index)).toEqual([
+      'gnomad_v4_exome_allele_number',
+      'gnomad_v4_genome_allele_number',
+    ])
+    // GRCh38 indices use chr-prefixed contig names.
+    expect(searches[0].body.query.bool.filter[0]).toEqual({ term: { 'locus.contig': 'chr1' } })
+  })
+
+  test('pads and merges exons the way the coverage query does', async () => {
+    const { searches, client } = stubEsClient()
+    await fetchAlleleNumberForGene(client, 'gnomad_r4', gene)
+
+    const { filter } = searches[0].body.query.bool
+    expect(filter[1].bool.should).toEqual([
+      { range: { 'locus.position': { gte: 55039372, lte: 55090165 } } },
+    ])
+    expect(searches[0].body.aggregations.allele_number.histogram.interval).toEqual(101)
+  })
+
+  test('rounds allele number to a whole count and the percentage to three decimals', async () => {
+    const { client } = stubEsClient({
+      gnomad_v4_exome_allele_number: [bucket(55039447, 1460123.6, 99.87654321)],
+      gnomad_v4_genome_allele_number: [bucket(55039447, 152345.2, 99.9191919)],
+    })
+
+    expect(await fetchAlleleNumberForGene(client, 'gnomad_r4', gene)).toEqual({
+      exome: [{ pos: 55039447, an: 1460124, an_percent: 99.877 }],
+      genome: [{ pos: 55039447, an: 152345, an_percent: 99.919 }],
+    })
+  })
+
+  test('preserves nulls instead of coercing them to zero', async () => {
+    const { client } = stubEsClient({
+      gnomad_v4_exome_allele_number: [bucket(55039447, null, null)],
+    })
+
+    // A bucket covering no indexed base is not a bucket where nobody was
+    // called; zero would draw a callability cliff that is not in the data.
+    const { exome } = await fetchAlleleNumberForGene(client, 'gnomad_r4', gene)
+    expect(exome).toEqual([{ pos: 55039447, an: null, an_percent: null }])
+  })
+})
+
+describe('fetchAlleleNumberForTranscript', () => {
+  test('queries the same indices and intervals as the gene query', async () => {
+    const { searches, client } = stubEsClient()
+    await fetchAlleleNumberForTranscript(client, 'gnomad_r4', transcript)
+
+    expect(searches.map((search) => search.index)).toEqual([
+      'gnomad_v4_exome_allele_number',
+      'gnomad_v4_genome_allele_number',
+    ])
+    expect(searches[0].body.aggregations.allele_number.histogram.interval).toEqual(101)
+  })
+})
+
+describe('region allele number queries', () => {
+  test('fetch exome and genome independently', async () => {
+    const { searches, client } = stubEsClient()
+    await fetchExomeAlleleNumberForRegion(client, 'gnomad_r4', region)
+    await fetchGenomeAlleleNumberForRegion(client, 'gnomad_r4', region)
+
+    expect(searches.map((search) => search.index)).toEqual([
+      'gnomad_v4_exome_allele_number',
+      'gnomad_v4_genome_allele_number',
+    ])
+  })
+
+  test('pad the region by 75 bases on each side', async () => {
+    const { searches, client } = stubEsClient()
+    await fetchExomeAlleleNumberForRegion(client, 'gnomad_r4', region)
+
+    expect(searches[0].body.query.bool.filter[1].bool.should).toEqual([
+      { range: { 'locus.position': { gte: 55039372, lte: 55064927 } } },
+    ])
+    // 25405 bases of region plus 150 of padding, over 500 buckets.
+    expect(searches[0].body.aggregations.allele_number.histogram.interval).toEqual(51)
+  })
+})
+
+describe('datasets without an allele number release', () => {
+  test.each([
+    ['gnomad_r4_non_ukb', 'GRCh38'],
+    ['gnomad_r3', 'GRCh38'],
+    ['gnomad_r2_1', 'GRCh37'],
+    ['exac', 'GRCh37'],
+  ])('%s is rejected rather than served the full callset', async (datasetId, referenceGenome) => {
+    const { searches, client } = stubEsClient()
+
+    await expect(
+      fetchAlleleNumberForGene(client, datasetId, { ...gene, reference_genome: referenceGenome })
+    ).rejects.toThrow('Allele number is not available for')
+    expect(searches).toHaveLength(0)
+  })
+})
+
+describe('when the Elasticsearch index has not been loaded yet', () => {
+  test('gene and transcript queries resolve to empty series', async () => {
+    const client = failingEsClient(indexNotFoundError)
+
+    // The pipeline may not have run yet. Serving no allele number lets the
+    // browser hide the call rate metric instead of failing the whole page.
+    expect(await fetchAlleleNumberForGene(client, 'gnomad_r4', gene)).toEqual({
+      exome: [],
+      genome: [],
+    })
+    expect(await fetchAlleleNumberForTranscript(client, 'gnomad_r4', transcript)).toEqual({
+      exome: [],
+      genome: [],
+    })
+  })
+
+  test('region queries resolve to an empty series', async () => {
+    const client = failingEsClient(indexNotFoundError)
+
+    expect(await fetchExomeAlleleNumberForRegion(client, 'gnomad_r4', region)).toEqual([])
+  })
+
+  test('the empty result is not cached', async () => {
+    // Cache entries have their expiration refreshed on every read, so caching
+    // an empty result would outlive the pipeline run that fixes it.
+    expect(
+      await fetchAlleleNumberForGene(failingEsClient(indexNotFoundError), 'gnomad_r4', gene)
+    ).toEqual({ exome: [], genome: [] })
+
+    const { client } = stubEsClient({
+      gnomad_v4_exome_allele_number: [bucket(55039447, 1460124, 99.877)],
+    })
+    const { exome } = await fetchAlleleNumberForGene(client, 'gnomad_r4', gene)
+    expect(exome).toEqual([{ pos: 55039447, an: 1460124, an_percent: 99.877 }])
+  })
+
+  test('other Elasticsearch failures are not swallowed', async () => {
+    const client = failingEsClient(new Error('search_phase_execution_exception'))
+
+    await expect(fetchAlleleNumberForGene(client, 'gnomad_r4', gene)).rejects.toThrow(
+      'search_phase_execution_exception'
+    )
+  })
+})

--- a/graphql-api/src/queries/allele-number-queries.ts
+++ b/graphql-api/src/queries/allele-number-queries.ts
@@ -1,0 +1,214 @@
+import { withCache } from '../cache'
+import { DATASET_LABELS } from '../datasets'
+import { UserVisibleError } from '../errors'
+import logger from '../logger'
+
+import { extendRegions, mergeOverlappingRegions, totalRegionSize } from './helpers/region-helpers'
+
+import { assertDatasetAndReferenceGenomeMatch } from './helpers/validation-helpers'
+
+/**
+ * Datasets with an all-sites allele number release.
+ *
+ * Both indices are genuinely v4.1, unlike coverage, where gnomAD v4 still reads
+ * its genome series from the v3.0.1 index.
+ *
+ * This is an allowlist rather than a "reject subsets" check. Subsets, older
+ * releases and the SV/CNV datasets all lack an allele number release, and an
+ * allowlist cannot quietly admit a new one -- a v4 subset would otherwise pass
+ * a `gnomad_r2_1_`/`gnomad_r3_` prefix check and be served the full callset's
+ * allele number, which is not the same number at all.
+ */
+const ALLELE_NUMBER_INDICES: { [datasetId: string]: { exome: string; genome: string } } = {
+  gnomad_r4: {
+    exome: 'gnomad_v4_exome_allele_number',
+    genome: 'gnomad_v4_genome_allele_number',
+  },
+}
+
+const assertAlleleNumberAvailable = (datasetId: string) => {
+  if (!(datasetId in ALLELE_NUMBER_INDICES)) {
+    // @ts-expect-error TS(7053) DATASET_LABELS is a literal object, not a Record.
+    throw new UserVisibleError(`Allele number is not available for ${DATASET_LABELS[datasetId]}`)
+  }
+}
+
+// GRCh38 indices use chr-prefixed contig names, GRCh37 indices do not.
+const contigForFeature = ({ chrom, reference_genome: referenceGenome }: any) =>
+  referenceGenome === 'GRCh38' ? `chr${chrom}` : chrom
+
+/**
+ * True for the error Elasticsearch raises when an index does not exist.
+ *
+ * The allele number indices are loaded by a pipeline run of their own, so an
+ * API deployed ahead of that load will see this. Matching on the exception type
+ * rather than on a 404 status keeps unrelated not-found responses out.
+ */
+const isIndexNotFoundError = (error: any) =>
+  (error?.meta?.body ?? error?.body)?.error?.type === 'index_not_found_exception'
+
+/**
+ * Run `fetch`, reporting a missing Elasticsearch index as "no data".
+ *
+ * A missing index means the pipeline has not been loaded yet. That is a
+ * transient operational state, not a bad request, and the browser handles it by
+ * hiding the call rate metric -- much better than failing the whole page.
+ *
+ * This deliberately wraps the *cached* function rather than sitting inside it.
+ * An empty result produced by an unloaded index must never reach the cache:
+ * cache entries have their expiration refreshed on every read, so an empty
+ * result cached for a popular gene would outlive the pipeline run that fixes it.
+ */
+const emptyIfIndexNotFound = async (empty: any, fetch: () => Promise<any>) => {
+  try {
+    return await fetch()
+  } catch (error) {
+    if (isIndexNotFoundError(error)) {
+      logger.warn(`Allele number index not loaded, serving no allele number data (${error})`)
+      return empty
+    }
+    throw error
+  }
+}
+
+// ================================================================================================
+// Base query
+// ================================================================================================
+
+const fetchAlleleNumber = async (esClient: any, { index, contig, regions, bucketSize }: any) => {
+  const response = await esClient.search({
+    index,
+    type: '_doc',
+    size: 0,
+    body: {
+      query: {
+        bool: {
+          filter: [
+            { term: { 'locus.contig': contig } },
+            {
+              bool: {
+                should: regions.map(({ start, stop }: any) => ({
+                  range: { 'locus.position': { gte: start, lte: stop } },
+                })),
+              },
+            },
+          ],
+        },
+      },
+      aggregations: {
+        allele_number: {
+          histogram: {
+            field: 'locus.position',
+            interval: bucketSize,
+          },
+          aggregations: {
+            an: { avg: { field: 'an' } },
+            an_percent: { avg: { field: 'an_percent' } },
+          },
+        },
+      },
+    },
+  })
+
+  return response.body.aggregations.allele_number.buckets.map((bucket: any) => ({
+    pos: bucket.key,
+    // Nulls are preserved rather than coerced to 0 the way the coverage query
+    // does. A bucket that covers no indexed base is not a bucket where nobody
+    // was called, and plotting it as zero would draw a callability cliff that
+    // is not in the data.
+    //
+    // Allele number is a count of alleles, so the average over a bucket is
+    // rounded back to a whole number.
+    an: bucket.an.value === null ? null : Math.round(bucket.an.value),
+    an_percent:
+      bucket.an_percent.value === null ? null : Math.round(bucket.an_percent.value * 1000) / 1000,
+  }))
+}
+
+// ================================================================================================
+// Region queries
+// ================================================================================================
+
+const fetchAlleleNumberForRegion = (
+  esClient: any,
+  datasetId: any,
+  region: any,
+  dataType: 'exome' | 'genome'
+) => {
+  assertDatasetAndReferenceGenomeMatch(datasetId, region.reference_genome)
+  assertAlleleNumberAvailable(datasetId)
+
+  // The +150 accounts for the 75 bases of padding added at each end below.
+  const regionSize = region.stop - region.start + 150
+  const bucketSize = Math.max(Math.floor(regionSize / 500), 1)
+
+  return fetchAlleleNumber(esClient, {
+    index: ALLELE_NUMBER_INDICES[datasetId][dataType],
+    contig: contigForFeature(region),
+    regions: [{ start: region.start - 75, stop: region.stop + 75 }],
+    bucketSize,
+  })
+}
+
+// Regions are not cached, matching the region coverage queries.
+export const fetchExomeAlleleNumberForRegion = (esClient: any, datasetId: any, region: any) =>
+  emptyIfIndexNotFound([], () => fetchAlleleNumberForRegion(esClient, datasetId, region, 'exome'))
+
+export const fetchGenomeAlleleNumberForRegion = (esClient: any, datasetId: any, region: any) =>
+  emptyIfIndexNotFound([], () => fetchAlleleNumberForRegion(esClient, datasetId, region, 'genome'))
+
+// ================================================================================================
+// Gene and transcript queries
+// ================================================================================================
+
+/**
+ * Allele number over the exons of a gene or transcript.
+ *
+ * The padding, merging and bucket sizing are the same as the coverage query for
+ * the same feature, so the two metrics bin to the same positions and a reader
+ * can compare them bucket for bucket.
+ */
+const fetchAlleleNumberForExons = async (esClient: any, datasetId: any, feature: any) => {
+  assertDatasetAndReferenceGenomeMatch(datasetId, feature.reference_genome)
+  assertAlleleNumberAvailable(datasetId)
+
+  const paddedExons = extendRegions(75, feature.exons)
+  const mergedExons = mergeOverlappingRegions(
+    paddedExons.sort((a: any, b: any) => a.start - b.start)
+  )
+  const totalIntervalSize = totalRegionSize(mergedExons)
+  const bucketSize = Math.max(Math.floor(totalIntervalSize / 500), 1)
+
+  const indices = ALLELE_NUMBER_INDICES[datasetId]
+  const query = { contig: contigForFeature(feature), regions: mergedExons, bucketSize }
+
+  const [exome, genome] = await Promise.all([
+    fetchAlleleNumber(esClient, { ...query, index: indices.exome }),
+    fetchAlleleNumber(esClient, { ...query, index: indices.genome }),
+  ])
+
+  return { exome, genome }
+}
+
+const cachedAlleleNumberForGene = withCache(
+  fetchAlleleNumberForExons,
+  (_: any, datasetId: any, gene: any) => `allele_number:${datasetId}:gene:${gene.gene_id}`,
+  { expiration: 604800 }
+)
+
+const cachedAlleleNumberForTranscript = withCache(
+  fetchAlleleNumberForExons,
+  (_: any, datasetId: any, transcript: any) =>
+    `allele_number:${datasetId}:transcript:${transcript.transcript_id}`,
+  { expiration: 3600 }
+)
+
+export const fetchAlleleNumberForGene = (esClient: any, datasetId: any, gene: any) =>
+  emptyIfIndexNotFound({ exome: [], genome: [] }, () =>
+    cachedAlleleNumberForGene(esClient, datasetId, gene)
+  )
+
+export const fetchAlleleNumberForTranscript = (esClient: any, datasetId: any, transcript: any) =>
+  emptyIfIndexNotFound({ exome: [], genome: [] }, () =>
+    cachedAlleleNumberForTranscript(esClient, datasetId, transcript)
+  )


### PR DESCRIPTION
Part of #1943. Refactor of #1944. Continuation of #1945.

Second of three stacked PRs adding a **Call rate (AN%)** metric to the coverage track
(#1943). Adds the GraphQL field the browser will read in PR 3. Nothing user-visible
changes here.

## What this does

```graphql
Gene.allele_number(dataset: DatasetId): FeatureAlleleNumber!
Transcript.allele_number(dataset: DatasetId): FeatureAlleleNumber!
Region.allele_number(dataset: DatasetId!): RegionAlleleNumber!
```

Each returns `exome` and `genome` arrays of `{ pos, an, an_percent }`. The shape mirrors
`coverage` on the same three types, including `Region` getting its own type so exome and
genome resolve independently, and the same 2.5 Mb region guard.

`allele-number-queries.ts` is deliberately close to `coverage-queries.ts` — same 75 bp
padding, same exon sort/merge, same `floor(size / 500)` bucketing — so the two metrics bin
to the same positions and a reader can compare them bucket for bucket. **It is worth
reading the two files side by side; the differences below are the whole review.**

## Review notes

### 1. Datasets are allowlisted, not denylisted

Coverage rejects subsets with `datasetId.startsWith('gnomad_r2_1_') || startsWith('gnomad_r3_')`.
Copying that would let `gnomad_r4_non_ukb` through and serve it the **full v4.1 release's**
allele number.

That matters more here than it does for coverage. Read depth barely differs between a
release and its subsets, which is why they share a coverage index. Call rate is a direct
function of which samples are in the callset, so the full release's number is simply the
wrong number for a subset.

`ALLELE_NUMBER_INDICES` is therefore the single source of truth, and anything not in it —
subsets, older releases, the SV/CNV datasets — gets a `UserVisibleError`. A future release
cannot be admitted by accident.

### 2. Nulls are preserved instead of coerced to zero

Coverage does `bucket.mean.value || 0`. Here a null bucket stays null. A bucket that covers
no indexed base is not a bucket where nobody was called, and drawing it at zero would put a
callability cliff in the plot that is not in the data. PR 3 breaks the plotted path at
these buckets instead.

### 3. A missing index resolves to empty — but is never cached

The allele number indices are loaded by a pipeline run of their own, so the API may well be
deployed before them. `index_not_found_exception` is reported as an empty series, which
lets the browser hide the call rate metric rather than failing the whole page.

The important detail is *where* that happens: `emptyIfIndexNotFound` wraps the **cached**
function rather than sitting inside it.

```ts
export const fetchAlleleNumberForGene = (esClient, datasetId, gene) =>
  emptyIfIndexNotFound({ exome: [], genome: [] }, () =>
    cachedAlleleNumberForGene(esClient, datasetId, gene)
  )
```

If the empty result went through `withCache`, it would be stored for 7 days — and
`cache.ts` refreshes an entry's expiration on every read, so a popular gene would keep
serving an empty track indefinitely, outliving the pipeline run that fixed it. There is a
test for exactly this (`the empty result is not cached`).

Two related choices:

- The check matches on the **exception type**, not on a 404 status, so unrelated not-found
  responses are not silently swallowed. Every other Elasticsearch failure propagates —
  also tested.
- `fetchAlleleNumber` does not wrap errors in `new Error("Couldn't fetch …")` the way
  coverage does. That wrapper would destroy the error body this check depends on, and the
  Elasticsearch layer already logs failures in detail.

### 4. Cache TTLs follow the coverage convention

Gene 7 days, transcript 1 hour, region uncached — matching `coverage-queries.ts` exactly.

### 5. `an` is an `Int`

It is a count of alleles, so the per-bucket average is rounded back to a whole number.
`an_percent` is a `Float` rounded to three decimals. The browser only reads `an_percent`
today; `an` is exposed for API users and for a possible raw-AN axis later.

## Verification

```bash
pnpm test:jest --selectProjects graphql-api
```

The spec uses a fake Elasticsearch client, so no cluster is needed. It covers index
selection, `chr`-prefixed contigs, the exon merge (the fixture has two exons that only
overlap once padded, and asserts the single merged range and the resulting bucket size),
region padding, rounding, null preservation, every dataset without a release, and the four
missing-index behaviours above.

```bash
pnpm lint:js
```

Against a live cluster, `Gene.allele_number(dataset: gnomad_r4)` on PCSK9
(`ENSG00000169174`) should return `an_percent` near 100 across the coding exons, and
`dataset: gnomad_r4_non_ukb` should return `Allele number is not available for gnomAD
v4.1.1 (non-UKB)`.
