### PR TITLE
Show call rate on the gene, transcript and region coverage tracks

### DIFF
--- a/browser/help/topics/call-rate.md
+++ b/browser/help/topics/call-rate.md
@@ -1,0 +1,20 @@
+---
+id: call-rate
+title: 'Call rate (AN%)'
+---
+
+<!-- DRAFT: wording pending methods review. -->
+
+The proportion of alleles that were successfully called at a site, expressed as a percentage of the alleles that could have been called there. It is the same quantity gnomAD publishes as allele number percent (AN%).
+
+The numerator is the allele number (AN): the number of alleles carrying a high-quality<sup>1</sup> genotype call at that site, summed across all samples in the release. The denominator is the largest allele number the site could have had if every sample had been called. For an autosomal site in a release of 10 samples, 5 high-quality genotypes give:
+
+5 genotypes × 2 alleles per genotype ÷ 20 possible alleles = 25%
+
+The denominator accounts for ploidy. Two alleles are counted per sample on the autosomes and in the pseudoautosomal (PAR) regions of chromosome X; two per XX sample and one per XY sample outside the PAR on chromosome X; one per XY sample on chromosome Y, where XX samples contribute nothing at all.
+
+Call rate is a higher-resolution alternative to the read depth metrics on the same track. Depth is measured on a subset of samples and says how well a site was sequenced; call rate is measured on every sample and says how often a genotype at that site actually survived quality control.
+
+Note that the exome and genome series shown for call rate both come from gnomAD v4.1, whereas the genome series shown for the read depth metrics is still the v3.0.1 release. The two are not drawn from the same set of genomes.
+
+<sup>1</sup> A genotype counts towards the allele number when it meets gnomAD's "adj" criteria: genotype quality (GQ) ≥ 20, depth (DP) ≥ 10, and, for heterozygous calls, an allele balance ≥ 0.2.

--- a/browser/src/AlleleNumberQuery.spec.tsx
+++ b/browser/src/AlleleNumberQuery.spec.tsx
@@ -1,0 +1,142 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+
+import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals'
+
+import { DatasetId, allDatasetIds, hasAlleleNumber } from '@gnomad/dataset-metadata/metadata'
+
+import { mockQueries } from '../../tests/__helpers__/queries'
+import AlleleNumberQuery, { AlleleNumberTrackProps } from './AlleleNumberQuery'
+import { BaseQuery } from './Query'
+
+jest.mock('./Query', () => {
+  const originalModule = jest.requireActual('./Query')
+
+  return {
+    __esModule: true,
+    ...(originalModule as object),
+    BaseQuery: jest.fn(),
+  }
+})
+
+const {
+  mockApiCalls,
+  resetMockApiCalls,
+  resetMockApiResponses,
+  setMockApiResponses,
+  simulateApiResponse,
+} = mockQueries()
+
+beforeEach(() => {
+  ;(BaseQuery as any).mockImplementation(
+    jest.fn(({ children, operationName, variables, query }: any) =>
+      simulateApiResponse('BaseQuery', query, children, operationName, variables)
+    )
+  )
+})
+
+afterEach(() => {
+  resetMockApiCalls()
+  resetMockApiResponses()
+})
+
+const operationName = 'GeneAlleleNumber'
+const query = `
+query ${operationName}($geneId: String!, $datasetId: DatasetId!, $referenceGenome: ReferenceGenomeId!) {
+  feature: gene(gene_id: $geneId, reference_genome: $referenceGenome) {
+    allele_number(dataset: $datasetId) {
+      exome {
+        pos
+        an_percent
+      }
+    }
+  }
+}
+`
+
+/** Renders the query and returns whatever it handed to its children. */
+const renderQuery = (datasetId: DatasetId): AlleleNumberTrackProps => {
+  let received: AlleleNumberTrackProps | undefined
+
+  renderer.create(
+    <AlleleNumberQuery
+      datasetId={datasetId}
+      operationName={operationName}
+      query={query}
+      variables={{ geneId: 'ENSG00000169174' }}
+    >
+      {(alleleNumber) => {
+        received = alleleNumber
+        return <div />
+      }}
+    </AlleleNumberQuery>
+  )
+
+  if (!received) {
+    throw new Error('AlleleNumberQuery did not render its children')
+  }
+  return received
+}
+
+const datasetsWithoutAlleleNumber = allDatasetIds.filter((id) => !hasAlleleNumber(id))
+
+describe('datasets without an allele number release', () => {
+  test.each(datasetsWithoutAlleleNumber)('%s is not queried at all', (datasetId) => {
+    // Subsets are in here as well as older releases. Call rate is a function of
+    // which samples are in the callset, so a subset must not be served the full
+    // release's allele number the way it is served the full release's coverage.
+    expect(renderQuery(datasetId)).toEqual({ isAlleleNumberLoading: false })
+    expect(mockApiCalls()).toEqual([])
+  })
+})
+
+describe('datasets with an allele number release', () => {
+  test('are queried with their own dataset and reference genome', () => {
+    setMockApiResponses({ [operationName]: () => ({ feature: { allele_number: {} } }) })
+
+    renderQuery('gnomad_r4')
+
+    expect(mockApiCalls()).toHaveLength(1)
+    expect(mockApiCalls()[0].variables).toEqual({
+      geneId: 'ENSG00000169174',
+      datasetId: 'gnomad_r4',
+      referenceGenome: 'GRCh38',
+    })
+  })
+
+  test('turn the response into exome and genome series', () => {
+    setMockApiResponses({
+      [operationName]: () => ({
+        feature: {
+          allele_number: {
+            exome: [{ pos: 100, an_percent: 99.5 }],
+            genome: [{ pos: 100, an_percent: 98.5 }],
+          },
+        },
+      }),
+    })
+
+    const { alleleNumberDatasets } = renderQuery('gnomad_r4')
+
+    expect(alleleNumberDatasets?.map((dataset) => dataset.name)).toEqual(['exome', 'genome'])
+    expect(alleleNumberDatasets?.[0].buckets).toEqual([{ pos: 100, an_percent: 99.5 }])
+  })
+
+  test('report no series when the response is empty', () => {
+    // An empty series would otherwise put a legend entry on the track for data
+    // that is not there.
+    setMockApiResponses({
+      [operationName]: () => ({ feature: { allele_number: { exome: [], genome: [] } } }),
+    })
+
+    expect(renderQuery('gnomad_r4')).toEqual({ isAlleleNumberLoading: false })
+  })
+
+  test('report no series when the query fails', () => {
+    // A failed allele number request must not take the coverage track with it,
+    // so a null feature is treated the same as an empty one.
+    setMockApiResponses({ [operationName]: () => ({ feature: null }) })
+
+    expect(renderQuery('gnomad_r4')).toEqual({ isAlleleNumberLoading: false })
+  })
+})

--- a/browser/src/AlleleNumberQuery.tsx
+++ b/browser/src/AlleleNumberQuery.tsx
@@ -1,0 +1,72 @@
+import React from 'react'
+
+import { DatasetId, hasAlleleNumber, referenceGenome } from '@gnomad/dataset-metadata/metadata'
+
+import { alleleNumberConfig } from './coverageStyles'
+import { BaseQuery } from './Query'
+
+/** The allele number props a CoverageTrack takes, ready to be spread onto it. */
+export type AlleleNumberTrackProps = {
+  alleleNumberDatasets?: ReturnType<typeof alleleNumberConfig>
+  isAlleleNumberLoading: boolean
+}
+
+const NO_ALLELE_NUMBER: AlleleNumberTrackProps = { isAlleleNumberLoading: false }
+
+type Props = {
+  datasetId: DatasetId
+  operationName: string
+  query: string
+  /** Feature identifiers only; dataset and reference genome are added here. */
+  variables: { [name: string]: any }
+  children: (alleleNumber: AlleleNumberTrackProps) => JSX.Element
+}
+
+/**
+ * Fetches the allele number series that backs a coverage track's call rate metric.
+ *
+ * This is a request of its own rather than extra fields on the coverage query,
+ * for two reasons. A single document would make the coverage track fail
+ * outright against an API that predates the `allele_number` field, because an
+ * unknown field is a query validation error rather than a null -- the browser
+ * could not then be deployed ahead of the API. And BaseQuery, unlike Query,
+ * renders its children whatever the request is doing, which is what lets the
+ * coverage track draw normally while allele number is loading or unavailable.
+ *
+ * Datasets without an allele number release skip the request entirely. Note
+ * this uses the dataset itself, not `coverageDatasetId`: coverage is shared
+ * between a release and its subsets because read depth barely differs between
+ * them, but call rate is a function of which samples are in the callset, so a
+ * subset must not be shown the full release's numbers.
+ *
+ * Queries passed here must alias their feature to `feature`, so that one
+ * component can read gene, transcript and region responses alike.
+ */
+const AlleleNumberQuery = ({ datasetId, operationName, query, variables, children }: Props) => {
+  if (!hasAlleleNumber(datasetId)) {
+    return children(NO_ALLELE_NUMBER)
+  }
+
+  return (
+    <BaseQuery
+      operationName={operationName}
+      query={query}
+      variables={{ ...variables, datasetId, referenceGenome: referenceGenome(datasetId) }}
+    >
+      {({ data, loading }: any) => {
+        const alleleNumber = data?.feature?.allele_number
+        // Empty series become undefined: alleleNumberConfig draws anything
+        // truthy, so [] would add a legend entry for a series with no data.
+        const exome = alleleNumber?.exome?.length ? alleleNumber.exome : null
+        const genome = alleleNumber?.genome?.length ? alleleNumber.genome : null
+
+        return children({
+          isAlleleNumberLoading: Boolean(loading),
+          alleleNumberDatasets: exome || genome ? alleleNumberConfig(exome, genome) : undefined,
+        })
+      }}
+    </BaseQuery>
+  )
+}
+
+export default AlleleNumberQuery

--- a/browser/src/CoverageTrack.spec.tsx
+++ b/browser/src/CoverageTrack.spec.tsx
@@ -1,0 +1,183 @@
+import React from 'react'
+import { createRenderer } from 'react-test-renderer/shallow'
+
+import { describe, expect, test } from '@jest/globals'
+
+import CoverageTrack, {
+  MetricOptions,
+  defaultCoverageMetric,
+  domainForMetric,
+  isAlleleNumberMetric,
+  tickFormatForMetric,
+  trackTitleForMetric,
+} from './CoverageTrack'
+import InfoButton from './help/InfoButton'
+
+const coverageDatasets = [
+  {
+    buckets: [
+      { pos: 100, mean: 30, median: 30, over_20: 0.97 },
+      { pos: 200, mean: 32, median: 31, over_20: 0.98 },
+    ],
+    color: 'green',
+    name: 'genome',
+  },
+]
+
+const alleleNumberDatasets = [
+  {
+    buckets: [
+      { pos: 100, an_percent: 99.5 },
+      { pos: 200, an_percent: 99.9 },
+    ],
+    color: 'green',
+    name: 'genome',
+  },
+]
+
+const renderShallow = (props: any) => {
+  const shallowRenderer = createRenderer()
+  shallowRenderer.render(<CoverageTrack datasetId="gnomad_r4" {...props} />)
+  return shallowRenderer
+}
+
+/** Every element in a React element tree, depth first. */
+const elementsIn = (node: any): any[] => {
+  if (!node || typeof node !== 'object') {
+    return []
+  }
+  if (Array.isArray(node)) {
+    return node.flatMap(elementsIn)
+  }
+  return [node, ...elementsIn(node.props?.children)]
+}
+
+/** The track's own panels, which are rendered by Track rather than inline. */
+const leftPanel = (props: any) => renderShallow(props).getRenderOutput().props.renderLeftPanel()
+const topPanel = (props: any) => renderShallow(props).getRenderOutput().props.renderTopPanel()
+
+describe('metric presentation', () => {
+  test.each([
+    [MetricOptions.mean, 'Per-base mean depth of coverage'],
+    [MetricOptions.median, 'Per-base median depth of coverage'],
+    [MetricOptions.over_20, 'Fraction of individuals with coverage over 20'],
+    [MetricOptions.an_percent, 'Call rate (AN%)'],
+  ])('%s is titled "%s"', (metric, expected) => {
+    expect(trackTitleForMetric(metric)).toBe(expected)
+  })
+
+  test('call rate is drawn on a percentage axis, not a fraction or a depth', () => {
+    expect(domainForMetric(MetricOptions.an_percent, 100)).toEqual([0, 100])
+    expect(domainForMetric(MetricOptions.over_20, 100)).toEqual([0, 1])
+    expect(domainForMetric(MetricOptions.mean, 250)).toEqual([0, 250])
+  })
+
+  test('only the call rate axis gets a percent suffix', () => {
+    const formatTick = tickFormatForMetric(MetricOptions.an_percent)!
+    expect(formatTick(100)).toBe('100%')
+    expect(tickFormatForMetric(MetricOptions.mean)).toBeUndefined()
+    expect(tickFormatForMetric(MetricOptions.over_20)).toBeUndefined()
+  })
+
+  test('identifies which metrics read from the allele number series', () => {
+    expect(isAlleleNumberMetric(MetricOptions.an_percent)).toBe(true)
+    expect(isAlleleNumberMetric(MetricOptions.over_20)).toBe(false)
+  })
+
+  test('defaults to a v4 metric only for v4 datasets', () => {
+    expect(defaultCoverageMetric('gnomad_r4')).toBe(MetricOptions.over_20)
+    expect(defaultCoverageMetric('exac')).toBe(MetricOptions.mean)
+  })
+})
+
+describe('the metric selector', () => {
+  const offersCallRate = (props: any) =>
+    elementsIn(topPanel(props)).some((element) => element.props?.value === MetricOptions.an_percent)
+
+  test('offers call rate once the allele number series has arrived', () => {
+    expect(offersCallRate({ datasets: coverageDatasets, alleleNumberDatasets })).toBe(true)
+  })
+
+  test('offers call rate while the allele number request is in flight', () => {
+    expect(offersCallRate({ datasets: coverageDatasets, isAlleleNumberLoading: true })).toBe(true)
+  })
+
+  test('does not offer call rate when there is no allele number for this dataset', () => {
+    expect(offersCallRate({ datasets: coverageDatasets })).toBe(false)
+  })
+})
+
+describe('the help button', () => {
+  const helpTopic = (props: any) =>
+    elementsIn(leftPanel(props)).find((element) => element.type === InfoButton)?.props?.topic
+
+  test('explains call rate', () => {
+    const props = { datasets: coverageDatasets, alleleNumberDatasets }
+    expect(helpTopic({ ...props, metric: MetricOptions.an_percent })).toBe('call-rate')
+  })
+
+  test('is absent for the depth metrics, which have no help topic', () => {
+    const props = { datasets: coverageDatasets, alleleNumberDatasets }
+    expect(helpTopic({ ...props, metric: MetricOptions.mean })).toBeUndefined()
+    expect(helpTopic({ ...props, metric: MetricOptions.over_20 })).toBeUndefined()
+  })
+})
+
+describe('choosing the metric to show', () => {
+  const selectedMetric = (props: any) =>
+    (renderShallow(props).getMountedInstance() as any).state.selectedMetric
+
+  test('shows call rate from the first render when it is on its way', () => {
+    // Chosen at mount rather than when the response lands, so the reader does
+    // not see the track change metric under them a moment later.
+    expect(selectedMetric({ datasets: coverageDatasets, isAlleleNumberLoading: true })).toBe(
+      MetricOptions.an_percent
+    )
+  })
+
+  test('shows a coverage metric when there is no allele number', () => {
+    expect(selectedMetric({ datasets: coverageDatasets })).toBe(MetricOptions.over_20)
+  })
+
+  test('respects a metric the caller asked for', () => {
+    const props = { datasets: coverageDatasets, isAlleleNumberLoading: true }
+    expect(selectedMetric({ ...props, metric: MetricOptions.mean })).toBe(MetricOptions.mean)
+  })
+
+  test('falls back to a coverage metric if the allele number never arrives', () => {
+    const shallowRenderer = renderShallow({
+      datasets: coverageDatasets,
+      isAlleleNumberLoading: true,
+    })
+    const track = shallowRenderer.getMountedInstance() as any
+    const loadingProps = track.props
+
+    // Shallow rendering does not run componentDidUpdate, so render the settled
+    // props and then drive the update by hand.
+    shallowRenderer.render(<CoverageTrack datasetId="gnomad_r4" datasets={coverageDatasets} />)
+    track.componentDidUpdate(loadingProps)
+
+    expect(track.state.selectedMetric).toBe(MetricOptions.over_20)
+  })
+
+  test('leaves a coverage metric alone if the allele number never arrives', () => {
+    const shallowRenderer = renderShallow({
+      datasets: coverageDatasets,
+      isAlleleNumberLoading: true,
+      metric: MetricOptions.median,
+    })
+    const track = shallowRenderer.getMountedInstance() as any
+    const loadingProps = track.props
+
+    shallowRenderer.render(
+      <CoverageTrack
+        datasetId="gnomad_r4"
+        datasets={coverageDatasets}
+        metric={MetricOptions.median}
+      />
+    )
+    track.componentDidUpdate(loadingProps)
+
+    expect(track.state.selectedMetric).toBe(MetricOptions.median)
+  })
+})

--- a/browser/src/CoverageTrack.tsx
+++ b/browser/src/CoverageTrack.tsx
@@ -7,6 +7,7 @@ import { AxisLeft } from '@visx/axis'
 import { Track } from '@gnomad/region-viewer'
 import { Button, Select } from '@gnomad/ui'
 import { DatasetId, isV4 } from '@gnomad/dataset-metadata/metadata'
+import InfoButton from './help/InfoButton'
 
 const TopPanel = styled.div`
   display: flex;
@@ -85,19 +86,58 @@ export enum MetricOptions {
   over_30 = 'over_30',
   over_50 = 'over_50',
   over_100 = 'over_100',
+  an_percent = 'an_percent',
+}
+
+/** Metrics read from the allele number series rather than the coverage series. */
+export const isAlleleNumberMetric = (metric: MetricOptions) => metric === MetricOptions.an_percent
+
+/** The metric to show when there is no call rate and the caller named none. */
+export const defaultCoverageMetric = (datasetId: DatasetId) =>
+  isV4(datasetId) ? MetricOptions.over_20 : MetricOptions.mean
+
+export const trackTitleForMetric = (metric: MetricOptions) => {
+  if (isAlleleNumberMetric(metric)) {
+    return 'Call rate (AN%)'
+  }
+  if (metric === MetricOptions.mean || metric === MetricOptions.median) {
+    return `Per-base ${metric} depth of coverage`
+  }
+  return `Fraction of individuals with coverage over ${metric.slice('over_'.length)}`
+}
+
+/** The y-axis extent for a metric: a percentage, a read depth, or a fraction. */
+export const domainForMetric = (metric: MetricOptions, maxCoverage: number): [number, number] => {
+  if (isAlleleNumberMetric(metric)) {
+    return [0, 100]
+  }
+  if (metric === MetricOptions.mean || metric === MetricOptions.median) {
+    return [0, maxCoverage]
+  }
+  return [0, 1]
+}
+
+const formatPercentTick = (value: any) => `${value}%`
+
+export const tickFormatForMetric = (metric: MetricOptions) =>
+  isAlleleNumberMetric(metric) ? formatPercentTick : undefined
+
+type CoverageTrackDataset = {
+  buckets: {
+    pos: number
+    mean?: number
+    median?: number
+    an_percent?: number
+  }[]
+  color: string
+  name: string
+  opacity?: number
 }
 
 type OwnCoverageTrackProps = {
-  datasets: {
-    buckets: {
-      pos: number
-      mean?: number
-      median?: number
-    }[]
-    color: string
-    name: string
-    opacity?: number
-  }[]
+  datasets: CoverageTrackDataset[]
+  alleleNumberDatasets?: CoverageTrackDataset[]
+  isAlleleNumberLoading?: boolean
   coverageOverThresholds?: number[]
   filenameForExport?: (...args: any[]) => any
   height?: number
@@ -110,6 +150,18 @@ type CoverageTrackState = { selectedMetric: MetricOptions }
 
 type CoverageTrackProps = OwnCoverageTrackProps & typeof CoverageTrack.defaultProps
 
+const offersAlleleNumber = (props: CoverageTrackProps) =>
+  Boolean(props.isAlleleNumberLoading || props.alleleNumberDatasets?.length)
+
+const initialMetric = (props: CoverageTrackProps) => {
+  if (props.metric) {
+    return props.metric
+  }
+  return offersAlleleNumber(props)
+    ? MetricOptions.an_percent
+    : defaultCoverageMetric(props.datasetId)
+}
+
 class CoverageTrack extends Component<CoverageTrackProps, CoverageTrackState> {
   static defaultProps = {
     filenameForExport: () => 'coverage',
@@ -121,13 +173,33 @@ class CoverageTrack extends Component<CoverageTrackProps, CoverageTrackState> {
 
   constructor(props: CoverageTrackProps) {
     super(props)
-    if (this.props.metric) {
-      this.state = { selectedMetric: this.props.metric }
-    } else if (isV4(this.props.datasetId)) {
-      this.state = { selectedMetric: MetricOptions.over_20 }
-    } else {
-      this.state = { selectedMetric: MetricOptions.mean }
+    this.state = { selectedMetric: initialMetric(props) }
+  }
+
+  componentDidUpdate(prevProps: CoverageTrackProps) {
+    // An allele number request that settles with nothing leaves the reader
+    // looking at an empty call rate plot, so fall back to a coverage metric.
+    // Guarded on a transition between props, so it cannot loop, and it leaves
+    // a metric the reader chose for themselves alone.
+    const wasOffered = offersAlleleNumber(prevProps)
+    const isOffered = offersAlleleNumber(this.props)
+
+    if (wasOffered && !isOffered && isAlleleNumberMetric(this.state.selectedMetric)) {
+      this.setState({ selectedMetric: defaultCoverageMetric(this.props.datasetId) })
     }
+  }
+
+  /** The series to draw: the allele number series under a call rate metric. */
+  activeDatasets = () => {
+    const { alleleNumberDatasets, datasets } = this.props
+    return isAlleleNumberMetric(this.state.selectedMetric) && alleleNumberDatasets?.length
+      ? alleleNumberDatasets
+      : datasets
+  }
+
+  metricValue = (bucket: any) => {
+    const value = bucket[this.state.selectedMetric]
+    return value === undefined ? null : value
   }
 
   plotRef = (el: any) => {
@@ -157,14 +229,17 @@ class CoverageTrack extends Component<CoverageTrackProps, CoverageTrackState> {
   }
 
   renderArea({ scaleCoverageMetric, scalePosition }: any) {
-    const { datasets, height } = this.props
-    const { selectedMetric } = this.state
+    const { height } = this.props
+    const datasets = this.activeDatasets()
 
     const pathGenerator = area()
+      // Buckets without a value for this metric break the path rather than
+      // being drawn at zero, which would put a callability cliff in the plot
+      // that is not in the data.
+      .defined((bucket) => this.metricValue(bucket) !== null)
       .x((bucket) => scalePosition((bucket as any).pos))
       .y0(height)
-      // @ts-expect-error TS(7015) FIXME: Element implicitly has an 'any' type because index... Remove this comment to see the full error message
-      .y1((bucket) => scaleCoverageMetric(bucket[selectedMetric]))
+      .y1((bucket) => scaleCoverageMetric(this.metricValue(bucket)))
 
     return datasets.map((dataset) => (
       <g key={dataset.name}>
@@ -179,8 +254,8 @@ class CoverageTrack extends Component<CoverageTrackProps, CoverageTrackState> {
   }
 
   renderBars({ isPositionDefined, scaleCoverageMetric, scalePosition, totalBases, width }: any) {
-    const { datasets, height } = this.props
-    const { selectedMetric } = this.state
+    const { height } = this.props
+    const datasets = this.activeDatasets()
 
     const barWidth = width / totalBases - 1
 
@@ -188,13 +263,10 @@ class CoverageTrack extends Component<CoverageTrackProps, CoverageTrackState> {
       <g key={dataset.name}>
         {dataset.buckets
           .filter(
-            (bucket: any) =>
-              bucket[selectedMetric] !== undefined &&
-              bucket[selectedMetric] !== null &&
-              isPositionDefined(bucket.pos)
+            (bucket: any) => this.metricValue(bucket) !== null && isPositionDefined(bucket.pos)
           )
           .map((bucket: any) => {
-            const barHeight = height - scaleCoverageMetric(bucket[selectedMetric])
+            const barHeight = height - scaleCoverageMetric(this.metricValue(bucket))
             const x = scalePosition(bucket.pos)
             return (
               <rect
@@ -236,17 +308,27 @@ class CoverageTrack extends Component<CoverageTrackProps, CoverageTrackState> {
   }
 
   render() {
-    const { coverageOverThresholds, datasets, height, maxCoverage } = this.props
+    const { coverageOverThresholds, height, maxCoverage } = this.props
     const { selectedMetric } = this.state
+    const datasets = this.activeDatasets()
 
-    const trackTitle =
-      selectedMetric === 'mean' || selectedMetric === 'median'
-        ? `Per-base ${selectedMetric} depth of coverage`
-        : `Fraction of individuals with coverage over ${selectedMetric.slice(5)}`
+    const trackTitle = trackTitleForMetric(selectedMetric)
 
     return (
       <Track
-        renderLeftPanel={() => <TitlePanel>{trackTitle}</TitlePanel>}
+        renderLeftPanel={() => (
+          <TitlePanel>
+            {isAlleleNumberMetric(selectedMetric) ? (
+              // Call rate is the only metric with a help topic. The title panel
+              // is a column, so the title and the button need a row of their own.
+              <span>
+                {trackTitle} <InfoButton topic="call-rate" />
+              </span>
+            ) : (
+              trackTitle
+            )}
+          </TitlePanel>
+        )}
         renderTopPanel={() => (
           <TopPanel>
             <Legend datasets={datasets} />
@@ -273,6 +355,11 @@ class CoverageTrack extends Component<CoverageTrackProps, CoverageTrackState> {
                     ))}
                   </optgroup>
                 )}
+                {offersAlleleNumber(this.props) && (
+                  <optgroup label="Allele number">
+                    <option value={MetricOptions.an_percent}>Call rate</option>
+                  </optgroup>
+                )}
               </Select>
             </label>
             <Button style={{ marginLeft: '1em' }} onClick={() => this.exportPlot()}>
@@ -283,9 +370,7 @@ class CoverageTrack extends Component<CoverageTrackProps, CoverageTrackState> {
       >
         {({ isPositionDefined, regions, scalePosition, width }: any) => {
           const scaleCoverageMetric = scaleLinear()
-            .domain(
-              selectedMetric === 'mean' || selectedMetric === 'median' ? [0, maxCoverage] : [0, 1]
-            )
+            .domain(domainForMetric(selectedMetric, maxCoverage))
             .range([height, 7])
 
           const axisWidth = 60
@@ -302,6 +387,7 @@ class CoverageTrack extends Component<CoverageTrackProps, CoverageTrackState> {
                     fontSize: 10,
                     textAnchor: 'end',
                   })}
+                  tickFormat={tickFormatForMetric(selectedMetric)}
                   scale={scaleCoverageMetric}
                   stroke="#333"
                 />

--- a/browser/src/GenePage/GeneCoverageTrack.tsx
+++ b/browser/src/GenePage/GeneCoverageTrack.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { referenceGenome, isExac, coverageDatasetId } from '@gnomad/dataset-metadata/metadata'
+import AlleleNumberQuery from '../AlleleNumberQuery'
 import { coverageConfigClassic, coverageConfigNew } from '../coverageStyles'
 import CoverageTrack from '../CoverageTrack'
 import Query from '../Query'
@@ -42,6 +43,25 @@ query ${operationName}($geneId: String!, $datasetId: DatasetId!, $referenceGenom
   }
 }
 `
+
+const alleleNumberOperationName = 'GeneAlleleNumber'
+const alleleNumberQuery = `
+query ${alleleNumberOperationName}($geneId: String!, $datasetId: DatasetId!, $referenceGenome: ReferenceGenomeId!, $includeExome: Boolean!, $includeGenome: Boolean!) {
+  feature: gene(gene_id: $geneId, reference_genome: $referenceGenome) {
+    allele_number(dataset: $datasetId) {
+      exome @include(if: $includeExome) {
+        pos
+        an_percent
+      }
+      genome @include(if: $includeGenome) {
+        pos
+        an_percent
+      }
+    }
+  }
+}
+`
+
 type OwnProps = {
   datasetId: string
   geneId: string
@@ -60,47 +80,61 @@ const GeneCoverageTrack = ({
   includeGenomeCoverage,
 }: Props) => {
   return (
-    <Query
-      operationName={operationName}
-      query={coverageQuery}
+    <AlleleNumberQuery
+      datasetId={datasetId}
+      operationName={alleleNumberOperationName}
+      query={alleleNumberQuery}
       variables={{
         geneId,
-        datasetId: coverageDatasetId(datasetId),
-        referenceGenome: referenceGenome(coverageDatasetId(datasetId)),
-        includeExomeCoverage,
-        includeGenomeCoverage,
-      }}
-      loadingMessage="Loading coverage"
-      loadingPlaceholderHeight={220}
-      errorMessage="Unable to load coverage"
-      success={(data: any) => {
-        if (!data.gene || !data.gene.coverage) {
-          return false
-        }
-        const exomeCoverage = includeExomeCoverage ? data.gene.coverage.exome : true
-        const genomeCoverage = includeGenomeCoverage ? data.gene.coverage.genome : true
-        return exomeCoverage || genomeCoverage
+        includeExome: includeExomeCoverage,
+        includeGenome: includeGenomeCoverage,
       }}
     >
-      {({ data }: any) => {
-        const exomeCoverage = includeExomeCoverage ? data.gene.coverage.exome : null
-        const genomeCoverage = includeGenomeCoverage ? data.gene.coverage.genome : null
+      {(alleleNumber) => (
+        <Query
+          operationName={operationName}
+          query={coverageQuery}
+          variables={{
+            geneId,
+            datasetId: coverageDatasetId(datasetId),
+            referenceGenome: referenceGenome(coverageDatasetId(datasetId)),
+            includeExomeCoverage,
+            includeGenomeCoverage,
+          }}
+          loadingMessage="Loading coverage"
+          loadingPlaceholderHeight={220}
+          errorMessage="Unable to load coverage"
+          success={(data: any) => {
+            if (!data.gene || !data.gene.coverage) {
+              return false
+            }
+            const exomeCoverage = includeExomeCoverage ? data.gene.coverage.exome : true
+            const genomeCoverage = includeGenomeCoverage ? data.gene.coverage.genome : true
+            return exomeCoverage || genomeCoverage
+          }}
+        >
+          {({ data }: any) => {
+            const exomeCoverage = includeExomeCoverage ? data.gene.coverage.exome : null
+            const genomeCoverage = includeGenomeCoverage ? data.gene.coverage.genome : null
 
-        const coverageConfig = isExac(datasetId)
-          ? coverageConfigClassic(exomeCoverage, genomeCoverage)
-          : coverageConfigNew(exomeCoverage, genomeCoverage)
+            const coverageConfig = isExac(datasetId)
+              ? coverageConfigClassic(exomeCoverage, genomeCoverage)
+              : coverageConfigNew(exomeCoverage, genomeCoverage)
 
-        return (
-          <CoverageTrack
-            coverageOverThresholds={[1, 5, 10, 15, 20, 25, 30, 50, 100]}
-            datasets={coverageConfig}
-            filenameForExport={() => `${geneId}_coverage`}
-            height={190}
-            datasetId={datasetId}
-          />
-        )
-      }}
-    </Query>
+            return (
+              <CoverageTrack
+                coverageOverThresholds={[1, 5, 10, 15, 20, 25, 30, 50, 100]}
+                datasets={coverageConfig}
+                {...alleleNumber}
+                filenameForExport={() => `${geneId}_coverage`}
+                height={190}
+                datasetId={datasetId}
+              />
+            )
+          }}
+        </Query>
+      )}
+    </AlleleNumberQuery>
   )
 }
 

--- a/browser/src/GenePage/GenePage.spec.tsx
+++ b/browser/src/GenePage/GenePage.spec.tsx
@@ -71,6 +71,11 @@ forDatasetsNotMatching(svRegexp, 'GenePage with non-SV dataset "%s"', (datasetId
           coverage: {},
         },
       }),
+      GeneAlleleNumber: () => ({
+        feature: {
+          allele_number: {},
+        },
+      }),
       CopyNumberVariantsInGene: () => ({
         gene: { copy_number_variants: [] },
       }),
@@ -127,6 +132,11 @@ forDatasetsMatching(svRegexp, 'GenePage with SV dataset "%s"', (datasetId) => {
           coverage: {},
         },
       }),
+      RegionAlleleNumber: () => ({
+        feature: {
+          allele_number: {},
+        },
+      }),
     })
     const tree = renderer.create(
       <MemoryRouter>
@@ -149,9 +159,19 @@ forDatasetsMatching(cnvRegexp, 'GenePage with CNV dataset "%s"', (datasetId) => 
           coverage: {},
         },
       }),
+      RegionAlleleNumber: () => ({
+        feature: {
+          allele_number: {},
+        },
+      }),
       GeneCoverage: () => ({
         gene: {
           coverage: {},
+        },
+      }),
+      GeneAlleleNumber: () => ({
+        feature: {
+          allele_number: {},
         },
       }),
     })
@@ -172,6 +192,11 @@ forDatasetsMatching(cnvRegexp, 'GenePage with CNV dataset "%s"', (datasetId) => 
       GeneCoverage: () => ({
         gene: {
           coverage: {},
+        },
+      }),
+      GeneAlleleNumber: () => ({
+        feature: {
+          allele_number: {},
         },
       }),
     })
@@ -215,6 +240,11 @@ describe.each([
       GeneCoverage: () => ({
         gene: {
           coverage: {},
+        },
+      }),
+      GeneAlleleNumber: () => ({
+        feature: {
+          allele_number: {},
         },
       }),
       CopyNumberVariantsInGene: () => ({

--- a/browser/src/RegionPage/RegionCoverageTrack.tsx
+++ b/browser/src/RegionPage/RegionCoverageTrack.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
-import { referenceGenome, coverageDatasetId } from '@gnomad/dataset-metadata/metadata'
+import { referenceGenome, coverageDatasetId, isExac } from '@gnomad/dataset-metadata/metadata'
+import AlleleNumberQuery from '../AlleleNumberQuery'
 import { coverageConfigClassic, coverageConfigNew } from '../coverageStyles'
 import CoverageTrack from '../CoverageTrack'
 import Query from '../Query'
@@ -43,6 +44,24 @@ query ${operationName}($chrom: String!, $start: Int!, $stop: Int!, $datasetId: D
 }
 `
 
+const alleleNumberOperationName = 'RegionAlleleNumber'
+const alleleNumberQuery = `
+query ${alleleNumberOperationName}($chrom: String!, $start: Int!, $stop: Int!, $datasetId: DatasetId!, $referenceGenome: ReferenceGenomeId!, $includeExome: Boolean!, $includeGenome: Boolean!) {
+  feature: region(chrom: $chrom, start: $start, stop: $stop, reference_genome: $referenceGenome) {
+    allele_number(dataset: $datasetId) {
+      exome @include(if: $includeExome) {
+        pos
+        an_percent
+      }
+      genome @include(if: $includeGenome) {
+        pos
+        an_percent
+      }
+    }
+  }
+}
+`
+
 type OwnProps = {
   datasetId: string
   chrom: string
@@ -65,50 +84,65 @@ const RegionCoverageTrack = ({
   includeGenomeCoverage,
 }: Props) => {
   return (
-    <Query
-      operationName={operationName}
-      query={coverageQuery}
+    <AlleleNumberQuery
+      datasetId={datasetId}
+      operationName={alleleNumberOperationName}
+      query={alleleNumberQuery}
       variables={{
         chrom,
         start,
         stop,
-        datasetId: coverageDatasetId(datasetId),
-        referenceGenome: referenceGenome(coverageDatasetId(datasetId)),
-        includeExomeCoverage,
-        includeGenomeCoverage,
-      }}
-      loadingMessage="Loading coverage"
-      loadingPlaceholderHeight={220}
-      errorMessage="Unable to load coverage"
-      success={(data: any) => {
-        if (!data.region || !data.region.coverage) {
-          return false
-        }
-        const exomeCoverage = includeExomeCoverage ? data.region.coverage.exome : true
-        const genomeCoverage = includeGenomeCoverage ? data.region.coverage.genome : true
-        return exomeCoverage || genomeCoverage
+        includeExome: includeExomeCoverage,
+        includeGenome: includeGenomeCoverage,
       }}
     >
-      {({ data }: any) => {
-        const exomeCoverage = includeExomeCoverage ? data.region.coverage.exome : null
-        const genomeCoverage = includeGenomeCoverage ? data.region.coverage.genome : null
+      {(alleleNumber) => (
+        <Query
+          operationName={operationName}
+          query={coverageQuery}
+          variables={{
+            chrom,
+            start,
+            stop,
+            datasetId: coverageDatasetId(datasetId),
+            referenceGenome: referenceGenome(coverageDatasetId(datasetId)),
+            includeExomeCoverage,
+            includeGenomeCoverage,
+          }}
+          loadingMessage="Loading coverage"
+          loadingPlaceholderHeight={220}
+          errorMessage="Unable to load coverage"
+          success={(data: any) => {
+            if (!data.region || !data.region.coverage) {
+              return false
+            }
+            const exomeCoverage = includeExomeCoverage ? data.region.coverage.exome : true
+            const genomeCoverage = includeGenomeCoverage ? data.region.coverage.genome : true
+            return exomeCoverage || genomeCoverage
+          }}
+        >
+          {({ data }: any) => {
+            const exomeCoverage = includeExomeCoverage ? data.region.coverage.exome : null
+            const genomeCoverage = includeGenomeCoverage ? data.region.coverage.genome : null
 
-        const coverageConfig =
-          datasetId === 'exac'
-            ? coverageConfigClassic(exomeCoverage, genomeCoverage)
-            : coverageConfigNew(exomeCoverage, genomeCoverage)
+            const coverageConfig = isExac(datasetId)
+              ? coverageConfigClassic(exomeCoverage, genomeCoverage)
+              : coverageConfigNew(exomeCoverage, genomeCoverage)
 
-        return (
-          <CoverageTrack
-            coverageOverThresholds={[1, 5, 10, 15, 20, 25, 30, 50, 100]}
-            filenameForExport={() => `${chrom}-${start}-${stop}_coverage`}
-            datasets={coverageConfig}
-            height={200}
-            datasetId={datasetId}
-          />
-        )
-      }}
-    </Query>
+            return (
+              <CoverageTrack
+                coverageOverThresholds={[1, 5, 10, 15, 20, 25, 30, 50, 100]}
+                filenameForExport={() => `${chrom}-${start}-${stop}_coverage`}
+                datasets={coverageConfig}
+                {...alleleNumber}
+                height={200}
+                datasetId={datasetId}
+              />
+            )
+          }}
+        </Query>
+      )}
+    </AlleleNumberQuery>
   )
 }
 

--- a/browser/src/TranscriptPage/TranscriptCoverageTrack.tsx
+++ b/browser/src/TranscriptPage/TranscriptCoverageTrack.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
-import { coverageDatasetId, referenceGenome } from '@gnomad/dataset-metadata/metadata'
+import { coverageDatasetId, isExac, referenceGenome } from '@gnomad/dataset-metadata/metadata'
+import AlleleNumberQuery from '../AlleleNumberQuery'
 import { coverageConfigClassic, coverageConfigNew } from '../coverageStyles'
 import CoverageTrack from '../CoverageTrack'
 import Query from '../Query'
@@ -43,6 +44,24 @@ query ${operationName}($transcriptId: String!, $datasetId: DatasetId!, $referenc
 }
 `
 
+const alleleNumberOperationName = 'TranscriptAlleleNumber'
+const alleleNumberQuery = `
+query ${alleleNumberOperationName}($transcriptId: String!, $datasetId: DatasetId!, $referenceGenome: ReferenceGenomeId!, $includeExome: Boolean!, $includeGenome: Boolean!) {
+  feature: transcript(transcript_id: $transcriptId, reference_genome: $referenceGenome) {
+    allele_number(dataset: $datasetId) {
+      exome @include(if: $includeExome) {
+        pos
+        an_percent
+      }
+      genome @include(if: $includeGenome) {
+        pos
+        an_percent
+      }
+    }
+  }
+}
+`
+
 type OwnProps = {
   datasetId: string
   transcriptId: string
@@ -61,48 +80,61 @@ const TranscriptCoverageTrack = ({
   includeGenomeCoverage,
 }: Props) => {
   return (
-    <Query
-      operationName={operationName}
-      query={coverageQuery}
+    <AlleleNumberQuery
+      datasetId={datasetId}
+      operationName={alleleNumberOperationName}
+      query={alleleNumberQuery}
       variables={{
         transcriptId,
-        datasetId: coverageDatasetId(datasetId),
-        referenceGenome: referenceGenome(coverageDatasetId(datasetId)),
-        includeExomeCoverage,
-        includeGenomeCoverage,
-      }}
-      loadingMessage="Loading coverage"
-      loadingPlaceholderHeight={220}
-      errorMessage="Unable to load coverage"
-      success={(data: any) => {
-        if (!data.transcript || !data.transcript.coverage) {
-          return false
-        }
-        const exomeCoverage = includeExomeCoverage ? data.transcript.coverage.exome : true
-        const genomeCoverage = includeGenomeCoverage ? data.transcript.coverage.genome : true
-        return exomeCoverage || genomeCoverage
+        includeExome: includeExomeCoverage,
+        includeGenome: includeGenomeCoverage,
       }}
     >
-      {({ data }: any) => {
-        const exomeCoverage = includeExomeCoverage ? data.transcript.coverage.exome : null
-        const genomeCoverage = includeGenomeCoverage ? data.transcript.coverage.genome : null
+      {(alleleNumber) => (
+        <Query
+          operationName={operationName}
+          query={coverageQuery}
+          variables={{
+            transcriptId,
+            datasetId: coverageDatasetId(datasetId),
+            referenceGenome: referenceGenome(coverageDatasetId(datasetId)),
+            includeExomeCoverage,
+            includeGenomeCoverage,
+          }}
+          loadingMessage="Loading coverage"
+          loadingPlaceholderHeight={220}
+          errorMessage="Unable to load coverage"
+          success={(data: any) => {
+            if (!data.transcript || !data.transcript.coverage) {
+              return false
+            }
+            const exomeCoverage = includeExomeCoverage ? data.transcript.coverage.exome : true
+            const genomeCoverage = includeGenomeCoverage ? data.transcript.coverage.genome : true
+            return exomeCoverage || genomeCoverage
+          }}
+        >
+          {({ data }: any) => {
+            const exomeCoverage = includeExomeCoverage ? data.transcript.coverage.exome : null
+            const genomeCoverage = includeGenomeCoverage ? data.transcript.coverage.genome : null
 
-        const coverageConfig =
-          datasetId === 'exac'
-            ? coverageConfigClassic(exomeCoverage, genomeCoverage)
-            : coverageConfigNew(exomeCoverage, genomeCoverage)
+            const coverageConfig = isExac(datasetId)
+              ? coverageConfigClassic(exomeCoverage, genomeCoverage)
+              : coverageConfigNew(exomeCoverage, genomeCoverage)
 
-        return (
-          <CoverageTrack
-            coverageOverThresholds={[1, 5, 10, 15, 20, 25, 30, 50, 100]}
-            datasets={coverageConfig}
-            filenameForExport={() => `${transcriptId}_coverage`}
-            height={190}
-            datasetId={datasetId}
-          />
-        )
-      }}
-    </Query>
+            return (
+              <CoverageTrack
+                coverageOverThresholds={[1, 5, 10, 15, 20, 25, 30, 50, 100]}
+                datasets={coverageConfig}
+                {...alleleNumber}
+                filenameForExport={() => `${transcriptId}_coverage`}
+                height={190}
+                datasetId={datasetId}
+              />
+            )
+          }}
+        </Query>
+      )}
+    </AlleleNumberQuery>
   )
 }
 

--- a/browser/src/TranscriptPage/TranscriptPageContainer.spec.tsx
+++ b/browser/src/TranscriptPage/TranscriptPageContainer.spec.tsx
@@ -61,6 +61,11 @@ forAllDatasets('TranscriptPageContainer with dataset %s', (datasetId) => {
           coverage: {},
         },
       }),
+      TranscriptAlleleNumber: () => ({
+        feature: {
+          allele_number: {},
+        },
+      }),
     })
 
     const tree = renderer.create(

--- a/browser/src/coverageStyles.ts
+++ b/browser/src/coverageStyles.ts
@@ -1,15 +1,26 @@
+// Shared appearance for the exome and genome series.
+//
+// The coverage configs and the allele number config draw the same two data
+// types on the same track, so they must not drift apart: switching metrics
+// should not change which colour is the exome, or which series is drawn on top.
+const EXOME_COLOR = 'rgb(70, 130, 180)'
+const GENOME_COLOR = 'rgb(115, 171, 61)'
+// The exome series covers less of the track, so it is the more opaque of the two.
+const EXOME_OPACITY = 0.7
+const GENOME_OPACITY = 0.5
+
 export const coverageConfigClassic = (exomeCoverage: any, genomeCoverage: any) => {
   const coverage = []
   if (exomeCoverage) {
     coverage.push({
-      color: 'rgb(70, 130, 180)',
+      color: EXOME_COLOR,
       buckets: exomeCoverage,
       name: 'exome',
     })
   }
   if (genomeCoverage) {
     coverage.push({
-      color: 'rgb(115, 171, 61)',
+      color: GENOME_COLOR,
       buckets: genomeCoverage,
       name: 'genome',
     })
@@ -21,19 +32,28 @@ export const coverageConfigNew = (exomeCoverage: any, genomeCoverage: any) => {
   const coverage = []
   if (exomeCoverage) {
     coverage.push({
-      color: 'rgb(70, 130, 180)',
+      color: EXOME_COLOR,
       buckets: exomeCoverage,
       name: 'exome',
-      opacity: 0.7,
+      opacity: EXOME_OPACITY,
     })
   }
   if (genomeCoverage) {
     coverage.push({
-      color: 'rgb(115, 171, 61)',
+      color: GENOME_COLOR,
       buckets: genomeCoverage,
       name: 'genome',
-      opacity: 0.5,
+      opacity: GENOME_OPACITY,
     })
   }
   return coverage
 }
+
+/**
+ * Series appearance for the call rate metric.
+ *
+ * Identical to `coverageConfigNew` on purpose, and aliased rather than copied so
+ * it cannot become different by accident: the legend must not change colour or
+ * order when the reader switches between a coverage metric and call rate.
+ */
+export const alleleNumberConfig = coverageConfigNew

--- a/data-pipeline/src/data_pipeline/data_types/allele_number.py
+++ b/data-pipeline/src/data_pipeline/data_types/allele_number.py
@@ -1,0 +1,125 @@
+from typing import Dict, List, Optional
+
+import hail as hl
+
+from data_pipeline.data_types.locus import x_position
+
+# Classes of contig that differ in how many alleles a sample can contribute.
+# Anything not called out here is diploid in every sample: the autosomes, and
+# the pseudoautosomal regions of chrX.
+AUTOSOMAL = "autosomal"
+X_NON_PAR = "X_non_par"
+Y_NON_PAR = "Y_non_par"
+Y_PAR = "Y_par"
+MITOCHONDRIAL = "mitochondrial"
+
+
+def max_allele_number(contig_class: str, n_xx: int, n_xy: int) -> int:
+    """The allele number a site would have if every sample were called there.
+
+    This is the denominator of the call rate. It depends on ploidy: XY samples
+    are haploid outside the pseudoautosomal regions of chrX and chrY, only XY
+    samples contribute anything on chrY, and the mitochondrion is haploid in
+    everyone.
+    """
+    if contig_class == AUTOSOMAL:
+        return 2 * (n_xx + n_xy)
+    if contig_class == X_NON_PAR:
+        return 2 * n_xx + n_xy
+    if contig_class == Y_NON_PAR:
+        return n_xy
+    if contig_class == Y_PAR:
+        return 2 * n_xy
+    if contig_class == MITOCHONDRIAL:
+        return n_xx + n_xy
+    raise ValueError(f"Unknown contig class {contig_class}")
+
+
+def _stratum_index(strata_meta: List[Dict[str, str]], keys: Dict[str, str]) -> int:
+    """The position of the stratum described exactly by ``keys``.
+
+    ``AN`` is an array parallel to the ``strata_meta`` global, so a stratum is
+    addressed by position. Matching on equality rather than containment matters:
+    ``{"group": "adj"}`` is contained in every ancestry- and sex-stratified
+    entry, so a containment match would return the first of hundreds of strata
+    instead of the whole-callset one.
+    """
+    matches = [index for index, meta in enumerate(strata_meta) if meta == keys]
+    if len(matches) != 1:
+        raise ValueError(f"Expected exactly one stratum matching {keys}, found {len(matches)}")
+    return matches[0]
+
+
+def prepare_allele_number(allele_number_path: str, filter_intervals: Optional[List[str]] = None):
+    """Prepare an all-sites allele number table for the browser's call rate track.
+
+    Emits, for every base in the release, the adj allele number (``an``) and that
+    allele number as a percentage of the attainable allele number
+    (``an_percent``). The percentage is what the track plots: raw allele number
+    scales with sample count, so exome and genome series drawn against one axis
+    are only comparable once both are normalised.
+    """
+    ds = hl.read_table(allele_number_path)
+
+    strata_meta, strata_sample_count = hl.eval((ds.strata_meta, ds.strata_sample_count))
+    strata_meta = [dict(meta) for meta in strata_meta]
+
+    if len(strata_meta) != len(strata_sample_count):
+        raise ValueError(
+            f"strata_meta ({len(strata_meta)}) and strata_sample_count ({len(strata_sample_count)}) "
+            "have different lengths, but are indexed in parallel"
+        )
+
+    # adj, not raw. A genotype contributes to AN only when it passes gnomAD's
+    # quality thresholds (GQ >= 20, DP >= 10 and, for heterozygous calls, an
+    # allele balance >= 0.2), so the track agrees with the allele counts shown
+    # in the variant tables.
+    adj_index = _stratum_index(strata_meta, {"group": "adj"})
+    n_total = strata_sample_count[adj_index]
+    n_xx = strata_sample_count[_stratum_index(strata_meta, {"group": "adj", "sex": "XX"})]
+    n_xy = strata_sample_count[_stratum_index(strata_meta, {"group": "adj", "sex": "XY"})]
+
+    # The sex strata partition the callset, so this is an identity rather than a
+    # tolerance check. If it does not hold, every denominator below is wrong.
+    if n_xx + n_xy != n_total:
+        raise ValueError(
+            f"XX ({n_xx:,}) + XY ({n_xy:,}) != total ({n_total:,}); "
+            "the ploidy-aware denominators need both karyotype counts"
+        )
+
+    an = ds.AN[adj_index]
+
+    # The default branch is the diploid case, which covers the autosomes and the
+    # pseudoautosomal regions of chrX. Every contig class that is *not* diploid
+    # is matched explicitly above it, so no haploid site can quietly take a
+    # diploid denominator and report half its true call rate.
+    max_an = (
+        hl.case()
+        .when(ds.locus.in_x_nonpar(), max_allele_number(X_NON_PAR, n_xx, n_xy))
+        .when(ds.locus.in_y_nonpar(), max_allele_number(Y_NON_PAR, n_xx, n_xy))
+        # chrY PAR calls are assigned to chrX in the release tables, so this
+        # branch matches nothing today. It is here so that the expression stays
+        # correct if those rows ever appear.
+        .when(ds.locus.in_y_par(), max_allele_number(Y_PAR, n_xx, n_xy))
+        .when(ds.locus.in_mito(), max_allele_number(MITOCHONDRIAL, n_xx, n_xy))
+        .default(max_allele_number(AUTOSOMAL, n_xx, n_xy))
+    )
+
+    ds = ds.select(
+        xpos=x_position(ds.locus),
+        an=an,
+        # chrY denominators are zero in an all-XX callset. A site where no
+        # sample could have been called has no meaningful call rate, so leave it
+        # missing rather than reporting 0%.
+        an_percent=hl.if_else(max_an > 0, 100 * (an / max_an), hl.missing(hl.tfloat64)),
+    )
+
+    # strata_meta and strata_sample_count describe hundreds of strata that this
+    # table no longer carries; drop them rather than passing them downstream.
+    ds = ds.select_globals()
+
+    if filter_intervals:
+        intervals = [hl.parse_locus_interval(interval, reference_genome="GRCh38") for interval in filter_intervals]
+        ds = hl.filter_intervals(ds, intervals)
+
+    return ds

--- a/data-pipeline/src/data_pipeline/helpers/datasets_config.py
+++ b/data-pipeline/src/data_pipeline/helpers/datasets_config.py
@@ -27,6 +27,7 @@ from data_pipeline.pipelines.gnomad_v3_mitochondrial_coverage import (
 from data_pipeline.pipelines.gnomad_v3_short_tandem_repeats import pipeline as gnomad_v3_short_tandem_repeats_pipeline
 from data_pipeline.pipelines.gnomad_v4_variants import pipeline as gnomad_v4_variants_pipeline
 from data_pipeline.pipelines.gnomad_v4_coverage import pipeline as gnomad_v4_coverage_pipeline
+from data_pipeline.pipelines.gnomad_v4_allele_number import pipeline as gnomad_v4_allele_number_pipeline
 from data_pipeline.pipelines.gnomad_v4_cnvs import pipeline as gnomad_v4_cnvs_pipeline
 from data_pipeline.pipelines.gnomad_v4_lof_curation_results import pipeline as gnomad_v4_lof_curation_results_pipeline
 from data_pipeline.data_types.variant import compressed_variant_id
@@ -132,6 +133,21 @@ DATASETS_CONFIG = {
     #     ),
     #     "args": {"index": "gnomad_v4_genome_coverage", "id_field": "xpos", "num_shards": 2, "block_size": 10_000},
     # },
+    # Both allele number indices carry one document per base of the release, the
+    # same shape and scale as the coverage indices, so they are sharded the same
+    # way as gnomad_v4_exome_coverage and gnomad_v3_genome_coverage.
+    "gnomad_v4_exome_allele_number": {
+        "get_table": lambda: subset_table(
+            hl.read_table(gnomad_v4_allele_number_pipeline.get_output("exome_allele_number").get_output_path())
+        ),
+        "args": {"index": "gnomad_v4_exome_allele_number", "id_field": "xpos", "num_shards": 48, "block_size": 10_000},
+    },
+    "gnomad_v4_genome_allele_number": {
+        "get_table": lambda: subset_table(
+            hl.read_table(gnomad_v4_allele_number_pipeline.get_output("genome_allele_number").get_output_path())
+        ),
+        "args": {"index": "gnomad_v4_genome_allele_number", "id_field": "xpos", "num_shards": 48, "block_size": 10_000},
+    },
     "gnomad_v4_lof_curation_results": {
         "get_table": lambda: add_variant_document_id(
             hl.read_table(gnomad_v4_lof_curation_results_pipeline.get_output("lof_curation_results").get_output_path())

--- a/data-pipeline/src/data_pipeline/pipelines/gnomad_v4_allele_number.py
+++ b/data-pipeline/src/data_pipeline/pipelines/gnomad_v4_allele_number.py
@@ -1,0 +1,47 @@
+from data_pipeline.pipeline import Pipeline, run_pipeline
+
+from data_pipeline.data_types.allele_number import prepare_allele_number
+
+output_sub_dir = "gnomad_v4_allele_number"
+
+pipeline = Pipeline()
+
+pipeline.add_task(
+    name="prepare_gnomad_v4_exome_allele_number",
+    task_function=prepare_allele_number,
+    output_path=f"/{output_sub_dir}/gnomad_v4_exome_allele_number.ht",
+    inputs={
+        "allele_number_path": "gs://gcp-public-data--gnomad/release/4.1/ht/exomes/gnomad.exomes.v4.1.allele_number_all_sites.ht",
+    },
+    # params={"filter_intervals": ["chr1:55039447-55064852"]},
+)
+
+# Unlike genome coverage, which v4 still inherits from v3.0.1, allele number is
+# published for v4.1 genomes directly.
+pipeline.add_task(
+    name="prepare_gnomad_v4_genome_allele_number",
+    task_function=prepare_allele_number,
+    output_path=f"/{output_sub_dir}/gnomad_v4_genome_allele_number.ht",
+    inputs={
+        "allele_number_path": "gs://gcp-public-data--gnomad/release/4.1/ht/genomes/gnomad.genomes.v4.1.allele_number_all_sites.ht",
+    },
+    # params={"filter_intervals": ["chr1:55039447-55064852"]},
+)
+
+###############################################
+# Outputs
+###############################################
+
+pipeline.set_outputs(
+    {
+        "exome_allele_number": "prepare_gnomad_v4_exome_allele_number",
+        "genome_allele_number": "prepare_gnomad_v4_genome_allele_number",
+    }
+)
+
+###############################################
+# Run
+###############################################
+
+if __name__ == "__main__":
+    run_pipeline(pipeline)

--- a/data-pipeline/tests/pipeline/test_allele_number.py
+++ b/data-pipeline/tests/pipeline/test_allele_number.py
@@ -1,0 +1,69 @@
+import pytest
+
+from data_pipeline.data_types.allele_number import (
+    AUTOSOMAL,
+    MITOCHONDRIAL,
+    X_NON_PAR,
+    Y_NON_PAR,
+    Y_PAR,
+    _stratum_index,
+    max_allele_number,
+)
+
+# Roughly the v4.1 exome karyotype split, so the numbers below are the ones the
+# pipeline actually divides by.
+N_XX = 399_053
+N_XY = 330_947
+
+
+def test_max_allele_number_is_diploid_off_the_sex_chromosomes():
+    assert max_allele_number(AUTOSOMAL, N_XX, N_XY) == 2 * (N_XX + N_XY)
+
+
+def test_max_allele_number_accounts_for_haploid_sex_chromosomes():
+    # XY samples carry one chrX outside the PAR, and no sample other than an XY
+    # sample carries a chrY at all.
+    assert max_allele_number(X_NON_PAR, N_XX, N_XY) == 2 * N_XX + N_XY
+    assert max_allele_number(Y_NON_PAR, N_XX, N_XY) == N_XY
+    assert max_allele_number(Y_PAR, N_XX, N_XY) == 2 * N_XY
+
+
+def test_max_allele_number_treats_the_mitochondrion_as_haploid():
+    # The diploid default would report half the true call rate here.
+    assert max_allele_number(MITOCHONDRIAL, N_XX, N_XY) == N_XX + N_XY
+
+
+def test_max_allele_number_rejects_an_unknown_contig_class():
+    with pytest.raises(ValueError):
+        max_allele_number("chr1", N_XX, N_XY)
+
+
+def test_stratum_index_finds_an_exact_match():
+    strata = [
+        {"group": "adj"},
+        {"group": "adj", "sex": "XX"},
+        {"group": "adj", "sex": "XY"},
+        {"group": "adj", "gen_anc": "afr", "sex": "XX"},
+    ]
+    assert _stratum_index(strata, {"group": "adj"}) == 0
+    assert _stratum_index(strata, {"group": "adj", "sex": "XX"}) == 1
+    assert _stratum_index(strata, {"group": "adj", "sex": "XY"}) == 2
+
+
+def test_stratum_index_does_not_accept_a_containment_match():
+    # {"group": "adj"} is contained in both entries below, and in every
+    # stratified entry of a real table. A containment match would return index 0
+    # for almost any query; failing is the only safe answer.
+    strata = [
+        {"group": "adj", "gen_anc": "afr"},
+        {"group": "adj", "gen_anc": "amr"},
+    ]
+    with pytest.raises(ValueError):
+        _stratum_index(strata, {"group": "adj"})
+
+
+def test_stratum_index_rejects_missing_and_duplicate_strata():
+    with pytest.raises(ValueError):
+        _stratum_index([{"group": "adj"}], {"group": "raw"})
+    with pytest.raises(ValueError):
+        _stratum_index([{"group": "adj"}, {"group": "adj"}], {"group": "adj"})

--- a/dataset-metadata/metadata.spec.ts
+++ b/dataset-metadata/metadata.spec.ts
@@ -1,5 +1,11 @@
 import { test, expect } from '@jest/globals'
-import { DatasetId, ReferenceGenome, referenceGenome } from './metadata'
+import {
+  DatasetId,
+  ReferenceGenome,
+  allDatasetIds,
+  hasAlleleNumber,
+  referenceGenome,
+} from './metadata'
 import { forAllDatasets } from '../tests/__helpers__/datasets'
 
 const expectedReferenceGenome: Record<DatasetId, ReferenceGenome> = {
@@ -28,4 +34,12 @@ forAllDatasets('referenceGenome(%s)', (datasetId) => {
   const expectedResult = expectedReferenceGenome[datasetId]
   test(`${datasetId} uses reference genome ${expectedResult}`, () =>
     expect(referenceGenome(datasetId)).toEqual(expectedResult))
+})
+
+// Allele number is what the coverage track's call rate metric is drawn from,
+// and it is a function of which samples are in the callset. A subset showing
+// the full release's call rate would be showing the wrong number, so pin the
+// list rather than trusting each record's flag to have been set by hand.
+test('only the full gnomAD v4.1 callset has an allele number release', () => {
+  expect(allDatasetIds.filter(hasAlleleNumber)).toEqual(['gnomad_r4'])
 })

--- a/dataset-metadata/metadata.ts
+++ b/dataset-metadata/metadata.ts
@@ -41,6 +41,7 @@ export type DatasetMetadata = {
   transcriptsHaveExomeCoverage: boolean
   regionsHaveExomeCoverage: boolean
   regionsHaveGenomeCoverage: boolean
+  hasAlleleNumber: boolean
   hasLocalAncestryPopulations: boolean
   isLiftoverSource: boolean
   isLiftoverTarget: boolean
@@ -88,6 +89,7 @@ const metadata: Record<DatasetId, DatasetMetadata> = {
     transcriptsHaveExomeCoverage: true,
     regionsHaveExomeCoverage: true,
     regionsHaveGenomeCoverage: true,
+    hasAlleleNumber: false,
     hasShortVariants: true,
     hasStructuralVariants: false,
     hasCopyNumberVariants: false,
@@ -138,6 +140,7 @@ const metadata: Record<DatasetId, DatasetMetadata> = {
     transcriptsHaveExomeCoverage: true,
     regionsHaveExomeCoverage: true,
     regionsHaveGenomeCoverage: true,
+    hasAlleleNumber: false,
     hasShortVariants: true,
     hasStructuralVariants: false,
     hasCopyNumberVariants: false,
@@ -188,6 +191,7 @@ const metadata: Record<DatasetId, DatasetMetadata> = {
     transcriptsHaveExomeCoverage: true,
     regionsHaveExomeCoverage: true,
     regionsHaveGenomeCoverage: true,
+    hasAlleleNumber: false,
     hasShortVariants: true,
     hasStructuralVariants: false,
     hasCopyNumberVariants: false,
@@ -238,6 +242,7 @@ const metadata: Record<DatasetId, DatasetMetadata> = {
     transcriptsHaveExomeCoverage: true,
     regionsHaveExomeCoverage: true,
     regionsHaveGenomeCoverage: true,
+    hasAlleleNumber: false,
     hasShortVariants: true,
     hasStructuralVariants: false,
     hasCopyNumberVariants: false,
@@ -288,6 +293,7 @@ const metadata: Record<DatasetId, DatasetMetadata> = {
     transcriptsHaveExomeCoverage: true,
     regionsHaveExomeCoverage: true,
     regionsHaveGenomeCoverage: true,
+    hasAlleleNumber: false,
     hasShortVariants: true,
     hasStructuralVariants: false,
     hasCopyNumberVariants: false,
@@ -338,6 +344,7 @@ const metadata: Record<DatasetId, DatasetMetadata> = {
     transcriptsHaveExomeCoverage: true,
     regionsHaveExomeCoverage: true,
     regionsHaveGenomeCoverage: true,
+    hasAlleleNumber: false,
     hasShortVariants: true,
     hasStructuralVariants: false,
     hasCopyNumberVariants: false,
@@ -388,6 +395,7 @@ const metadata: Record<DatasetId, DatasetMetadata> = {
     transcriptsHaveExomeCoverage: false,
     regionsHaveExomeCoverage: false,
     regionsHaveGenomeCoverage: true,
+    hasAlleleNumber: false,
     hasShortVariants: true,
     hasStructuralVariants: false,
     hasCopyNumberVariants: false,
@@ -438,6 +446,7 @@ const metadata: Record<DatasetId, DatasetMetadata> = {
     transcriptsHaveExomeCoverage: false,
     regionsHaveExomeCoverage: false,
     regionsHaveGenomeCoverage: true,
+    hasAlleleNumber: false,
     hasShortVariants: true,
     hasStructuralVariants: false,
     hasCopyNumberVariants: false,
@@ -488,6 +497,7 @@ const metadata: Record<DatasetId, DatasetMetadata> = {
     transcriptsHaveExomeCoverage: false,
     regionsHaveExomeCoverage: false,
     regionsHaveGenomeCoverage: true,
+    hasAlleleNumber: false,
     hasShortVariants: true,
     hasStructuralVariants: false,
     hasCopyNumberVariants: false,
@@ -538,6 +548,7 @@ const metadata: Record<DatasetId, DatasetMetadata> = {
     transcriptsHaveExomeCoverage: false,
     regionsHaveExomeCoverage: false,
     regionsHaveGenomeCoverage: true,
+    hasAlleleNumber: false,
     hasShortVariants: true,
     hasStructuralVariants: false,
     hasCopyNumberVariants: false,
@@ -588,6 +599,7 @@ const metadata: Record<DatasetId, DatasetMetadata> = {
     transcriptsHaveExomeCoverage: false,
     regionsHaveExomeCoverage: false,
     regionsHaveGenomeCoverage: true,
+    hasAlleleNumber: false,
     hasShortVariants: true,
     hasStructuralVariants: false,
     hasCopyNumberVariants: false,
@@ -638,6 +650,7 @@ const metadata: Record<DatasetId, DatasetMetadata> = {
     transcriptsHaveExomeCoverage: false,
     regionsHaveExomeCoverage: false,
     regionsHaveGenomeCoverage: true,
+    hasAlleleNumber: false,
     hasShortVariants: true,
     hasStructuralVariants: false,
     hasCopyNumberVariants: false,
@@ -688,6 +701,7 @@ const metadata: Record<DatasetId, DatasetMetadata> = {
     transcriptsHaveExomeCoverage: true,
     regionsHaveExomeCoverage: false,
     regionsHaveGenomeCoverage: true,
+    hasAlleleNumber: false,
     hasShortVariants: false,
     hasStructuralVariants: true,
     hasCopyNumberVariants: false,
@@ -738,6 +752,7 @@ const metadata: Record<DatasetId, DatasetMetadata> = {
     transcriptsHaveExomeCoverage: true,
     regionsHaveExomeCoverage: false,
     regionsHaveGenomeCoverage: true,
+    hasAlleleNumber: false,
     hasShortVariants: false,
     hasStructuralVariants: true,
     hasCopyNumberVariants: false,
@@ -788,6 +803,7 @@ const metadata: Record<DatasetId, DatasetMetadata> = {
     transcriptsHaveExomeCoverage: true,
     regionsHaveExomeCoverage: false,
     regionsHaveGenomeCoverage: true,
+    hasAlleleNumber: false,
     hasShortVariants: false,
     hasStructuralVariants: true,
     hasCopyNumberVariants: false,
@@ -838,6 +854,7 @@ const metadata: Record<DatasetId, DatasetMetadata> = {
     transcriptsHaveExomeCoverage: false,
     regionsHaveExomeCoverage: false,
     regionsHaveGenomeCoverage: true,
+    hasAlleleNumber: false,
     hasShortVariants: false,
     hasStructuralVariants: true,
     hasCopyNumberVariants: false,
@@ -888,6 +905,7 @@ const metadata: Record<DatasetId, DatasetMetadata> = {
     transcriptsHaveExomeCoverage: true,
     regionsHaveExomeCoverage: true,
     regionsHaveGenomeCoverage: false,
+    hasAlleleNumber: false,
     hasShortVariants: false,
     hasStructuralVariants: false,
     hasCopyNumberVariants: true,
@@ -938,6 +956,7 @@ const metadata: Record<DatasetId, DatasetMetadata> = {
     transcriptsHaveExomeCoverage: true,
     regionsHaveExomeCoverage: true,
     regionsHaveGenomeCoverage: true,
+    hasAlleleNumber: true,
     hasShortVariants: true,
     hasStructuralVariants: false,
     hasCopyNumberVariants: false,
@@ -988,6 +1007,7 @@ const metadata: Record<DatasetId, DatasetMetadata> = {
     transcriptsHaveExomeCoverage: true,
     regionsHaveExomeCoverage: true,
     regionsHaveGenomeCoverage: true,
+    hasAlleleNumber: false,
     hasShortVariants: true,
     hasStructuralVariants: false,
     hasCopyNumberVariants: false,
@@ -1064,6 +1084,12 @@ export const regionsHaveExomeCoverage = (datsetId: DatasetId) =>
 
 export const regionsHaveGenomeCoverage = (datsetId: DatasetId) =>
   getMetadata(datsetId, 'regionsHaveGenomeCoverage')
+
+// Whether an all-sites allele number release exists for this dataset, which is
+// what the coverage track's call rate metric is drawn from. Only the full
+// gnomAD v4.1 callset has one: a subset's call rate is a different number, so a
+// subset must not be shown the full release's.
+export const hasAlleleNumber = (datasetId: DatasetId) => getMetadata(datasetId, 'hasAlleleNumber')
 
 export const hasShortVariants = (datasetId: DatasetId) => getMetadata(datasetId, 'hasShortVariants')
 

--- a/graphql-api/src/graphql/resolvers/allele-number.ts
+++ b/graphql-api/src/graphql/resolvers/allele-number.ts
@@ -1,0 +1,41 @@
+import { UserVisibleError } from '../../errors'
+import {
+  fetchExomeAlleleNumberForRegion,
+  fetchGenomeAlleleNumberForRegion,
+  fetchAlleleNumberForGene,
+  fetchAlleleNumberForTranscript,
+} from '../../queries/allele-number-queries'
+
+// The same limit the coverage resolver applies. Allele number is indexed one
+// document per base, so an unbounded region would ask Elasticsearch to
+// aggregate over most of a chromosome.
+const MAX_REGION_SIZE = 2.5e6
+
+const resolvers = {
+  Region: {
+    allele_number: (obj: any, args: any) => {
+      if (obj.stop - obj.start >= MAX_REGION_SIZE) {
+        throw new UserVisibleError('Allele number is not available for a region this large')
+      }
+
+      // Forward region and dataset argument to exome/genome allele number resolvers.
+      return { ...obj, dataset: args.dataset }
+    },
+  },
+  RegionAlleleNumber: {
+    exome: (obj: any, _args: any, ctx: any) =>
+      fetchExomeAlleleNumberForRegion(ctx.esClient, obj.dataset, obj),
+    genome: (obj: any, _args: any, ctx: any) =>
+      fetchGenomeAlleleNumberForRegion(ctx.esClient, obj.dataset, obj),
+  },
+  Gene: {
+    allele_number: (obj: any, args: any, ctx: any) =>
+      fetchAlleleNumberForGene(ctx.esClient, args.dataset, obj),
+  },
+  Transcript: {
+    allele_number: (obj: any, args: any, ctx: any) =>
+      fetchAlleleNumberForTranscript(ctx.esClient, args.dataset, obj),
+  },
+}
+
+export default resolvers

--- a/graphql-api/src/graphql/schema.ts
+++ b/graphql-api/src/graphql/schema.ts
@@ -4,6 +4,7 @@ import { mergeTypeDefs, mergeResolvers } from '@graphql-tools/merge'
 import { makeExecutableSchema } from '@graphql-tools/schema'
 
 import aliasResolvers from './resolvers/aliases'
+import alleleNumberResolvers from './resolvers/allele-number'
 import browserMetadataResolvers from './resolvers/browser-metadata'
 import clinVarVariantResolvers from './resolvers/clinvar-variants'
 import clinVarVariantFieldResolvers from './resolvers/clinvar-variant-fields'
@@ -33,6 +34,7 @@ const typeDefs = mergeTypeDefs([
 
 const resolvers = mergeResolvers([
   aliasResolvers,
+  alleleNumberResolvers,
   browserMetadataResolvers,
   clinVarVariantResolvers,
   clinVarVariantFieldResolvers,

--- a/graphql-api/src/graphql/types/allele-number.graphql
+++ b/graphql-api/src/graphql/types/allele-number.graphql
@@ -1,0 +1,10 @@
+type AlleleNumberBin {
+  pos: Int!
+  an: Int
+  an_percent: Float
+}
+
+type FeatureAlleleNumber {
+  exome: [AlleleNumberBin!]!
+  genome: [AlleleNumberBin!]!
+}

--- a/graphql-api/src/graphql/types/gene.graphql
+++ b/graphql-api/src/graphql/types/gene.graphql
@@ -79,6 +79,7 @@ type Gene {
   clinvar_variants: [ClinVarVariant!] @cost(value: 10)
 
   coverage(dataset: DatasetId): FeatureCoverage! @cost(value: 5)
+  allele_number(dataset: DatasetId): FeatureAlleleNumber! @cost(value: 5)
   mitochondrial_coverage(dataset: DatasetId!): [MitochondrialCoverageBin!] @cost(value: 5)
   cnv_track_callable_coverage(dataset: CopyNumberVariantDatasetId!): [CNVTrackCallableCoverageBin!]
     @cost(value: 5)

--- a/graphql-api/src/graphql/types/region.graphql
+++ b/graphql-api/src/graphql/types/region.graphql
@@ -19,6 +19,11 @@ type RegionCoverage {
   genome: [CoverageBin!]! @cost(value: 5)
 }
 
+type RegionAlleleNumber {
+  exome: [AlleleNumberBin!]! @cost(value: 5)
+  genome: [AlleleNumberBin!]! @cost(value: 5)
+}
+
 type Region {
   reference_genome: ReferenceGenomeId!
   chrom: String!
@@ -36,6 +41,7 @@ type Region {
   clinvar_variants: [ClinVarVariant!] @cost(value: 10)
 
   coverage(dataset: DatasetId!): RegionCoverage!
+  allele_number(dataset: DatasetId!): RegionAlleleNumber!
   mitochondrial_coverage(dataset: DatasetId!): [MitochondrialCoverageBin!] @cost(value: 5)
 
   short_tandem_repeats(dataset: DatasetId!): [ShortTandemRepeat!]! @cost(value: 5)

--- a/graphql-api/src/graphql/types/transcript.graphql
+++ b/graphql-api/src/graphql/types/transcript.graphql
@@ -49,5 +49,6 @@ type Transcript {
   clinvar_variants: [ClinVarVariant!] @cost(value: 10)
 
   coverage(dataset: DatasetId): FeatureCoverage! @cost(value: 5)
+  allele_number(dataset: DatasetId): FeatureAlleleNumber! @cost(value: 5)
   mitochondrial_coverage(dataset: DatasetId!): [MitochondrialCoverageBin!] @cost(value: 5)
 }

--- a/graphql-api/src/queries/allele-number-queries.spec.ts
+++ b/graphql-api/src/queries/allele-number-queries.spec.ts
@@ -1,0 +1,231 @@
+import { beforeEach, describe, expect, jest, test } from '@jest/globals'
+
+import {
+  fetchAlleleNumberForGene,
+  fetchAlleleNumberForTranscript,
+  fetchExomeAlleleNumberForRegion,
+  fetchGenomeAlleleNumberForRegion,
+} from './allele-number-queries'
+
+/**
+ * A cache double that actually memoizes.
+ *
+ * The real cache module cannot be loaded here: it pulls in the API config,
+ * which requires ELASTICSEARCH_URL, and it would talk to Redis. Memoizing
+ * rather than passing calls straight through is deliberate -- it lets
+ * "an empty result is never cached" below be a real test.
+ */
+jest.mock('../cache', () => {
+  const entries = new Map<string, any>()
+  return {
+    clearTestCache: () => entries.clear(),
+    withCache: (fn: any, keyFn: any) => async (...args: any[]) => {
+      const key = keyFn(...args)
+      if (!entries.has(key)) {
+        entries.set(key, await fn(...args))
+      }
+      return entries.get(key)
+    },
+  }
+})
+
+const { clearTestCache } = jest.requireMock('../cache') as any
+
+beforeEach(() => clearTestCache())
+
+// Two PCSK9 exons 101 bases apart. Padding each side by 75 makes them overlap,
+// so they merge into the single interval 55039372-55090165 (50793 bases, and
+// therefore a bucket size of floor(50793 / 500) = 101).
+const gene = {
+  gene_id: 'ENSG00000169174',
+  reference_genome: 'GRCh38',
+  chrom: '1',
+  exons: [
+    { feature_type: 'CDS', start: 55039447, stop: 55039666, xstart: 1055039447, xstop: 1055039666 },
+    { feature_type: 'CDS', start: 55039767, stop: 55090090, xstart: 1055039767, xstop: 1055090090 },
+  ],
+}
+
+const transcript = { ...gene, transcript_id: 'ENST00000302118' }
+
+const region = { reference_genome: 'GRCh38', chrom: '1', start: 55039447, stop: 55064852 }
+
+/** An Elasticsearch double that records every search it is asked to run. */
+const stubEsClient = (bucketsByIndex: { [index: string]: any[] } = {}) => {
+  const searches: any[] = []
+  return {
+    searches,
+    client: {
+      search: async (params: any) => {
+        searches.push(params)
+        return {
+          body: {
+            aggregations: { allele_number: { buckets: bucketsByIndex[params.index] ?? [] } },
+          },
+        }
+      },
+    },
+  }
+}
+
+const failingEsClient = (error: any) => ({
+  search: async () => {
+    throw error
+  },
+})
+
+const indexNotFoundError = {
+  meta: { statusCode: 404, body: { error: { type: 'index_not_found_exception' } } },
+}
+
+const bucket = (key: number, an: number | null, anPercent: number | null) => ({
+  key,
+  an: { value: an },
+  an_percent: { value: anPercent },
+})
+
+describe('fetchAlleleNumberForGene', () => {
+  test('queries the v4 exome and genome indices', async () => {
+    const { searches, client } = stubEsClient()
+    await fetchAlleleNumberForGene(client, 'gnomad_r4', gene)
+
+    expect(searches.map((search) => search.index)).toEqual([
+      'gnomad_v4_exome_allele_number',
+      'gnomad_v4_genome_allele_number',
+    ])
+    // GRCh38 indices use chr-prefixed contig names.
+    expect(searches[0].body.query.bool.filter[0]).toEqual({ term: { 'locus.contig': 'chr1' } })
+  })
+
+  test('pads and merges exons the way the coverage query does', async () => {
+    const { searches, client } = stubEsClient()
+    await fetchAlleleNumberForGene(client, 'gnomad_r4', gene)
+
+    const { filter } = searches[0].body.query.bool
+    expect(filter[1].bool.should).toEqual([
+      { range: { 'locus.position': { gte: 55039372, lte: 55090165 } } },
+    ])
+    expect(searches[0].body.aggregations.allele_number.histogram.interval).toEqual(101)
+  })
+
+  test('rounds allele number to a whole count and the percentage to three decimals', async () => {
+    const { client } = stubEsClient({
+      gnomad_v4_exome_allele_number: [bucket(55039447, 1460123.6, 99.87654321)],
+      gnomad_v4_genome_allele_number: [bucket(55039447, 152345.2, 99.9191919)],
+    })
+
+    expect(await fetchAlleleNumberForGene(client, 'gnomad_r4', gene)).toEqual({
+      exome: [{ pos: 55039447, an: 1460124, an_percent: 99.877 }],
+      genome: [{ pos: 55039447, an: 152345, an_percent: 99.919 }],
+    })
+  })
+
+  test('preserves nulls instead of coercing them to zero', async () => {
+    const { client } = stubEsClient({
+      gnomad_v4_exome_allele_number: [bucket(55039447, null, null)],
+    })
+
+    // A bucket covering no indexed base is not a bucket where nobody was
+    // called; zero would draw a callability cliff that is not in the data.
+    const { exome } = await fetchAlleleNumberForGene(client, 'gnomad_r4', gene)
+    expect(exome).toEqual([{ pos: 55039447, an: null, an_percent: null }])
+  })
+})
+
+describe('fetchAlleleNumberForTranscript', () => {
+  test('queries the same indices and intervals as the gene query', async () => {
+    const { searches, client } = stubEsClient()
+    await fetchAlleleNumberForTranscript(client, 'gnomad_r4', transcript)
+
+    expect(searches.map((search) => search.index)).toEqual([
+      'gnomad_v4_exome_allele_number',
+      'gnomad_v4_genome_allele_number',
+    ])
+    expect(searches[0].body.aggregations.allele_number.histogram.interval).toEqual(101)
+  })
+})
+
+describe('region allele number queries', () => {
+  test('fetch exome and genome independently', async () => {
+    const { searches, client } = stubEsClient()
+    await fetchExomeAlleleNumberForRegion(client, 'gnomad_r4', region)
+    await fetchGenomeAlleleNumberForRegion(client, 'gnomad_r4', region)
+
+    expect(searches.map((search) => search.index)).toEqual([
+      'gnomad_v4_exome_allele_number',
+      'gnomad_v4_genome_allele_number',
+    ])
+  })
+
+  test('pad the region by 75 bases on each side', async () => {
+    const { searches, client } = stubEsClient()
+    await fetchExomeAlleleNumberForRegion(client, 'gnomad_r4', region)
+
+    expect(searches[0].body.query.bool.filter[1].bool.should).toEqual([
+      { range: { 'locus.position': { gte: 55039372, lte: 55064927 } } },
+    ])
+    // 25405 bases of region plus 150 of padding, over 500 buckets.
+    expect(searches[0].body.aggregations.allele_number.histogram.interval).toEqual(51)
+  })
+})
+
+describe('datasets without an allele number release', () => {
+  test.each([
+    ['gnomad_r4_non_ukb', 'GRCh38'],
+    ['gnomad_r3', 'GRCh38'],
+    ['gnomad_r2_1', 'GRCh37'],
+    ['exac', 'GRCh37'],
+  ])('%s is rejected rather than served the full callset', async (datasetId, referenceGenome) => {
+    const { searches, client } = stubEsClient()
+
+    await expect(
+      fetchAlleleNumberForGene(client, datasetId, { ...gene, reference_genome: referenceGenome })
+    ).rejects.toThrow('Allele number is not available for')
+    expect(searches).toHaveLength(0)
+  })
+})
+
+describe('when the Elasticsearch index has not been loaded yet', () => {
+  test('gene and transcript queries resolve to empty series', async () => {
+    const client = failingEsClient(indexNotFoundError)
+
+    // The pipeline may not have run yet. Serving no allele number lets the
+    // browser hide the call rate metric instead of failing the whole page.
+    expect(await fetchAlleleNumberForGene(client, 'gnomad_r4', gene)).toEqual({
+      exome: [],
+      genome: [],
+    })
+    expect(await fetchAlleleNumberForTranscript(client, 'gnomad_r4', transcript)).toEqual({
+      exome: [],
+      genome: [],
+    })
+  })
+
+  test('region queries resolve to an empty series', async () => {
+    const client = failingEsClient(indexNotFoundError)
+
+    expect(await fetchExomeAlleleNumberForRegion(client, 'gnomad_r4', region)).toEqual([])
+  })
+
+  test('the empty result is not cached', async () => {
+    // Cache entries have their expiration refreshed on every read, so caching
+    // an empty result would outlive the pipeline run that fixes it.
+    expect(
+      await fetchAlleleNumberForGene(failingEsClient(indexNotFoundError), 'gnomad_r4', gene)
+    ).toEqual({ exome: [], genome: [] })
+
+    const { client } = stubEsClient({
+      gnomad_v4_exome_allele_number: [bucket(55039447, 1460124, 99.877)],
+    })
+    const { exome } = await fetchAlleleNumberForGene(client, 'gnomad_r4', gene)
+    expect(exome).toEqual([{ pos: 55039447, an: 1460124, an_percent: 99.877 }])
+  })
+
+  test('other Elasticsearch failures are not swallowed', async () => {
+    const client = failingEsClient(new Error('search_phase_execution_exception'))
+
+    await expect(fetchAlleleNumberForGene(client, 'gnomad_r4', gene)).rejects.toThrow(
+      'search_phase_execution_exception'
+    )
+  })
+})

--- a/graphql-api/src/queries/allele-number-queries.ts
+++ b/graphql-api/src/queries/allele-number-queries.ts
@@ -1,0 +1,214 @@
+import { withCache } from '../cache'
+import { DATASET_LABELS } from '../datasets'
+import { UserVisibleError } from '../errors'
+import logger from '../logger'
+
+import { extendRegions, mergeOverlappingRegions, totalRegionSize } from './helpers/region-helpers'
+
+import { assertDatasetAndReferenceGenomeMatch } from './helpers/validation-helpers'
+
+/**
+ * Datasets with an all-sites allele number release.
+ *
+ * Both indices are genuinely v4.1, unlike coverage, where gnomAD v4 still reads
+ * its genome series from the v3.0.1 index.
+ *
+ * This is an allowlist rather than a "reject subsets" check. Subsets, older
+ * releases and the SV/CNV datasets all lack an allele number release, and an
+ * allowlist cannot quietly admit a new one -- a v4 subset would otherwise pass
+ * a `gnomad_r2_1_`/`gnomad_r3_` prefix check and be served the full callset's
+ * allele number, which is not the same number at all.
+ */
+const ALLELE_NUMBER_INDICES: { [datasetId: string]: { exome: string; genome: string } } = {
+  gnomad_r4: {
+    exome: 'gnomad_v4_exome_allele_number',
+    genome: 'gnomad_v4_genome_allele_number',
+  },
+}
+
+const assertAlleleNumberAvailable = (datasetId: string) => {
+  if (!(datasetId in ALLELE_NUMBER_INDICES)) {
+    // @ts-expect-error TS(7053) DATASET_LABELS is a literal object, not a Record.
+    throw new UserVisibleError(`Allele number is not available for ${DATASET_LABELS[datasetId]}`)
+  }
+}
+
+// GRCh38 indices use chr-prefixed contig names, GRCh37 indices do not.
+const contigForFeature = ({ chrom, reference_genome: referenceGenome }: any) =>
+  referenceGenome === 'GRCh38' ? `chr${chrom}` : chrom
+
+/**
+ * True for the error Elasticsearch raises when an index does not exist.
+ *
+ * The allele number indices are loaded by a pipeline run of their own, so an
+ * API deployed ahead of that load will see this. Matching on the exception type
+ * rather than on a 404 status keeps unrelated not-found responses out.
+ */
+const isIndexNotFoundError = (error: any) =>
+  (error?.meta?.body ?? error?.body)?.error?.type === 'index_not_found_exception'
+
+/**
+ * Run `fetch`, reporting a missing Elasticsearch index as "no data".
+ *
+ * A missing index means the pipeline has not been loaded yet. That is a
+ * transient operational state, not a bad request, and the browser handles it by
+ * hiding the call rate metric -- much better than failing the whole page.
+ *
+ * This deliberately wraps the *cached* function rather than sitting inside it.
+ * An empty result produced by an unloaded index must never reach the cache:
+ * cache entries have their expiration refreshed on every read, so an empty
+ * result cached for a popular gene would outlive the pipeline run that fixes it.
+ */
+const emptyIfIndexNotFound = async (empty: any, fetch: () => Promise<any>) => {
+  try {
+    return await fetch()
+  } catch (error) {
+    if (isIndexNotFoundError(error)) {
+      logger.warn(`Allele number index not loaded, serving no allele number data (${error})`)
+      return empty
+    }
+    throw error
+  }
+}
+
+// ================================================================================================
+// Base query
+// ================================================================================================
+
+const fetchAlleleNumber = async (esClient: any, { index, contig, regions, bucketSize }: any) => {
+  const response = await esClient.search({
+    index,
+    type: '_doc',
+    size: 0,
+    body: {
+      query: {
+        bool: {
+          filter: [
+            { term: { 'locus.contig': contig } },
+            {
+              bool: {
+                should: regions.map(({ start, stop }: any) => ({
+                  range: { 'locus.position': { gte: start, lte: stop } },
+                })),
+              },
+            },
+          ],
+        },
+      },
+      aggregations: {
+        allele_number: {
+          histogram: {
+            field: 'locus.position',
+            interval: bucketSize,
+          },
+          aggregations: {
+            an: { avg: { field: 'an' } },
+            an_percent: { avg: { field: 'an_percent' } },
+          },
+        },
+      },
+    },
+  })
+
+  return response.body.aggregations.allele_number.buckets.map((bucket: any) => ({
+    pos: bucket.key,
+    // Nulls are preserved rather than coerced to 0 the way the coverage query
+    // does. A bucket that covers no indexed base is not a bucket where nobody
+    // was called, and plotting it as zero would draw a callability cliff that
+    // is not in the data.
+    //
+    // Allele number is a count of alleles, so the average over a bucket is
+    // rounded back to a whole number.
+    an: bucket.an.value === null ? null : Math.round(bucket.an.value),
+    an_percent:
+      bucket.an_percent.value === null ? null : Math.round(bucket.an_percent.value * 1000) / 1000,
+  }))
+}
+
+// ================================================================================================
+// Region queries
+// ================================================================================================
+
+const fetchAlleleNumberForRegion = (
+  esClient: any,
+  datasetId: any,
+  region: any,
+  dataType: 'exome' | 'genome'
+) => {
+  assertDatasetAndReferenceGenomeMatch(datasetId, region.reference_genome)
+  assertAlleleNumberAvailable(datasetId)
+
+  // The +150 accounts for the 75 bases of padding added at each end below.
+  const regionSize = region.stop - region.start + 150
+  const bucketSize = Math.max(Math.floor(regionSize / 500), 1)
+
+  return fetchAlleleNumber(esClient, {
+    index: ALLELE_NUMBER_INDICES[datasetId][dataType],
+    contig: contigForFeature(region),
+    regions: [{ start: region.start - 75, stop: region.stop + 75 }],
+    bucketSize,
+  })
+}
+
+// Regions are not cached, matching the region coverage queries.
+export const fetchExomeAlleleNumberForRegion = (esClient: any, datasetId: any, region: any) =>
+  emptyIfIndexNotFound([], () => fetchAlleleNumberForRegion(esClient, datasetId, region, 'exome'))
+
+export const fetchGenomeAlleleNumberForRegion = (esClient: any, datasetId: any, region: any) =>
+  emptyIfIndexNotFound([], () => fetchAlleleNumberForRegion(esClient, datasetId, region, 'genome'))
+
+// ================================================================================================
+// Gene and transcript queries
+// ================================================================================================
+
+/**
+ * Allele number over the exons of a gene or transcript.
+ *
+ * The padding, merging and bucket sizing are the same as the coverage query for
+ * the same feature, so the two metrics bin to the same positions and a reader
+ * can compare them bucket for bucket.
+ */
+const fetchAlleleNumberForExons = async (esClient: any, datasetId: any, feature: any) => {
+  assertDatasetAndReferenceGenomeMatch(datasetId, feature.reference_genome)
+  assertAlleleNumberAvailable(datasetId)
+
+  const paddedExons = extendRegions(75, feature.exons)
+  const mergedExons = mergeOverlappingRegions(
+    paddedExons.sort((a: any, b: any) => a.start - b.start)
+  )
+  const totalIntervalSize = totalRegionSize(mergedExons)
+  const bucketSize = Math.max(Math.floor(totalIntervalSize / 500), 1)
+
+  const indices = ALLELE_NUMBER_INDICES[datasetId]
+  const query = { contig: contigForFeature(feature), regions: mergedExons, bucketSize }
+
+  const [exome, genome] = await Promise.all([
+    fetchAlleleNumber(esClient, { ...query, index: indices.exome }),
+    fetchAlleleNumber(esClient, { ...query, index: indices.genome }),
+  ])
+
+  return { exome, genome }
+}
+
+const cachedAlleleNumberForGene = withCache(
+  fetchAlleleNumberForExons,
+  (_: any, datasetId: any, gene: any) => `allele_number:${datasetId}:gene:${gene.gene_id}`,
+  { expiration: 604800 }
+)
+
+const cachedAlleleNumberForTranscript = withCache(
+  fetchAlleleNumberForExons,
+  (_: any, datasetId: any, transcript: any) =>
+    `allele_number:${datasetId}:transcript:${transcript.transcript_id}`,
+  { expiration: 3600 }
+)
+
+export const fetchAlleleNumberForGene = (esClient: any, datasetId: any, gene: any) =>
+  emptyIfIndexNotFound({ exome: [], genome: [] }, () =>
+    cachedAlleleNumberForGene(esClient, datasetId, gene)
+  )
+
+export const fetchAlleleNumberForTranscript = (esClient: any, datasetId: any, transcript: any) =>
+  emptyIfIndexNotFound({ exome: [], genome: [] }, () =>
+    cachedAlleleNumberForTranscript(esClient, datasetId, transcript)
+  )


### PR DESCRIPTION
Resolves #1943. Refactor of #1944. Continuation of #1945 and #1946.

Last of three stacked PRs. This is the user-visible one.

## What changes for the reader

On gnomAD v4.1 gene, transcript and region pages, the coverage track now opens on
**Call rate (AN%)** instead of *Fraction of individuals with coverage over 20*, with a `?`
button explaining the metric. Every coverage metric is still in the selector; only the
default changes.

Nothing changes on any other dataset — ExAC, v2, v3, the subsets, SV and CNV pages all
render exactly as before and issue exactly one request.

## Review notes

### 1. `hasAlleleNumber` lives in dataset metadata

Rather than three copies of an `isV4(...) && !isSubset(...)` test, this adds a
`hasAlleleNumber` flag alongside the existing per-dataset flags, true only for
`gnomad_r4`, with a one-line test pinning that list.

This is the browser half of the allowlist in PR 2, and the reason it is not
`coverageDatasetId`-based: coverage is deliberately shared between a release and its
subsets, and call rate must not be.

### 2. `AlleleNumberQuery` — one component, three tracks

Each track wraps its existing coverage `Query` in an `AlleleNumberQuery`, which either
skips the request entirely or hands the track a ready-made series to spread onto
`CoverageTrack`.

Three things worth knowing:

- **It is a separate request, not extra fields on the coverage query.** An unknown field is
  a GraphQL *validation* error, not a null, so a merged document would make the coverage
  track fail outright against an API that predates `allele_number` — the browser could not
  be deployed before the API.
- **It uses `BaseQuery`, not `Query`.** `BaseQuery` renders its children whatever the
  request is doing, which is what lets coverage draw normally while allele number is
  loading, missing or failing.
- **Each query aliases its feature to `feature`**, so one component can read gene,
  transcript and region responses alike. `AlleleNumberQuery` supplies `datasetId` and
  `referenceGenome`; callers supply only the feature identifiers.

Cost: a second request per page on v4, issued in parallel with the coverage request rather
than after it.

### 3. The metric is chosen at mount, not when the response lands

This is the subtlest part, and the one I would most want a second opinion on.

The obvious implementation — default to `over_20`, switch to call rate when the data
arrives — makes the track visibly change metric under a reader who is already looking at
it, possibly with the selector open. It also cannot tell "still on the default" from "the
reader deliberately picked `over_20`".

Instead, `CoverageTrack` takes both `alleleNumberDatasets` **and** `isAlleleNumberLoading`,
and `offersAlleleNumber(props)` is true for either. Because loading is known synchronously,
the constructor picks call rate on the very first render. While the request is in flight the
plot is empty but the axis and title are already correct, and when the data lands nothing
about the track changes except the shape being drawn.

`componentDidUpdate` then handles only the failure case: if the request settles with
nothing — no release, or an index that has not been loaded — the track falls back to a
coverage metric. It is guarded on a transition between props, so it cannot loop, and it
leaves a metric the reader chose alone.

### 4. Two fixes that fell out

- **`renderArea` now breaks the path at buckets with no value.** `renderBars` already
  filtered these; the area path did not, so a null produced a `NaN` segment. This affects
  coverage on `main` too.
- **`coverageStyles` colours are constants**, and `alleleNumberConfig` is an alias of
  `coverageConfigNew` rather than a copy, so the exome blue and genome green cannot drift
  between metrics and the legend cannot reorder when the reader switches.

Also replaces the literal `datasetId === 'exac'` in the transcript and region tracks with
`isExac`, matching the gene track. Behaviourally identical.

### 5. No snapshots were regenerated

The existing `GenePage` and `TranscriptPageContainer` snapshots do render the coverage
track, and they are **unchanged** — which is the evidence that no existing rendering moved.
Two details keep it that way, and both are deliberate:

- The call rate `optgroup` and the `?` button only appear when allele number is available,
  and the title panel keeps its bare-text child otherwise.
- Those specs mock the new operations with an empty `allele_number`, so the tracks take the
  unavailable path.

**If either snapshot churns on your machine, that is a bug, not a snapshot to update.**

### 6. Help copy is a DRAFT

`browser/help/topics/call-rate.md` follows the existing gnomAD wording — the browser
already says *AN%* / *allele number percent* in `constraint.md` and the flags FAQ — and
counts alleles rather than people. Two things for the methods reviewer:

- The example works through 5 called genotypes of 10 samples → 25%.
- It states that the genome series differs between metrics: call rate is v4.1 for both data
  types, while the read depth metrics still show v3.0.1 genomes. This is true today and
  users will otherwise be comparing two different sets of genomes without knowing it.

The topic is not listed in `helpPageTableOfContents.ts`, so it appears in the `?` modal
only, like the other track help topics. Easy to add if it should also be on `/help`.

## Verification

```bash
pnpm test:jest --selectProjects browser dataset-metadata
```

```bash
pnpm lint:js
```

New tests cover the pure metric helpers, the selector and help button, the mount-time
metric choice and the fallback, and — enumerating every dataset without a release — that no
allele number request is issued for them.

Against a live API with the indices loaded:

| page | expected |
|---|---|
| PCSK9 (`ENSG00000169174`) on v4.1 | opens on Call rate, axis reads `100%`, `?` opens the topic |
| a PCSK9 transcript on v4.1 | same, and agrees with the gene page over the shared exons |
| region `1-55039447-55064852` on v4.1 | same |
| a region ≥ 2.5 Mb on v4.1 | coverage's existing error, no call rate option, no 500 |
| any page on v4.1 (non-UKB), v3, v2, ExAC | no call rate option, one request, unchanged |
| v4.1 with the indices *not* loaded | no call rate option, coverage renders normally |
