### PR TITLE
fix(frontend): make age distribution permalinks accessible

### DIFF
--- a/browser/src/AnchorLink.spec.tsx
+++ b/browser/src/AnchorLink.spec.tsx
@@ -1,10 +1,11 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals'
 import styled from 'styled-components'
 
-import { AnchoredSectionHeading, withAnchor } from './AnchorLink'
+import { AgeDistributionHeading, withAnchor } from './AnchorLink'
+import Notifications from './Notifications'
 
 const PlainHeading = withAnchor(styled.h2``)
 
@@ -15,6 +16,14 @@ const originalClipboard = navigator.clipboard
 const setClipboard = (value: any) => {
   Object.defineProperty(navigator, 'clipboard', { value, configurable: true, writable: true })
 }
+
+const renderAgeDistributionHeading = () =>
+  render(
+    <>
+      <Notifications />
+      <AgeDistributionHeading>Age Distribution</AgeDistributionHeading>
+    </>
+  )
 
 describe('withAnchor', () => {
   beforeEach(() => {
@@ -27,40 +36,84 @@ describe('withAnchor', () => {
     setClipboard(originalClipboard)
   })
 
-  test('renders an anchor carrying the section id', () => {
-    const { container } = render(
-      <PlainHeading id="age-distribution">Age Distribution</PlainHeading>
-    )
-    const anchor = container.querySelector('#age-distribution')
-    expect(anchor).not.toBeNull()
-    expect(anchor!.getAttribute('href')).toBe('#age-distribution')
-  })
+  test('keeps existing heading anchors unchanged and does not touch the clipboard', async () => {
+    const { container } = render(<PlainHeading id="help-section">Help section</PlainHeading>)
+    const anchor = container.querySelector('#help-section')
 
-  test('does not touch the clipboard by default', async () => {
-    const { container } = render(
-      <PlainHeading id="age-distribution">Age Distribution</PlainHeading>
-    )
-    await userEvent.click(container.querySelector('#age-distribution')!)
+    expect(anchor).not.toBeNull()
+    expect(anchor?.getAttribute('href')).toBe('#help-section')
+    expect(anchor?.getAttribute('aria-hidden')).toBe('true')
+
+    await userEvent.click(anchor!)
     expect(writeText).not.toHaveBeenCalled()
   })
 
-  test('AnchoredSectionHeading copies the full section URL on click', async () => {
-    const { container } = render(
-      <AnchoredSectionHeading id="age-distribution">Age Distribution</AnchoredSectionHeading>
+  test('renders the Age Distribution control as a named link with a practical target', () => {
+    renderAgeDistributionHeading()
+
+    const link = screen.getByRole('link', { name: 'Copy link to Age Distribution' })
+    expect(link.getAttribute('href')).toBe('#age-distribution')
+    expect(link.getAttribute('id')).toBe('age-distribution')
+    expect(getComputedStyle(link).width).toBe('44px')
+    expect(getComputedStyle(link).height).toBe('44px')
+  })
+
+  test('focuses and activates the Age Distribution link from the keyboard', async () => {
+    renderAgeDistributionHeading()
+    const link = screen.getByRole('link', { name: 'Copy link to Age Distribution' })
+
+    await userEvent.tab()
+    expect(document.activeElement).toBe(link)
+    expect(getComputedStyle(link).opacity).toBe('1')
+    await userEvent.keyboard('{Enter}')
+
+    expect(writeText).toHaveBeenCalledWith(
+      'http://localhost/variant/1-55051215-G-GA?dataset=gnomad_r4#age-distribution'
     )
-    await userEvent.click(container.querySelector('#age-distribution')!)
+    expect(window.location.hash).toBe('#age-distribution')
+    expect(screen.getByRole('status').textContent).toContain('Link copied')
+  })
+
+  test('preserves the full current URL when replacing its fragment', async () => {
+    window.history.pushState({}, '', '/variant/1-55051215-G-GA?dataset=gnomad_r4#another-section')
+    renderAgeDistributionHeading()
+
+    await userEvent.click(screen.getByRole('link', { name: 'Copy link to Age Distribution' }))
+
     expect(writeText).toHaveBeenCalledWith(
       'http://localhost/variant/1-55051215-G-GA?dataset=gnomad_r4#age-distribution'
     )
   })
 
-  test('does nothing when the Clipboard API is unavailable', async () => {
+  test('shows an announced error and still navigates when clipboard access is rejected', async () => {
+    writeText.mockRejectedValueOnce(new Error('Permission denied'))
+    renderAgeDistributionHeading()
+
+    await userEvent.click(screen.getByRole('link', { name: 'Copy link to Age Distribution' }))
+
+    expect(window.location.hash).toBe('#age-distribution')
+    expect(screen.getByRole('alert').textContent).toContain('Unable to copy link')
+  })
+
+  test('shows an announced error and still navigates when clipboard access throws', async () => {
+    writeText.mockImplementationOnce(() => {
+      throw new Error('Clipboard failure')
+    })
+    renderAgeDistributionHeading()
+
+    await userEvent.click(screen.getByRole('link', { name: 'Copy link to Age Distribution' }))
+
+    expect(window.location.hash).toBe('#age-distribution')
+    expect(screen.getByRole('alert').textContent).toContain('Unable to copy link')
+  })
+
+  test('shows an announced error and still navigates when the Clipboard API is unavailable', async () => {
     setClipboard(undefined)
-    const { container } = render(
-      <AnchoredSectionHeading id="age-distribution">Age Distribution</AnchoredSectionHeading>
-    )
-    await expect(
-      userEvent.click(container.querySelector('#age-distribution')!)
-    ).resolves.not.toThrow()
+    renderAgeDistributionHeading()
+
+    await userEvent.click(screen.getByRole('link', { name: 'Copy link to Age Distribution' }))
+
+    expect(window.location.hash).toBe('#age-distribution')
+    expect(screen.getByRole('alert').textContent).toContain('Unable to copy link')
   })
 })

--- a/browser/src/AnchorLink.tsx
+++ b/browser/src/AnchorLink.tsx
@@ -27,39 +27,11 @@ const AnchorWrapper = styled.span`
   }
 `
 
-// The link still navigates, so the address bar updates either way. Copying is a convenience on
-// top of that, and is skipped where the Clipboard API is unavailable.
-export const copyLinkToSection = (id: string) => {
-  if (!navigator.clipboard || !navigator.clipboard.writeText) {
-    return
-  }
-
-  const { origin, pathname, search } = window.location
-  navigator.clipboard.writeText(`${origin}${pathname}${search}#${id}`).then(
-    () => {
-      showNotification({ title: 'Link copied', status: 'success' })
-    },
-    () => {
-      showNotification({ title: 'Unable to copy link', status: 'error' })
-    }
-  )
-}
-
 export const withAnchor = (Component: any) => {
-  const ComposedComponent = ({ children, id, copyUrlOnClick, ...props }: any) => (
+  const ComposedComponent = ({ children, id, ...props }: any) => (
     <AnchorWrapper>
       <Component {...props}>
-        <AnchorLink
-          href={`#${id}`}
-          id={id}
-          onClick={
-            copyUrlOnClick
-              ? () => {
-                  copyLinkToSection(id)
-                }
-              : undefined
-          }
-        >
+        <AnchorLink href={`#${id}`} id={id}>
           <img src={LinkIcon} alt="" aria-hidden="true" height={12} width={12} />
         </AnchorLink>
         {children}
@@ -71,16 +43,87 @@ export const withAnchor = (Component: any) => {
   ComposedComponent.propTypes = {
     children: PropTypes.node.isRequired,
     id: PropTypes.string.isRequired,
-    copyUrlOnClick: PropTypes.bool,
-  }
-  ComposedComponent.defaultProps = {
-    copyUrlOnClick: false,
   }
   return ComposedComponent
 }
 
-const SectionHeadingWithAnchor = withAnchor(styled.h2``)
+const AGE_DISTRIBUTION_ID = 'age-distribution'
 
-export const AnchoredSectionHeading = (props: any) => (
-  <SectionHeadingWithAnchor {...props} copyUrlOnClick />
+const AgeDistributionLink = styled.a`
+  position: absolute;
+  top: 50%;
+  left: 0;
+  transform: translate(-29px, -50%);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  width: 44px;
+  height: 44px;
+  opacity: 0;
+  vertical-align: middle;
+
+  /* stylelint-disable selector-type-no-unknown */
+  :hover,
+  :focus,
+  :focus-visible,
+  ${AnchorWrapper}:hover &,
+  ${AnchorWrapper}:focus-within & {
+    opacity: 1;
+  }
+  /* stylelint-enable selector-type-no-unknown */
+
+  :focus,
+  :focus-visible {
+    outline: 2px solid currentColor;
+    outline-offset: -8px;
+  }
+
+  @media (hover: none) {
+    opacity: 1;
+  }
+
+  /* Without the centered page's outer gutter, reserve inline space for the full target. */
+  @media (max-width: 1230px) {
+    position: static;
+    transform: none;
+    display: inline-flex;
+  }
+`
+
+// Clipboard failures must not suppress the link's default fragment navigation.
+const copyAgeDistributionLink = async () => {
+  try {
+    const clipboard = navigator.clipboard
+    if (!clipboard || !clipboard.writeText) {
+      throw new Error('Clipboard API unavailable')
+    }
+
+    const sectionUrl = new URL(window.location.href)
+    sectionUrl.hash = AGE_DISTRIBUTION_ID
+    await clipboard.writeText(sectionUrl.toString())
+    showNotification({ title: 'Link copied', status: 'success' })
+  } catch {
+    showNotification({ title: 'Unable to copy link', status: 'error' })
+  }
+}
+
+type AgeDistributionHeadingProps = Omit<React.ComponentPropsWithoutRef<'h2'>, 'id'>
+
+export const AgeDistributionHeading = ({ children, ...props }: AgeDistributionHeadingProps) => (
+  <AnchorWrapper>
+    <h2 {...props}>
+      <AgeDistributionLink
+        href={`#${AGE_DISTRIBUTION_ID}`}
+        id={AGE_DISTRIBUTION_ID}
+        aria-label="Copy link to Age Distribution"
+        onClick={() => {
+          copyAgeDistributionLink()
+        }}
+      >
+        <img src={LinkIcon} alt="" aria-hidden="true" height={12} width={12} />
+      </AgeDistributionLink>
+      {children}
+    </h2>
+  </AnchorWrapper>
 )

--- a/browser/src/MitochondrialVariantPage/MitochondrialVariantPage.tsx
+++ b/browser/src/MitochondrialVariantPage/MitochondrialVariantPage.tsx
@@ -28,7 +28,7 @@ import MitochondrialVariantGenotypeQualityMetrics from './MitochondrialVariantGe
 import MitochondrialVariantHaplogroupFrequenciesTable from './MitochondrialVariantHaplogroupFrequenciesTable'
 import MitochondrialVariantHeteroplasmyDistribution from './MitochondrialVariantHeteroplasmyDistribution'
 import MitochondrialVariantPopulationFrequenciesTable from './MitochondrialVariantPopulationFrequenciesTable'
-import { AnchoredSectionHeading } from '../AnchorLink'
+import { AgeDistributionHeading } from '../AnchorLink'
 import useScrollToHash from '../useScrollToHash'
 import MitochondrialVariantReferenceList from './MitochondrialVariantReferenceList'
 import MitochondrialVariantSiteQualityMetrics from './MitochondrialVariantSiteQualityMetrics'
@@ -247,9 +247,9 @@ const MitochondrialVariantPage = ({ datasetId, variant }: MitochondrialVariantPa
           <MitochondrialVariantHeteroplasmyDistribution variant={variant} />
         </ResponsiveSection>
         <ResponsiveSection>
-          <AnchoredSectionHeading id="age-distribution">
+          <AgeDistributionHeading>
             Age Distribution <InfoButton topic="age" />
-          </AnchoredSectionHeading>
+          </AgeDistributionHeading>
           <MitochondrialVariantAgeDistribution variant={variant} />
         </ResponsiveSection>
       </Wrapper>

--- a/browser/src/MitochondrialVariantPage/__snapshots__/MitochondrialVariantPage.spec.tsx.snap
+++ b/browser/src/MitochondrialVariantPage/__snapshots__/MitochondrialVariantPage.spec.tsx.snap
@@ -1494,12 +1494,10 @@ exports[`MitochondrialVariantPage with dataset gnomad_cnv_r4 has no unexpected c
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -9444,12 +9442,10 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3 has no unexpected chang
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -17304,12 +17300,10 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_controls_and_biobanks h
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -25164,12 +25158,10 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_non_cancer has no unexp
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -33024,12 +33016,10 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_non_neuro has no unexpe
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -40884,12 +40874,10 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_non_topmed has no unexp
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -48744,12 +48732,10 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_non_v2 has no unexpecte
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -56604,12 +56590,10 @@ exports[`MitochondrialVariantPage with dataset gnomad_r4 has no unexpected chang
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -64464,12 +64448,10 @@ exports[`MitochondrialVariantPage with dataset gnomad_r4_non_ukb has no unexpect
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -72324,12 +72306,10 @@ exports[`MitochondrialVariantPage with dataset gnomad_sv_r2_1 has no unexpected 
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -80184,12 +80164,10 @@ exports[`MitochondrialVariantPage with dataset gnomad_sv_r2_1_controls has no un
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -88044,12 +88022,10 @@ exports[`MitochondrialVariantPage with dataset gnomad_sv_r2_1_non_neuro has no u
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -95904,12 +95880,10 @@ exports[`MitochondrialVariantPage with dataset gnomad_sv_r4 has no unexpected ch
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}

--- a/browser/src/Notifications.spec.tsx
+++ b/browser/src/Notifications.spec.tsx
@@ -1,0 +1,119 @@
+import React from 'react'
+import { act, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals'
+
+import Notifications, { showNotification } from './Notifications'
+
+describe('Notifications', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers()
+    jest.useRealTimers()
+  })
+
+  test('positions feedback relative to the viewport with a narrow-screen width bound', () => {
+    const { container, unmount } = render(<Notifications />)
+    act(() => {
+      showNotification({ title: 'Link copied', status: 'success' })
+    })
+    const notification = container.querySelector('strong')!.parentElement!
+    const styles = getComputedStyle(notification.parentElement!)
+    expect(styles.position).toBe('fixed')
+    expect(styles.top).toBe('1rem')
+    expect(styles.left).toBe('calc(100vw - 1rem)')
+    expect(styles.transform).toBe('translateX(-100%)')
+    expect(styles.zIndex).toBe('1000')
+    expect(getComputedStyle(notification).maxWidth).toBe('calc(100vw - 2rem)')
+    // Only the pre-mounted region announces success, not the visual notification too.
+    expect(notification.getAttribute('role')).toBeNull()
+    expect(notification.getAttribute('aria-live')).toBeNull()
+    unmount()
+  })
+
+  test.each(['success', 'info', 'warning'])(
+    'updates a pre-mounted polite region for %s',
+    (status) => {
+      const { unmount } = render(<Notifications />)
+      const region = screen.getByRole('status')
+      expect(region.textContent).toBe('')
+      expect(region.getAttribute('aria-atomic')).toBe('false')
+      expect(region.getAttribute('aria-relevant')).toBe('additions')
+
+      act(() => {
+        showNotification({ title: 'Notification title', message: 'Details', status, duration: 2 })
+      })
+      expect(screen.getByRole('status')).toBe(region)
+      expect(region.textContent).toBe('Notification title Details')
+      expect(region.firstElementChild?.getAttribute('aria-atomic')).toBe('true')
+
+      act(() => {
+        jest.advanceTimersByTime(2000)
+      })
+      expect(screen.getByRole('status')).toBe(region)
+      expect(region.textContent).toBe('')
+      unmount()
+    }
+  )
+
+  test('adds distinct updates for repeated messages without replacing older announcements', () => {
+    const { unmount } = render(<Notifications />)
+    const region = screen.getByRole('status')
+    act(() => {
+      showNotification({ title: 'Link copied', status: 'success', duration: 2 })
+    })
+    const firstAnnouncement = region.firstElementChild
+    act(() => {
+      jest.advanceTimersByTime(1000)
+      showNotification({ title: 'Link copied', status: 'success', duration: 2 })
+    })
+    expect(region.children).toHaveLength(2)
+    expect(region.lastElementChild).toBe(firstAnnouncement)
+    expect(region.firstElementChild).not.toBe(firstAnnouncement)
+
+    act(() => {
+      jest.advanceTimersByTime(1000)
+    })
+    expect(region.children).toHaveLength(1)
+    expect(region.textContent).toBe('Link copied')
+    act(() => {
+      jest.advanceTimersByTime(1000)
+    })
+    expect(region.textContent).toBe('')
+    unmount()
+  })
+
+  test('urgently announces errors once, outside the polite region', () => {
+    const { unmount } = render(<Notifications />)
+
+    act(() => {
+      showNotification({ title: 'Unable to copy link', status: 'error', duration: 2 })
+    })
+    expect(screen.getAllByRole('alert')).toHaveLength(1)
+    expect(screen.getByRole('alert').textContent).toBe('Unable to copy link')
+    expect(screen.getByRole('status').textContent).toBe('')
+
+    act(() => {
+      jest.advanceTimersByTime(2000)
+    })
+    expect(screen.queryByRole('alert')).toBeNull()
+    unmount()
+  })
+
+  test('unsubscribes and clears all removal timers on unmount', () => {
+    const { unmount } = render(<Notifications />)
+    act(() => {
+      showNotification({ title: 'First' })
+      showNotification({ title: 'Second', status: 'error' })
+    })
+    expect(jest.getTimerCount()).toBe(2)
+    unmount()
+    expect(jest.getTimerCount()).toBe(0)
+    act(() => {
+      showNotification({ title: 'After unmount' })
+    })
+    expect(jest.getTimerCount()).toBe(0)
+  })
+})

--- a/browser/src/Notifications.tsx
+++ b/browser/src/Notifications.tsx
@@ -9,10 +9,22 @@ const NotificationsAnchor = styled.div`
 `
 
 const NotificationsContainer = styled.div`
-  position: absolute;
-  z-index: 2;
+  position: fixed;
+  z-index: 1000;
   top: 1rem;
-  right: 1rem;
+
+  /* Overflowing page content can widen the layout viewport beyond the screen. */
+  left: calc(100vw - 1rem);
+  transform: translateX(-100%);
+`
+
+const PoliteAnnouncements = styled.div`
+  position: absolute;
+  overflow: hidden;
+  width: 1px;
+  height: 1px;
+  clip-path: inset(50%);
+  white-space: nowrap;
 `
 
 const STATUS_COLOR = {
@@ -29,6 +41,7 @@ const Notification = styled.div<{ status: Status }>`
   flex-direction: column;
   box-sizing: border-box;
   width: 240px;
+  max-width: calc(100vw - 2rem);
   min-height: 30px;
   padding: 0.5rem 0.5rem 0.5rem calc(10px + 0.5rem);
   border: 1px solid #333;
@@ -100,11 +113,27 @@ class Notifications extends Component<Record<string, never>, State> {
 
     return (
       <NotificationsAnchor>
+        {/* Keep the polite region mounted; announce additions, not the whole stack or removals. */}
+        <PoliteAnnouncements role="status" aria-atomic="false" aria-relevant="additions">
+          {notifications
+            .filter(({ status }) => status !== 'error')
+            .map(({ id, title, message }) => (
+              <div key={id} aria-atomic="true">
+                {title}
+                {message ? <> {message}</> : null}
+              </div>
+            ))}
+        </PoliteAnnouncements>
         <NotificationsContainer>
           {notifications.map((notification) => {
             const { id, title, message, status } = notification
             return (
-              <Notification key={id} status={status}>
+              <Notification
+                key={id}
+                status={status}
+                role={status === 'error' ? 'alert' : undefined}
+                aria-atomic={status === 'error' ? 'true' : undefined}
+              >
                 <strong>{title}</strong>
                 {message}
               </Notification>

--- a/browser/src/ShortTandemRepeatPage/ShortTandemRepeatPage.tsx
+++ b/browser/src/ShortTandemRepeatPage/ShortTandemRepeatPage.tsx
@@ -33,7 +33,7 @@ import {
   genotypeRepunitPairs,
 } from './shortTandemRepeatHelpers'
 import { PopulationId } from '@gnomad/dataset-metadata/gnomadPopulations'
-import { AnchoredSectionHeading } from '../AnchorLink'
+import { AgeDistributionHeading } from '../AnchorLink'
 import useScrollToHash from '../useScrollToHash'
 import { GenotypeQuality } from './qualityDescription'
 import { QScoreBin } from './qScore'
@@ -622,9 +622,9 @@ const ShortTandemRepeatPage = ({ datasetId, shortTandemRepeat }: ShortTandemRepe
       )}
 
       <section style={{ marginBottom: '3em' }}>
-        <AnchoredSectionHeading id="age-distribution">
+        <AgeDistributionHeading>
           Age Distribution <InfoButton topic="str-age-distribution" />
-        </AnchoredSectionHeading>
+        </AgeDistributionHeading>
         <ShortTandemRepeatAgeDistributionPlot
           ageDistribution={shortTandemRepeat.age_distribution}
           maxRepeats={maxAlleleRepeats}

--- a/browser/src/ShortTandemRepeatPage/__snapshots__/ShortTandemRepeatPage.spec.tsx.snap
+++ b/browser/src/ShortTandemRepeatPage/__snapshots__/ShortTandemRepeatPage.spec.tsx.snap
@@ -769,14 +769,12 @@ exports[`ShortTandemRepeatPage with "exac" dataset has no unexected changes 1`] 
       }
     }
   >
-    <AnchoredSectionHeading
-      id="age-distribution"
-    >
+    <AgeDistributionHeading>
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </AnchoredSectionHeading>
+    </AgeDistributionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -1746,14 +1744,12 @@ exports[`ShortTandemRepeatPage with "gnomad_cnv_r4" dataset has no unexected cha
       }
     }
   >
-    <AnchoredSectionHeading
-      id="age-distribution"
-    >
+    <AgeDistributionHeading>
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </AnchoredSectionHeading>
+    </AgeDistributionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -2723,14 +2719,12 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1" dataset has no unexected chang
       }
     }
   >
-    <AnchoredSectionHeading
-      id="age-distribution"
-    >
+    <AgeDistributionHeading>
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </AnchoredSectionHeading>
+    </AgeDistributionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -3700,14 +3694,12 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1_controls" dataset has no unexec
       }
     }
   >
-    <AnchoredSectionHeading
-      id="age-distribution"
-    >
+    <AgeDistributionHeading>
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </AnchoredSectionHeading>
+    </AgeDistributionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -4677,14 +4669,12 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1_non_cancer" dataset has no unex
       }
     }
   >
-    <AnchoredSectionHeading
-      id="age-distribution"
-    >
+    <AgeDistributionHeading>
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </AnchoredSectionHeading>
+    </AgeDistributionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -5654,14 +5644,12 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1_non_neuro" dataset has no unexe
       }
     }
   >
-    <AnchoredSectionHeading
-      id="age-distribution"
-    >
+    <AgeDistributionHeading>
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </AnchoredSectionHeading>
+    </AgeDistributionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -6631,14 +6619,12 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1_non_topmed" dataset has no unex
       }
     }
   >
-    <AnchoredSectionHeading
-      id="age-distribution"
-    >
+    <AgeDistributionHeading>
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </AnchoredSectionHeading>
+    </AgeDistributionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -7608,14 +7594,12 @@ exports[`ShortTandemRepeatPage with "gnomad_r3" dataset has no unexected changes
       }
     }
   >
-    <AnchoredSectionHeading
-      id="age-distribution"
-    >
+    <AgeDistributionHeading>
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </AnchoredSectionHeading>
+    </AgeDistributionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -8585,14 +8569,12 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_controls_and_biobanks" dataset ha
       }
     }
   >
-    <AnchoredSectionHeading
-      id="age-distribution"
-    >
+    <AgeDistributionHeading>
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </AnchoredSectionHeading>
+    </AgeDistributionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -9562,14 +9544,12 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_non_cancer" dataset has no unexec
       }
     }
   >
-    <AnchoredSectionHeading
-      id="age-distribution"
-    >
+    <AgeDistributionHeading>
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </AnchoredSectionHeading>
+    </AgeDistributionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -10539,14 +10519,12 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_non_neuro" dataset has no unexect
       }
     }
   >
-    <AnchoredSectionHeading
-      id="age-distribution"
-    >
+    <AgeDistributionHeading>
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </AnchoredSectionHeading>
+    </AgeDistributionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -11516,14 +11494,12 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_non_topmed" dataset has no unexec
       }
     }
   >
-    <AnchoredSectionHeading
-      id="age-distribution"
-    >
+    <AgeDistributionHeading>
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </AnchoredSectionHeading>
+    </AgeDistributionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -12493,14 +12469,12 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_non_v2" dataset has no unexected 
       }
     }
   >
-    <AnchoredSectionHeading
-      id="age-distribution"
-    >
+    <AgeDistributionHeading>
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </AnchoredSectionHeading>
+    </AgeDistributionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -13470,14 +13444,12 @@ exports[`ShortTandemRepeatPage with "gnomad_r4" dataset has no unexected changes
       }
     }
   >
-    <AnchoredSectionHeading
-      id="age-distribution"
-    >
+    <AgeDistributionHeading>
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </AnchoredSectionHeading>
+    </AgeDistributionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -14447,14 +14419,12 @@ exports[`ShortTandemRepeatPage with "gnomad_r4_non_ukb" dataset has no unexected
       }
     }
   >
-    <AnchoredSectionHeading
-      id="age-distribution"
-    >
+    <AgeDistributionHeading>
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </AnchoredSectionHeading>
+    </AgeDistributionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -15424,14 +15394,12 @@ exports[`ShortTandemRepeatPage with "gnomad_sv_r2_1" dataset has no unexected ch
       }
     }
   >
-    <AnchoredSectionHeading
-      id="age-distribution"
-    >
+    <AgeDistributionHeading>
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </AnchoredSectionHeading>
+    </AgeDistributionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -16401,14 +16369,12 @@ exports[`ShortTandemRepeatPage with "gnomad_sv_r2_1_controls" dataset has no une
       }
     }
   >
-    <AnchoredSectionHeading
-      id="age-distribution"
-    >
+    <AgeDistributionHeading>
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </AnchoredSectionHeading>
+    </AgeDistributionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -17378,14 +17344,12 @@ exports[`ShortTandemRepeatPage with "gnomad_sv_r2_1_non_neuro" dataset has no un
       }
     }
   >
-    <AnchoredSectionHeading
-      id="age-distribution"
-    >
+    <AgeDistributionHeading>
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </AnchoredSectionHeading>
+    </AgeDistributionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -18355,14 +18319,12 @@ exports[`ShortTandemRepeatPage with "gnomad_sv_r4" dataset has no unexected chan
       }
     }
   >
-    <AnchoredSectionHeading
-      id="age-distribution"
-    >
+    <AgeDistributionHeading>
       Age Distribution 
       <InfoButton
         topic="str-age-distribution"
       />
-    </AnchoredSectionHeading>
+    </AgeDistributionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [

--- a/browser/src/StructuralVariantPage/StructuralVariantPage.tsx
+++ b/browser/src/StructuralVariantPage/StructuralVariantPage.tsx
@@ -17,7 +17,7 @@ import StructuralVariantConsequenceList from './StructuralVariantConsequenceList
 import StructuralVariantGenotypeQualityMetrics from './StructuralVariantGenotypeQualityMetrics'
 import StructuralVariantPopulationsTable from './StructuralVariantPopulationsTable'
 import SVReferenceList from './SVReferenceList'
-import { AnchoredSectionHeading } from '../AnchorLink'
+import { AgeDistributionHeading } from '../AnchorLink'
 import useScrollToHash from '../useScrollToHash'
 
 const Wrapper = styled.div`
@@ -163,9 +163,9 @@ const StructuralVariantPage = ({ datasetId, variant }: StructuralVariantPageProp
         </ResponsiveSection>
 
         <ResponsiveSection>
-          <AnchoredSectionHeading id="age-distribution">
+          <AgeDistributionHeading>
             Age Distribution <InfoButton topic="age" />
-          </AnchoredSectionHeading>
+          </AgeDistributionHeading>
           {variant.age_distribution ? (
             <React.Fragment>
               {datasetId !== 'gnomad_sv_r2_1' && (

--- a/browser/src/StructuralVariantPage/__snapshots__/StructuralVariantPage.spec.tsx.snap
+++ b/browser/src/StructuralVariantPage/__snapshots__/StructuralVariantPage.spec.tsx.snap
@@ -573,12 +573,10 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with a complex varian
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -1202,12 +1200,10 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with interchromosomal
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -1831,12 +1827,10 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with interchromosomal
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -2443,12 +2437,10 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -3055,12 +3047,10 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -3665,12 +3655,10 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -4277,12 +4265,10 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -5456,12 +5442,10 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -6086,12 +6070,10 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with a compl
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -6715,12 +6697,10 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with interch
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -7344,12 +7324,10 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with interch
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -7956,12 +7934,10 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -8568,12 +8544,10 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -9178,12 +9152,10 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -9790,12 +9762,10 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -10969,12 +10939,10 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -11599,12 +11567,10 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with a comp
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -12228,12 +12194,10 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with interc
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -12857,12 +12821,10 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with interc
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -13469,12 +13431,10 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -14081,12 +14041,10 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -14691,12 +14649,10 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -15303,12 +15259,10 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}
@@ -16482,12 +16436,10 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
       <span
         className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
       >
-        <h2
-          className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-        >
+        <h2>
           <a
-            aria-hidden="true"
-            className="AnchorLink-sc-77ly3x-0 isLygD"
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
             href="#age-distribution"
             id="age-distribution"
             onClick={[Function]}

--- a/browser/src/VariantPage/VariantPage.tsx
+++ b/browser/src/VariantPage/VariantPage.tsx
@@ -48,7 +48,7 @@ import {
   FullLocalAncestryPopulationId,
 } from '@gnomad/dataset-metadata/gnomadPopulations'
 import { Filter } from '../QCFilter'
-import { AnchoredSectionHeading } from '../AnchorLink'
+import { AgeDistributionHeading } from '../AnchorLink'
 import useScrollToHash from '../useScrollToHash'
 
 const Section = styled.section`
@@ -433,9 +433,9 @@ export const VariantPageContent = ({ datasetId, variant }: VariantPageContentPro
         <ResponsiveSection>
           {((variant.exome || {}).age_distribution || (variant.genome || {}).age_distribution) && (
             <React.Fragment>
-              <AnchoredSectionHeading id="age-distribution">
+              <AgeDistributionHeading>
                 Age Distribution <InfoButton topic="age" />
-              </AnchoredSectionHeading>
+              </AgeDistributionHeading>
               {isV3Subset(datasetId) && (
                 <p>
                   Age distribution is based on the full gnomAD dataset, not the selected subset.

--- a/browser/src/VariantPage/__snapshots__/VariantPage.spec.tsx.snap
+++ b/browser/src/VariantPage/__snapshots__/VariantPage.spec.tsx.snap
@@ -1632,12 +1632,10 @@ exports[`VariantPage with the dataset "gnomad_r3" has no unexpected changes 1`] 
         <span
           className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
         >
-          <h2
-            className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-          >
+          <h2>
             <a
-              aria-hidden="true"
-              className="AnchorLink-sc-77ly3x-0 isLygD"
+              aria-label="Copy link to Age Distribution"
+              className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
               href="#age-distribution"
               id="age-distribution"
               onClick={[Function]}
@@ -9064,12 +9062,10 @@ exports[`VariantPage with the dataset "gnomad_r3_controls_and_biobanks" has no u
         <span
           className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
         >
-          <h2
-            className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-          >
+          <h2>
             <a
-              aria-hidden="true"
-              className="AnchorLink-sc-77ly3x-0 isLygD"
+              aria-label="Copy link to Age Distribution"
+              className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
               href="#age-distribution"
               id="age-distribution"
               onClick={[Function]}
@@ -16499,12 +16495,10 @@ exports[`VariantPage with the dataset "gnomad_r3_non_cancer" has no unexpected c
         <span
           className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
         >
-          <h2
-            className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-          >
+          <h2>
             <a
-              aria-hidden="true"
-              className="AnchorLink-sc-77ly3x-0 isLygD"
+              aria-label="Copy link to Age Distribution"
+              className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
               href="#age-distribution"
               id="age-distribution"
               onClick={[Function]}
@@ -23934,12 +23928,10 @@ exports[`VariantPage with the dataset "gnomad_r3_non_neuro" has no unexpected ch
         <span
           className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
         >
-          <h2
-            className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-          >
+          <h2>
             <a
-              aria-hidden="true"
-              className="AnchorLink-sc-77ly3x-0 isLygD"
+              aria-label="Copy link to Age Distribution"
+              className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
               href="#age-distribution"
               id="age-distribution"
               onClick={[Function]}
@@ -31369,12 +31361,10 @@ exports[`VariantPage with the dataset "gnomad_r3_non_topmed" has no unexpected c
         <span
           className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
         >
-          <h2
-            className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-          >
+          <h2>
             <a
-              aria-hidden="true"
-              className="AnchorLink-sc-77ly3x-0 isLygD"
+              aria-label="Copy link to Age Distribution"
+              className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
               href="#age-distribution"
               id="age-distribution"
               onClick={[Function]}
@@ -38804,12 +38794,10 @@ exports[`VariantPage with the dataset "gnomad_r3_non_v2" has no unexpected chang
         <span
           className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
         >
-          <h2
-            className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-          >
+          <h2>
             <a
-              aria-hidden="true"
-              className="AnchorLink-sc-77ly3x-0 isLygD"
+              aria-label="Copy link to Age Distribution"
+              className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
               href="#age-distribution"
               id="age-distribution"
               onClick={[Function]}
@@ -45908,12 +45896,10 @@ exports[`VariantPage with the dataset exac has no unexpected changes 1`] = `
         <span
           className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
         >
-          <h2
-            className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-          >
+          <h2>
             <a
-              aria-hidden="true"
-              className="AnchorLink-sc-77ly3x-0 isLygD"
+              aria-label="Copy link to Age Distribution"
+              className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
               href="#age-distribution"
               id="age-distribution"
               onClick={[Function]}
@@ -52310,12 +52296,10 @@ exports[`VariantPage with the dataset gnomad_r2_1 has no unexpected changes 1`] 
         <span
           className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
         >
-          <h2
-            className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-          >
+          <h2>
             <a
-              aria-hidden="true"
-              className="AnchorLink-sc-77ly3x-0 isLygD"
+              aria-label="Copy link to Age Distribution"
+              className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
               href="#age-distribution"
               id="age-distribution"
               onClick={[Function]}
@@ -59863,12 +59847,10 @@ exports[`VariantPage with the dataset gnomad_r2_1_controls has no unexpected cha
         <span
           className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
         >
-          <h2
-            className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-          >
+          <h2>
             <a
-              aria-hidden="true"
-              className="AnchorLink-sc-77ly3x-0 isLygD"
+              aria-label="Copy link to Age Distribution"
+              className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
               href="#age-distribution"
               id="age-distribution"
               onClick={[Function]}
@@ -67416,12 +67398,10 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_cancer has no unexpected c
         <span
           className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
         >
-          <h2
-            className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-          >
+          <h2>
             <a
-              aria-hidden="true"
-              className="AnchorLink-sc-77ly3x-0 isLygD"
+              aria-label="Copy link to Age Distribution"
+              className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
               href="#age-distribution"
               id="age-distribution"
               onClick={[Function]}
@@ -74969,12 +74949,10 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_neuro has no unexpected ch
         <span
           className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
         >
-          <h2
-            className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-          >
+          <h2>
             <a
-              aria-hidden="true"
-              className="AnchorLink-sc-77ly3x-0 isLygD"
+              aria-label="Copy link to Age Distribution"
+              className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
               href="#age-distribution"
               id="age-distribution"
               onClick={[Function]}
@@ -82522,12 +82500,10 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_topmed has no unexpected c
         <span
           className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
         >
-          <h2
-            className="AnchorLink__SectionHeadingWithAnchor-sc-77ly3x-2"
-          >
+          <h2>
             <a
-              aria-hidden="true"
-              className="AnchorLink-sc-77ly3x-0 isLygD"
+              aria-label="Copy link to Age Distribution"
+              className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
               href="#age-distribution"
               id="age-distribution"
               onClick={[Function]}

--- a/browser/src/useScrollToHash.spec.tsx
+++ b/browser/src/useScrollToHash.spec.tsx
@@ -42,6 +42,7 @@ describe('useScrollToHash', () => {
 
   afterEach(() => {
     window.HTMLElement.prototype.getBoundingClientRect = originalGetBoundingClientRect
+    jest.restoreAllMocks()
   })
 
   test('scrolls to the element identified by the hash', async () => {
@@ -68,18 +69,84 @@ describe('useScrollToHash', () => {
     expect(scrollIntoView).not.toHaveBeenCalled()
   })
 
-  test('stops re-aligning once the reader scrolls', async () => {
+  test('re-aligns after an aligned frame if later content moves the target', async () => {
     window.location.hash = '#age-distribution'
+    mockOffsetFromViewportTop(0)
     render(<TestComponent />)
     await flushAnimationFrames(1)
-    const callsBeforeUserScroll = scrollIntoView.mock.calls.length
+    expect(scrollIntoView).not.toHaveBeenCalled()
 
+    mockOffsetFromViewportTop(200)
+    await flushAnimationFrames(1)
+    expect(scrollIntoView).toHaveBeenCalled()
+  })
+
+  test.each(['wheel', 'touchstart', 'keydown', 'mousedown'])(
+    'cancels the pending frame and detaches listeners on reader %s input',
+    async (eventType) => {
+      const cancelFrame = jest.spyOn(window, 'cancelAnimationFrame')
+      const removeEventListener = jest.spyOn(window, 'removeEventListener')
+      window.location.hash = '#age-distribution'
+      render(<TestComponent />)
+      await flushAnimationFrames(1)
+      const callsBeforeUserScroll = scrollIntoView.mock.calls.length
+
+      act(() => {
+        window.dispatchEvent(new Event(eventType))
+      })
+      await flushAnimationFrames(3)
+
+      expect(scrollIntoView.mock.calls.length).toBe(callsBeforeUserScroll)
+      expect(cancelFrame).toHaveBeenCalled()
+      expect(removeEventListener).toHaveBeenCalledWith('wheel', expect.any(Function))
+      expect(removeEventListener).toHaveBeenCalledWith('touchstart', expect.any(Function))
+      expect(removeEventListener).toHaveBeenCalledWith('keydown', expect.any(Function))
+      expect(removeEventListener).toHaveBeenCalledWith('mousedown', expect.any(Function))
+    }
+  )
+
+  test('stops scheduling frames and detaches listeners when the settle window expires', () => {
+    const frameCallbacks: FrameRequestCallback[] = []
+    const requestFrame = jest
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback) => {
+        frameCallbacks.push(callback)
+        return frameCallbacks.length
+      })
+    const removeEventListener = jest.spyOn(window, 'removeEventListener')
+    let now = 0
+    jest.spyOn(performance, 'now').mockImplementation(() => now)
+    window.location.hash = '#age-distribution'
+
+    render(<TestComponent />)
+    expect(frameCallbacks).toHaveLength(1)
+
+    now = 2001
     act(() => {
-      window.dispatchEvent(new Event('wheel'))
+      frameCallbacks.shift()!(now)
     })
-    await flushAnimationFrames(3)
 
-    expect(scrollIntoView.mock.calls.length).toBe(callsBeforeUserScroll)
+    expect(requestFrame).toHaveBeenCalledTimes(1)
+    expect(frameCallbacks).toHaveLength(0)
+    expect(removeEventListener).toHaveBeenCalledWith('wheel', expect.any(Function))
+    expect(removeEventListener).toHaveBeenCalledWith('touchstart', expect.any(Function))
+    expect(removeEventListener).toHaveBeenCalledWith('keydown', expect.any(Function))
+    expect(removeEventListener).toHaveBeenCalledWith('mousedown', expect.any(Function))
+  })
+
+  test('cancels the pending frame and detaches listeners on unmount', () => {
+    const cancelFrame = jest.spyOn(window, 'cancelAnimationFrame')
+    const removeEventListener = jest.spyOn(window, 'removeEventListener')
+    window.location.hash = '#age-distribution'
+
+    const { unmount } = render(<TestComponent />)
+    unmount()
+
+    expect(cancelFrame).toHaveBeenCalled()
+    expect(removeEventListener).toHaveBeenCalledWith('wheel', expect.any(Function))
+    expect(removeEventListener).toHaveBeenCalledWith('touchstart', expect.any(Function))
+    expect(removeEventListener).toHaveBeenCalledWith('keydown', expect.any(Function))
+    expect(removeEventListener).toHaveBeenCalledWith('mousedown', expect.any(Function))
   })
 
   test('does not scroll when the URL has no hash', async () => {

--- a/browser/src/useScrollToHash.ts
+++ b/browser/src/useScrollToHash.ts
@@ -3,15 +3,9 @@ import { useEffect } from 'react'
 // How long to keep re-aligning after mount while the rest of the page renders.
 const SETTLE_TIMEOUT_MS = 2000
 
-// The app scrolls to the URL's hash when a page's code finishes loading (see App.tsx). Pages
-// whose content renders only after a query resolves are still showing a loading message at that
-// point, so their sections are not yet in the document and that scroll finds nothing. Such pages
-// call this hook from the component that renders once their data is available.
-//
-// A single scroll on mount is not enough: the sections below the target have not rendered yet,
-// so the document is often too short for the browser to bring the target all the way to the top
-// and the scroll is clamped to the bottom of the page. Keep re-aligning while the page grows,
-// stopping early if the reader takes over.
+// App.tsx scrolls before query-loaded sections exist. Data-loaded pages retry here while
+// layout settles: short documents can clamp scrolling, and later content can move an already
+// aligned target. Stop after the bounded window or as soon as the reader takes over.
 const useScrollToHash = () => {
   useEffect(() => {
     const { hash } = window.location
@@ -23,15 +17,32 @@ const useScrollToHash = () => {
     // the URL is not necessarily a valid selector.
     const id = hash.slice(1)
     const start = performance.now()
-    let animationFrame = 0
-    let readerTookOver = false
+    let animationFrame: number | undefined
+    let finished = false
 
-    const stopAligning = () => {
-      readerTookOver = true
+    const removeInputListeners = () => {
+      window.removeEventListener('wheel', finish)
+      window.removeEventListener('touchstart', finish)
+      window.removeEventListener('keydown', finish)
+      window.removeEventListener('mousedown', finish)
+    }
+
+    function finish() {
+      if (finished) {
+        return
+      }
+
+      finished = true
+      if (animationFrame !== undefined) {
+        cancelAnimationFrame(animationFrame)
+        animationFrame = undefined
+      }
+      removeInputListeners()
     }
 
     const align = () => {
-      if (readerTookOver) {
+      animationFrame = undefined
+      if (finished) {
         return
       }
 
@@ -42,24 +53,20 @@ const useScrollToHash = () => {
 
       if (performance.now() - start < SETTLE_TIMEOUT_MS) {
         animationFrame = requestAnimationFrame(align)
+      } else {
+        finish()
       }
     }
 
     // Deliberate input only. A plain 'scroll' listener would also catch our own scrolling.
-    window.addEventListener('wheel', stopAligning, { passive: true })
-    window.addEventListener('touchstart', stopAligning, { passive: true })
-    window.addEventListener('keydown', stopAligning)
-    window.addEventListener('mousedown', stopAligning)
+    window.addEventListener('wheel', finish, { passive: true })
+    window.addEventListener('touchstart', finish, { passive: true })
+    window.addEventListener('keydown', finish)
+    window.addEventListener('mousedown', finish)
 
     animationFrame = requestAnimationFrame(align)
 
-    return () => {
-      cancelAnimationFrame(animationFrame)
-      window.removeEventListener('wheel', stopAligning)
-      window.removeEventListener('touchstart', stopAligning)
-      window.removeEventListener('keydown', stopAligning)
-      window.removeEventListener('mousedown', stopAligning)
-    }
+    return finish
   }, [])
 }
 

--- a/tests/e2e/VariantPage.playwright.spec.ts
+++ b/tests/e2e/VariantPage.playwright.spec.ts
@@ -1,14 +1,59 @@
 import { test, expect } from '@playwright/test'
 
 test.describe('Variant page', () => {
-  test('v4 renders without crashes', async ({ page }) => {
+  test.describe('narrow touch viewport', () => {
+    test.use({ viewport: { width: 320, height: 720 }, hasTouch: true, isMobile: true })
+
+    test('keeps the whole permalink target and feedback on screen', async ({ page }) => {
+      await page.context().grantPermissions(['clipboard-read', 'clipboard-write'])
+      await page.goto('/variant/1-55051215-G-GA?dataset=gnomad_r4#age-distribution')
+      const link = page.getByRole('link', { name: 'Copy link to Age Distribution' })
+      await expect(link).toBeAttached({ timeout: 30_000 })
+      await expect(link).toHaveCSS('opacity', '1')
+      const target = await link.boundingBox()
+      expect(target!.width).toBeGreaterThanOrEqual(44)
+      expect(target!.height).toBeGreaterThanOrEqual(44)
+      expect(target!.x).toBeGreaterThanOrEqual(0)
+      expect(target!.x + target!.width).toBeLessThanOrEqual(320)
+      await link.tap()
+
+      const card = page
+        .locator('strong')
+        .filter({ hasText: /^Link copied$/ })
+        .locator('..')
+      await expect(card).toBeInViewport({ ratio: 1 })
+      const feedback = await card.boundingBox()
+      expect(feedback!.x).toBeGreaterThanOrEqual(0)
+      expect(feedback!.x + feedback!.width).toBeLessThanOrEqual(320)
+    })
+  })
+
+  test('v4 renders after navigating from the homepage', async ({ page }) => {
     await page.goto('/')
     await page.getByRole('link', { name: '-55051215-G-GA' }).click()
 
-    // expect variant query to finish loading, and to render
     await expect(
       page.getByText('Insertion (1 base):1-55051215-G-GA (GRCh38)Copy variant IDGene page')
+    ).toBeVisible({ timeout: 30_000 })
+    await expect(
+      page.locator('table').filter({ hasText: 'ExomesGenomesTotalFilters' })
     ).toBeVisible()
+    await expect(
+      page.getByText('Genetic Ancestry Group Frequencies More informationgnomADHGDP1KGLocal')
+    ).toBeVisible()
+    await expect(page.getByText('Variant Effect PredictorThis')).toBeVisible()
+    await page
+      .getByText('Age Distribution More informationExomeGenomeVariant carriersAll individuals<')
+      .click()
+  })
+
+  test('v4 deep link and copyable Age Distribution anchor work', async ({ page }) => {
+    test.setTimeout(60_000)
+    await page.goto('/variant/1-55051215-G-GA?dataset=gnomad_r4#age-distribution')
+
+    await expect(
+      page.getByText('Insertion (1 base):1-55051215-G-GA (GRCh38)Copy variant IDGene page')
+    ).toBeVisible({ timeout: 30_000 })
 
     await expect(
       page.locator('table').filter({ hasText: 'ExomesGenomesTotalFilters' })
@@ -20,8 +65,48 @@ test.describe('Variant page', () => {
 
     await expect(page.getByText('Variant Effect PredictorThis')).toBeVisible()
 
-    await page
-      .getByText('Age Distribution More informationExomeGenomeVariant carriersAll individuals<')
-      .click()
+    const ageDistributionLink = page.getByRole('link', {
+      name: 'Copy link to Age Distribution',
+    })
+    await expect(ageDistributionLink).toBeAttached({ timeout: 30_000 })
+    // Check the final layout, not merely an aligned frame inside the two-second settle window.
+    await page.waitForTimeout(2200)
+    expect(
+      Math.abs(await ageDistributionLink.evaluate((link) => link.getBoundingClientRect().top))
+    ).toBeLessThanOrEqual(2)
+
+    const linkTarget = await ageDistributionLink.boundingBox()
+    expect(linkTarget).not.toBeNull()
+    expect(linkTarget!.width).toBeGreaterThanOrEqual(44)
+    expect(linkTarget!.height).toBeGreaterThanOrEqual(44)
+    await page.mouse.move(Math.max(linkTarget!.x + 2, 1), linkTarget!.y + linkTarget!.height / 2)
+    await expect(ageDistributionLink).toHaveCSS('opacity', '1')
+
+    await page.mouse.move(1200, 600)
+    await page.context().grantPermissions(['clipboard-read', 'clipboard-write'])
+    // Fragment navigation sets the sequential focus starting point at the link.
+    await page.keyboard.press('Shift+Tab')
+    await expect(ageDistributionLink).not.toBeFocused()
+    await page.keyboard.press('Tab')
+    await expect(ageDistributionLink).toBeFocused()
+    await expect(ageDistributionLink).toHaveCSS('opacity', '1')
+    await page.keyboard.press('Enter')
+
+    const copyNotification = page
+      .locator('strong')
+      .filter({ hasText: /^Link copied$/ })
+      .locator('..')
+    await expect(copyNotification).toBeInViewport({ ratio: 1 })
+    await expect(page.getByRole('status')).toHaveText('Link copied')
+    await expect
+      .poll(() =>
+        copyNotification.evaluate(
+          (notification) => getComputedStyle(notification.parentElement!).position
+        )
+      )
+      .toBe('fixed')
+    expect(new URL(page.url()).hash).toBe('#age-distribution')
+    expect(new URL(page.url()).searchParams.get('dataset')).toBe('gnomad_r4')
+    expect(await page.evaluate(() => navigator.clipboard.readText())).toBe(page.url())
   })
 })


### PR DESCRIPTION
## Summary
Follow-up to #1925, **targeting `kc/age-distribution-link`, not `main`**. Contains only four fix commits on KC's current PR head; no unrelated main-branch commits.

- Make Age Distribution links keyboard accessible, directly discoverable from their gutter, and usable on narrow/touch screens.
- Keep copy feedback inside the viewport; use a persistent polite announcement region with separate error alerts.
- Preserve native fragment navigation and handle unavailable/denied clipboard access.
- Clean up hash-settling frames/listeners on reader input, timeout and unmount.
- Trim redundant comments and strengthen unit/browser regressions, retaining homepage navigation coverage.

The additional variant-section links are intentionally a separate PR, #1951, stacked on this branch. Keep this branch until that follow-up is retargeted.

## Validation
- Before restacking: 1,792 browser tests / 1,144 snapshots and 3 Chromium regressions passed; lint, Stylelint and production build passed.
- After cherry-picking onto KC's exact head, the combined fixes + stacked expansion pass 1,811 browser tests / 1,144 snapshots and all 5 Chromium regressions.
- Independent code review found no blockers.
- Typecheck on the implementation tree encountered the existing two missing `@google-cloud/storage` imports, not changed-file errors.

Human screen-reader speech-output and physical-device touch verification remain outstanding. A broader mitochondrial mobile-overflow/emulation issue was recorded separately; this PR does not claim to resolve it.
