### PR TITLE
feat(frontend): add permalinks to variant page sections

### DIFF
--- a/browser/src/AnchorLink.spec.tsx
+++ b/browser/src/AnchorLink.spec.tsx
@@ -1,119 +1,124 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals'
 import styled from 'styled-components'
 
-import { AgeDistributionHeading, withAnchor } from './AnchorLink'
+import { SectionHeading, withAnchor } from './AnchorLink'
 import Notifications from './Notifications'
 
 const PlainHeading = withAnchor(styled.h2``)
-
 const writeText = jest.fn(() => Promise.resolve())
-
 const originalClipboard = navigator.clipboard
 
 const setClipboard = (value: any) => {
   Object.defineProperty(navigator, 'clipboard', { value, configurable: true, writable: true })
 }
 
-const renderAgeDistributionHeading = () =>
-  render(
-    <>
-      <Notifications />
-      <AgeDistributionHeading>Age Distribution</AgeDistributionHeading>
-    </>
+beforeEach(() => {
+  writeText.mockClear()
+  setClipboard({ writeText })
+  window.history.pushState({}, '', '/variant/1-55051215-G-GA?dataset=gnomad_r4')
+})
+
+afterEach(() => {
+  setClipboard(originalClipboard)
+})
+
+test('withAnchor keeps legacy anchor targets unchanged and does not touch the clipboard', async () => {
+  const { container } = render(<PlainHeading id="help-section">Help section</PlainHeading>)
+  const anchor = container.querySelector('#help-section')
+
+  expect(anchor?.tagName).toBe('A')
+  expect(anchor?.getAttribute('href')).toBe('#help-section')
+  expect(anchor?.getAttribute('aria-hidden')).toBe('true')
+
+  await userEvent.click(anchor!)
+  expect(writeText).not.toHaveBeenCalled()
+})
+
+test('SectionHeading renders its title and adornments and forwards h2 attributes', () => {
+  const { container } = render(
+    <SectionHeading id="ancestry" title="Genetic Ancestry" className="custom" data-test="heading">
+      <button type="button">More information</button>
+    </SectionHeading>
   )
+  const heading = screen.getByRole('heading', { level: 2 })
+  expect(heading.textContent).toBe('Genetic Ancestry More information')
+  expect(container.firstElementChild).toBe(heading)
+  expect(getComputedStyle(heading).position).toBe('relative')
+  expect(heading.classList.contains('custom')).toBe(true)
+  expect(heading.getAttribute('data-test')).toBe('heading')
+  expect(heading.hasAttribute('title')).toBe(false)
+  expect(within(heading).getByRole('button', { name: 'More information' })).toBeTruthy()
+  expect(within(heading).getByRole('link', { name: 'Copy link to Genetic Ancestry' })).toBeTruthy()
+})
 
-describe('withAnchor', () => {
-  beforeEach(() => {
-    writeText.mockClear()
-    setClipboard({ writeText })
-    window.history.pushState({}, '', '/variant/1-55051215-G-GA?dataset=gnomad_r4')
-  })
+describe.each([
+  ['age-distribution', 'Age Distribution'],
+  ['variant-effect-predictor', 'Ensembl Variant Effect Predictor'],
+])('SectionHeading #%s', (id, title) => {
+  const renderHeading = () => {
+    render(
+      <>
+        <Notifications />
+        <SectionHeading id={id} title={title} />
+      </>
+    )
+    return screen.getByRole('link', { name: `Copy link to ${title}` })
+  }
+  const expectedUrl = `http://localhost/variant/1-55051215-G-GA?dataset=gnomad_r4#${id}`
 
-  afterEach(() => {
-    setClipboard(originalClipboard)
-  })
-
-  test('keeps existing heading anchors unchanged and does not touch the clipboard', async () => {
-    const { container } = render(<PlainHeading id="help-section">Help section</PlainHeading>)
-    const anchor = container.querySelector('#help-section')
-
-    expect(anchor).not.toBeNull()
-    expect(anchor?.getAttribute('href')).toBe('#help-section')
-    expect(anchor?.getAttribute('aria-hidden')).toBe('true')
-
-    await userEvent.click(anchor!)
-    expect(writeText).not.toHaveBeenCalled()
-  })
-
-  test('renders the Age Distribution control as a named link with a practical target', () => {
-    renderAgeDistributionHeading()
-
-    const link = screen.getByRole('link', { name: 'Copy link to Age Distribution' })
-    expect(link.getAttribute('href')).toBe('#age-distribution')
-    expect(link.getAttribute('id')).toBe('age-distribution')
+  test('puts the unique target ID on h2 and provides a named native link with a practical target', () => {
+    const link = renderHeading()
+    const heading = screen.getByRole('heading', { level: 2 })
+    expect(heading.tagName).toBe('H2')
+    expect(heading.id).toBe(id)
+    expect(document.querySelectorAll(`[id="${id}"]`)).toHaveLength(1)
+    expect(link.getAttribute('href')).toBe(`#${id}`)
+    expect(link.hasAttribute('id')).toBe(false)
     expect(getComputedStyle(link).width).toBe('44px')
     expect(getComputedStyle(link).height).toBe('44px')
   })
 
-  test('focuses and activates the Age Distribution link from the keyboard', async () => {
-    renderAgeDistributionHeading()
-    const link = screen.getByRole('link', { name: 'Copy link to Age Distribution' })
-
+  test('focuses and activates the link from the keyboard', async () => {
+    const link = renderHeading()
     await userEvent.tab()
     expect(document.activeElement).toBe(link)
     expect(getComputedStyle(link).opacity).toBe('1')
     await userEvent.keyboard('{Enter}')
 
-    expect(writeText).toHaveBeenCalledWith(
-      'http://localhost/variant/1-55051215-G-GA?dataset=gnomad_r4#age-distribution'
-    )
-    expect(window.location.hash).toBe('#age-distribution')
+    expect(writeText).toHaveBeenCalledWith(expectedUrl)
+    expect(window.location.hash).toBe(`#${id}`)
     expect(screen.getByRole('status').textContent).toContain('Link copied')
   })
 
   test('preserves the full current URL when replacing its fragment', async () => {
     window.history.pushState({}, '', '/variant/1-55051215-G-GA?dataset=gnomad_r4#another-section')
-    renderAgeDistributionHeading()
-
-    await userEvent.click(screen.getByRole('link', { name: 'Copy link to Age Distribution' }))
-
-    expect(writeText).toHaveBeenCalledWith(
-      'http://localhost/variant/1-55051215-G-GA?dataset=gnomad_r4#age-distribution'
-    )
+    await userEvent.click(renderHeading())
+    expect(writeText).toHaveBeenCalledWith(expectedUrl)
+    expect(window.location.hash).toBe(`#${id}`)
   })
 
-  test('shows an announced error and still navigates when clipboard access is rejected', async () => {
-    writeText.mockRejectedValueOnce(new Error('Permission denied'))
-    renderAgeDistributionHeading()
+  test.each(['rejects', 'throws', 'is unavailable'])(
+    'announces an error and still navigates by keyboard when clipboard access %s',
+    async (failure) => {
+      if (failure === 'rejects') {
+        writeText.mockRejectedValueOnce(new Error('Permission denied'))
+      } else if (failure === 'throws') {
+        writeText.mockImplementationOnce(() => {
+          throw new Error('Clipboard failure')
+        })
+      } else {
+        setClipboard(undefined)
+      }
+      renderHeading()
+      await userEvent.tab()
+      await userEvent.keyboard('{Enter}')
 
-    await userEvent.click(screen.getByRole('link', { name: 'Copy link to Age Distribution' }))
-
-    expect(window.location.hash).toBe('#age-distribution')
-    expect(screen.getByRole('alert').textContent).toContain('Unable to copy link')
-  })
-
-  test('shows an announced error and still navigates when clipboard access throws', async () => {
-    writeText.mockImplementationOnce(() => {
-      throw new Error('Clipboard failure')
-    })
-    renderAgeDistributionHeading()
-
-    await userEvent.click(screen.getByRole('link', { name: 'Copy link to Age Distribution' }))
-
-    expect(window.location.hash).toBe('#age-distribution')
-    expect(screen.getByRole('alert').textContent).toContain('Unable to copy link')
-  })
-
-  test('shows an announced error and still navigates when the Clipboard API is unavailable', async () => {
-    setClipboard(undefined)
-    renderAgeDistributionHeading()
-
-    await userEvent.click(screen.getByRole('link', { name: 'Copy link to Age Distribution' }))
-
-    expect(window.location.hash).toBe('#age-distribution')
-    expect(screen.getByRole('alert').textContent).toContain('Unable to copy link')
-  })
+      expect(window.location.hash).toBe(`#${id}`)
+      expect(screen.getByRole('alert').textContent).toContain('Unable to copy link')
+      expect(screen.getByRole('status').textContent).toBe('')
+    }
+  )
 })

--- a/browser/src/AnchorLink.tsx
+++ b/browser/src/AnchorLink.tsx
@@ -116,12 +116,23 @@ type SectionHeadingProps = Omit<
 > & {
   id: string
   title: string
+  // Reserve the full hit area when there is not enough space around the heading.
+  inlineLink?: boolean
   children?: React.ReactNode
 }
 
-export const SectionHeading = ({ id, title, children, ...props }: SectionHeadingProps) => (
+export const SectionHeading = ({
+  id,
+  title,
+  inlineLink = false,
+  children,
+  ...props
+}: SectionHeadingProps) => (
   <Heading {...props} id={id}>
     <SectionLink
+      style={
+        inlineLink ? { position: 'static', transform: 'none', display: 'inline-flex' } : undefined
+      }
       href={`#${id}`}
       aria-label={`Copy link to ${title}`}
       onClick={() => {

--- a/browser/src/AnchorLink.tsx
+++ b/browser/src/AnchorLink.tsx
@@ -116,22 +116,28 @@ type SectionHeadingProps = Omit<
 > & {
   id: string
   title: string
-  // Reserve the full hit area when there is not enough space around the heading.
-  inlineLink?: boolean
+  // The container must reserve a 44px left gutter for the full link target.
+  linkInGutter?: boolean
   children?: React.ReactNode
 }
 
 export const SectionHeading = ({
   id,
   title,
-  inlineLink = false,
+  linkInGutter = false,
   children,
   ...props
 }: SectionHeadingProps) => (
-  <Heading {...props} id={id}>
+  <Heading
+    {...props}
+    id={id}
+    style={linkInGutter ? { padding: '8px 0', ...props.style } : props.style}
+  >
     <SectionLink
       style={
-        inlineLink ? { position: 'static', transform: 'none', display: 'inline-flex' } : undefined
+        linkInGutter
+          ? { position: 'absolute', transform: 'translate(-100%, -50%)', display: 'flex' }
+          : undefined
       }
       href={`#${id}`}
       aria-label={`Copy link to ${title}`}

--- a/browser/src/AnchorLink.tsx
+++ b/browser/src/AnchorLink.tsx
@@ -47,9 +47,11 @@ export const withAnchor = (Component: any) => {
   return ComposedComponent
 }
 
-const AGE_DISTRIBUTION_ID = 'age-distribution'
+const Heading = styled.h2`
+  position: relative;
+`
 
-const AgeDistributionLink = styled.a`
+const SectionLink = styled.a`
   position: absolute;
   top: 50%;
   left: 0;
@@ -67,8 +69,8 @@ const AgeDistributionLink = styled.a`
   :hover,
   :focus,
   :focus-visible,
-  ${AnchorWrapper}:hover &,
-  ${AnchorWrapper}:focus-within & {
+  ${Heading}:hover &,
+  ${Heading}:focus-within & {
     opacity: 1;
   }
   /* stylelint-enable selector-type-no-unknown */
@@ -92,7 +94,7 @@ const AgeDistributionLink = styled.a`
 `
 
 // Clipboard failures must not suppress the link's default fragment navigation.
-const copyAgeDistributionLink = async () => {
+const copySectionLink = async (id: string) => {
   try {
     const clipboard = navigator.clipboard
     if (!clipboard || !clipboard.writeText) {
@@ -100,7 +102,7 @@ const copyAgeDistributionLink = async () => {
     }
 
     const sectionUrl = new URL(window.location.href)
-    sectionUrl.hash = AGE_DISTRIBUTION_ID
+    sectionUrl.hash = id
     await clipboard.writeText(sectionUrl.toString())
     showNotification({ title: 'Link copied', status: 'success' })
   } catch {
@@ -108,22 +110,27 @@ const copyAgeDistributionLink = async () => {
   }
 }
 
-type AgeDistributionHeadingProps = Omit<React.ComponentPropsWithoutRef<'h2'>, 'id'>
+type SectionHeadingProps = Omit<
+  React.ComponentPropsWithoutRef<'h2'>,
+  'id' | 'title' | 'children'
+> & {
+  id: string
+  title: string
+  children?: React.ReactNode
+}
 
-export const AgeDistributionHeading = ({ children, ...props }: AgeDistributionHeadingProps) => (
-  <AnchorWrapper>
-    <h2 {...props}>
-      <AgeDistributionLink
-        href={`#${AGE_DISTRIBUTION_ID}`}
-        id={AGE_DISTRIBUTION_ID}
-        aria-label="Copy link to Age Distribution"
-        onClick={() => {
-          copyAgeDistributionLink()
-        }}
-      >
-        <img src={LinkIcon} alt="" aria-hidden="true" height={12} width={12} />
-      </AgeDistributionLink>
-      {children}
-    </h2>
-  </AnchorWrapper>
+export const SectionHeading = ({ id, title, children, ...props }: SectionHeadingProps) => (
+  <Heading {...props} id={id}>
+    <SectionLink
+      href={`#${id}`}
+      aria-label={`Copy link to ${title}`}
+      onClick={() => {
+        copySectionLink(id)
+      }}
+    >
+      <img src={LinkIcon} alt="" aria-hidden="true" height={12} width={12} />
+    </SectionLink>
+    {title}
+    {children && <> {children}</>}
+  </Heading>
 )

--- a/browser/src/App.spec.tsx
+++ b/browser/src/App.spec.tsx
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals'
+
+import { scrollToAnchorOrStartOfPage } from './App'
+
+describe('App hash scrolling', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+    jest.spyOn(window, 'scrollTo').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    document.body.replaceChildren()
+    jest.useRealTimers()
+    jest.restoreAllMocks()
+  })
+
+  test.each(['h2', 'a'])('scrolls to a %s target after the render tick', (tag) => {
+    scrollToAnchorOrStartOfPage({ hash: '#section' })
+    const target = document.createElement(tag)
+    target.id = 'section'
+    target.scrollIntoView = jest.fn()
+    document.body.appendChild(target)
+    expect(target.scrollIntoView).not.toHaveBeenCalled()
+
+    jest.runOnlyPendingTimers()
+    expect(target.scrollIntoView).toHaveBeenCalledTimes(1)
+    expect(window.scrollTo).not.toHaveBeenCalled()
+  })
+
+  test.each(['#missing', '#[', '#123 not a selector'])(
+    'safely falls back to the top for missing target %s',
+    (hash) => {
+      scrollToAnchorOrStartOfPage({ hash })
+      expect(window.scrollTo).not.toHaveBeenCalled()
+      expect(() => jest.runOnlyPendingTimers()).not.toThrow()
+      expect(window.scrollTo).toHaveBeenCalledWith(0, 0)
+    }
+  )
+
+  test('scrolls to the top immediately when there is no hash', () => {
+    scrollToAnchorOrStartOfPage({ hash: '' })
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 0)
+    expect(jest.getTimerCount()).toBe(0)
+  })
+})

--- a/browser/src/App.tsx
+++ b/browser/src/App.tsx
@@ -13,10 +13,10 @@ import { ExternalLink } from '@gnomad/ui'
 const NavBar = lazy(() => import('./NavBar'))
 const Routes = lazy(() => import('./Routes'))
 
-const scrollToAnchorOrStartOfPage = (location: any) => {
+export const scrollToAnchorOrStartOfPage = (location: any) => {
   if (location.hash) {
     setTimeout(() => {
-      const anchor = document.querySelector(`a${location.hash}`)
+      const anchor = document.getElementById(location.hash.slice(1))
       if (anchor) {
         anchor.scrollIntoView()
       } else {

--- a/browser/src/DataPage/DataPage.tsx
+++ b/browser/src/DataPage/DataPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import styled from 'styled-components'
 
 import { Badge, ExternalLink, PageHeading } from '@gnomad/ui'
@@ -7,6 +7,7 @@ import Link from '../Link'
 
 import DocumentTitle from '../DocumentTitle'
 import InfoPage from '../InfoPage'
+import useScrollToHash from '../useScrollToHash'
 
 import { SectionTitle, StyledParagraph, CodeBlock } from './downloadsPageStyles'
 
@@ -53,15 +54,7 @@ const DataPage = () => {
   // Load stylesheet to make smooth scroll behavior active
   const _style = styles.html
 
-  useEffect(() => {
-    const hash = window.location.hash
-    if (hash !== '') {
-      const element = document.querySelector(`${hash}`)
-      if (element) {
-        element.scrollIntoView()
-      }
-    }
-  }, [])
+  useScrollToHash()
 
   return (
     <InfoPage>
@@ -89,9 +82,7 @@ const DataPage = () => {
           .
         </div>
         <div>
-          <SectionTitle id="summary" subject="datasets">
-            Summary
-          </SectionTitle>
+          <SectionTitle id="summary" $subject="datasets" title="Summary" />
           <StyledParagraph>
             gnomAD data is available for download through{' '}
             <ExternalLink href="https://cloud.google.com/public-datasets">

--- a/browser/src/DataPage/DataPage.tsx
+++ b/browser/src/DataPage/DataPage.tsx
@@ -57,7 +57,7 @@ const DataPage = () => {
   useScrollToHash()
 
   return (
-    <InfoPage>
+    <InfoPage $withSectionLinks>
       <DocumentTitle title="Data" />
       <PageHeading>Data</PageHeading>
 

--- a/browser/src/DataPage/ExacDownloads.tsx
+++ b/browser/src/DataPage/ExacDownloads.tsx
@@ -40,23 +40,19 @@ const coverageFiles = [
 
 const ExacDownloads = () => (
   <>
-    <SectionTitle id="exac" subject="release">
-      ExAC Downloads
-    </SectionTitle>
+    <SectionTitle id="exac" $subject="release" title="ExAC Downloads" />
     <StyledParagraph>
       The ExAC data set contains data from 60,706 exomes, all mapped to the GRCh37/hg19 reference
       sequence.
     </StyledParagraph>
 
-    <SectionTitle id="exac-core-dataset" subject="datasets">
-      Core Dataset
-    </SectionTitle>
+    <SectionTitle id="exac-core-dataset" $subject="datasets" title="Core Dataset" />
     <StyledParagraph>
       gnomAD database and features created and maintained by the gnomAD production team.
     </StyledParagraph>
 
     <DownloadsSection>
-      <SectionTitle id="exac-variants">Variants</SectionTitle>
+      <SectionTitle id="exac-variants" title="Variants" />
       <h3>Exomes</h3>
       <FileList>
         <ListItem>
@@ -72,7 +68,7 @@ const ExacDownloads = () => (
     </DownloadsSection>
 
     <DownloadsSection>
-      <SectionTitle id="exac-coverage">Coverage</SectionTitle>
+      <SectionTitle id="exac-coverage" title="Coverage" />
       <FileList>
         {coverageFiles.map(({ chrom, md5, size }) => (
           <ListItem key={chrom}>
@@ -88,7 +84,7 @@ const ExacDownloads = () => (
     </DownloadsSection>
 
     <DownloadsSection>
-      <SectionTitle id="exac-constraint">Constraint</SectionTitle>
+      <SectionTitle id="exac-constraint" title="Constraint" />
       <FileList>
         <ListItem>
           <DownloadLinks
@@ -100,9 +96,7 @@ const ExacDownloads = () => (
     </DownloadsSection>
 
     <DownloadsSection>
-      <SectionTitle id="exac-regional-missense-constraint">
-        Regional Missense Constraint
-      </SectionTitle>
+      <SectionTitle id="exac-regional-missense-constraint" title="Regional Missense Constraint" />
       <FileList>
         <ListItem>
           <DownloadLinks
@@ -114,7 +108,7 @@ const ExacDownloads = () => (
     </DownloadsSection>
 
     <DownloadsSection>
-      <SectionTitle id="exac-resources">Resources</SectionTitle>
+      <SectionTitle id="exac-resources" title="Resources" />
       <FileList>
         <ListItem>
           <DownloadLinks
@@ -126,7 +120,7 @@ const ExacDownloads = () => (
     </DownloadsSection>
 
     <section>
-      <SectionTitle id="exac-other">Other</SectionTitle>
+      <SectionTitle id="exac-other" title="Other" />
       <FileList>
         <ListItem>
           <GetUrlButtons

--- a/browser/src/DataPage/GnomadV2Downloads.tsx
+++ b/browser/src/DataPage/GnomadV2Downloads.tsx
@@ -154,23 +154,19 @@ const LDFiles = () => {
 const GnomadV2Downloads = () => {
   return (
     <>
-      <SectionTitle id="v2" subject="release">
-        v2 Downloads
-      </SectionTitle>
+      <SectionTitle id="v2" $subject="release" title="v2 Downloads" />
       <StyledParagraph>
         The gnomAD v2.1.1 data set contains data from 125,748 exomes and 15,708 whole genomes, all
         mapped to the GRCh37/hg19 reference sequence.
       </StyledParagraph>
 
-      <SectionTitle id="v2-core-dataset" subject="datasets">
-        Core Dataset
-      </SectionTitle>
+      <SectionTitle id="v2-core-dataset" $subject="datasets" title="Core Dataset" />
       <StyledParagraph>
         gnomAD database and features created and maintained by the gnomAD production team.
       </StyledParagraph>
 
       <DownloadsSection>
-        <SectionTitle id="v2-variants">Variants</SectionTitle>
+        <SectionTitle id="v2-variants" title="Variants" />
         <p>
           <Badge level="info">Note</Badge> Find out what changed in the latest release in the{' '}
           <ExternalLink href="https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/README.txt">
@@ -260,7 +256,7 @@ const GnomadV2Downloads = () => {
       </DownloadsSection>
 
       <DownloadsSection>
-        <SectionTitle id="v2-browser-tables">Browser Tables</SectionTitle>
+        <SectionTitle id="v2-browser-tables" title="Browser Tables" />
 
         <p>
           For more information about these files, see our{' '}
@@ -282,7 +278,7 @@ const GnomadV2Downloads = () => {
       </DownloadsSection>
 
       <DownloadsSection>
-        <SectionTitle id="v2-coverage">Coverage</SectionTitle>
+        <SectionTitle id="v2-coverage" title="Coverage" />
         <FileList>
           <ListItem>
             <GetUrlButtons
@@ -316,7 +312,7 @@ const GnomadV2Downloads = () => {
       </DownloadsSection>
 
       <DownloadsSection>
-        <SectionTitle id="v2-structural-variants">Structural variants</SectionTitle>
+        <SectionTitle id="v2-structural-variants" title="Structural variants" />
         <p>
           For information on gnomAD structural variants, see{' '}
           <ExternalLink href="https://doi.org/10.1038/s41586-020-2287-8">
@@ -371,12 +367,12 @@ const GnomadV2Downloads = () => {
       </DownloadsSection>
 
       <DownloadsSection>
-        <SectionTitle id="v2-linkage-disequilibrium">Linkage disequilibrium</SectionTitle>
+        <SectionTitle id="v2-linkage-disequilibrium" title="Linkage disequilibrium" />
         <LDFiles />
       </DownloadsSection>
 
       <DownloadsSection>
-        <SectionTitle id="v2-ancestry-classification">Ancestry classification</SectionTitle>
+        <SectionTitle id="v2-ancestry-classification" title="Ancestry classification" />
         <p>
           For more information about these files, see our blog post on{' '}
           <ExternalLink href="https://gnomad.broadinstitute.org/news/2021-09-using-the-gnomad-ancestry-principal-components-analysis-loadings-and-random-forest-classifier-on-your-dataset/">
@@ -403,9 +399,7 @@ const GnomadV2Downloads = () => {
       </DownloadsSection>
 
       <DownloadsSection>
-        <SectionTitle id="v2-regional-missense-constraint">
-          Regional Missense Constraint
-        </SectionTitle>
+        <SectionTitle id="v2-regional-missense-constraint" title="Regional Missense Constraint" />
         <FileList>
           <ListItem>
             <GetUrlButtons
@@ -429,7 +423,7 @@ const GnomadV2Downloads = () => {
       </DownloadsSection>
 
       <DownloadsSection>
-        <SectionTitle id="v2-clinvar-grch37">ClinVar</SectionTitle>
+        <SectionTitle id="v2-clinvar-grch37" title="ClinVar" />
         <p>
           For more information about these files, including how to download a specific previous
           version of the gnomAD browser ClinVar GRCh37 table, see the{' '}
@@ -449,7 +443,7 @@ const GnomadV2Downloads = () => {
       </DownloadsSection>
 
       <DownloadsSection>
-        <SectionTitle id="v2-resources">Resources</SectionTitle>
+        <SectionTitle id="v2-resources" title="Resources" />
         <FileList>
           <ListItem>
             <DownloadLinks
@@ -484,16 +478,14 @@ const GnomadV2Downloads = () => {
         </FileList>
       </DownloadsSection>
 
-      <SectionTitle id="v2-secondary-analyses" subject="datasets">
-        Secondary Analyses
-      </SectionTitle>
+      <SectionTitle id="v2-secondary-analyses" $subject="datasets" title="Secondary Analyses" />
       <StyledParagraph>
         Additional research analyses created using the core gnomAD releases in collaboration with
         members of the gnomAD steering committee.
       </StyledParagraph>
 
       <DownloadsSection>
-        <SectionTitle id="v2-constraint">Constraint</SectionTitle>
+        <SectionTitle id="v2-constraint" title="Constraint" />
         <p>
           For information on constraint, see{' '}
           <ExternalLink href="https://doi.org/10.1038/s41586-020-2308-7">
@@ -536,9 +528,7 @@ const GnomadV2Downloads = () => {
       </DownloadsSection>
 
       <DownloadsSection>
-        <SectionTitle id="v2-multi-nucleotide-variants">
-          Multi-nucleotide variants (MNVs)
-        </SectionTitle>
+        <SectionTitle id="v2-multi-nucleotide-variants" title="Multi-nucleotide variants (MNVs)" />
         <p>
           For information on multi-nucleotide variants in gnomAD, see{' '}
           <ExternalLink href="https://doi.org/10.1038/s41467-019-12438-5">
@@ -588,7 +578,7 @@ const GnomadV2Downloads = () => {
       </DownloadsSection>
 
       <DownloadsSection>
-        <SectionTitle id="v2-pext">Proportion expressed across transcripts (pext)</SectionTitle>
+        <SectionTitle id="v2-pext" title="Proportion expressed across transcripts (pext)" />
         <p>
           For information on pext, see{' '}
           <ExternalLink href="https://doi.org/10.1038/s41586-020-2329-2">
@@ -625,7 +615,7 @@ const GnomadV2Downloads = () => {
       </DownloadsSection>
 
       <DownloadsSection>
-        <SectionTitle id="v2-variant-cooccurrence">Variant co-occurrence</SectionTitle>
+        <SectionTitle id="v2-variant-cooccurrence" title="Variant co-occurrence" />
         <FileList>
           <ListItem>
             <DownloadLinks
@@ -656,7 +646,7 @@ const GnomadV2Downloads = () => {
       </DownloadsSection>
 
       <DownloadsSection>
-        <SectionTitle id="v2-lof-curation-results">Loss-of-function curation results</SectionTitle>
+        <SectionTitle id="v2-lof-curation-results" title="Loss-of-function curation results" />
         <p>
           For information on loss-of-function curation results, see{' '}
           <ExternalLink href="https://doi.org/10.1038/s41586-020-2308-7">

--- a/browser/src/DataPage/GnomadV2LiftoverDownloads.tsx
+++ b/browser/src/DataPage/GnomadV2LiftoverDownloads.tsx
@@ -69,23 +69,19 @@ const liftoverGenomeChromosomeVcfs = [
 const Gnomadv2LiftoverDownloads = () => {
   return (
     <>
-      <SectionTitle id="v2-liftover" subject="release">
-        v2 Liftover Downloads
-      </SectionTitle>
+      <SectionTitle id="v2-liftover" $subject="release" title="v2 Liftover Downloads" />
       <StyledParagraph>
         The gnomAD v2.1.1 liftover data set contains data from 125,748 exomes and 15,708 whole
         genomes, lifted over from the GRCh37 to the GRCh38 reference sequence.
       </StyledParagraph>
 
-      <SectionTitle id="v2-liftover-core-dataset" subject="datasets">
-        Core Dataset
-      </SectionTitle>
+      <SectionTitle id="v2-liftover-core-dataset" $subject="datasets" title="Core Dataset" />
       <StyledParagraph>
         gnomAD database and features created and maintained by the gnomAD production team.
       </StyledParagraph>
 
       <DownloadsSection>
-        <SectionTitle id="v2-liftover-variants">Variants (GRCh38 liftover)</SectionTitle>
+        <SectionTitle id="v2-liftover-variants" title="Variants (GRCh38 liftover)" />
         <p>
           The variant dataset files below contain all subsets (non-neuro, non-cancer, controls-only,
           and non-TOPMed).
@@ -159,9 +155,10 @@ const Gnomadv2LiftoverDownloads = () => {
       </DownloadsSection>
 
       <DownloadsSection>
-        <SectionTitle id="v2-liftover-structural-variants">
-          Structural variants (GRCh38 liftover)
-        </SectionTitle>
+        <SectionTitle
+          id="v2-liftover-structural-variants"
+          title="Structural variants (GRCh38 liftover)"
+        />
         <p>
           <Badge level="info">Note</Badge> The lifted over structural variant dataset was created by
           dbVar and has not been assessed by the gnomAD production team.

--- a/browser/src/DataPage/GnomadV3Downloads.tsx
+++ b/browser/src/DataPage/GnomadV3Downloads.tsx
@@ -69,23 +69,19 @@ const hgdpAnd1kgChromosomeVcfs = [
 
 const GnomadV3Downloads = () => (
   <>
-    <SectionTitle id="v3" subject="release">
-      v3 Downloads
-    </SectionTitle>
+    <SectionTitle id="v3" $subject="release" title="v3 Downloads" />
     <StyledParagraph>
       The gnomAD v3.1.2 data set contains 76,156 whole genomes (and no exomes), all mapped to the
       GRCh38 reference sequence.
     </StyledParagraph>
 
-    <SectionTitle id="v3-core-dataset" subject="datasets">
-      Core Dataset
-    </SectionTitle>
+    <SectionTitle id="v3-core-dataset" $subject="datasets" title="Core Dataset" />
     <StyledParagraph>
       gnomAD database and features created and maintained by the gnomAD production team.
     </StyledParagraph>
 
     <DownloadsSection>
-      <SectionTitle id="v3-variants">Variants</SectionTitle>
+      <SectionTitle id="v3-variants" title="Variants" />
       <p>
         <Badge level="info">Note</Badge> Find out what changed in the latest release in the{' '}
         <ExternalLink href="https://gnomad.broadinstitute.org/news/2021-10-gnomad-v3-1-2-minor-release/">
@@ -121,7 +117,7 @@ const GnomadV3Downloads = () => (
     </DownloadsSection>
 
     <DownloadsSection>
-      <SectionTitle id="v3-coverage">Coverage</SectionTitle>
+      <SectionTitle id="v3-coverage" title="Coverage" />
       <FileList>
         <ListItem>
           <GetUrlButtons
@@ -141,7 +137,7 @@ const GnomadV3Downloads = () => (
     </DownloadsSection>
 
     <DownloadsSection>
-      <SectionTitle id="v3-hgdp-1kg">HGDP + 1KG callset</SectionTitle>
+      <SectionTitle id="v3-hgdp-1kg" title="HGDP + 1KG callset" />
       <p>
         These files contain individual genotypes for all samples in the HGDP and 1KG subsets. For
         more information, see the{' '}
@@ -202,7 +198,7 @@ const GnomadV3Downloads = () => (
     </DownloadsSection>
 
     <DownloadsSection>
-      <SectionTitle id="v3-mitochondrial-dna">Mitochondrial DNA (mtDNA)</SectionTitle>
+      <SectionTitle id="v3-mitochondrial-dna" title="Mitochondrial DNA (mtDNA)" />
       <p>
         For details about these files, see the{' '}
         <ExternalLink href="https://gnomad.broadinstitute.org/news/2020-11-gnomad-v3-1-mitochondrial-dna-variants/">
@@ -244,9 +240,7 @@ const GnomadV3Downloads = () => (
     </DownloadsSection>
 
     <DownloadsSection>
-      <SectionTitle id="v3-ancestry-classification">
-        Genetic ancestry group classification
-      </SectionTitle>
+      <SectionTitle id="v3-ancestry-classification" title="Genetic ancestry group classification" />
       <p>
         For more information about these files, see our blog post on{' '}
         <ExternalLink href="https://gnomad.broadinstitute.org/news/2021-09-using-the-gnomad-ancestry-principal-components-analysis-loadings-and-random-forest-classifier-on-your-dataset/">
@@ -273,7 +267,7 @@ const GnomadV3Downloads = () => (
     </DownloadsSection>
 
     <DownloadsSection>
-      <SectionTitle id="v3-local-ancestry">Local ancestry</SectionTitle>
+      <SectionTitle id="v3-local-ancestry" title="Local ancestry" />
       <p>
         For more information about these files, see our blog posts on local ancestry inference for{' '}
         <ExternalLink href="https://gnomad.broadinstitute.org/news/2021-12-local-ancestry-inference-for-latino-admixed-american-samples-in-gnomad/">
@@ -306,7 +300,7 @@ const GnomadV3Downloads = () => (
     </DownloadsSection>
 
     <DownloadsSection>
-      <SectionTitle id="v3-short-tandem-repeats">Short tandem repeats</SectionTitle>
+      <SectionTitle id="v3-short-tandem-repeats" title="Short tandem repeats" />
       <p>
         These files contain the data that underlies the{' '}
         <ExternalLink href="https://gnomad.broadinstitute.org/short-tandem-repeats?dataset=gnomad_r4">
@@ -397,16 +391,14 @@ const GnomadV3Downloads = () => (
       </FileList>
     </DownloadsSection>
 
-    <SectionTitle id="v3-secondary-analyses" subject="datasets">
-      Secondary Analyses
-    </SectionTitle>
+    <SectionTitle id="v3-secondary-analyses" $subject="datasets" title="Secondary Analyses" />
     <StyledParagraph>
       Additional research analyses created using the core gnomAD releases in collaboration with
       members of the gnomAD steering committee.
     </StyledParagraph>
 
     <DownloadsSection>
-      <SectionTitle id="v3-genomic-constraint">Genomic constraint</SectionTitle>
+      <SectionTitle id="v3-genomic-constraint" title="Genomic constraint" />
       <p>For more information about these files, see the README included in the download.</p>
       <FileList>
         <ListItem>
@@ -438,7 +430,7 @@ const GnomadV3Downloads = () => (
     </DownloadsSection>
 
     <DownloadsSection>
-      <SectionTitle id="v3-hgdp-1kg-tutorials">HGDP + 1KG tutorials</SectionTitle>
+      <SectionTitle id="v3-hgdp-1kg-tutorials" title="HGDP + 1KG tutorials" />
       <p>
         For more information about these files, see the{' '}
         <ExternalLink href="https://docs.google.com/document/d/16W0KyrpRGRKHaOwahxtogtepbHe181BoOrSpTQVSVHc/edit?usp=sharing">
@@ -666,7 +658,7 @@ const GnomadV3Downloads = () => (
     </DownloadsSection>
 
     <DownloadsSection>
-      <SectionTitle id="v3-mito-constraint">Mitochondrial constraint</SectionTitle>
+      <SectionTitle id="v3-mito-constraint" title="Mitochondrial constraint" />
       <p>
         For more information about mitochondrial constraint, see{' '}
         <ExternalLink href="https://doi.org/10.1038/s41586-024-08048-x">

--- a/browser/src/DataPage/GnomadV4Downloads.tsx
+++ b/browser/src/DataPage/GnomadV4Downloads.tsx
@@ -98,23 +98,19 @@ const jointChromosomeVcfs = [
 const GnomadV4Downloads = () => {
   return (
     <>
-      <SectionTitle id="v4" subject="release">
-        v4 Downloads
-      </SectionTitle>
+      <SectionTitle id="v4" $subject="release" title="v4 Downloads" />
       <StyledParagraph>
         The gnomAD v4.1.0 data set contains data from 730,947 exomes and 76,215 whole genomes, all
         mapped to the GRCh38 reference sequence.
       </StyledParagraph>
 
-      <SectionTitle id="v4-core-dataset" subject="datasets">
-        Core Dataset
-      </SectionTitle>
+      <SectionTitle id="v4-core-dataset" $subject="datasets" title="Core Dataset" />
       <StyledParagraph>
         gnomAD database and features created and maintained by the gnomAD production team.
       </StyledParagraph>
 
       <DownloadsSection>
-        <SectionTitle id="v4-variants">Variants</SectionTitle>
+        <SectionTitle id="v4-variants" title="Variants" />
         <p>
           For more information, read the{' '}
           <ExternalLink href="https://gnomad.broadinstitute.org/news/2023-11-gnomad-v4-0">
@@ -176,7 +172,7 @@ const GnomadV4Downloads = () => {
       </DownloadsSection>
 
       <DownloadsSection>
-        <SectionTitle id="v4-joint-freq-stats">Joint Frequency</SectionTitle>
+        <SectionTitle id="v4-joint-freq-stats" title="Joint Frequency" />
         <FileList>
           <ListItem>
             <GetUrlButtons
@@ -199,7 +195,7 @@ const GnomadV4Downloads = () => {
       </DownloadsSection>
 
       <DownloadsSection>
-        <SectionTitle id="v4-all-sites-allele-number">All sites allele numbers</SectionTitle>
+        <SectionTitle id="v4-all-sites-allele-number" title="All sites allele numbers" />
         <ColumnsWrapper>
           <Column>
             <h3>Exomes</h3>
@@ -246,7 +242,7 @@ const GnomadV4Downloads = () => {
       </DownloadsSection>
 
       <DownloadsSection>
-        <SectionTitle id="v4-browser-tables">Browser Tables</SectionTitle>
+        <SectionTitle id="v4-browser-tables" title="Browser Tables" />
 
         <p>
           For more information about these files, see our{' '}
@@ -290,7 +286,7 @@ const GnomadV4Downloads = () => {
       </DownloadsSection>
 
       <DownloadsSection>
-        <SectionTitle id="v4-coverage">Coverage</SectionTitle>
+        <SectionTitle id="v4-coverage" title="Coverage" />
         <FileList>
           <ListItem>
             <GetUrlButtons
@@ -310,9 +306,10 @@ const GnomadV4Downloads = () => {
       </DownloadsSection>
 
       <DownloadsSection>
-        <SectionTitle id="v4-genetic-ancestry-group-classification">
-          Genetic ancestry group classification
-        </SectionTitle>
+        <SectionTitle
+          id="v4-genetic-ancestry-group-classification"
+          title="Genetic ancestry group classification"
+        />
         <p>
           For more information about these files, see our blog post on{' '}
           <ExternalLink href="https://gnomad.broadinstitute.org/news/2021-09-using-the-gnomad-ancestry-principal-components-analysis-loadings-and-random-forest-classifier-on-your-dataset/">
@@ -344,7 +341,7 @@ const GnomadV4Downloads = () => {
       </DownloadsSection>
 
       <DownloadsSection>
-        <SectionTitle id="v4-constraint">Constraint</SectionTitle>
+        <SectionTitle id="v4-constraint" title="Constraint" />
         <p>
           For information on constraint, see our <Link to="/help/constraint">help text</Link>
         </p>
@@ -408,7 +405,7 @@ const GnomadV4Downloads = () => {
       </DownloadsSection>
 
       <DownloadsSection>
-        <SectionTitle id="v4-structural-variants">Structural variants</SectionTitle>
+        <SectionTitle id="v4-structural-variants" title="Structural variants" />
         <p>
           For information on structural variants, see our{' '}
           <Link to="/help/sv-overview">help text</Link>
@@ -452,7 +449,7 @@ const GnomadV4Downloads = () => {
       </DownloadsSection>
 
       <DownloadsSection>
-        <SectionTitle id="v4-copy-number-variants">Copy number variants</SectionTitle>
+        <SectionTitle id="v4-copy-number-variants" title="Copy number variants" />
         <p>
           For information on copy number variants, see our{' '}
           <Link to="/help/sv-overview">help text</Link>
@@ -486,7 +483,7 @@ const GnomadV4Downloads = () => {
       </DownloadsSection>
 
       <DownloadsSection>
-        <SectionTitle id="v4-pext">Proportion expressed across transcripts (pext)</SectionTitle>
+        <SectionTitle id="v4-pext" title="Proportion expressed across transcripts (pext)" />
         <p>
           For information on pext, see{' '}
           <ExternalLink href="https://doi.org/10.1038/s41586-020-2329-2">
@@ -523,7 +520,7 @@ const GnomadV4Downloads = () => {
       </DownloadsSection>
 
       <DownloadsSection>
-        <SectionTitle id="v4-de-novo">De novo variants (DNVs)</SectionTitle>
+        <SectionTitle id="v4-de-novo" title="De novo variants (DNVs)" />
         <p>
           For more information on DNVs, see the{' '}
           <ExternalLink href="https://gnomad.broadinstitute.org/news/2025-03-de-novo-variants-in-gnomad-v4-exomes">
@@ -553,7 +550,7 @@ const GnomadV4Downloads = () => {
       </DownloadsSection>
 
       <DownloadsSection>
-        <SectionTitle id="v4-clinvar-grch38">ClinVar</SectionTitle>
+        <SectionTitle id="v4-clinvar-grch38" title="ClinVar" />
         <p>
           For more information about these files, including how to download a specific previous
           version of the gnomAD browser ClinVar GRCh38 table, see the{' '}
@@ -573,7 +570,7 @@ const GnomadV4Downloads = () => {
       </DownloadsSection>
 
       <DownloadsSection>
-        <SectionTitle id="v4-resources">Resources</SectionTitle>
+        <SectionTitle id="v4-resources" title="Resources" />
         <FileList>
           <ListItem>
             <DownloadLinks
@@ -614,16 +611,14 @@ const GnomadV4Downloads = () => {
         </FileList>
       </DownloadsSection>
 
-      <SectionTitle id="v4-secondary-analyses" subject="datasets">
-        Secondary Analyses
-      </SectionTitle>
+      <SectionTitle id="v4-secondary-analyses" $subject="datasets" title="Secondary Analyses" />
       <StyledParagraph>
         Additional research analyses created using the core gnomAD releases in collaboration with
         members of the gnomAD steering committee.
       </StyledParagraph>
 
       <DownloadsSection>
-        <SectionTitle id="v4-lof-curation-results">Loss-of-function curation results</SectionTitle>
+        <SectionTitle id="v4-lof-curation-results" title="Loss-of-function curation results" />
         <p>
           For information on v4 loss-of-function curation results, see{' '}
           <ExternalLink href="https://doi.org/10.1038/s41586-020-2308-7">

--- a/browser/src/DataPage/GraphQLDocs.tsx
+++ b/browser/src/DataPage/GraphQLDocs.tsx
@@ -19,7 +19,7 @@ const GraphQLCodeBlock = styled(CodeBlock)`
 
 const GraphQLDocs = () => (
   <>
-    <SectionTitle id="api">gnomAD API</SectionTitle>
+    <SectionTitle id="api" title="gnomAD API" />
     <StyledParagraph>
       The gnomAD browser gets its data through a{' '}
       <ExternalLink href="https://graphql.org">GraphQL</ExternalLink> API which is open to the

--- a/browser/src/DataPage/TableOfContents.tsx
+++ b/browser/src/DataPage/TableOfContents.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 
 import useHeadsObserver from './downloadsHooks'
 
-const TableOfContents = styled.div`
+const TableOfContents = styled.nav`
   margin-left: 1rem;
 `
 
@@ -24,8 +24,14 @@ const TableOfContentsStyledItem = styled.div<{
   }
 `
 
+type ContentItem = {
+  link: string
+  indent: string
+  text: string
+}
+
 const DataPageTableOfContents = () => {
-  const [headings, setHeadings] = useState([])
+  const [headings, setHeadings] = useState<ContentItem[]>([])
   const { activeId } = useHeadsObserver()
   const [activeSection, setActiveSection] = useState('')
 
@@ -39,15 +45,12 @@ const DataPageTableOfContents = () => {
     return '3.5rem'
   }
 
-  // useEffect to dynamically grab all the section titles on first page load
   useEffect(() => {
-    const elements = Array.from(document.querySelectorAll('a[id]')).map((el) => ({
-      // @ts-expect-error
-      text: el.nextSibling.data,
+    const elements = Array.from(document.querySelectorAll('h2[id]')).map((el) => ({
+      text: el.textContent ?? '',
       link: el.id,
       indent: checkIndent(el.id),
     }))
-    // @ts-expect-error
     setHeadings(elements)
   }, [])
 
@@ -89,15 +92,9 @@ const DataPageTableOfContents = () => {
     )
   }
 
-  type ContentItem = {
-    link: string
-    indent: string
-    text: string
-  }
-
   return (
     <>
-      <TableOfContents>
+      <TableOfContents aria-label="Data sections">
         {/* Filter to only the sections that should show, then render the ToC */}
         {headings
           .filter((item: ContentItem) => filterSection(item.link))

--- a/browser/src/DataPage/__snapshots__/DataPage.spec.tsx.snap
+++ b/browser/src/DataPage/__snapshots__/DataPage.spec.tsx.snap
@@ -363,7 +363,8 @@ exports[`Data Page has no unexpected changes 1`] = `
   <div
     className="c4"
   >
-    <div
+    <nav
+      aria-label="Data sections"
       className="c5"
     />
   </div>

--- a/browser/src/DataPage/__snapshots__/DataPage.spec.tsx.snap
+++ b/browser/src/DataPage/__snapshots__/DataPage.spec.tsx.snap
@@ -170,6 +170,7 @@ exports[`Data Page has no unexpected changes 1`] = `
 }
 
 .c1 {
+  padding-left: 44px;
   font-size: 16px;
 }
 
@@ -414,6 +415,11 @@ exports[`Data Page has no unexpected changes 1`] = `
       <h2
         className="c9 c10 c11"
         id="summary"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to Summary"
@@ -422,9 +428,9 @@ exports[`Data Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -655,6 +661,11 @@ exports[`Data Page has no unexpected changes 1`] = `
     <h2
       className="c9 c10 c15"
       id="v4"
+      style={
+        {
+          "padding": "8px 0",
+        }
+      }
     >
       <a
         aria-label="Copy link to v4 Downloads"
@@ -663,9 +674,9 @@ exports[`Data Page has no unexpected changes 1`] = `
         onClick={[Function]}
         style={
           {
-            "display": "inline-flex",
-            "position": "static",
-            "transform": "none",
+            "display": "flex",
+            "position": "absolute",
+            "transform": "translate(-100%, -50%)",
           }
         }
       >
@@ -687,6 +698,11 @@ exports[`Data Page has no unexpected changes 1`] = `
     <h2
       className="c9 c10 c11"
       id="v4-core-dataset"
+      style={
+        {
+          "padding": "8px 0",
+        }
+      }
     >
       <a
         aria-label="Copy link to Core Dataset"
@@ -695,9 +711,9 @@ exports[`Data Page has no unexpected changes 1`] = `
         onClick={[Function]}
         style={
           {
-            "display": "inline-flex",
-            "position": "static",
-            "transform": "none",
+            "display": "flex",
+            "position": "absolute",
+            "transform": "translate(-100%, -50%)",
           }
         }
       >
@@ -722,6 +738,11 @@ exports[`Data Page has no unexpected changes 1`] = `
       <h2
         className="c9 c10 c17"
         id="v4-variants"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to Variants"
@@ -730,9 +751,9 @@ exports[`Data Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -3977,6 +3998,11 @@ exports[`Data Page has no unexpected changes 1`] = `
       <h2
         className="c9 c10 c17"
         id="v4-joint-freq-stats"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to Joint Frequency"
@@ -3985,9 +4011,9 @@ exports[`Data Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -5599,6 +5625,11 @@ exports[`Data Page has no unexpected changes 1`] = `
       <h2
         className="c9 c10 c17"
         id="v4-all-sites-allele-number"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to All sites allele numbers"
@@ -5607,9 +5638,9 @@ exports[`Data Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -5788,6 +5819,11 @@ exports[`Data Page has no unexpected changes 1`] = `
       <h2
         className="c9 c10 c17"
         id="v4-browser-tables"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to Browser Tables"
@@ -5796,9 +5832,9 @@ exports[`Data Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -5963,6 +5999,11 @@ exports[`Data Page has no unexpected changes 1`] = `
       <h2
         className="c9 c10 c17"
         id="v4-coverage"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to Coverage"
@@ -5971,9 +6012,9 @@ exports[`Data Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -6064,6 +6105,11 @@ exports[`Data Page has no unexpected changes 1`] = `
       <h2
         className="c9 c10 c17"
         id="v4-genetic-ancestry-group-classification"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to Genetic ancestry group classification"
@@ -6072,9 +6118,9 @@ exports[`Data Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -6205,6 +6251,11 @@ exports[`Data Page has no unexpected changes 1`] = `
       <h2
         className="c9 c10 c17"
         id="v4-constraint"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to Constraint"
@@ -6213,9 +6264,9 @@ exports[`Data Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -6529,6 +6580,11 @@ exports[`Data Page has no unexpected changes 1`] = `
       <h2
         className="c9 c10 c17"
         id="v4-structural-variants"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to Structural variants"
@@ -6537,9 +6593,9 @@ exports[`Data Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -6783,6 +6839,11 @@ exports[`Data Page has no unexpected changes 1`] = `
       <h2
         className="c9 c10 c17"
         id="v4-copy-number-variants"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to Copy number variants"
@@ -6791,9 +6852,9 @@ exports[`Data Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -6946,6 +7007,11 @@ exports[`Data Page has no unexpected changes 1`] = `
       <h2
         className="c9 c10 c17"
         id="v4-pext"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to Proportion expressed across transcripts (pext)"
@@ -6954,9 +7020,9 @@ exports[`Data Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -7117,6 +7183,11 @@ exports[`Data Page has no unexpected changes 1`] = `
       <h2
         className="c9 c10 c17"
         id="v4-de-novo"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to De novo variants (DNVs)"
@@ -7125,9 +7196,9 @@ exports[`Data Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -7252,6 +7323,11 @@ exports[`Data Page has no unexpected changes 1`] = `
       <h2
         className="c9 c10 c17"
         id="v4-clinvar-grch38"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to ClinVar"
@@ -7260,9 +7336,9 @@ exports[`Data Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -7317,6 +7393,11 @@ exports[`Data Page has no unexpected changes 1`] = `
       <h2
         className="c9 c10 c17"
         id="v4-resources"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to Resources"
@@ -7325,9 +7406,9 @@ exports[`Data Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -7541,6 +7622,11 @@ exports[`Data Page has no unexpected changes 1`] = `
     <h2
       className="c9 c10 c11"
       id="v4-secondary-analyses"
+      style={
+        {
+          "padding": "8px 0",
+        }
+      }
     >
       <a
         aria-label="Copy link to Secondary Analyses"
@@ -7549,9 +7635,9 @@ exports[`Data Page has no unexpected changes 1`] = `
         onClick={[Function]}
         style={
           {
-            "display": "inline-flex",
-            "position": "static",
-            "transform": "none",
+            "display": "flex",
+            "position": "absolute",
+            "transform": "translate(-100%, -50%)",
           }
         }
       >
@@ -7576,6 +7662,11 @@ exports[`Data Page has no unexpected changes 1`] = `
       <h2
         className="c9 c10 c17"
         id="v4-lof-curation-results"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to Loss-of-function curation results"
@@ -7584,9 +7675,9 @@ exports[`Data Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -7688,6 +7779,11 @@ exports[`Data Page has no unexpected changes 1`] = `
     <h2
       className="c9 c10 c15"
       id="v3"
+      style={
+        {
+          "padding": "8px 0",
+        }
+      }
     >
       <a
         aria-label="Copy link to v3 Downloads"
@@ -7696,9 +7792,9 @@ exports[`Data Page has no unexpected changes 1`] = `
         onClick={[Function]}
         style={
           {
-            "display": "inline-flex",
-            "position": "static",
-            "transform": "none",
+            "display": "flex",
+            "position": "absolute",
+            "transform": "translate(-100%, -50%)",
           }
         }
       >
@@ -7720,6 +7816,11 @@ exports[`Data Page has no unexpected changes 1`] = `
     <h2
       className="c9 c10 c11"
       id="v3-core-dataset"
+      style={
+        {
+          "padding": "8px 0",
+        }
+      }
     >
       <a
         aria-label="Copy link to Core Dataset"
@@ -7728,9 +7829,9 @@ exports[`Data Page has no unexpected changes 1`] = `
         onClick={[Function]}
         style={
           {
-            "display": "inline-flex",
-            "position": "static",
-            "transform": "none",
+            "display": "flex",
+            "position": "absolute",
+            "transform": "translate(-100%, -50%)",
           }
         }
       >
@@ -7755,6 +7856,11 @@ exports[`Data Page has no unexpected changes 1`] = `
       <h2
         className="c9 c10 c17"
         id="v3-variants"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to Variants"
@@ -7763,9 +7869,9 @@ exports[`Data Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -9402,6 +9508,11 @@ exports[`Data Page has no unexpected changes 1`] = `
       <h2
         className="c9 c10 c17"
         id="v3-coverage"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to Coverage"
@@ -9410,9 +9521,9 @@ exports[`Data Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -9503,6 +9614,11 @@ exports[`Data Page has no unexpected changes 1`] = `
       <h2
         className="c9 c10 c17"
         id="v3-hgdp-1kg"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to HGDP + 1KG callset"
@@ -9511,9 +9627,9 @@ exports[`Data Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -11265,6 +11381,11 @@ exports[`Data Page has no unexpected changes 1`] = `
       <h2
         className="c9 c10 c17"
         id="v3-mitochondrial-dna"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to Mitochondrial DNA (mtDNA)"
@@ -11273,9 +11394,9 @@ exports[`Data Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -11471,6 +11592,11 @@ exports[`Data Page has no unexpected changes 1`] = `
       <h2
         className="c9 c10 c17"
         id="v3-ancestry-classification"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to Genetic ancestry group classification"
@@ -11479,9 +11605,9 @@ exports[`Data Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -11579,6 +11705,11 @@ exports[`Data Page has no unexpected changes 1`] = `
       <h2
         className="c9 c10 c17"
         id="v3-local-ancestry"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to Local ancestry"
@@ -11587,9 +11718,9 @@ exports[`Data Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -11709,6 +11840,11 @@ exports[`Data Page has no unexpected changes 1`] = `
       <h2
         className="c9 c10 c17"
         id="v3-short-tandem-repeats"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to Short tandem repeats"
@@ -11717,9 +11853,9 @@ exports[`Data Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -12094,6 +12230,11 @@ exports[`Data Page has no unexpected changes 1`] = `
     <h2
       className="c9 c10 c11"
       id="v3-secondary-analyses"
+      style={
+        {
+          "padding": "8px 0",
+        }
+      }
     >
       <a
         aria-label="Copy link to Secondary Analyses"
@@ -12102,9 +12243,9 @@ exports[`Data Page has no unexpected changes 1`] = `
         onClick={[Function]}
         style={
           {
-            "display": "inline-flex",
-            "position": "static",
-            "transform": "none",
+            "display": "flex",
+            "position": "absolute",
+            "transform": "translate(-100%, -50%)",
           }
         }
       >
@@ -12129,6 +12270,11 @@ exports[`Data Page has no unexpected changes 1`] = `
       <h2
         className="c9 c10 c17"
         id="v3-genomic-constraint"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to Genomic constraint"
@@ -12137,9 +12283,9 @@ exports[`Data Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -12299,6 +12445,11 @@ exports[`Data Page has no unexpected changes 1`] = `
       <h2
         className="c9 c10 c17"
         id="v3-hgdp-1kg-tutorials"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to HGDP + 1KG tutorials"
@@ -12307,9 +12458,9 @@ exports[`Data Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -13381,6 +13532,11 @@ exports[`Data Page has no unexpected changes 1`] = `
       <h2
         className="c9 c10 c17"
         id="v3-mito-constraint"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to Mitochondrial constraint"
@@ -13389,9 +13545,9 @@ exports[`Data Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -13561,6 +13717,11 @@ exports[`Data Page has no unexpected changes 1`] = `
     <h2
       className="c9 c10 c15"
       id="v2-liftover"
+      style={
+        {
+          "padding": "8px 0",
+        }
+      }
     >
       <a
         aria-label="Copy link to v2 Liftover Downloads"
@@ -13569,9 +13730,9 @@ exports[`Data Page has no unexpected changes 1`] = `
         onClick={[Function]}
         style={
           {
-            "display": "inline-flex",
-            "position": "static",
-            "transform": "none",
+            "display": "flex",
+            "position": "absolute",
+            "transform": "translate(-100%, -50%)",
           }
         }
       >
@@ -13593,6 +13754,11 @@ exports[`Data Page has no unexpected changes 1`] = `
     <h2
       className="c9 c10 c11"
       id="v2-liftover-core-dataset"
+      style={
+        {
+          "padding": "8px 0",
+        }
+      }
     >
       <a
         aria-label="Copy link to Core Dataset"
@@ -13601,9 +13767,9 @@ exports[`Data Page has no unexpected changes 1`] = `
         onClick={[Function]}
         style={
           {
-            "display": "inline-flex",
-            "position": "static",
-            "transform": "none",
+            "display": "flex",
+            "position": "absolute",
+            "transform": "translate(-100%, -50%)",
           }
         }
       >
@@ -13628,6 +13794,11 @@ exports[`Data Page has no unexpected changes 1`] = `
       <h2
         className="c9 c10 c17"
         id="v2-liftover-variants"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to Variants (GRCh38 liftover)"
@@ -13636,9 +13807,9 @@ exports[`Data Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -16927,6 +17098,11 @@ exports[`Data Page has no unexpected changes 1`] = `
       <h2
         className="c9 c10 c17"
         id="v2-liftover-structural-variants"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to Structural variants (GRCh38 liftover)"
@@ -16935,9 +17111,9 @@ exports[`Data Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -16980,6 +17156,11 @@ exports[`Data Page has no unexpected changes 1`] = `
     <h2
       className="c9 c10 c15"
       id="v2"
+      style={
+        {
+          "padding": "8px 0",
+        }
+      }
     >
       <a
         aria-label="Copy link to v2 Downloads"
@@ -16988,9 +17169,9 @@ exports[`Data Page has no unexpected changes 1`] = `
         onClick={[Function]}
         style={
           {
-            "display": "inline-flex",
-            "position": "static",
-            "transform": "none",
+            "display": "flex",
+            "position": "absolute",
+            "transform": "translate(-100%, -50%)",
           }
         }
       >
@@ -17012,6 +17193,11 @@ exports[`Data Page has no unexpected changes 1`] = `
     <h2
       className="c9 c10 c11"
       id="v2-core-dataset"
+      style={
+        {
+          "padding": "8px 0",
+        }
+      }
     >
       <a
         aria-label="Copy link to Core Dataset"
@@ -17020,9 +17206,9 @@ exports[`Data Page has no unexpected changes 1`] = `
         onClick={[Function]}
         style={
           {
-            "display": "inline-flex",
-            "position": "static",
-            "transform": "none",
+            "display": "flex",
+            "position": "absolute",
+            "transform": "translate(-100%, -50%)",
           }
         }
       >
@@ -17047,6 +17233,11 @@ exports[`Data Page has no unexpected changes 1`] = `
       <h2
         className="c9 c10 c17"
         id="v2-variants"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to Variants"
@@ -17055,9 +17246,9 @@ exports[`Data Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -20430,6 +20621,11 @@ exports[`Data Page has no unexpected changes 1`] = `
       <h2
         className="c9 c10 c17"
         id="v2-browser-tables"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to Browser Tables"
@@ -20438,9 +20634,9 @@ exports[`Data Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -20516,6 +20712,11 @@ exports[`Data Page has no unexpected changes 1`] = `
       <h2
         className="c9 c10 c17"
         id="v2-coverage"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to Coverage"
@@ -20524,9 +20725,9 @@ exports[`Data Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -20683,6 +20884,11 @@ exports[`Data Page has no unexpected changes 1`] = `
       <h2
         className="c9 c10 c17"
         id="v2-structural-variants"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to Structural variants"
@@ -20691,9 +20897,9 @@ exports[`Data Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -21087,6 +21293,11 @@ exports[`Data Page has no unexpected changes 1`] = `
       <h2
         className="c9 c10 c17"
         id="v2-linkage-disequilibrium"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to Linkage disequilibrium"
@@ -21095,9 +21306,9 @@ exports[`Data Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -21366,6 +21577,11 @@ exports[`Data Page has no unexpected changes 1`] = `
       <h2
         className="c9 c10 c17"
         id="v2-ancestry-classification"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to Ancestry classification"
@@ -21374,9 +21590,9 @@ exports[`Data Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -21474,6 +21690,11 @@ exports[`Data Page has no unexpected changes 1`] = `
       <h2
         className="c9 c10 c17"
         id="v2-regional-missense-constraint"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to Regional Missense Constraint"
@@ -21482,9 +21703,9 @@ exports[`Data Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -21602,6 +21823,11 @@ exports[`Data Page has no unexpected changes 1`] = `
       <h2
         className="c9 c10 c17"
         id="v2-clinvar-grch37"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to ClinVar"
@@ -21610,9 +21836,9 @@ exports[`Data Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -21667,6 +21893,11 @@ exports[`Data Page has no unexpected changes 1`] = `
       <h2
         className="c9 c10 c17"
         id="v2-resources"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to Resources"
@@ -21675,9 +21906,9 @@ exports[`Data Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -21852,6 +22083,11 @@ exports[`Data Page has no unexpected changes 1`] = `
     <h2
       className="c9 c10 c11"
       id="v2-secondary-analyses"
+      style={
+        {
+          "padding": "8px 0",
+        }
+      }
     >
       <a
         aria-label="Copy link to Secondary Analyses"
@@ -21860,9 +22096,9 @@ exports[`Data Page has no unexpected changes 1`] = `
         onClick={[Function]}
         style={
           {
-            "display": "inline-flex",
-            "position": "static",
-            "transform": "none",
+            "display": "flex",
+            "position": "absolute",
+            "transform": "translate(-100%, -50%)",
           }
         }
       >
@@ -21887,6 +22123,11 @@ exports[`Data Page has no unexpected changes 1`] = `
       <h2
         className="c9 c10 c17"
         id="v2-constraint"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to Constraint"
@@ -21895,9 +22136,9 @@ exports[`Data Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -22076,6 +22317,11 @@ exports[`Data Page has no unexpected changes 1`] = `
       <h2
         className="c9 c10 c17"
         id="v2-multi-nucleotide-variants"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to Multi-nucleotide variants (MNVs)"
@@ -22084,9 +22330,9 @@ exports[`Data Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -22833,6 +23079,11 @@ exports[`Data Page has no unexpected changes 1`] = `
       <h2
         className="c9 c10 c17"
         id="v2-pext"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to Proportion expressed across transcripts (pext)"
@@ -22841,9 +23092,9 @@ exports[`Data Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -23004,6 +23255,11 @@ exports[`Data Page has no unexpected changes 1`] = `
       <h2
         className="c9 c10 c17"
         id="v2-variant-cooccurrence"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to Variant co-occurrence"
@@ -23012,9 +23268,9 @@ exports[`Data Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -23165,6 +23421,11 @@ exports[`Data Page has no unexpected changes 1`] = `
       <h2
         className="c9 c10 c17"
         id="v2-lof-curation-results"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to Loss-of-function curation results"
@@ -23173,9 +23434,9 @@ exports[`Data Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -23527,6 +23788,11 @@ exports[`Data Page has no unexpected changes 1`] = `
     <h2
       className="c9 c10 c15"
       id="exac"
+      style={
+        {
+          "padding": "8px 0",
+        }
+      }
     >
       <a
         aria-label="Copy link to ExAC Downloads"
@@ -23535,9 +23801,9 @@ exports[`Data Page has no unexpected changes 1`] = `
         onClick={[Function]}
         style={
           {
-            "display": "inline-flex",
-            "position": "static",
-            "transform": "none",
+            "display": "flex",
+            "position": "absolute",
+            "transform": "translate(-100%, -50%)",
           }
         }
       >
@@ -23559,6 +23825,11 @@ exports[`Data Page has no unexpected changes 1`] = `
     <h2
       className="c9 c10 c11"
       id="exac-core-dataset"
+      style={
+        {
+          "padding": "8px 0",
+        }
+      }
     >
       <a
         aria-label="Copy link to Core Dataset"
@@ -23567,9 +23838,9 @@ exports[`Data Page has no unexpected changes 1`] = `
         onClick={[Function]}
         style={
           {
-            "display": "inline-flex",
-            "position": "static",
-            "transform": "none",
+            "display": "flex",
+            "position": "absolute",
+            "transform": "translate(-100%, -50%)",
           }
         }
       >
@@ -23594,6 +23865,11 @@ exports[`Data Page has no unexpected changes 1`] = `
       <h2
         className="c9 c10 c17"
         id="exac-variants"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to Variants"
@@ -23602,9 +23878,9 @@ exports[`Data Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -23697,6 +23973,11 @@ exports[`Data Page has no unexpected changes 1`] = `
       <h2
         className="c9 c10 c17"
         id="exac-coverage"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to Coverage"
@@ -23705,9 +23986,9 @@ exports[`Data Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -24668,6 +24949,11 @@ exports[`Data Page has no unexpected changes 1`] = `
       <h2
         className="c9 c10 c17"
         id="exac-constraint"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to Constraint"
@@ -24676,9 +24962,9 @@ exports[`Data Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -24736,6 +25022,11 @@ exports[`Data Page has no unexpected changes 1`] = `
       <h2
         className="c9 c10 c17"
         id="exac-regional-missense-constraint"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to Regional Missense Constraint"
@@ -24744,9 +25035,9 @@ exports[`Data Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -24804,6 +25095,11 @@ exports[`Data Page has no unexpected changes 1`] = `
       <h2
         className="c9 c10 c17"
         id="exac-resources"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to Resources"
@@ -24812,9 +25108,9 @@ exports[`Data Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -24870,6 +25166,11 @@ exports[`Data Page has no unexpected changes 1`] = `
       <h2
         className="c9 c10 c17"
         id="exac-other"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to Other"
@@ -24878,9 +25179,9 @@ exports[`Data Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -24983,6 +25284,11 @@ exports[`Data Page has no unexpected changes 1`] = `
     <h2
       className="c9 c10 c17"
       id="api"
+      style={
+        {
+          "padding": "8px 0",
+        }
+      }
     >
       <a
         aria-label="Copy link to gnomAD API"
@@ -24991,9 +25297,9 @@ exports[`Data Page has no unexpected changes 1`] = `
         onClick={[Function]}
         style={
           {
-            "display": "inline-flex",
-            "position": "static",
-            "transform": "none",
+            "display": "flex",
+            "position": "absolute",
+            "transform": "translate(-100%, -50%)",
           }
         }
       >

--- a/browser/src/DataPage/__snapshots__/DataPage.spec.tsx.snap
+++ b/browser/src/DataPage/__snapshots__/DataPage.spec.tsx.snap
@@ -178,30 +178,44 @@ exports[`Data Page has no unexpected changes 1`] = `
   line-height: 1.4;
 }
 
-.c12 {
-  position: absolute;
-  transform: translate(-15px,calc(50% - 0.5em));
-  display: flex;
-  align-items: center;
-  width: 15px;
-  height: 1em;
-  visibility: hidden;
-  vertical-align: middle;
-}
-
-.c9 {
+.c10 {
   position: relative;
 }
 
-.c9 :hover .c11 {
-  visibility: visible;
+.c12 {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  transform: translate(-29px,-50%);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  width: 44px;
+  height: 44px;
+  opacity: 0;
+  vertical-align: middle;
+}
+
+.c12 :hover,
+.c12 :focus,
+.c12 :focus-visible,
+.c9:hover .c12,
+.c9:focus-within .c12 {
+  opacity: 1;
+}
+
+.c12 :focus,
+.c12 :focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: -8px;
 }
 
 .c21 li {
   line-height: 1.25;
 }
 
-.c10 {
+.c11 {
   font-size: 1.88rem;
 }
 
@@ -301,6 +315,20 @@ exports[`Data Page has no unexpected changes 1`] = `
   }
 }
 
+@media (hover:none) {
+  .c12 {
+    opacity: 1;
+  }
+}
+
+@media (max-width:1230px) {
+  .c12 {
+    position: static;
+    transform: none;
+    display: inline-flex;
+  }
+}
+
 @media (max-width:900px) {
   .c19 {
     flex-basis: 100%;
@@ -383,30 +411,33 @@ exports[`Data Page has no unexpected changes 1`] = `
       .
     </div>
     <div>
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c11"
+        id="summary"
       >
-        <h2
-          className="c10 "
-          subject="datasets"
+        <a
+          aria-label="Copy link to Summary"
+          className="c12"
+          href="#summary"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#summary"
-            id="summary"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Summary
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Summary
+      </h2>
       <p
         className="c13"
       >
@@ -621,59 +652,65 @@ exports[`Data Page has no unexpected changes 1`] = `
       </p>
     </div>
     <hr />
-    <span
-      className="c9"
+    <h2
+      className="c9 c10 c15"
+      id="v4"
     >
-      <h2
-        className="c15 "
-        subject="release"
+      <a
+        aria-label="Copy link to v4 Downloads"
+        className="c12"
+        href="#v4"
+        onClick={[Function]}
+        style={
+          {
+            "display": "inline-flex",
+            "position": "static",
+            "transform": "none",
+          }
+        }
       >
-        <a
+        <img
+          alt=""
           aria-hidden="true"
-          className="c11 c12"
-          href="#v4"
-          id="v4"
-        >
-          <img
-            alt=""
-            aria-hidden="true"
-            height={12}
-            src="test-file-stub"
-            width={12}
-          />
-        </a>
-        v4 Downloads
-      </h2>
-    </span>
+          height={12}
+          src="test-file-stub"
+          width={12}
+        />
+      </a>
+      v4 Downloads
+    </h2>
     <p
       className="c13"
     >
       The gnomAD v4.1.0 data set contains data from 730,947 exomes and 76,215 whole genomes, all mapped to the GRCh38 reference sequence.
     </p>
-    <span
-      className="c9"
+    <h2
+      className="c9 c10 c11"
+      id="v4-core-dataset"
     >
-      <h2
-        className="c10 "
-        subject="datasets"
+      <a
+        aria-label="Copy link to Core Dataset"
+        className="c12"
+        href="#v4-core-dataset"
+        onClick={[Function]}
+        style={
+          {
+            "display": "inline-flex",
+            "position": "static",
+            "transform": "none",
+          }
+        }
       >
-        <a
+        <img
+          alt=""
           aria-hidden="true"
-          className="c11 c12"
-          href="#v4-core-dataset"
-          id="v4-core-dataset"
-        >
-          <img
-            alt=""
-            aria-hidden="true"
-            height={12}
-            src="test-file-stub"
-            width={12}
-          />
-        </a>
-        Core Dataset
-      </h2>
-    </span>
+          height={12}
+          src="test-file-stub"
+          width={12}
+        />
+      </a>
+      Core Dataset
+    </h2>
     <p
       className="c13"
     >
@@ -682,29 +719,33 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v4-variants"
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Variants"
+          className="c12"
+          href="#v4-variants"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v4-variants"
-            id="v4-variants"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Variants
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Variants
+      </h2>
       <p>
         For more information, read the
          
@@ -3933,29 +3974,33 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v4-joint-freq-stats"
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Joint Frequency"
+          className="c12"
+          href="#v4-joint-freq-stats"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v4-joint-freq-stats"
-            id="v4-joint-freq-stats"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Joint Frequency
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Joint Frequency
+      </h2>
       <ul
         className="c20 c21"
       >
@@ -5551,29 +5596,33 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v4-all-sites-allele-number"
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to All sites allele numbers"
+          className="c12"
+          href="#v4-all-sites-allele-number"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v4-all-sites-allele-number"
-            id="v4-all-sites-allele-number"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          All sites allele numbers
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        All sites allele numbers
+      </h2>
       <div
         className="c18"
       >
@@ -5736,29 +5785,33 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v4-browser-tables"
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Browser Tables"
+          className="c12"
+          href="#v4-browser-tables"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v4-browser-tables"
-            id="v4-browser-tables"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Browser Tables
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Browser Tables
+      </h2>
       <p>
         For more information about these files, see our
          
@@ -5907,29 +5960,33 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v4-coverage"
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Coverage"
+          className="c12"
+          href="#v4-coverage"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v4-coverage"
-            id="v4-coverage"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Coverage
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Coverage
+      </h2>
       <ul
         className="c20 c21"
       >
@@ -6004,29 +6061,33 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v4-genetic-ancestry-group-classification"
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Genetic ancestry group classification"
+          className="c12"
+          href="#v4-genetic-ancestry-group-classification"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v4-genetic-ancestry-group-classification"
-            id="v4-genetic-ancestry-group-classification"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Genetic ancestry group classification
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Genetic ancestry group classification
+      </h2>
       <p>
         For more information about these files, see our blog post on
          
@@ -6141,29 +6202,33 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v4-constraint"
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Constraint"
+          className="c12"
+          href="#v4-constraint"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v4-constraint"
-            id="v4-constraint"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Constraint
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Constraint
+      </h2>
       <p>
         For information on constraint, see our 
         <a
@@ -6461,29 +6526,33 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v4-structural-variants"
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Structural variants"
+          className="c12"
+          href="#v4-structural-variants"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v4-structural-variants"
-            id="v4-structural-variants"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Structural variants
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Structural variants
+      </h2>
       <p>
         For information on structural variants, see our
          
@@ -6711,29 +6780,33 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v4-copy-number-variants"
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Copy number variants"
+          className="c12"
+          href="#v4-copy-number-variants"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v4-copy-number-variants"
-            id="v4-copy-number-variants"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Copy number variants
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Copy number variants
+      </h2>
       <p>
         For information on copy number variants, see our
          
@@ -6870,29 +6943,33 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v4-pext"
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Proportion expressed across transcripts (pext)"
+          className="c12"
+          href="#v4-pext"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v4-pext"
-            id="v4-pext"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Proportion expressed across transcripts (pext)
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Proportion expressed across transcripts (pext)
+      </h2>
       <p>
         For information on pext, see
          
@@ -7037,29 +7114,33 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v4-de-novo"
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to De novo variants (DNVs)"
+          className="c12"
+          href="#v4-de-novo"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v4-de-novo"
-            id="v4-de-novo"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          De novo variants (DNVs)
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        De novo variants (DNVs)
+      </h2>
       <p>
         For more information on DNVs, see the
          
@@ -7168,29 +7249,33 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v4-clinvar-grch38"
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to ClinVar"
+          className="c12"
+          href="#v4-clinvar-grch38"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v4-clinvar-grch38"
-            id="v4-clinvar-grch38"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          ClinVar
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        ClinVar
+      </h2>
       <p>
         For more information about these files, including how to download a specific previous version of the gnomAD browser ClinVar GRCh38 table, see the
          
@@ -7229,29 +7314,33 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v4-resources"
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Resources"
+          className="c12"
+          href="#v4-resources"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v4-resources"
-            id="v4-resources"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Resources
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Resources
+      </h2>
       <ul
         className="c20 c21"
       >
@@ -7449,18 +7538,57 @@ exports[`Data Page has no unexpected changes 1`] = `
         </li>
       </ul>
     </section>
-    <span
-      className="c9"
+    <h2
+      className="c9 c10 c11"
+      id="v4-secondary-analyses"
+    >
+      <a
+        aria-label="Copy link to Secondary Analyses"
+        className="c12"
+        href="#v4-secondary-analyses"
+        onClick={[Function]}
+        style={
+          {
+            "display": "inline-flex",
+            "position": "static",
+            "transform": "none",
+          }
+        }
+      >
+        <img
+          alt=""
+          aria-hidden="true"
+          height={12}
+          src="test-file-stub"
+          width={12}
+        />
+      </a>
+      Secondary Analyses
+    </h2>
+    <p
+      className="c13"
+    >
+      Additional research analyses created using the core gnomAD releases in collaboration with members of the gnomAD steering committee.
+    </p>
+    <section
+      className="c16"
     >
       <h2
-        className="c10 "
-        subject="datasets"
+        className="c9 c10 c17"
+        id="v4-lof-curation-results"
       >
         <a
-          aria-hidden="true"
-          className="c11 c12"
-          href="#v4-secondary-analyses"
-          id="v4-secondary-analyses"
+          aria-label="Copy link to Loss-of-function curation results"
+          className="c12"
+          href="#v4-lof-curation-results"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
           <img
             alt=""
@@ -7470,40 +7598,8 @@ exports[`Data Page has no unexpected changes 1`] = `
             width={12}
           />
         </a>
-        Secondary Analyses
+        Loss-of-function curation results
       </h2>
-    </span>
-    <p
-      className="c13"
-    >
-      Additional research analyses created using the core gnomAD releases in collaboration with members of the gnomAD steering committee.
-    </p>
-    <section
-      className="c16"
-    >
-      <span
-        className="c9"
-      >
-        <h2
-          className="c17 "
-        >
-          <a
-            aria-hidden="true"
-            className="c11 c12"
-            href="#v4-lof-curation-results"
-            id="v4-lof-curation-results"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Loss-of-function curation results
-        </h2>
-      </span>
       <p>
         For information on v4 loss-of-function curation results, see
          
@@ -7589,59 +7685,65 @@ exports[`Data Page has no unexpected changes 1`] = `
         </li>
       </ul>
     </section>
-    <span
-      className="c9"
+    <h2
+      className="c9 c10 c15"
+      id="v3"
     >
-      <h2
-        className="c15 "
-        subject="release"
+      <a
+        aria-label="Copy link to v3 Downloads"
+        className="c12"
+        href="#v3"
+        onClick={[Function]}
+        style={
+          {
+            "display": "inline-flex",
+            "position": "static",
+            "transform": "none",
+          }
+        }
       >
-        <a
+        <img
+          alt=""
           aria-hidden="true"
-          className="c11 c12"
-          href="#v3"
-          id="v3"
-        >
-          <img
-            alt=""
-            aria-hidden="true"
-            height={12}
-            src="test-file-stub"
-            width={12}
-          />
-        </a>
-        v3 Downloads
-      </h2>
-    </span>
+          height={12}
+          src="test-file-stub"
+          width={12}
+        />
+      </a>
+      v3 Downloads
+    </h2>
     <p
       className="c13"
     >
       The gnomAD v3.1.2 data set contains 76,156 whole genomes (and no exomes), all mapped to the GRCh38 reference sequence.
     </p>
-    <span
-      className="c9"
+    <h2
+      className="c9 c10 c11"
+      id="v3-core-dataset"
     >
-      <h2
-        className="c10 "
-        subject="datasets"
+      <a
+        aria-label="Copy link to Core Dataset"
+        className="c12"
+        href="#v3-core-dataset"
+        onClick={[Function]}
+        style={
+          {
+            "display": "inline-flex",
+            "position": "static",
+            "transform": "none",
+          }
+        }
       >
-        <a
+        <img
+          alt=""
           aria-hidden="true"
-          className="c11 c12"
-          href="#v3-core-dataset"
-          id="v3-core-dataset"
-        >
-          <img
-            alt=""
-            aria-hidden="true"
-            height={12}
-            src="test-file-stub"
-            width={12}
-          />
-        </a>
-        Core Dataset
-      </h2>
-    </span>
+          height={12}
+          src="test-file-stub"
+          width={12}
+        />
+      </a>
+      Core Dataset
+    </h2>
     <p
       className="c13"
     >
@@ -7650,29 +7752,33 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v3-variants"
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Variants"
+          className="c12"
+          href="#v3-variants"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v3-variants"
-            id="v3-variants"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Variants
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Variants
+      </h2>
       <p>
         <span
           className="c24"
@@ -9293,29 +9399,33 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v3-coverage"
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Coverage"
+          className="c12"
+          href="#v3-coverage"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v3-coverage"
-            id="v3-coverage"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Coverage
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Coverage
+      </h2>
       <ul
         className="c20 c21"
       >
@@ -9390,29 +9500,33 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v3-hgdp-1kg"
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to HGDP + 1KG callset"
+          className="c12"
+          href="#v3-hgdp-1kg"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v3-hgdp-1kg"
-            id="v3-hgdp-1kg"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          HGDP + 1KG callset
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        HGDP + 1KG callset
+      </h2>
       <p>
         These files contain individual genotypes for all samples in the HGDP and 1KG subsets. For more information, see the
          
@@ -11148,29 +11262,33 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v3-mitochondrial-dna"
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Mitochondrial DNA (mtDNA)"
+          className="c12"
+          href="#v3-mitochondrial-dna"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v3-mitochondrial-dna"
-            id="v3-mitochondrial-dna"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Mitochondrial DNA (mtDNA)
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Mitochondrial DNA (mtDNA)
+      </h2>
       <p>
         For details about these files, see the
          
@@ -11350,29 +11468,33 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v3-ancestry-classification"
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Genetic ancestry group classification"
+          className="c12"
+          href="#v3-ancestry-classification"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v3-ancestry-classification"
-            id="v3-ancestry-classification"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Genetic ancestry group classification
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Genetic ancestry group classification
+      </h2>
       <p>
         For more information about these files, see our blog post on
          
@@ -11454,29 +11576,33 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v3-local-ancestry"
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Local ancestry"
+          className="c12"
+          href="#v3-local-ancestry"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v3-local-ancestry"
-            id="v3-local-ancestry"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Local ancestry
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Local ancestry
+      </h2>
       <p>
         For more information about these files, see our blog posts on local ancestry inference for
          
@@ -11580,29 +11706,33 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v3-short-tandem-repeats"
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Short tandem repeats"
+          className="c12"
+          href="#v3-short-tandem-repeats"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v3-short-tandem-repeats"
-            id="v3-short-tandem-repeats"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Short tandem repeats
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Short tandem repeats
+      </h2>
       <p>
         These files contain the data that underlies the
          
@@ -11961,18 +12091,57 @@ exports[`Data Page has no unexpected changes 1`] = `
         </li>
       </ul>
     </section>
-    <span
-      className="c9"
+    <h2
+      className="c9 c10 c11"
+      id="v3-secondary-analyses"
+    >
+      <a
+        aria-label="Copy link to Secondary Analyses"
+        className="c12"
+        href="#v3-secondary-analyses"
+        onClick={[Function]}
+        style={
+          {
+            "display": "inline-flex",
+            "position": "static",
+            "transform": "none",
+          }
+        }
+      >
+        <img
+          alt=""
+          aria-hidden="true"
+          height={12}
+          src="test-file-stub"
+          width={12}
+        />
+      </a>
+      Secondary Analyses
+    </h2>
+    <p
+      className="c13"
+    >
+      Additional research analyses created using the core gnomAD releases in collaboration with members of the gnomAD steering committee.
+    </p>
+    <section
+      className="c16"
     >
       <h2
-        className="c10 "
-        subject="datasets"
+        className="c9 c10 c17"
+        id="v3-genomic-constraint"
       >
         <a
-          aria-hidden="true"
-          className="c11 c12"
-          href="#v3-secondary-analyses"
-          id="v3-secondary-analyses"
+          aria-label="Copy link to Genomic constraint"
+          className="c12"
+          href="#v3-genomic-constraint"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
           <img
             alt=""
@@ -11982,40 +12151,8 @@ exports[`Data Page has no unexpected changes 1`] = `
             width={12}
           />
         </a>
-        Secondary Analyses
+        Genomic constraint
       </h2>
-    </span>
-    <p
-      className="c13"
-    >
-      Additional research analyses created using the core gnomAD releases in collaboration with members of the gnomAD steering committee.
-    </p>
-    <section
-      className="c16"
-    >
-      <span
-        className="c9"
-      >
-        <h2
-          className="c17 "
-        >
-          <a
-            aria-hidden="true"
-            className="c11 c12"
-            href="#v3-genomic-constraint"
-            id="v3-genomic-constraint"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Genomic constraint
-        </h2>
-      </span>
       <p>
         For more information about these files, see the README included in the download.
       </p>
@@ -12159,29 +12296,33 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v3-hgdp-1kg-tutorials"
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to HGDP + 1KG tutorials"
+          className="c12"
+          href="#v3-hgdp-1kg-tutorials"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v3-hgdp-1kg-tutorials"
-            id="v3-hgdp-1kg-tutorials"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          HGDP + 1KG tutorials
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        HGDP + 1KG tutorials
+      </h2>
       <p>
         For more information about these files, see the
          
@@ -13237,29 +13378,33 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v3-mito-constraint"
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Mitochondrial constraint"
+          className="c12"
+          href="#v3-mito-constraint"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v3-mito-constraint"
-            id="v3-mito-constraint"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Mitochondrial constraint
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Mitochondrial constraint
+      </h2>
       <p>
         For more information about mitochondrial constraint, see
          
@@ -13413,59 +13558,65 @@ exports[`Data Page has no unexpected changes 1`] = `
         </li>
       </ul>
     </section>
-    <span
-      className="c9"
+    <h2
+      className="c9 c10 c15"
+      id="v2-liftover"
     >
-      <h2
-        className="c15 "
-        subject="release"
+      <a
+        aria-label="Copy link to v2 Liftover Downloads"
+        className="c12"
+        href="#v2-liftover"
+        onClick={[Function]}
+        style={
+          {
+            "display": "inline-flex",
+            "position": "static",
+            "transform": "none",
+          }
+        }
       >
-        <a
+        <img
+          alt=""
           aria-hidden="true"
-          className="c11 c12"
-          href="#v2-liftover"
-          id="v2-liftover"
-        >
-          <img
-            alt=""
-            aria-hidden="true"
-            height={12}
-            src="test-file-stub"
-            width={12}
-          />
-        </a>
-        v2 Liftover Downloads
-      </h2>
-    </span>
+          height={12}
+          src="test-file-stub"
+          width={12}
+        />
+      </a>
+      v2 Liftover Downloads
+    </h2>
     <p
       className="c13"
     >
       The gnomAD v2.1.1 liftover data set contains data from 125,748 exomes and 15,708 whole genomes, lifted over from the GRCh37 to the GRCh38 reference sequence.
     </p>
-    <span
-      className="c9"
+    <h2
+      className="c9 c10 c11"
+      id="v2-liftover-core-dataset"
     >
-      <h2
-        className="c10 "
-        subject="datasets"
+      <a
+        aria-label="Copy link to Core Dataset"
+        className="c12"
+        href="#v2-liftover-core-dataset"
+        onClick={[Function]}
+        style={
+          {
+            "display": "inline-flex",
+            "position": "static",
+            "transform": "none",
+          }
+        }
       >
-        <a
+        <img
+          alt=""
           aria-hidden="true"
-          className="c11 c12"
-          href="#v2-liftover-core-dataset"
-          id="v2-liftover-core-dataset"
-        >
-          <img
-            alt=""
-            aria-hidden="true"
-            height={12}
-            src="test-file-stub"
-            width={12}
-          />
-        </a>
-        Core Dataset
-      </h2>
-    </span>
+          height={12}
+          src="test-file-stub"
+          width={12}
+        />
+      </a>
+      Core Dataset
+    </h2>
     <p
       className="c13"
     >
@@ -13474,29 +13625,33 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v2-liftover-variants"
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Variants (GRCh38 liftover)"
+          className="c12"
+          href="#v2-liftover-variants"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v2-liftover-variants"
-            id="v2-liftover-variants"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Variants (GRCh38 liftover)
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Variants (GRCh38 liftover)
+      </h2>
       <p>
         The variant dataset files below contain all subsets (non-neuro, non-cancer, controls-only, and non-TOPMed).
       </p>
@@ -16769,29 +16924,33 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v2-liftover-structural-variants"
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Structural variants (GRCh38 liftover)"
+          className="c12"
+          href="#v2-liftover-structural-variants"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v2-liftover-structural-variants"
-            id="v2-liftover-structural-variants"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Structural variants (GRCh38 liftover)
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Structural variants (GRCh38 liftover)
+      </h2>
       <p>
         <span
           className="c24"
@@ -16818,59 +16977,65 @@ exports[`Data Page has no unexpected changes 1`] = `
         </li>
       </ul>
     </section>
-    <span
-      className="c9"
+    <h2
+      className="c9 c10 c15"
+      id="v2"
     >
-      <h2
-        className="c15 "
-        subject="release"
+      <a
+        aria-label="Copy link to v2 Downloads"
+        className="c12"
+        href="#v2"
+        onClick={[Function]}
+        style={
+          {
+            "display": "inline-flex",
+            "position": "static",
+            "transform": "none",
+          }
+        }
       >
-        <a
+        <img
+          alt=""
           aria-hidden="true"
-          className="c11 c12"
-          href="#v2"
-          id="v2"
-        >
-          <img
-            alt=""
-            aria-hidden="true"
-            height={12}
-            src="test-file-stub"
-            width={12}
-          />
-        </a>
-        v2 Downloads
-      </h2>
-    </span>
+          height={12}
+          src="test-file-stub"
+          width={12}
+        />
+      </a>
+      v2 Downloads
+    </h2>
     <p
       className="c13"
     >
       The gnomAD v2.1.1 data set contains data from 125,748 exomes and 15,708 whole genomes, all mapped to the GRCh37/hg19 reference sequence.
     </p>
-    <span
-      className="c9"
+    <h2
+      className="c9 c10 c11"
+      id="v2-core-dataset"
     >
-      <h2
-        className="c10 "
-        subject="datasets"
+      <a
+        aria-label="Copy link to Core Dataset"
+        className="c12"
+        href="#v2-core-dataset"
+        onClick={[Function]}
+        style={
+          {
+            "display": "inline-flex",
+            "position": "static",
+            "transform": "none",
+          }
+        }
       >
-        <a
+        <img
+          alt=""
           aria-hidden="true"
-          className="c11 c12"
-          href="#v2-core-dataset"
-          id="v2-core-dataset"
-        >
-          <img
-            alt=""
-            aria-hidden="true"
-            height={12}
-            src="test-file-stub"
-            width={12}
-          />
-        </a>
-        Core Dataset
-      </h2>
-    </span>
+          height={12}
+          src="test-file-stub"
+          width={12}
+        />
+      </a>
+      Core Dataset
+    </h2>
     <p
       className="c13"
     >
@@ -16879,29 +17044,33 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v2-variants"
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Variants"
+          className="c12"
+          href="#v2-variants"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v2-variants"
-            id="v2-variants"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Variants
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Variants
+      </h2>
       <p>
         <span
           className="c24"
@@ -20258,29 +20427,33 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v2-browser-tables"
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Browser Tables"
+          className="c12"
+          href="#v2-browser-tables"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v2-browser-tables"
-            id="v2-browser-tables"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Browser Tables
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Browser Tables
+      </h2>
       <p>
         For more information about these files, see our
          
@@ -20340,29 +20513,33 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v2-coverage"
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Coverage"
+          className="c12"
+          href="#v2-coverage"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v2-coverage"
-            id="v2-coverage"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Coverage
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Coverage
+      </h2>
       <ul
         className="c20 c21"
       >
@@ -20503,29 +20680,33 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v2-structural-variants"
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Structural variants"
+          className="c12"
+          href="#v2-structural-variants"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v2-structural-variants"
-            id="v2-structural-variants"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Structural variants
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Structural variants
+      </h2>
       <p>
         For information on gnomAD structural variants, see
          
@@ -20903,29 +21084,33 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v2-linkage-disequilibrium"
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Linkage disequilibrium"
+          className="c12"
+          href="#v2-linkage-disequilibrium"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v2-linkage-disequilibrium"
-            id="v2-linkage-disequilibrium"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Linkage disequilibrium
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Linkage disequilibrium
+      </h2>
       <p>
         <label
           htmlFor="ld-files-population"
@@ -21178,29 +21363,33 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v2-ancestry-classification"
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Ancestry classification"
+          className="c12"
+          href="#v2-ancestry-classification"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v2-ancestry-classification"
-            id="v2-ancestry-classification"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Ancestry classification
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Ancestry classification
+      </h2>
       <p>
         For more information about these files, see our blog post on
          
@@ -21282,29 +21471,33 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v2-regional-missense-constraint"
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Regional Missense Constraint"
+          className="c12"
+          href="#v2-regional-missense-constraint"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v2-regional-missense-constraint"
-            id="v2-regional-missense-constraint"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Regional Missense Constraint
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Regional Missense Constraint
+      </h2>
       <ul
         className="c20 c21"
       >
@@ -21406,29 +21599,33 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v2-clinvar-grch37"
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to ClinVar"
+          className="c12"
+          href="#v2-clinvar-grch37"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v2-clinvar-grch37"
-            id="v2-clinvar-grch37"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          ClinVar
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        ClinVar
+      </h2>
       <p>
         For more information about these files, including how to download a specific previous version of the gnomAD browser ClinVar GRCh37 table, see the
          
@@ -21467,29 +21664,33 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v2-resources"
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Resources"
+          className="c12"
+          href="#v2-resources"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v2-resources"
-            id="v2-resources"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Resources
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Resources
+      </h2>
       <ul
         className="c20 c21"
       >
@@ -21648,18 +21849,57 @@ exports[`Data Page has no unexpected changes 1`] = `
         </li>
       </ul>
     </section>
-    <span
-      className="c9"
+    <h2
+      className="c9 c10 c11"
+      id="v2-secondary-analyses"
+    >
+      <a
+        aria-label="Copy link to Secondary Analyses"
+        className="c12"
+        href="#v2-secondary-analyses"
+        onClick={[Function]}
+        style={
+          {
+            "display": "inline-flex",
+            "position": "static",
+            "transform": "none",
+          }
+        }
+      >
+        <img
+          alt=""
+          aria-hidden="true"
+          height={12}
+          src="test-file-stub"
+          width={12}
+        />
+      </a>
+      Secondary Analyses
+    </h2>
+    <p
+      className="c13"
+    >
+      Additional research analyses created using the core gnomAD releases in collaboration with members of the gnomAD steering committee.
+    </p>
+    <section
+      className="c16"
     >
       <h2
-        className="c10 "
-        subject="datasets"
+        className="c9 c10 c17"
+        id="v2-constraint"
       >
         <a
-          aria-hidden="true"
-          className="c11 c12"
-          href="#v2-secondary-analyses"
-          id="v2-secondary-analyses"
+          aria-label="Copy link to Constraint"
+          className="c12"
+          href="#v2-constraint"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
           <img
             alt=""
@@ -21669,40 +21909,8 @@ exports[`Data Page has no unexpected changes 1`] = `
             width={12}
           />
         </a>
-        Secondary Analyses
+        Constraint
       </h2>
-    </span>
-    <p
-      className="c13"
-    >
-      Additional research analyses created using the core gnomAD releases in collaboration with members of the gnomAD steering committee.
-    </p>
-    <section
-      className="c16"
-    >
-      <span
-        className="c9"
-      >
-        <h2
-          className="c17 "
-        >
-          <a
-            aria-hidden="true"
-            className="c11 c12"
-            href="#v2-constraint"
-            id="v2-constraint"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Constraint
-        </h2>
-      </span>
       <p>
         For information on constraint, see
          
@@ -21865,29 +22073,33 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v2-multi-nucleotide-variants"
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Multi-nucleotide variants (MNVs)"
+          className="c12"
+          href="#v2-multi-nucleotide-variants"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v2-multi-nucleotide-variants"
-            id="v2-multi-nucleotide-variants"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Multi-nucleotide variants (MNVs)
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Multi-nucleotide variants (MNVs)
+      </h2>
       <p>
         For information on multi-nucleotide variants in gnomAD, see
          
@@ -22618,29 +22830,33 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v2-pext"
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Proportion expressed across transcripts (pext)"
+          className="c12"
+          href="#v2-pext"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v2-pext"
-            id="v2-pext"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Proportion expressed across transcripts (pext)
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Proportion expressed across transcripts (pext)
+      </h2>
       <p>
         For information on pext, see
          
@@ -22785,29 +23001,33 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v2-variant-cooccurrence"
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Variant co-occurrence"
+          className="c12"
+          href="#v2-variant-cooccurrence"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v2-variant-cooccurrence"
-            id="v2-variant-cooccurrence"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Variant co-occurrence
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Variant co-occurrence
+      </h2>
       <ul
         className="c20 c21"
       >
@@ -22942,29 +23162,33 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="v2-lof-curation-results"
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Loss-of-function curation results"
+          className="c12"
+          href="#v2-lof-curation-results"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#v2-lof-curation-results"
-            id="v2-lof-curation-results"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Loss-of-function curation results
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Loss-of-function curation results
+      </h2>
       <p>
         For information on loss-of-function curation results, see
          
@@ -23300,59 +23524,65 @@ exports[`Data Page has no unexpected changes 1`] = `
         </li>
       </ul>
     </section>
-    <span
-      className="c9"
+    <h2
+      className="c9 c10 c15"
+      id="exac"
     >
-      <h2
-        className="c15 "
-        subject="release"
+      <a
+        aria-label="Copy link to ExAC Downloads"
+        className="c12"
+        href="#exac"
+        onClick={[Function]}
+        style={
+          {
+            "display": "inline-flex",
+            "position": "static",
+            "transform": "none",
+          }
+        }
       >
-        <a
+        <img
+          alt=""
           aria-hidden="true"
-          className="c11 c12"
-          href="#exac"
-          id="exac"
-        >
-          <img
-            alt=""
-            aria-hidden="true"
-            height={12}
-            src="test-file-stub"
-            width={12}
-          />
-        </a>
-        ExAC Downloads
-      </h2>
-    </span>
+          height={12}
+          src="test-file-stub"
+          width={12}
+        />
+      </a>
+      ExAC Downloads
+    </h2>
     <p
       className="c13"
     >
       The ExAC data set contains data from 60,706 exomes, all mapped to the GRCh37/hg19 reference sequence.
     </p>
-    <span
-      className="c9"
+    <h2
+      className="c9 c10 c11"
+      id="exac-core-dataset"
     >
-      <h2
-        className="c10 "
-        subject="datasets"
+      <a
+        aria-label="Copy link to Core Dataset"
+        className="c12"
+        href="#exac-core-dataset"
+        onClick={[Function]}
+        style={
+          {
+            "display": "inline-flex",
+            "position": "static",
+            "transform": "none",
+          }
+        }
       >
-        <a
+        <img
+          alt=""
           aria-hidden="true"
-          className="c11 c12"
-          href="#exac-core-dataset"
-          id="exac-core-dataset"
-        >
-          <img
-            alt=""
-            aria-hidden="true"
-            height={12}
-            src="test-file-stub"
-            width={12}
-          />
-        </a>
-        Core Dataset
-      </h2>
-    </span>
+          height={12}
+          src="test-file-stub"
+          width={12}
+        />
+      </a>
+      Core Dataset
+    </h2>
     <p
       className="c13"
     >
@@ -23361,29 +23591,33 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="exac-variants"
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Variants"
+          className="c12"
+          href="#exac-variants"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#exac-variants"
-            id="exac-variants"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Variants
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Variants
+      </h2>
       <h3>
         Exomes
       </h3>
@@ -23460,29 +23694,33 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="exac-coverage"
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Coverage"
+          className="c12"
+          href="#exac-coverage"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#exac-coverage"
-            id="exac-coverage"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Coverage
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Coverage
+      </h2>
       <ul
         className="c20 c21"
       >
@@ -24427,29 +24665,33 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="exac-constraint"
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Constraint"
+          className="c12"
+          href="#exac-constraint"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#exac-constraint"
-            id="exac-constraint"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Constraint
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Constraint
+      </h2>
       <ul
         className="c20 c21"
       >
@@ -24491,29 +24733,33 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="exac-regional-missense-constraint"
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Regional Missense Constraint"
+          className="c12"
+          href="#exac-regional-missense-constraint"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#exac-regional-missense-constraint"
-            id="exac-regional-missense-constraint"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Regional Missense Constraint
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Regional Missense Constraint
+      </h2>
       <ul
         className="c20 c21"
       >
@@ -24555,29 +24801,33 @@ exports[`Data Page has no unexpected changes 1`] = `
     <section
       className="c16"
     >
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="exac-resources"
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Resources"
+          className="c12"
+          href="#exac-resources"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#exac-resources"
-            id="exac-resources"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Resources
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Resources
+      </h2>
       <ul
         className="c20 c21"
       >
@@ -24617,29 +24867,33 @@ exports[`Data Page has no unexpected changes 1`] = `
       </ul>
     </section>
     <section>
-      <span
-        className="c9"
+      <h2
+        className="c9 c10 c17"
+        id="exac-other"
       >
-        <h2
-          className="c17 "
+        <a
+          aria-label="Copy link to Other"
+          className="c12"
+          href="#exac-other"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c11 c12"
-            href="#exac-other"
-            id="exac-other"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Other
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Other
+      </h2>
       <ul
         className="c20 c21"
       >
@@ -24726,29 +24980,33 @@ exports[`Data Page has no unexpected changes 1`] = `
         </li>
       </ul>
     </section>
-    <span
-      className="c9"
+    <h2
+      className="c9 c10 c17"
+      id="api"
     >
-      <h2
-        className="c17 "
+      <a
+        aria-label="Copy link to gnomAD API"
+        className="c12"
+        href="#api"
+        onClick={[Function]}
+        style={
+          {
+            "display": "inline-flex",
+            "position": "static",
+            "transform": "none",
+          }
+        }
       >
-        <a
+        <img
+          alt=""
           aria-hidden="true"
-          className="c11 c12"
-          href="#api"
-          id="api"
-        >
-          <img
-            alt=""
-            aria-hidden="true"
-            height={12}
-            src="test-file-stub"
-            width={12}
-          />
-        </a>
-        gnomAD API
-      </h2>
-    </span>
+          height={12}
+          src="test-file-stub"
+          width={12}
+        />
+      </a>
+      gnomAD API
+    </h2>
     <p
       className="c13"
     >

--- a/browser/src/DataPage/downloadsHooks.ts
+++ b/browser/src/DataPage/downloadsHooks.ts
@@ -20,7 +20,7 @@ const useHeadsObserver = () => {
       rootMargin: '0% 0px -90% 0px',
     })
 
-    const elements = document.querySelectorAll('a[id]')
+    const elements = document.querySelectorAll('h2[id]')
     // @ts-expect-error
     elements.forEach((element) => observer.current.observe(element))
     // @ts-expect-error

--- a/browser/src/DataPage/downloadsPageStyles.tsx
+++ b/browser/src/DataPage/downloadsPageStyles.tsx
@@ -14,7 +14,7 @@ export const FileList = styled(List)`
 
 type SectionTitleProps = { $subject?: 'release' | 'datasets' }
 
-export const SectionTitle = styled(SectionHeading).attrs({ inlineLink: true })<SectionTitleProps>`
+export const SectionTitle = styled(SectionHeading).attrs({ linkInGutter: true })<SectionTitleProps>`
   font-size: ${(props) => {
     if (props.$subject === 'release') {
       return '2.25rem'

--- a/browser/src/DataPage/downloadsPageStyles.tsx
+++ b/browser/src/DataPage/downloadsPageStyles.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 
 import { Button, ExternalLink, List, Modal, PrimaryButton, TextButton } from '@gnomad/ui'
 
-import { withAnchor } from '../AnchorLink'
+import { SectionHeading } from '../AnchorLink'
 import { logButtonClick } from '../analytics'
 
 export const FileList = styled(List)`
@@ -12,21 +12,19 @@ export const FileList = styled(List)`
   }
 `
 
-type BaseSectionTitleProps = { subject?: string }
+type SectionTitleProps = { $subject?: 'release' | 'datasets' }
 
-const BaseSectionTitle = styled.h2<BaseSectionTitleProps>`
+export const SectionTitle = styled(SectionHeading).attrs({ inlineLink: true })<SectionTitleProps>`
   font-size: ${(props) => {
-    if (props.subject === 'release') {
+    if (props.$subject === 'release') {
       return '2.25rem'
     }
-    if (props.subject === 'datasets') {
+    if (props.$subject === 'datasets') {
       return '1.88rem'
     }
     return '1.5rem'
   }};
 `
-
-export const SectionTitle = styled(withAnchor(BaseSectionTitle))``
 
 export const StyledParagraph = styled.p`
   padding-bottom: 1rem;

--- a/browser/src/InfoPage.ts
+++ b/browser/src/InfoPage.ts
@@ -2,7 +2,8 @@ import styled from 'styled-components'
 
 import { Page } from '@gnomad/ui'
 
-export default styled(Page)`
+export default styled(Page)<{ $withSectionLinks?: boolean }>`
+  ${(props) => props.$withSectionLinks && 'padding-left: 44px;'}
   font-size: 16px;
 
   p {

--- a/browser/src/MitochondrialVariantPage/MitochondrialVariantPage.tsx
+++ b/browser/src/MitochondrialVariantPage/MitochondrialVariantPage.tsx
@@ -28,7 +28,7 @@ import MitochondrialVariantGenotypeQualityMetrics from './MitochondrialVariantGe
 import MitochondrialVariantHaplogroupFrequenciesTable from './MitochondrialVariantHaplogroupFrequenciesTable'
 import MitochondrialVariantHeteroplasmyDistribution from './MitochondrialVariantHeteroplasmyDistribution'
 import MitochondrialVariantPopulationFrequenciesTable from './MitochondrialVariantPopulationFrequenciesTable'
-import { AgeDistributionHeading } from '../AnchorLink'
+import { SectionHeading } from '../AnchorLink'
 import useScrollToHash from '../useScrollToHash'
 import MitochondrialVariantReferenceList from './MitochondrialVariantReferenceList'
 import MitochondrialVariantSiteQualityMetrics from './MitochondrialVariantSiteQualityMetrics'
@@ -247,9 +247,9 @@ const MitochondrialVariantPage = ({ datasetId, variant }: MitochondrialVariantPa
           <MitochondrialVariantHeteroplasmyDistribution variant={variant} />
         </ResponsiveSection>
         <ResponsiveSection>
-          <AgeDistributionHeading>
-            Age Distribution <InfoButton topic="age" />
-          </AgeDistributionHeading>
+          <SectionHeading id="age-distribution" title="Age Distribution">
+            <InfoButton topic="age" />
+          </SectionHeading>
           <MitochondrialVariantAgeDistribution variant={variant} />
         </ResponsiveSection>
       </Wrapper>

--- a/browser/src/MitochondrialVariantPage/__snapshots__/MitochondrialVariantPage.spec.tsx.snap
+++ b/browser/src/MitochondrialVariantPage/__snapshots__/MitochondrialVariantPage.spec.tsx.snap
@@ -1491,56 +1491,55 @@ exports[`MitochondrialVariantPage with dataset gnomad_cnv_r4 has no unexpected c
     <section
       className="MitochondrialVariantPage__ResponsiveSection-sc-1h2n2ff-2 eVwzkj"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <div>
         <div
           className="MitochondrialVariantAgeDistribution__LegendWrapper-sc-h2p9a2-0 kmBkbi"
@@ -9439,56 +9438,55 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3 has no unexpected chang
     <section
       className="MitochondrialVariantPage__ResponsiveSection-sc-1h2n2ff-2 eVwzkj"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <div>
         <div
           className="MitochondrialVariantAgeDistribution__LegendWrapper-sc-h2p9a2-0 kmBkbi"
@@ -17297,56 +17295,55 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_controls_and_biobanks h
     <section
       className="MitochondrialVariantPage__ResponsiveSection-sc-1h2n2ff-2 eVwzkj"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <div>
         <div
           className="MitochondrialVariantAgeDistribution__LegendWrapper-sc-h2p9a2-0 kmBkbi"
@@ -25155,56 +25152,55 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_non_cancer has no unexp
     <section
       className="MitochondrialVariantPage__ResponsiveSection-sc-1h2n2ff-2 eVwzkj"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <div>
         <div
           className="MitochondrialVariantAgeDistribution__LegendWrapper-sc-h2p9a2-0 kmBkbi"
@@ -33013,56 +33009,55 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_non_neuro has no unexpe
     <section
       className="MitochondrialVariantPage__ResponsiveSection-sc-1h2n2ff-2 eVwzkj"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <div>
         <div
           className="MitochondrialVariantAgeDistribution__LegendWrapper-sc-h2p9a2-0 kmBkbi"
@@ -40871,56 +40866,55 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_non_topmed has no unexp
     <section
       className="MitochondrialVariantPage__ResponsiveSection-sc-1h2n2ff-2 eVwzkj"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <div>
         <div
           className="MitochondrialVariantAgeDistribution__LegendWrapper-sc-h2p9a2-0 kmBkbi"
@@ -48729,56 +48723,55 @@ exports[`MitochondrialVariantPage with dataset gnomad_r3_non_v2 has no unexpecte
     <section
       className="MitochondrialVariantPage__ResponsiveSection-sc-1h2n2ff-2 eVwzkj"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <div>
         <div
           className="MitochondrialVariantAgeDistribution__LegendWrapper-sc-h2p9a2-0 kmBkbi"
@@ -56587,56 +56580,55 @@ exports[`MitochondrialVariantPage with dataset gnomad_r4 has no unexpected chang
     <section
       className="MitochondrialVariantPage__ResponsiveSection-sc-1h2n2ff-2 eVwzkj"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <div>
         <div
           className="MitochondrialVariantAgeDistribution__LegendWrapper-sc-h2p9a2-0 kmBkbi"
@@ -64445,56 +64437,55 @@ exports[`MitochondrialVariantPage with dataset gnomad_r4_non_ukb has no unexpect
     <section
       className="MitochondrialVariantPage__ResponsiveSection-sc-1h2n2ff-2 eVwzkj"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <div>
         <div
           className="MitochondrialVariantAgeDistribution__LegendWrapper-sc-h2p9a2-0 kmBkbi"
@@ -72303,56 +72294,55 @@ exports[`MitochondrialVariantPage with dataset gnomad_sv_r2_1 has no unexpected 
     <section
       className="MitochondrialVariantPage__ResponsiveSection-sc-1h2n2ff-2 eVwzkj"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <div>
         <div
           className="MitochondrialVariantAgeDistribution__LegendWrapper-sc-h2p9a2-0 kmBkbi"
@@ -80161,56 +80151,55 @@ exports[`MitochondrialVariantPage with dataset gnomad_sv_r2_1_controls has no un
     <section
       className="MitochondrialVariantPage__ResponsiveSection-sc-1h2n2ff-2 eVwzkj"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <div>
         <div
           className="MitochondrialVariantAgeDistribution__LegendWrapper-sc-h2p9a2-0 kmBkbi"
@@ -88019,56 +88008,55 @@ exports[`MitochondrialVariantPage with dataset gnomad_sv_r2_1_non_neuro has no u
     <section
       className="MitochondrialVariantPage__ResponsiveSection-sc-1h2n2ff-2 eVwzkj"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <div>
         <div
           className="MitochondrialVariantAgeDistribution__LegendWrapper-sc-h2p9a2-0 kmBkbi"
@@ -95877,56 +95865,55 @@ exports[`MitochondrialVariantPage with dataset gnomad_sv_r4 has no unexpected ch
     <section
       className="MitochondrialVariantPage__ResponsiveSection-sc-1h2n2ff-2 eVwzkj"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <div>
         <div
           className="MitochondrialVariantAgeDistribution__LegendWrapper-sc-h2p9a2-0 kmBkbi"

--- a/browser/src/SectionHeadingPages.spec.tsx
+++ b/browser/src/SectionHeadingPages.spec.tsx
@@ -56,6 +56,9 @@ test.each([
     links.forEach((link) => {
       const heading = link.closest('h2')!
       expect(heading).not.toBeNull()
+      expect(heading.firstElementChild).toBe(link)
+      expect(getComputedStyle(link).position).toBe('absolute')
+      expect(getComputedStyle(link).transform).toBe('translate(-100%, -50%)')
       expect(link.getAttribute('href')).toBe(`#${heading.id}`)
       expect(link.getAttribute('aria-label')).toBe(`Copy link to ${heading.textContent}`)
       expect(container.querySelectorAll(`[id="${heading.id}"]`)).toHaveLength(1)
@@ -71,10 +74,6 @@ test.each([
     expect(window.location.hash).toBe(`#${id}`)
     expect(screen.getByRole('status').textContent).toContain('Link copied')
 
-    if (path === '/help') {
-      expect(getComputedStyle(link).position).toBe('static')
-      expect(getComputedStyle(link).display).toBe('inline-flex')
-    }
     if (path === '/data') {
       expect(getComputedStyle(document.getElementById('v4')!).fontSize).toBe('2.25rem')
       expect(getComputedStyle(document.getElementById('v4-core-dataset')!).fontSize).toBe('1.88rem')

--- a/browser/src/SectionHeadingPages.spec.tsx
+++ b/browser/src/SectionHeadingPages.spec.tsx
@@ -75,6 +75,23 @@ test.each([
     expect(screen.getByRole('status').textContent).toContain('Link copied')
 
     if (path === '/data') {
+      const contents = screen.getByRole('navigation', { name: 'Data sections' })
+      expect(
+        within(contents)
+          .getAllByRole('link')
+          .map((item) => ({
+            text: item.textContent,
+            href: item.getAttribute('href'),
+          }))
+      ).toEqual([
+        { text: 'Summary', href: '#summary' },
+        { text: 'v4 Downloads', href: '#v4' },
+        { text: 'v3 Downloads', href: '#v3' },
+        { text: 'v2 Liftover Downloads', href: '#v2-liftover' },
+        { text: 'v2 Downloads', href: '#v2' },
+        { text: 'ExAC Downloads', href: '#exac' },
+        { text: 'gnomAD API', href: '#api' },
+      ])
       expect(getComputedStyle(document.getElementById('v4')!).fontSize).toBe('2.25rem')
       expect(getComputedStyle(document.getElementById('v4-core-dataset')!).fontSize).toBe('1.88rem')
       expect(getComputedStyle(heading).fontSize).toBe('1.5rem')

--- a/browser/src/SectionHeadingPages.spec.tsx
+++ b/browser/src/SectionHeadingPages.spec.tsx
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, expect, jest, test } from '@jest/globals'
+import React from 'react'
+import { BrowserRouter } from 'react-router-dom'
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import DataPage from './DataPage/DataPage'
+import HelpPage from './help/HelpPage'
+import Notifications from './Notifications'
+import StatsPage from './StatsPage/StatsPage'
+
+const originalClipboard = navigator.clipboard
+const originalIntersectionObserver = window.IntersectionObserver
+const observe = jest.fn()
+const writeText = jest.fn(() => Promise.resolve())
+
+beforeEach(() => {
+  writeText.mockClear()
+  observe.mockClear()
+  Object.defineProperty(window, 'IntersectionObserver', {
+    value: jest.fn(() => ({ observe, disconnect: jest.fn() })),
+    configurable: true,
+    writable: true,
+  })
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText },
+    configurable: true,
+  })
+})
+
+afterEach(() => {
+  window.IntersectionObserver = originalIntersectionObserver
+  Object.defineProperty(navigator, 'clipboard', { value: originalClipboard, configurable: true })
+  window.history.replaceState({}, '', '/')
+})
+
+test.each([
+  { path: '/help', Page: HelpPage, count: 1, id: 'frequently-asked-questions' },
+  { path: '/data', Page: DataPage, count: 61, id: 'v4-genetic-ancestry-group-classification' },
+  { path: '/stats', Page: StatsPage, count: 6, id: 'age-and-sex-distribution' },
+])(
+  '$path uses shared, copyable headings with stable fragment targets',
+  async ({ path, Page, count, id }) => {
+    window.history.replaceState({}, '', `${path}?dataset=gnomad_r4`)
+    const { container } = render(
+      <BrowserRouter>
+        <Notifications />
+        <Page />
+      </BrowserRouter>
+    )
+
+    const links = Array.from(container.querySelectorAll<HTMLHeadingElement>('h2[id]')).map(
+      (heading) => within(heading).getByRole('link', { name: /^Copy link to / })
+    )
+    expect(links).toHaveLength(count)
+    links.forEach((link) => {
+      const heading = link.closest('h2')!
+      expect(heading).not.toBeNull()
+      expect(link.getAttribute('href')).toBe(`#${heading.id}`)
+      expect(link.getAttribute('aria-label')).toBe(`Copy link to ${heading.textContent}`)
+      expect(container.querySelectorAll(`[id="${heading.id}"]`)).toHaveLength(1)
+      expect(link.hasAttribute('aria-hidden')).toBe(false)
+    })
+
+    const heading = document.getElementById(id)!
+    const link = within(heading).getByRole('link')
+    window.history.replaceState({}, '', `${path}?dataset=gnomad_r4#previous-section`)
+    link.focus()
+    await userEvent.keyboard('{Enter}')
+    expect(writeText).toHaveBeenCalledWith(`http://localhost${path}?dataset=gnomad_r4#${id}`)
+    expect(window.location.hash).toBe(`#${id}`)
+    expect(screen.getByRole('status').textContent).toContain('Link copied')
+
+    if (path === '/help') {
+      expect(getComputedStyle(link).position).toBe('static')
+      expect(getComputedStyle(link).display).toBe('inline-flex')
+    }
+    if (path === '/data') {
+      expect(getComputedStyle(document.getElementById('v4')!).fontSize).toBe('2.25rem')
+      expect(getComputedStyle(document.getElementById('v4-core-dataset')!).fontSize).toBe('1.88rem')
+      expect(getComputedStyle(heading).fontSize).toBe('1.5rem')
+      expect(container.querySelector('[subject]')).toBeNull()
+      expect(observe).toHaveBeenCalledTimes(count)
+      links.forEach((sectionLink) => {
+        expect(observe).toHaveBeenCalledWith(sectionLink.closest('h2'))
+      })
+    }
+  }
+)

--- a/browser/src/ShortTandemRepeatPage/ShortTandemRepeatPage.tsx
+++ b/browser/src/ShortTandemRepeatPage/ShortTandemRepeatPage.tsx
@@ -33,7 +33,7 @@ import {
   genotypeRepunitPairs,
 } from './shortTandemRepeatHelpers'
 import { PopulationId } from '@gnomad/dataset-metadata/gnomadPopulations'
-import { AgeDistributionHeading } from '../AnchorLink'
+import { SectionHeading } from '../AnchorLink'
 import useScrollToHash from '../useScrollToHash'
 import { GenotypeQuality } from './qualityDescription'
 import { QScoreBin } from './qScore'
@@ -622,9 +622,9 @@ const ShortTandemRepeatPage = ({ datasetId, shortTandemRepeat }: ShortTandemRepe
       )}
 
       <section style={{ marginBottom: '3em' }}>
-        <AgeDistributionHeading>
-          Age Distribution <InfoButton topic="str-age-distribution" />
-        </AgeDistributionHeading>
+        <SectionHeading id="age-distribution" title="Age Distribution">
+          <InfoButton topic="str-age-distribution" />
+        </SectionHeading>
         <ShortTandemRepeatAgeDistributionPlot
           ageDistribution={shortTandemRepeat.age_distribution}
           maxRepeats={maxAlleleRepeats}

--- a/browser/src/ShortTandemRepeatPage/__snapshots__/ShortTandemRepeatPage.spec.tsx.snap
+++ b/browser/src/ShortTandemRepeatPage/__snapshots__/ShortTandemRepeatPage.spec.tsx.snap
@@ -769,12 +769,14 @@ exports[`ShortTandemRepeatPage with "exac" dataset has no unexected changes 1`] 
       }
     }
   >
-    <AgeDistributionHeading>
-      Age Distribution 
+    <SectionHeading
+      id="age-distribution"
+      title="Age Distribution"
+    >
       <InfoButton
         topic="str-age-distribution"
       />
-    </AgeDistributionHeading>
+    </SectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -1744,12 +1746,14 @@ exports[`ShortTandemRepeatPage with "gnomad_cnv_r4" dataset has no unexected cha
       }
     }
   >
-    <AgeDistributionHeading>
-      Age Distribution 
+    <SectionHeading
+      id="age-distribution"
+      title="Age Distribution"
+    >
       <InfoButton
         topic="str-age-distribution"
       />
-    </AgeDistributionHeading>
+    </SectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -2719,12 +2723,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1" dataset has no unexected chang
       }
     }
   >
-    <AgeDistributionHeading>
-      Age Distribution 
+    <SectionHeading
+      id="age-distribution"
+      title="Age Distribution"
+    >
       <InfoButton
         topic="str-age-distribution"
       />
-    </AgeDistributionHeading>
+    </SectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -3694,12 +3700,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1_controls" dataset has no unexec
       }
     }
   >
-    <AgeDistributionHeading>
-      Age Distribution 
+    <SectionHeading
+      id="age-distribution"
+      title="Age Distribution"
+    >
       <InfoButton
         topic="str-age-distribution"
       />
-    </AgeDistributionHeading>
+    </SectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -4669,12 +4677,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1_non_cancer" dataset has no unex
       }
     }
   >
-    <AgeDistributionHeading>
-      Age Distribution 
+    <SectionHeading
+      id="age-distribution"
+      title="Age Distribution"
+    >
       <InfoButton
         topic="str-age-distribution"
       />
-    </AgeDistributionHeading>
+    </SectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -5644,12 +5654,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1_non_neuro" dataset has no unexe
       }
     }
   >
-    <AgeDistributionHeading>
-      Age Distribution 
+    <SectionHeading
+      id="age-distribution"
+      title="Age Distribution"
+    >
       <InfoButton
         topic="str-age-distribution"
       />
-    </AgeDistributionHeading>
+    </SectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -6619,12 +6631,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r2_1_non_topmed" dataset has no unex
       }
     }
   >
-    <AgeDistributionHeading>
-      Age Distribution 
+    <SectionHeading
+      id="age-distribution"
+      title="Age Distribution"
+    >
       <InfoButton
         topic="str-age-distribution"
       />
-    </AgeDistributionHeading>
+    </SectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -7594,12 +7608,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r3" dataset has no unexected changes
       }
     }
   >
-    <AgeDistributionHeading>
-      Age Distribution 
+    <SectionHeading
+      id="age-distribution"
+      title="Age Distribution"
+    >
       <InfoButton
         topic="str-age-distribution"
       />
-    </AgeDistributionHeading>
+    </SectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -8569,12 +8585,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_controls_and_biobanks" dataset ha
       }
     }
   >
-    <AgeDistributionHeading>
-      Age Distribution 
+    <SectionHeading
+      id="age-distribution"
+      title="Age Distribution"
+    >
       <InfoButton
         topic="str-age-distribution"
       />
-    </AgeDistributionHeading>
+    </SectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -9544,12 +9562,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_non_cancer" dataset has no unexec
       }
     }
   >
-    <AgeDistributionHeading>
-      Age Distribution 
+    <SectionHeading
+      id="age-distribution"
+      title="Age Distribution"
+    >
       <InfoButton
         topic="str-age-distribution"
       />
-    </AgeDistributionHeading>
+    </SectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -10519,12 +10539,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_non_neuro" dataset has no unexect
       }
     }
   >
-    <AgeDistributionHeading>
-      Age Distribution 
+    <SectionHeading
+      id="age-distribution"
+      title="Age Distribution"
+    >
       <InfoButton
         topic="str-age-distribution"
       />
-    </AgeDistributionHeading>
+    </SectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -11494,12 +11516,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_non_topmed" dataset has no unexec
       }
     }
   >
-    <AgeDistributionHeading>
-      Age Distribution 
+    <SectionHeading
+      id="age-distribution"
+      title="Age Distribution"
+    >
       <InfoButton
         topic="str-age-distribution"
       />
-    </AgeDistributionHeading>
+    </SectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -12469,12 +12493,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r3_non_v2" dataset has no unexected 
       }
     }
   >
-    <AgeDistributionHeading>
-      Age Distribution 
+    <SectionHeading
+      id="age-distribution"
+      title="Age Distribution"
+    >
       <InfoButton
         topic="str-age-distribution"
       />
-    </AgeDistributionHeading>
+    </SectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -13444,12 +13470,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r4" dataset has no unexected changes
       }
     }
   >
-    <AgeDistributionHeading>
-      Age Distribution 
+    <SectionHeading
+      id="age-distribution"
+      title="Age Distribution"
+    >
       <InfoButton
         topic="str-age-distribution"
       />
-    </AgeDistributionHeading>
+    </SectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -14419,12 +14447,14 @@ exports[`ShortTandemRepeatPage with "gnomad_r4_non_ukb" dataset has no unexected
       }
     }
   >
-    <AgeDistributionHeading>
-      Age Distribution 
+    <SectionHeading
+      id="age-distribution"
+      title="Age Distribution"
+    >
       <InfoButton
         topic="str-age-distribution"
       />
-    </AgeDistributionHeading>
+    </SectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -15394,12 +15424,14 @@ exports[`ShortTandemRepeatPage with "gnomad_sv_r2_1" dataset has no unexected ch
       }
     }
   >
-    <AgeDistributionHeading>
-      Age Distribution 
+    <SectionHeading
+      id="age-distribution"
+      title="Age Distribution"
+    >
       <InfoButton
         topic="str-age-distribution"
       />
-    </AgeDistributionHeading>
+    </SectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -16369,12 +16401,14 @@ exports[`ShortTandemRepeatPage with "gnomad_sv_r2_1_controls" dataset has no une
       }
     }
   >
-    <AgeDistributionHeading>
-      Age Distribution 
+    <SectionHeading
+      id="age-distribution"
+      title="Age Distribution"
+    >
       <InfoButton
         topic="str-age-distribution"
       />
-    </AgeDistributionHeading>
+    </SectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -17344,12 +17378,14 @@ exports[`ShortTandemRepeatPage with "gnomad_sv_r2_1_non_neuro" dataset has no un
       }
     }
   >
-    <AgeDistributionHeading>
-      Age Distribution 
+    <SectionHeading
+      id="age-distribution"
+      title="Age Distribution"
+    >
       <InfoButton
         topic="str-age-distribution"
       />
-    </AgeDistributionHeading>
+    </SectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [
@@ -18319,12 +18355,14 @@ exports[`ShortTandemRepeatPage with "gnomad_sv_r4" dataset has no unexected chan
       }
     }
   >
-    <AgeDistributionHeading>
-      Age Distribution 
+    <SectionHeading
+      id="age-distribution"
+      title="Age Distribution"
+    >
       <InfoButton
         topic="str-age-distribution"
       />
-    </AgeDistributionHeading>
+    </SectionHeading>
     <ShortTandemRepeatAgeDistributionPlot
       ageDistribution={
         [

--- a/browser/src/StatsPage/StatsPage.tsx
+++ b/browser/src/StatsPage/StatsPage.tsx
@@ -11,7 +11,8 @@ import SnvsPerBPAvg from '../../about/stats/snvs_per_bp_avg.png'
 
 import DocumentTitle from '../DocumentTitle'
 import Histogram from '../Histogram'
-import { SectionHeading } from '../help/HelpPage'
+import { SectionHeading } from '../AnchorLink'
+import useScrollToHash from '../useScrollToHash'
 import InfoPage from '../InfoPage'
 import Link from '../Link'
 
@@ -177,6 +178,7 @@ const barGraphTooltip = (row: any) => (
 )
 
 const StatsPage = () => {
+  useScrollToHash()
   return (
     <InfoPage>
       <DocumentTitle title="Stats" />
@@ -227,9 +229,11 @@ const StatsPage = () => {
         </StatsSection>
 
         <StatsSection>
-          <SectionHeading id="age-and-sex-distribution">
-            What is the age and sex distribution in gnomAD?
-          </SectionHeading>
+          <SectionHeading
+            id="age-and-sex-distribution"
+            title="What is the age and sex distribution in gnomAD?"
+            inlineLink
+          />
           <TwoColumnLayout>
             <ResponsiveGnomadSamplesContainer>
               <h3>Age</h3>
@@ -283,7 +287,7 @@ const StatsPage = () => {
         </StatsSection>
 
         <StatsSection>
-          <SectionHeading id="samples">Where do gnomAD samples come from?</SectionHeading>
+          <SectionHeading id="samples" title="Where do gnomAD samples come from?" inlineLink />
           <div style={{ width: '100%' }}>
             <TwoColumnLayout>
               <StatsHighlightBlock color={gnomadBlue} title="308" text="Data Contributors" />
@@ -315,7 +319,7 @@ const StatsPage = () => {
         </StatsSection>
 
         <StatsSection>
-          <SectionHeading id="diversity">Diversity in gnomAD</SectionHeading>
+          <SectionHeading id="diversity" title="Diversity in gnomAD" inlineLink />
 
           <h3 style={{ marginBottom: '2em' }}>Genetic ancestry groups in gnomAD by version</h3>
 
@@ -392,9 +396,11 @@ const StatsPage = () => {
         </StatsSection>
 
         <StatsSection>
-          <SectionHeading id="study-provided-labels">
-            Study-provided labels and genetic ancestry groups
-          </SectionHeading>
+          <SectionHeading
+            id="study-provided-labels"
+            title="Study-provided labels and genetic ancestry groups"
+            inlineLink
+          />
 
           <p>
             The following table is provided in order to present how our inferred genetic ancestry
@@ -415,7 +421,7 @@ const StatsPage = () => {
         </StatsSection>
 
         <StatsSection>
-          <SectionHeading id="study-diseases">Study Diseases in gnomAD</SectionHeading>
+          <SectionHeading id="study-diseases" title="Study Diseases in gnomAD" inlineLink />
 
           <p style={{ marginBottom: '2em' }}>
             During the sample aggregation phase of v4 we began collecting study-disease of interest
@@ -432,7 +438,7 @@ const StatsPage = () => {
         </StatsSection>
 
         <StatsSection>
-          <SectionHeading id="browser">gnomAD Browser Stats</SectionHeading>
+          <SectionHeading id="browser" title="gnomAD Browser Stats" inlineLink />
           <p>{`The gnomAD browser averages ~200,000 page views per week and had >377,000 unique users in the last year`}</p>
           <TwoColumnLayout>
             <ResponsiveHalfWidthColumn>

--- a/browser/src/StatsPage/StatsPage.tsx
+++ b/browser/src/StatsPage/StatsPage.tsx
@@ -180,7 +180,7 @@ const barGraphTooltip = (row: any) => (
 const StatsPage = () => {
   useScrollToHash()
   return (
-    <InfoPage>
+    <InfoPage $withSectionLinks>
       <DocumentTitle title="Stats" />
       {/* @ts-expect-error */}
       <PageHeading id="gnomad-stats">What&apos;s in gnomAD</PageHeading>
@@ -232,7 +232,7 @@ const StatsPage = () => {
           <SectionHeading
             id="age-and-sex-distribution"
             title="What is the age and sex distribution in gnomAD?"
-            inlineLink
+            linkInGutter
           />
           <TwoColumnLayout>
             <ResponsiveGnomadSamplesContainer>
@@ -287,7 +287,7 @@ const StatsPage = () => {
         </StatsSection>
 
         <StatsSection>
-          <SectionHeading id="samples" title="Where do gnomAD samples come from?" inlineLink />
+          <SectionHeading id="samples" title="Where do gnomAD samples come from?" linkInGutter />
           <div style={{ width: '100%' }}>
             <TwoColumnLayout>
               <StatsHighlightBlock color={gnomadBlue} title="308" text="Data Contributors" />
@@ -319,7 +319,7 @@ const StatsPage = () => {
         </StatsSection>
 
         <StatsSection>
-          <SectionHeading id="diversity" title="Diversity in gnomAD" inlineLink />
+          <SectionHeading id="diversity" title="Diversity in gnomAD" linkInGutter />
 
           <h3 style={{ marginBottom: '2em' }}>Genetic ancestry groups in gnomAD by version</h3>
 
@@ -399,7 +399,7 @@ const StatsPage = () => {
           <SectionHeading
             id="study-provided-labels"
             title="Study-provided labels and genetic ancestry groups"
-            inlineLink
+            linkInGutter
           />
 
           <p>
@@ -421,7 +421,7 @@ const StatsPage = () => {
         </StatsSection>
 
         <StatsSection>
-          <SectionHeading id="study-diseases" title="Study Diseases in gnomAD" inlineLink />
+          <SectionHeading id="study-diseases" title="Study Diseases in gnomAD" linkInGutter />
 
           <p style={{ marginBottom: '2em' }}>
             During the sample aggregation phase of v4 we began collecting study-disease of interest
@@ -438,7 +438,7 @@ const StatsPage = () => {
         </StatsSection>
 
         <StatsSection>
-          <SectionHeading id="browser" title="gnomAD Browser Stats" inlineLink />
+          <SectionHeading id="browser" title="gnomAD Browser Stats" linkInGutter />
           <p>{`The gnomAD browser averages ~200,000 page views per week and had >377,000 unique users in the last year`}</p>
           <TwoColumnLayout>
             <ResponsiveHalfWidthColumn>

--- a/browser/src/StatsPage/__snapshots__/StatsPage.spec.tsx.snap
+++ b/browser/src/StatsPage/__snapshots__/StatsPage.spec.tsx.snap
@@ -56,37 +56,37 @@ exports[`Stats Page has no unexpected changes 1`] = `
   fill: rgba(0,0,0,0.05);
 }
 
-.c25 {
-  position: absolute;
-  transform: translate(-15px,calc(50% - 0.5em));
-  display: flex;
-  align-items: center;
-  width: 15px;
-  height: 1em;
-  visibility: hidden;
-  vertical-align: middle;
-}
-
-.c23 {
+.c24 {
   position: relative;
 }
 
-.c23 :hover .c24 {
-  visibility: visible;
+.c25 {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  transform: translate(-29px,-50%);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  width: 44px;
+  height: 44px;
+  opacity: 0;
+  vertical-align: middle;
 }
 
-.c20 {
-  display: flex;
-  flex-wrap: wrap;
-  flex-direction: row;
-  padding: 0;
-  margin: 0 1em 0 0;
-  list-style-type: none;
+.c25 :hover,
+.c25 :focus,
+.c25 :focus-visible,
+.c23:hover .c25,
+.c23:focus-within .c25 {
+  opacity: 1;
 }
 
-.c21 {
-  display: flex;
-  margin: 0 1em 0.33em 0;
+.c25 :focus,
+.c25 :focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: -8px;
 }
 
 .c1 {
@@ -117,6 +117,20 @@ exports[`Stats Page has no unexpected changes 1`] = `
 
 .c6 li {
   margin-bottom: 0.5em;
+}
+
+.c20 {
+  display: flex;
+  flex-wrap: wrap;
+  flex-direction: row;
+  padding: 0;
+  margin: 0 1em 0 0;
+  list-style-type: none;
+}
+
+.c21 {
+  display: flex;
+  margin: 0 1em 0.33em 0;
 }
 
 .c13 {
@@ -346,6 +360,20 @@ exports[`Stats Page has no unexpected changes 1`] = `
     padding-bottom: 0.5em;
     border-bottom: 1px solid #ccc;
     margin-bottom: 0.5em;
+  }
+}
+
+@media (hover:none) {
+  .c25 {
+    opacity: 1;
+  }
+}
+
+@media (max-width:1230px) {
+  .c25 {
+    position: static;
+    transform: none;
+    display: inline-flex;
   }
 }
 
@@ -1566,29 +1594,33 @@ exports[`Stats Page has no unexpected changes 1`] = `
     <div
       className="c4"
     >
-      <span
-        className="c23"
+      <h2
+        className="c23 c24"
+        id="age-and-sex-distribution"
       >
-        <h2
-          className=""
+        <a
+          aria-label="Copy link to What is the age and sex distribution in gnomAD?"
+          className="c25"
+          href="#age-and-sex-distribution"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c24 c25"
-            href="#age-and-sex-distribution"
-            id="age-and-sex-distribution"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          What is the age and sex distribution in gnomAD?
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        What is the age and sex distribution in gnomAD?
+      </h2>
       <div
         className="c5"
       >
@@ -4146,29 +4178,33 @@ exports[`Stats Page has no unexpected changes 1`] = `
     <div
       className="c4"
     >
-      <span
-        className="c23"
+      <h2
+        className="c23 c24"
+        id="samples"
       >
-        <h2
-          className=""
+        <a
+          aria-label="Copy link to Where do gnomAD samples come from?"
+          className="c25"
+          href="#samples"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c24 c25"
-            href="#samples"
-            id="samples"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Where do gnomAD samples come from?
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Where do gnomAD samples come from?
+      </h2>
       <div
         style={
           {
@@ -4244,29 +4280,33 @@ exports[`Stats Page has no unexpected changes 1`] = `
     <div
       className="c4"
     >
-      <span
-        className="c23"
+      <h2
+        className="c23 c24"
+        id="diversity"
       >
-        <h2
-          className=""
+        <a
+          aria-label="Copy link to Diversity in gnomAD"
+          className="c25"
+          href="#diversity"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c24 c25"
-            href="#diversity"
-            id="diversity"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Diversity in gnomAD
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Diversity in gnomAD
+      </h2>
       <h3
         style={
           {
@@ -8327,29 +8367,33 @@ exports[`Stats Page has no unexpected changes 1`] = `
     <div
       className="c4"
     >
-      <span
-        className="c23"
+      <h2
+        className="c23 c24"
+        id="study-provided-labels"
       >
-        <h2
-          className=""
+        <a
+          aria-label="Copy link to Study-provided labels and genetic ancestry groups"
+          className="c25"
+          href="#study-provided-labels"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c24 c25"
-            href="#study-provided-labels"
-            id="study-provided-labels"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Study-provided labels and genetic ancestry groups
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Study-provided labels and genetic ancestry groups
+      </h2>
       <p>
         The following table is provided in order to present how our inferred genetic ancestry groups correspond to descriptors provided by each contributing
         <a
@@ -8787,29 +8831,33 @@ exports[`Stats Page has no unexpected changes 1`] = `
     <div
       className="c4"
     >
-      <span
-        className="c23"
+      <h2
+        className="c23 c24"
+        id="study-diseases"
       >
-        <h2
-          className=""
+        <a
+          aria-label="Copy link to Study Diseases in gnomAD"
+          className="c25"
+          href="#study-diseases"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c24 c25"
-            href="#study-diseases"
-            id="study-diseases"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Study Diseases in gnomAD
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Study Diseases in gnomAD
+      </h2>
       <p
         style={
           {
@@ -9168,29 +9216,33 @@ exports[`Stats Page has no unexpected changes 1`] = `
     <div
       className="c4"
     >
-      <span
-        className="c23"
+      <h2
+        className="c23 c24"
+        id="browser"
       >
-        <h2
-          className=""
+        <a
+          aria-label="Copy link to gnomAD Browser Stats"
+          className="c25"
+          href="#browser"
+          onClick={[Function]}
+          style={
+            {
+              "display": "inline-flex",
+              "position": "static",
+              "transform": "none",
+            }
+          }
         >
-          <a
+          <img
+            alt=""
             aria-hidden="true"
-            className="c24 c25"
-            href="#browser"
-            id="browser"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          gnomAD Browser Stats
-        </h2>
-      </span>
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        gnomAD Browser Stats
+      </h2>
       <p>
         The gnomAD browser averages ~200,000 page views per week and had &gt;377,000 unique users in the last year
       </p>

--- a/browser/src/StatsPage/__snapshots__/StatsPage.spec.tsx.snap
+++ b/browser/src/StatsPage/__snapshots__/StatsPage.spec.tsx.snap
@@ -90,6 +90,7 @@ exports[`Stats Page has no unexpected changes 1`] = `
 }
 
 .c1 {
+  padding-left: 44px;
   font-size: 16px;
 }
 
@@ -1597,6 +1598,11 @@ exports[`Stats Page has no unexpected changes 1`] = `
       <h2
         className="c23 c24"
         id="age-and-sex-distribution"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to What is the age and sex distribution in gnomAD?"
@@ -1605,9 +1611,9 @@ exports[`Stats Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -4181,6 +4187,11 @@ exports[`Stats Page has no unexpected changes 1`] = `
       <h2
         className="c23 c24"
         id="samples"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to Where do gnomAD samples come from?"
@@ -4189,9 +4200,9 @@ exports[`Stats Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -4283,6 +4294,11 @@ exports[`Stats Page has no unexpected changes 1`] = `
       <h2
         className="c23 c24"
         id="diversity"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to Diversity in gnomAD"
@@ -4291,9 +4307,9 @@ exports[`Stats Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -8370,6 +8386,11 @@ exports[`Stats Page has no unexpected changes 1`] = `
       <h2
         className="c23 c24"
         id="study-provided-labels"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to Study-provided labels and genetic ancestry groups"
@@ -8378,9 +8399,9 @@ exports[`Stats Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -8834,6 +8855,11 @@ exports[`Stats Page has no unexpected changes 1`] = `
       <h2
         className="c23 c24"
         id="study-diseases"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to Study Diseases in gnomAD"
@@ -8842,9 +8868,9 @@ exports[`Stats Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >
@@ -9219,6 +9245,11 @@ exports[`Stats Page has no unexpected changes 1`] = `
       <h2
         className="c23 c24"
         id="browser"
+        style={
+          {
+            "padding": "8px 0",
+          }
+        }
       >
         <a
           aria-label="Copy link to gnomAD Browser Stats"
@@ -9227,9 +9258,9 @@ exports[`Stats Page has no unexpected changes 1`] = `
           onClick={[Function]}
           style={
             {
-              "display": "inline-flex",
-              "position": "static",
-              "transform": "none",
+              "display": "flex",
+              "position": "absolute",
+              "transform": "translate(-100%, -50%)",
             }
           }
         >

--- a/browser/src/StructuralVariantPage/StructuralVariantPage.tsx
+++ b/browser/src/StructuralVariantPage/StructuralVariantPage.tsx
@@ -17,7 +17,7 @@ import StructuralVariantConsequenceList from './StructuralVariantConsequenceList
 import StructuralVariantGenotypeQualityMetrics from './StructuralVariantGenotypeQualityMetrics'
 import StructuralVariantPopulationsTable from './StructuralVariantPopulationsTable'
 import SVReferenceList from './SVReferenceList'
-import { AgeDistributionHeading } from '../AnchorLink'
+import { SectionHeading } from '../AnchorLink'
 import useScrollToHash from '../useScrollToHash'
 
 const Wrapper = styled.div`
@@ -163,9 +163,9 @@ const StructuralVariantPage = ({ datasetId, variant }: StructuralVariantPageProp
         </ResponsiveSection>
 
         <ResponsiveSection>
-          <AgeDistributionHeading>
-            Age Distribution <InfoButton topic="age" />
-          </AgeDistributionHeading>
+          <SectionHeading id="age-distribution" title="Age Distribution">
+            <InfoButton topic="age" />
+          </SectionHeading>
           {variant.age_distribution ? (
             <React.Fragment>
               {datasetId !== 'gnomad_sv_r2_1' && (

--- a/browser/src/StructuralVariantPage/__snapshots__/StructuralVariantPage.spec.tsx.snap
+++ b/browser/src/StructuralVariantPage/__snapshots__/StructuralVariantPage.spec.tsx.snap
@@ -570,56 +570,55 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with a complex varian
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <p>
         Age data is not available for this variant.
       </p>
@@ -1197,56 +1196,55 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with interchromosomal
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <p>
         Age data is not available for this variant.
       </p>
@@ -1824,56 +1822,55 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with interchromosomal
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <p>
         Age data is not available for this variant.
       </p>
@@ -2434,56 +2431,55 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <p>
         Age data is not available for this variant.
       </p>
@@ -3044,56 +3040,55 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <p>
         Age data is not available for this variant.
       </p>
@@ -3652,56 +3647,55 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <p>
         Age data is not available for this variant.
       </p>
@@ -4262,56 +4256,55 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <p>
         Age data is not available for this variant.
       </p>
@@ -5439,56 +5432,55 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1 with non-interchromos
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <p>
         Age data is not available for this variant.
       </p>
@@ -6067,56 +6059,55 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with a compl
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <p>
         Age data is not available for this variant.
       </p>
@@ -6694,56 +6685,55 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with interch
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <p>
         Age data is not available for this variant.
       </p>
@@ -7321,56 +7311,55 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with interch
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <p>
         Age data is not available for this variant.
       </p>
@@ -7931,56 +7920,55 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <p>
         Age data is not available for this variant.
       </p>
@@ -8541,56 +8529,55 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <p>
         Age data is not available for this variant.
       </p>
@@ -9149,56 +9136,55 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <p>
         Age data is not available for this variant.
       </p>
@@ -9759,56 +9745,55 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <p>
         Age data is not available for this variant.
       </p>
@@ -10936,56 +10921,55 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_controls with non-int
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <p>
         Age data is not available for this variant.
       </p>
@@ -11564,56 +11548,55 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with a comp
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <p>
         Age data is not available for this variant.
       </p>
@@ -12191,56 +12174,55 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with interc
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <p>
         Age data is not available for this variant.
       </p>
@@ -12818,56 +12800,55 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with interc
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <p>
         Age data is not available for this variant.
       </p>
@@ -13428,56 +13409,55 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <p>
         Age data is not available for this variant.
       </p>
@@ -14038,56 +14018,55 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <p>
         Age data is not available for this variant.
       </p>
@@ -14646,56 +14625,55 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <p>
         Age data is not available for this variant.
       </p>
@@ -15256,56 +15234,55 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <p>
         Age data is not available for this variant.
       </p>
@@ -16433,56 +16410,55 @@ exports[`StructuralVariantPage with dataset gnomad_sv_r2_1_non_neuro with non-in
     <section
       className="StructuralVariantPage__ResponsiveSection-sc-61jf9a-1 cevMXi"
     >
-      <span
-        className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="age-distribution"
       >
-        <h2>
-          <a
-            aria-label="Copy link to Age Distribution"
-            className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-            href="#age-distribution"
-            id="age-distribution"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              height={12}
-              src="test-file-stub"
-              width={12}
-            />
-          </a>
-          Age Distribution 
-          <button
-            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-            onClick={[Function]}
-            type="button"
-          >
-            <img
-              alt=""
-              aria-hidden="true"
-              src="test-file-stub"
-            />
-            <span
-              style={
-                {
-                  "border": "0",
-                  "clip": "rect(0 0 0 0)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
+        <a
+          aria-label="Copy link to Age Distribution"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#age-distribution"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Age Distribution
+         
+        <button
+          className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+          onClick={[Function]}
+          type="button"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="test-file-stub"
+          />
+          <span
+            style={
+              {
+                "border": "0",
+                "clip": "rect(0 0 0 0)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
               }
-            >
-              More information
-            </span>
-          </button>
-        </h2>
-      </span>
+            }
+          >
+            More information
+          </span>
+        </button>
+      </h2>
       <p>
         Age data is not available for this variant.
       </p>

--- a/browser/src/VariantPage/VariantPage.spec.tsx
+++ b/browser/src/VariantPage/VariantPage.spec.tsx
@@ -4,8 +4,10 @@ import renderer from 'react-test-renderer'
 import { mockQueries } from '../../../tests/__helpers__/queries'
 import Query, { BaseQuery } from '../Query'
 import { forDatasetsMatching } from '../../../tests/__helpers__/datasets'
-import VariantPage from './VariantPage'
-import { v2VariantFactory, v3VariantFactory } from '../__factories__/Variant'
+import VariantPage, { Variant, VariantPageContent } from './VariantPage'
+import { v2VariantFactory, v3VariantFactory, sequencingFactory } from '../__factories__/Variant'
+import clinvarVariantFactory from '../__factories__/ClinvarVariant'
+import { DatasetId } from '@gnomad/dataset-metadata/metadata'
 import { BrowserRouter } from 'react-router-dom'
 
 jest.mock('../Query', () => {
@@ -98,5 +100,98 @@ describe('VariantPage with the dataset exac', () => {
       </BrowserRouter>
     )
     expect(tree).toMatchSnapshot()
+  })
+})
+
+const sectionTitles = {
+  'external-resources': 'External Resources',
+  feedback: 'Feedback',
+  'genetic-ancestry-group-frequencies': 'Genetic Ancestry Group Frequencies',
+  'related-variants': 'Related Variants',
+  'variant-effect-predictor': 'Ensembl Variant Effect Predictor',
+  'lof-curation': 'LoF Curation',
+  'in-silico-predictors': 'In Silico Predictors',
+  'genomic-constraint': 'Genomic Constraint of Surrounding 1kb Region',
+  clinvar: 'ClinVar',
+  'age-distribution': 'Age Distribution',
+  'genotype-quality-metrics': 'Genotype Quality Metrics',
+  'site-quality-metrics': 'Site Quality Metrics',
+  'read-data': 'Read Data',
+}
+
+const conditionalIds = [
+  'lof-curation',
+  'in-silico-predictors',
+  'genomic-constraint',
+  'clinvar',
+  'age-distribution',
+]
+
+const expectSections = (variant: Variant, datasetId: DatasetId, present: string[]) => {
+  setMockApiResponses({ ReadData: () => ({ variant_0: { exome: null, genome: [] } }) })
+  const tree = renderer.create(
+    <BrowserRouter>
+      <VariantPageContent datasetId={datasetId} variant={variant} />
+    </BrowserRouter>
+  )
+  const expectedIds = Object.keys(sectionTitles).filter(
+    (id) => !conditionalIds.includes(id) || present.includes(id)
+  )
+  const headings = tree.root.findAllByType('h2')
+  expect(headings.map(({ props }) => props.id)).toEqual(expectedIds)
+  headings.forEach((heading) => {
+    const title = sectionTitles[heading.props.id as keyof typeof sectionTitles]
+    expect(heading.children).toContain(title)
+    expect(heading.findByType('a').props).toMatchObject({
+      href: `#${heading.props.id}`,
+      'aria-label': `Copy link to ${title}`,
+    })
+  })
+  const ids = tree.root
+    .findAll((node) => typeof node.type === 'string' && !!node.props.id)
+    .map(({ props }) => props.id)
+  expect(new Set(ids).size).toBe(ids.length)
+  tree.unmount()
+}
+
+describe('short-variant section permalinks', () => {
+  test('v4 exposes all 13 stable, uniquely named targets, including empty LoF and missing constraint data', () => {
+    const variant = v3VariantFactory.build()
+    variant.lof_curations = []
+    variant.in_silico_predictors = [{ id: 'cadd', value: '10', flags: [] }]
+    variant.clinvar = clinvarVariantFactory.build()
+    expectSections(variant, 'gnomad_r4', conditionalIds)
+  })
+
+  test.each([null, []])('omits missing conditional sections with predictors %j', (predictors) => {
+    const variant = v3VariantFactory.build()
+    variant.genome = { ...variant.genome!, age_distribution: null }
+    variant.in_silico_predictors = predictors
+    expectSections(variant, 'gnomad_r2_1', [])
+  })
+
+  test.each(['exome', 'genome'] as const)(
+    'keeps the age target for %s age data alone',
+    (source) => {
+      const variant = v3VariantFactory.build()
+      variant.exome = null
+      variant.genome = null
+      variant[source] = sequencingFactory.build()
+      expectSections(variant, 'gnomad_r4', ['genomic-constraint', 'age-distribution'])
+    }
+  )
+
+  test('does not expose the age target for joint-only age data', () => {
+    const variant = v3VariantFactory.build()
+    variant.genome = { ...variant.genome!, age_distribution: null }
+    variant.joint = {
+      ...sequencingFactory.build(),
+      freq_comparison_stats: {
+        contingency_table_test: [],
+        cochran_mantel_haenszel_test: { chisq: 0, p_value: 1 },
+        stat_union: { p_value: 1, stat_test_name: '', gen_ancs: [] },
+      },
+    }
+    expectSections(variant, 'gnomad_r4', ['genomic-constraint'])
   })
 })

--- a/browser/src/VariantPage/VariantPage.tsx
+++ b/browser/src/VariantPage/VariantPage.tsx
@@ -48,7 +48,7 @@ import {
   FullLocalAncestryPopulationId,
 } from '@gnomad/dataset-metadata/gnomadPopulations'
 import { Filter } from '../QCFilter'
-import { AgeDistributionHeading } from '../AnchorLink'
+import { SectionHeading } from '../AnchorLink'
 import useScrollToHash from '../useScrollToHash'
 
 const Section = styled.section`
@@ -366,38 +366,41 @@ export const VariantPageContent = ({ datasetId, variant }: VariantPageContentPro
         )}
       </ResponsiveSection>
       <ResponsiveSection>
-        <h2>External Resources</h2>
+        <SectionHeading id="external-resources" title="External Resources" />
         {/* @ts-expect-error TS(2739) FIXME: Type '{ variant_id: string; chrom: string; flags: ... Remove this comment to see the full error message */}
         <ReferenceList variant={variant} />
-        <h2>Feedback</h2>
+        <SectionHeading id="feedback" title="Feedback" />
         <ExternalLink href={variantFeedbackUrl(variant, datasetId)}>
           Report an issue with this variant
         </ExternalLink>
       </ResponsiveSection>
 
       <Section>
-        <h2>
-          Genetic Ancestry Group Frequencies <InfoButton topic="ancestry" />
-        </h2>
+        <SectionHeading
+          id="genetic-ancestry-group-frequencies"
+          title="Genetic Ancestry Group Frequencies"
+        >
+          <InfoButton topic="ancestry" />
+        </SectionHeading>
         <VariantPopulationFrequencies datasetId={datasetId} variant={variant} />
       </Section>
 
       <Section>
-        <h2>Related Variants</h2>
+        <SectionHeading id="related-variants" title="Related Variants" />
         <VariantRelatedVariants datasetId={datasetId} variant={variant} />
       </Section>
 
       <Section>
-        <h2>Ensembl Variant Effect Predictor</h2>
+        <SectionHeading id="variant-effect-predictor" title="Ensembl Variant Effect Predictor" />
         {/* @ts-expect-error TS(2741) FIXME: Property 'reference_genome' is missing in type '{ ... Remove this comment to see the full error message */}
         <VariantTranscriptConsequences variant={variant} />
       </Section>
 
       {variant.lof_curations && (
         <Section>
-          <h2>
-            LoF Curation <InfoButton topic="lof-curation" />
-          </h2>
+          <SectionHeading id="lof-curation" title="LoF Curation">
+            <InfoButton topic="lof-curation" />
+          </SectionHeading>
           {/* @ts-expect-error TS(2322) FIXME: Type '{ variant_id: string; chrom: string; flags: ... Remove this comment to see the full error message */}
           <VariantLoFCurationResults variant={variant} />
         </Section>
@@ -406,13 +409,16 @@ export const VariantPageContent = ({ datasetId, variant }: VariantPageContentPro
       <FlexWrapper>
         {variant.in_silico_predictors && variant.in_silico_predictors.length && (
           <ResponsiveSection>
-            <h2>In Silico Predictors</h2>
+            <SectionHeading id="in-silico-predictors" title="In Silico Predictors" />
             <VariantInSilicoPredictors variant={variant} datasetId={datasetId} />
           </ResponsiveSection>
         )}
         {hasNonCodingConstraints(datasetId) && (
           <ResponsiveSection>
-            <h2>Genomic Constraint of Surrounding 1kb Region</h2>
+            <SectionHeading
+              id="genomic-constraint"
+              title="Genomic Constraint of Surrounding 1kb Region"
+            />
             <GnomadNonCodingConstraintTableVariant
               variantId={variant.variant_id}
               chrom={variant.chrom}
@@ -424,7 +430,7 @@ export const VariantPageContent = ({ datasetId, variant }: VariantPageContentPro
 
       {variant.clinvar && (
         <Section>
-          <h2>ClinVar</h2>
+          <SectionHeading id="clinvar" title="ClinVar" />
           <VariantClinvarInfo clinvar={variant.clinvar} />
         </Section>
       )}
@@ -433,9 +439,9 @@ export const VariantPageContent = ({ datasetId, variant }: VariantPageContentPro
         <ResponsiveSection>
           {((variant.exome || {}).age_distribution || (variant.genome || {}).age_distribution) && (
             <React.Fragment>
-              <AgeDistributionHeading>
-                Age Distribution <InfoButton topic="age" />
-              </AgeDistributionHeading>
+              <SectionHeading id="age-distribution" title="Age Distribution">
+                <InfoButton topic="age" />
+              </SectionHeading>
               {isV3Subset(datasetId) && (
                 <p>
                   Age distribution is based on the full gnomAD dataset, not the selected subset.
@@ -448,15 +454,15 @@ export const VariantPageContent = ({ datasetId, variant }: VariantPageContentPro
       </FlexWrapper>
 
       <ResponsiveSection>
-        <h2>Genotype Quality Metrics</h2>
+        <SectionHeading id="genotype-quality-metrics" title="Genotype Quality Metrics" />
         <VariantGenotypeQualityMetrics datasetId={datasetId} variant={variant} />
       </ResponsiveSection>
       <ResponsiveSection>
-        <h2>Site Quality Metrics</h2>
+        <SectionHeading id="site-quality-metrics" title="Site Quality Metrics" />
         <VariantSiteQualityMetrics datasetId={datasetId} variant={variant} />
       </ResponsiveSection>
       <Section>
-        <h2>Read Data</h2>
+        <SectionHeading id="read-data" title="Read Data" />
         <ReadData datasetId={datasetId} variantIds={[variant.variant_id]} />
       </Section>
     </FlexWrapper>

--- a/browser/src/VariantPage/__snapshots__/VariantPage.spec.tsx.snap
+++ b/browser/src/VariantPage/__snapshots__/VariantPage.spec.tsx.snap
@@ -643,7 +643,24 @@ exports[`VariantPage with the dataset "gnomad_r3" has no unexpected changes 1`] 
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="external-resources"
+      >
+        <a
+          aria-label="Copy link to External Resources"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#external-resources"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         External Resources
       </h2>
       <ul
@@ -674,7 +691,24 @@ exports[`VariantPage with the dataset "gnomad_r3" has no unexpected changes 1`] 
           </a>
         </li>
       </ul>
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="feedback"
+      >
+        <a
+          aria-label="Copy link to Feedback"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#feedback"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Feedback
       </h2>
       <a
@@ -689,8 +723,26 @@ exports[`VariantPage with the dataset "gnomad_r3" has no unexpected changes 1`] 
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
-        Genetic Ancestry Group Frequencies 
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="genetic-ancestry-group-frequencies"
+      >
+        <a
+          aria-label="Copy link to Genetic Ancestry Group Frequencies"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#genetic-ancestry-group-frequencies"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Genetic Ancestry Group Frequencies
+         
         <button
           className="InfoButton__Button-sc-13t5e82-0 faZoWY"
           onClick={[Function]}
@@ -1438,7 +1490,24 @@ exports[`VariantPage with the dataset "gnomad_r3" has no unexpected changes 1`] 
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="related-variants"
+      >
+        <a
+          aria-label="Copy link to Related Variants"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#related-variants"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Related Variants
       </h2>
       <div
@@ -1465,7 +1534,24 @@ exports[`VariantPage with the dataset "gnomad_r3" has no unexpected changes 1`] 
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="variant-effect-predictor"
+      >
+        <a
+          aria-label="Copy link to Ensembl Variant Effect Predictor"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#variant-effect-predictor"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Ensembl Variant Effect Predictor
       </h2>
       <div>
@@ -1617,7 +1703,24 @@ exports[`VariantPage with the dataset "gnomad_r3" has no unexpected changes 1`] 
       <section
         className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
       >
-        <h2>
+        <h2
+          className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+          id="genomic-constraint"
+        >
+          <a
+            aria-label="Copy link to Genomic Constraint of Surrounding 1kb Region"
+            className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+            href="#genomic-constraint"
+            onClick={[Function]}
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
           Genomic Constraint of Surrounding 1kb Region
         </h2>
         This variant does not have non coding constraint data for the surrounding region.
@@ -1629,56 +1732,55 @@ exports[`VariantPage with the dataset "gnomad_r3" has no unexpected changes 1`] 
       <section
         className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
       >
-        <span
-          className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+        <h2
+          className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+          id="age-distribution"
         >
-          <h2>
-            <a
-              aria-label="Copy link to Age Distribution"
-              className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-              href="#age-distribution"
-              id="age-distribution"
-              onClick={[Function]}
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                height={12}
-                src="test-file-stub"
-                width={12}
-              />
-            </a>
-            Age Distribution 
-            <button
-              className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-              onClick={[Function]}
-              type="button"
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                src="test-file-stub"
-              />
-              <span
-                style={
-                  {
-                    "border": "0",
-                    "clip": "rect(0 0 0 0)",
-                    "height": "1px",
-                    "margin": "-1px",
-                    "overflow": "hidden",
-                    "padding": "0",
-                    "position": "absolute",
-                    "whiteSpace": "nowrap",
-                    "width": "1px",
-                  }
+          <a
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+            href="#age-distribution"
+            onClick={[Function]}
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution
+           
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
                 }
-              >
-                More information
-              </span>
-            </button>
-          </h2>
-        </span>
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
         <div>
           <div
             className="GnomadAgeDistribution__LegendWrapper-sc-ty24oq-0 fPhNex"
@@ -3260,7 +3362,24 @@ exports[`VariantPage with the dataset "gnomad_r3" has no unexpected changes 1`] 
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="genotype-quality-metrics"
+      >
+        <a
+          aria-label="Copy link to Genotype Quality Metrics"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#genotype-quality-metrics"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Genotype Quality Metrics
       </h2>
       <div>
@@ -4803,7 +4922,24 @@ exports[`VariantPage with the dataset "gnomad_r3" has no unexpected changes 1`] 
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="site-quality-metrics"
+      >
+        <a
+          aria-label="Copy link to Site Quality Metrics"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#site-quality-metrics"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Site Quality Metrics
       </h2>
       <div
@@ -7364,7 +7500,24 @@ exports[`VariantPage with the dataset "gnomad_r3" has no unexpected changes 1`] 
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="read-data"
+      >
+        <a
+          aria-label="Copy link to Read Data"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#read-data"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Read Data
       </h2>
       <div
@@ -8073,7 +8226,24 @@ exports[`VariantPage with the dataset "gnomad_r3_controls_and_biobanks" has no u
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="external-resources"
+      >
+        <a
+          aria-label="Copy link to External Resources"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#external-resources"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         External Resources
       </h2>
       <ul
@@ -8104,7 +8274,24 @@ exports[`VariantPage with the dataset "gnomad_r3_controls_and_biobanks" has no u
           </a>
         </li>
       </ul>
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="feedback"
+      >
+        <a
+          aria-label="Copy link to Feedback"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#feedback"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Feedback
       </h2>
       <a
@@ -8119,8 +8306,26 @@ exports[`VariantPage with the dataset "gnomad_r3_controls_and_biobanks" has no u
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
-        Genetic Ancestry Group Frequencies 
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="genetic-ancestry-group-frequencies"
+      >
+        <a
+          aria-label="Copy link to Genetic Ancestry Group Frequencies"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#genetic-ancestry-group-frequencies"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Genetic Ancestry Group Frequencies
+         
         <button
           className="InfoButton__Button-sc-13t5e82-0 faZoWY"
           onClick={[Function]}
@@ -8868,7 +9073,24 @@ exports[`VariantPage with the dataset "gnomad_r3_controls_and_biobanks" has no u
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="related-variants"
+      >
+        <a
+          aria-label="Copy link to Related Variants"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#related-variants"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Related Variants
       </h2>
       <div
@@ -8895,7 +9117,24 @@ exports[`VariantPage with the dataset "gnomad_r3_controls_and_biobanks" has no u
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="variant-effect-predictor"
+      >
+        <a
+          aria-label="Copy link to Ensembl Variant Effect Predictor"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#variant-effect-predictor"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Ensembl Variant Effect Predictor
       </h2>
       <div>
@@ -9047,7 +9286,24 @@ exports[`VariantPage with the dataset "gnomad_r3_controls_and_biobanks" has no u
       <section
         className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
       >
-        <h2>
+        <h2
+          className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+          id="genomic-constraint"
+        >
+          <a
+            aria-label="Copy link to Genomic Constraint of Surrounding 1kb Region"
+            className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+            href="#genomic-constraint"
+            onClick={[Function]}
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
           Genomic Constraint of Surrounding 1kb Region
         </h2>
         This variant does not have non coding constraint data for the surrounding region.
@@ -9059,56 +9315,55 @@ exports[`VariantPage with the dataset "gnomad_r3_controls_and_biobanks" has no u
       <section
         className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
       >
-        <span
-          className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+        <h2
+          className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+          id="age-distribution"
         >
-          <h2>
-            <a
-              aria-label="Copy link to Age Distribution"
-              className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-              href="#age-distribution"
-              id="age-distribution"
-              onClick={[Function]}
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                height={12}
-                src="test-file-stub"
-                width={12}
-              />
-            </a>
-            Age Distribution 
-            <button
-              className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-              onClick={[Function]}
-              type="button"
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                src="test-file-stub"
-              />
-              <span
-                style={
-                  {
-                    "border": "0",
-                    "clip": "rect(0 0 0 0)",
-                    "height": "1px",
-                    "margin": "-1px",
-                    "overflow": "hidden",
-                    "padding": "0",
-                    "position": "absolute",
-                    "whiteSpace": "nowrap",
-                    "width": "1px",
-                  }
+          <a
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+            href="#age-distribution"
+            onClick={[Function]}
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution
+           
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
                 }
-              >
-                More information
-              </span>
-            </button>
-          </h2>
-        </span>
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
         <p>
           Age distribution is based on the full gnomAD dataset, not the selected subset.
         </p>
@@ -10693,7 +10948,24 @@ exports[`VariantPage with the dataset "gnomad_r3_controls_and_biobanks" has no u
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="genotype-quality-metrics"
+      >
+        <a
+          aria-label="Copy link to Genotype Quality Metrics"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#genotype-quality-metrics"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Genotype Quality Metrics
       </h2>
       <div>
@@ -12236,7 +12508,24 @@ exports[`VariantPage with the dataset "gnomad_r3_controls_and_biobanks" has no u
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="site-quality-metrics"
+      >
+        <a
+          aria-label="Copy link to Site Quality Metrics"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#site-quality-metrics"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Site Quality Metrics
       </h2>
       <div
@@ -14797,7 +15086,24 @@ exports[`VariantPage with the dataset "gnomad_r3_controls_and_biobanks" has no u
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="read-data"
+      >
+        <a
+          aria-label="Copy link to Read Data"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#read-data"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Read Data
       </h2>
       <div
@@ -15506,7 +15812,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_cancer" has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="external-resources"
+      >
+        <a
+          aria-label="Copy link to External Resources"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#external-resources"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         External Resources
       </h2>
       <ul
@@ -15537,7 +15860,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_cancer" has no unexpected c
           </a>
         </li>
       </ul>
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="feedback"
+      >
+        <a
+          aria-label="Copy link to Feedback"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#feedback"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Feedback
       </h2>
       <a
@@ -15552,8 +15892,26 @@ exports[`VariantPage with the dataset "gnomad_r3_non_cancer" has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
-        Genetic Ancestry Group Frequencies 
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="genetic-ancestry-group-frequencies"
+      >
+        <a
+          aria-label="Copy link to Genetic Ancestry Group Frequencies"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#genetic-ancestry-group-frequencies"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Genetic Ancestry Group Frequencies
+         
         <button
           className="InfoButton__Button-sc-13t5e82-0 faZoWY"
           onClick={[Function]}
@@ -16301,7 +16659,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_cancer" has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="related-variants"
+      >
+        <a
+          aria-label="Copy link to Related Variants"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#related-variants"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Related Variants
       </h2>
       <div
@@ -16328,7 +16703,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_cancer" has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="variant-effect-predictor"
+      >
+        <a
+          aria-label="Copy link to Ensembl Variant Effect Predictor"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#variant-effect-predictor"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Ensembl Variant Effect Predictor
       </h2>
       <div>
@@ -16480,7 +16872,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_cancer" has no unexpected c
       <section
         className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
       >
-        <h2>
+        <h2
+          className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+          id="genomic-constraint"
+        >
+          <a
+            aria-label="Copy link to Genomic Constraint of Surrounding 1kb Region"
+            className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+            href="#genomic-constraint"
+            onClick={[Function]}
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
           Genomic Constraint of Surrounding 1kb Region
         </h2>
         This variant does not have non coding constraint data for the surrounding region.
@@ -16492,56 +16901,55 @@ exports[`VariantPage with the dataset "gnomad_r3_non_cancer" has no unexpected c
       <section
         className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
       >
-        <span
-          className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+        <h2
+          className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+          id="age-distribution"
         >
-          <h2>
-            <a
-              aria-label="Copy link to Age Distribution"
-              className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-              href="#age-distribution"
-              id="age-distribution"
-              onClick={[Function]}
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                height={12}
-                src="test-file-stub"
-                width={12}
-              />
-            </a>
-            Age Distribution 
-            <button
-              className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-              onClick={[Function]}
-              type="button"
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                src="test-file-stub"
-              />
-              <span
-                style={
-                  {
-                    "border": "0",
-                    "clip": "rect(0 0 0 0)",
-                    "height": "1px",
-                    "margin": "-1px",
-                    "overflow": "hidden",
-                    "padding": "0",
-                    "position": "absolute",
-                    "whiteSpace": "nowrap",
-                    "width": "1px",
-                  }
+          <a
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+            href="#age-distribution"
+            onClick={[Function]}
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution
+           
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
                 }
-              >
-                More information
-              </span>
-            </button>
-          </h2>
-        </span>
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
         <p>
           Age distribution is based on the full gnomAD dataset, not the selected subset.
         </p>
@@ -18126,7 +18534,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_cancer" has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="genotype-quality-metrics"
+      >
+        <a
+          aria-label="Copy link to Genotype Quality Metrics"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#genotype-quality-metrics"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Genotype Quality Metrics
       </h2>
       <div>
@@ -19669,7 +20094,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_cancer" has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="site-quality-metrics"
+      >
+        <a
+          aria-label="Copy link to Site Quality Metrics"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#site-quality-metrics"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Site Quality Metrics
       </h2>
       <div
@@ -22230,7 +22672,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_cancer" has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="read-data"
+      >
+        <a
+          aria-label="Copy link to Read Data"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#read-data"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Read Data
       </h2>
       <div
@@ -22939,7 +23398,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_neuro" has no unexpected ch
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="external-resources"
+      >
+        <a
+          aria-label="Copy link to External Resources"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#external-resources"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         External Resources
       </h2>
       <ul
@@ -22970,7 +23446,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_neuro" has no unexpected ch
           </a>
         </li>
       </ul>
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="feedback"
+      >
+        <a
+          aria-label="Copy link to Feedback"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#feedback"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Feedback
       </h2>
       <a
@@ -22985,8 +23478,26 @@ exports[`VariantPage with the dataset "gnomad_r3_non_neuro" has no unexpected ch
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
-        Genetic Ancestry Group Frequencies 
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="genetic-ancestry-group-frequencies"
+      >
+        <a
+          aria-label="Copy link to Genetic Ancestry Group Frequencies"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#genetic-ancestry-group-frequencies"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Genetic Ancestry Group Frequencies
+         
         <button
           className="InfoButton__Button-sc-13t5e82-0 faZoWY"
           onClick={[Function]}
@@ -23734,7 +24245,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_neuro" has no unexpected ch
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="related-variants"
+      >
+        <a
+          aria-label="Copy link to Related Variants"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#related-variants"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Related Variants
       </h2>
       <div
@@ -23761,7 +24289,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_neuro" has no unexpected ch
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="variant-effect-predictor"
+      >
+        <a
+          aria-label="Copy link to Ensembl Variant Effect Predictor"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#variant-effect-predictor"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Ensembl Variant Effect Predictor
       </h2>
       <div>
@@ -23913,7 +24458,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_neuro" has no unexpected ch
       <section
         className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
       >
-        <h2>
+        <h2
+          className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+          id="genomic-constraint"
+        >
+          <a
+            aria-label="Copy link to Genomic Constraint of Surrounding 1kb Region"
+            className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+            href="#genomic-constraint"
+            onClick={[Function]}
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
           Genomic Constraint of Surrounding 1kb Region
         </h2>
         This variant does not have non coding constraint data for the surrounding region.
@@ -23925,56 +24487,55 @@ exports[`VariantPage with the dataset "gnomad_r3_non_neuro" has no unexpected ch
       <section
         className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
       >
-        <span
-          className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+        <h2
+          className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+          id="age-distribution"
         >
-          <h2>
-            <a
-              aria-label="Copy link to Age Distribution"
-              className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-              href="#age-distribution"
-              id="age-distribution"
-              onClick={[Function]}
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                height={12}
-                src="test-file-stub"
-                width={12}
-              />
-            </a>
-            Age Distribution 
-            <button
-              className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-              onClick={[Function]}
-              type="button"
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                src="test-file-stub"
-              />
-              <span
-                style={
-                  {
-                    "border": "0",
-                    "clip": "rect(0 0 0 0)",
-                    "height": "1px",
-                    "margin": "-1px",
-                    "overflow": "hidden",
-                    "padding": "0",
-                    "position": "absolute",
-                    "whiteSpace": "nowrap",
-                    "width": "1px",
-                  }
+          <a
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+            href="#age-distribution"
+            onClick={[Function]}
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution
+           
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
                 }
-              >
-                More information
-              </span>
-            </button>
-          </h2>
-        </span>
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
         <p>
           Age distribution is based on the full gnomAD dataset, not the selected subset.
         </p>
@@ -25559,7 +26120,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_neuro" has no unexpected ch
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="genotype-quality-metrics"
+      >
+        <a
+          aria-label="Copy link to Genotype Quality Metrics"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#genotype-quality-metrics"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Genotype Quality Metrics
       </h2>
       <div>
@@ -27102,7 +27680,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_neuro" has no unexpected ch
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="site-quality-metrics"
+      >
+        <a
+          aria-label="Copy link to Site Quality Metrics"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#site-quality-metrics"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Site Quality Metrics
       </h2>
       <div
@@ -29663,7 +30258,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_neuro" has no unexpected ch
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="read-data"
+      >
+        <a
+          aria-label="Copy link to Read Data"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#read-data"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Read Data
       </h2>
       <div
@@ -30372,7 +30984,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_topmed" has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="external-resources"
+      >
+        <a
+          aria-label="Copy link to External Resources"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#external-resources"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         External Resources
       </h2>
       <ul
@@ -30403,7 +31032,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_topmed" has no unexpected c
           </a>
         </li>
       </ul>
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="feedback"
+      >
+        <a
+          aria-label="Copy link to Feedback"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#feedback"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Feedback
       </h2>
       <a
@@ -30418,8 +31064,26 @@ exports[`VariantPage with the dataset "gnomad_r3_non_topmed" has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
-        Genetic Ancestry Group Frequencies 
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="genetic-ancestry-group-frequencies"
+      >
+        <a
+          aria-label="Copy link to Genetic Ancestry Group Frequencies"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#genetic-ancestry-group-frequencies"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Genetic Ancestry Group Frequencies
+         
         <button
           className="InfoButton__Button-sc-13t5e82-0 faZoWY"
           onClick={[Function]}
@@ -31167,7 +31831,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_topmed" has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="related-variants"
+      >
+        <a
+          aria-label="Copy link to Related Variants"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#related-variants"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Related Variants
       </h2>
       <div
@@ -31194,7 +31875,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_topmed" has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="variant-effect-predictor"
+      >
+        <a
+          aria-label="Copy link to Ensembl Variant Effect Predictor"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#variant-effect-predictor"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Ensembl Variant Effect Predictor
       </h2>
       <div>
@@ -31346,7 +32044,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_topmed" has no unexpected c
       <section
         className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
       >
-        <h2>
+        <h2
+          className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+          id="genomic-constraint"
+        >
+          <a
+            aria-label="Copy link to Genomic Constraint of Surrounding 1kb Region"
+            className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+            href="#genomic-constraint"
+            onClick={[Function]}
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
           Genomic Constraint of Surrounding 1kb Region
         </h2>
         This variant does not have non coding constraint data for the surrounding region.
@@ -31358,56 +32073,55 @@ exports[`VariantPage with the dataset "gnomad_r3_non_topmed" has no unexpected c
       <section
         className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
       >
-        <span
-          className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+        <h2
+          className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+          id="age-distribution"
         >
-          <h2>
-            <a
-              aria-label="Copy link to Age Distribution"
-              className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-              href="#age-distribution"
-              id="age-distribution"
-              onClick={[Function]}
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                height={12}
-                src="test-file-stub"
-                width={12}
-              />
-            </a>
-            Age Distribution 
-            <button
-              className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-              onClick={[Function]}
-              type="button"
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                src="test-file-stub"
-              />
-              <span
-                style={
-                  {
-                    "border": "0",
-                    "clip": "rect(0 0 0 0)",
-                    "height": "1px",
-                    "margin": "-1px",
-                    "overflow": "hidden",
-                    "padding": "0",
-                    "position": "absolute",
-                    "whiteSpace": "nowrap",
-                    "width": "1px",
-                  }
+          <a
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+            href="#age-distribution"
+            onClick={[Function]}
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution
+           
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
                 }
-              >
-                More information
-              </span>
-            </button>
-          </h2>
-        </span>
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
         <p>
           Age distribution is based on the full gnomAD dataset, not the selected subset.
         </p>
@@ -32992,7 +33706,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_topmed" has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="genotype-quality-metrics"
+      >
+        <a
+          aria-label="Copy link to Genotype Quality Metrics"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#genotype-quality-metrics"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Genotype Quality Metrics
       </h2>
       <div>
@@ -34535,7 +35266,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_topmed" has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="site-quality-metrics"
+      >
+        <a
+          aria-label="Copy link to Site Quality Metrics"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#site-quality-metrics"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Site Quality Metrics
       </h2>
       <div
@@ -37096,7 +37844,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_topmed" has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="read-data"
+      >
+        <a
+          aria-label="Copy link to Read Data"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#read-data"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Read Data
       </h2>
       <div
@@ -37805,7 +38570,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_v2" has no unexpected chang
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="external-resources"
+      >
+        <a
+          aria-label="Copy link to External Resources"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#external-resources"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         External Resources
       </h2>
       <ul
@@ -37836,7 +38618,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_v2" has no unexpected chang
           </a>
         </li>
       </ul>
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="feedback"
+      >
+        <a
+          aria-label="Copy link to Feedback"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#feedback"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Feedback
       </h2>
       <a
@@ -37851,8 +38650,26 @@ exports[`VariantPage with the dataset "gnomad_r3_non_v2" has no unexpected chang
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
-        Genetic Ancestry Group Frequencies 
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="genetic-ancestry-group-frequencies"
+      >
+        <a
+          aria-label="Copy link to Genetic Ancestry Group Frequencies"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#genetic-ancestry-group-frequencies"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Genetic Ancestry Group Frequencies
+         
         <button
           className="InfoButton__Button-sc-13t5e82-0 faZoWY"
           onClick={[Function]}
@@ -38600,7 +39417,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_v2" has no unexpected chang
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="related-variants"
+      >
+        <a
+          aria-label="Copy link to Related Variants"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#related-variants"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Related Variants
       </h2>
       <div
@@ -38627,7 +39461,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_v2" has no unexpected chang
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="variant-effect-predictor"
+      >
+        <a
+          aria-label="Copy link to Ensembl Variant Effect Predictor"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#variant-effect-predictor"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Ensembl Variant Effect Predictor
       </h2>
       <div>
@@ -38779,7 +39630,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_v2" has no unexpected chang
       <section
         className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
       >
-        <h2>
+        <h2
+          className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+          id="genomic-constraint"
+        >
+          <a
+            aria-label="Copy link to Genomic Constraint of Surrounding 1kb Region"
+            className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+            href="#genomic-constraint"
+            onClick={[Function]}
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
           Genomic Constraint of Surrounding 1kb Region
         </h2>
         This variant does not have non coding constraint data for the surrounding region.
@@ -38791,56 +39659,55 @@ exports[`VariantPage with the dataset "gnomad_r3_non_v2" has no unexpected chang
       <section
         className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
       >
-        <span
-          className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+        <h2
+          className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+          id="age-distribution"
         >
-          <h2>
-            <a
-              aria-label="Copy link to Age Distribution"
-              className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-              href="#age-distribution"
-              id="age-distribution"
-              onClick={[Function]}
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                height={12}
-                src="test-file-stub"
-                width={12}
-              />
-            </a>
-            Age Distribution 
-            <button
-              className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-              onClick={[Function]}
-              type="button"
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                src="test-file-stub"
-              />
-              <span
-                style={
-                  {
-                    "border": "0",
-                    "clip": "rect(0 0 0 0)",
-                    "height": "1px",
-                    "margin": "-1px",
-                    "overflow": "hidden",
-                    "padding": "0",
-                    "position": "absolute",
-                    "whiteSpace": "nowrap",
-                    "width": "1px",
-                  }
+          <a
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+            href="#age-distribution"
+            onClick={[Function]}
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution
+           
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
                 }
-              >
-                More information
-              </span>
-            </button>
-          </h2>
-        </span>
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
         <p>
           Age distribution is based on the full gnomAD dataset, not the selected subset.
         </p>
@@ -40425,7 +41292,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_v2" has no unexpected chang
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="genotype-quality-metrics"
+      >
+        <a
+          aria-label="Copy link to Genotype Quality Metrics"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#genotype-quality-metrics"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Genotype Quality Metrics
       </h2>
       <div>
@@ -41968,7 +42852,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_v2" has no unexpected chang
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="site-quality-metrics"
+      >
+        <a
+          aria-label="Copy link to Site Quality Metrics"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#site-quality-metrics"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Site Quality Metrics
       </h2>
       <div
@@ -44529,7 +45430,24 @@ exports[`VariantPage with the dataset "gnomad_r3_non_v2" has no unexpected chang
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="read-data"
+      >
+        <a
+          aria-label="Copy link to Read Data"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#read-data"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Read Data
       </h2>
       <div
@@ -45165,7 +46083,24 @@ exports[`VariantPage with the dataset exac has no unexpected changes 1`] = `
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="external-resources"
+      >
+        <a
+          aria-label="Copy link to External Resources"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#external-resources"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         External Resources
       </h2>
       <ul
@@ -45184,7 +46119,24 @@ exports[`VariantPage with the dataset exac has no unexpected changes 1`] = `
           </a>
         </li>
       </ul>
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="feedback"
+      >
+        <a
+          aria-label="Copy link to Feedback"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#feedback"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Feedback
       </h2>
       <a
@@ -45199,8 +46151,26 @@ exports[`VariantPage with the dataset exac has no unexpected changes 1`] = `
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
-        Genetic Ancestry Group Frequencies 
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="genetic-ancestry-group-frequencies"
+      >
+        <a
+          aria-label="Copy link to Genetic Ancestry Group Frequencies"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#genetic-ancestry-group-frequencies"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Genetic Ancestry Group Frequencies
+         
         <button
           className="InfoButton__Button-sc-13t5e82-0 faZoWY"
           onClick={[Function]}
@@ -45711,7 +46681,24 @@ exports[`VariantPage with the dataset exac has no unexpected changes 1`] = `
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="related-variants"
+      >
+        <a
+          aria-label="Copy link to Related Variants"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#related-variants"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Related Variants
       </h2>
       <div
@@ -45738,7 +46725,24 @@ exports[`VariantPage with the dataset exac has no unexpected changes 1`] = `
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="variant-effect-predictor"
+      >
+        <a
+          aria-label="Copy link to Ensembl Variant Effect Predictor"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#variant-effect-predictor"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Ensembl Variant Effect Predictor
       </h2>
       <div>
@@ -45893,56 +46897,55 @@ exports[`VariantPage with the dataset exac has no unexpected changes 1`] = `
       <section
         className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
       >
-        <span
-          className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+        <h2
+          className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+          id="age-distribution"
         >
-          <h2>
-            <a
-              aria-label="Copy link to Age Distribution"
-              className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-              href="#age-distribution"
-              id="age-distribution"
-              onClick={[Function]}
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                height={12}
-                src="test-file-stub"
-                width={12}
-              />
-            </a>
-            Age Distribution 
-            <button
-              className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-              onClick={[Function]}
-              type="button"
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                src="test-file-stub"
-              />
-              <span
-                style={
-                  {
-                    "border": "0",
-                    "clip": "rect(0 0 0 0)",
-                    "height": "1px",
-                    "margin": "-1px",
-                    "overflow": "hidden",
-                    "padding": "0",
-                    "position": "absolute",
-                    "whiteSpace": "nowrap",
-                    "width": "1px",
-                  }
+          <a
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+            href="#age-distribution"
+            onClick={[Function]}
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution
+           
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
                 }
-              >
-                More information
-              </span>
-            </button>
-          </h2>
-        </span>
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
         <div>
           <div
             className="GnomadAgeDistribution__LegendWrapper-sc-ty24oq-0 fPhNex"
@@ -46881,7 +47884,24 @@ exports[`VariantPage with the dataset exac has no unexpected changes 1`] = `
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="genotype-quality-metrics"
+      >
+        <a
+          aria-label="Copy link to Genotype Quality Metrics"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#genotype-quality-metrics"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Genotype Quality Metrics
       </h2>
       <div>
@@ -48405,7 +49425,24 @@ exports[`VariantPage with the dataset exac has no unexpected changes 1`] = `
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="site-quality-metrics"
+      >
+        <a
+          aria-label="Copy link to Site Quality Metrics"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#site-quality-metrics"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Site Quality Metrics
       </h2>
       <div
@@ -50749,7 +51786,24 @@ exports[`VariantPage with the dataset exac has no unexpected changes 1`] = `
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="read-data"
+      >
+        <a
+          aria-label="Copy link to Read Data"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#read-data"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Read Data
       </h2>
       <div
@@ -51521,7 +52575,24 @@ exports[`VariantPage with the dataset gnomad_r2_1 has no unexpected changes 1`] 
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="external-resources"
+      >
+        <a
+          aria-label="Copy link to External Resources"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#external-resources"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         External Resources
       </h2>
       <ul
@@ -51540,7 +52611,24 @@ exports[`VariantPage with the dataset gnomad_r2_1 has no unexpected changes 1`] 
           </a>
         </li>
       </ul>
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="feedback"
+      >
+        <a
+          aria-label="Copy link to Feedback"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#feedback"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Feedback
       </h2>
       <a
@@ -51555,8 +52643,26 @@ exports[`VariantPage with the dataset gnomad_r2_1 has no unexpected changes 1`] 
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
-        Genetic Ancestry Group Frequencies 
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="genetic-ancestry-group-frequencies"
+      >
+        <a
+          aria-label="Copy link to Genetic Ancestry Group Frequencies"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#genetic-ancestry-group-frequencies"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Genetic Ancestry Group Frequencies
+         
         <button
           className="InfoButton__Button-sc-13t5e82-0 faZoWY"
           onClick={[Function]}
@@ -52111,7 +53217,24 @@ exports[`VariantPage with the dataset gnomad_r2_1 has no unexpected changes 1`] 
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="related-variants"
+      >
+        <a
+          aria-label="Copy link to Related Variants"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#related-variants"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Related Variants
       </h2>
       <div
@@ -52138,7 +53261,24 @@ exports[`VariantPage with the dataset gnomad_r2_1 has no unexpected changes 1`] 
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="variant-effect-predictor"
+      >
+        <a
+          aria-label="Copy link to Ensembl Variant Effect Predictor"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#variant-effect-predictor"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Ensembl Variant Effect Predictor
       </h2>
       <div>
@@ -52293,56 +53433,55 @@ exports[`VariantPage with the dataset gnomad_r2_1 has no unexpected changes 1`] 
       <section
         className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
       >
-        <span
-          className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+        <h2
+          className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+          id="age-distribution"
         >
-          <h2>
-            <a
-              aria-label="Copy link to Age Distribution"
-              className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-              href="#age-distribution"
-              id="age-distribution"
-              onClick={[Function]}
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                height={12}
-                src="test-file-stub"
-                width={12}
-              />
-            </a>
-            Age Distribution 
-            <button
-              className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-              onClick={[Function]}
-              type="button"
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                src="test-file-stub"
-              />
-              <span
-                style={
-                  {
-                    "border": "0",
-                    "clip": "rect(0 0 0 0)",
-                    "height": "1px",
-                    "margin": "-1px",
-                    "overflow": "hidden",
-                    "padding": "0",
-                    "position": "absolute",
-                    "whiteSpace": "nowrap",
-                    "width": "1px",
-                  }
+          <a
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+            href="#age-distribution"
+            onClick={[Function]}
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution
+           
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
                 }
-              >
-                More information
-              </span>
-            </button>
-          </h2>
-        </span>
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
         <div>
           <div
             className="GnomadAgeDistribution__LegendWrapper-sc-ty24oq-0 fPhNex"
@@ -54053,7 +55192,24 @@ exports[`VariantPage with the dataset gnomad_r2_1 has no unexpected changes 1`] 
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="genotype-quality-metrics"
+      >
+        <a
+          aria-label="Copy link to Genotype Quality Metrics"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#genotype-quality-metrics"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Genotype Quality Metrics
       </h2>
       <div>
@@ -55599,7 +56755,24 @@ exports[`VariantPage with the dataset gnomad_r2_1 has no unexpected changes 1`] 
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="site-quality-metrics"
+      >
+        <a
+          aria-label="Copy link to Site Quality Metrics"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#site-quality-metrics"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Site Quality Metrics
       </h2>
       <div
@@ -58300,7 +59473,24 @@ exports[`VariantPage with the dataset gnomad_r2_1 has no unexpected changes 1`] 
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="read-data"
+      >
+        <a
+          aria-label="Copy link to Read Data"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#read-data"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Read Data
       </h2>
       <div
@@ -59072,7 +60262,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_controls has no unexpected cha
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="external-resources"
+      >
+        <a
+          aria-label="Copy link to External Resources"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#external-resources"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         External Resources
       </h2>
       <ul
@@ -59091,7 +60298,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_controls has no unexpected cha
           </a>
         </li>
       </ul>
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="feedback"
+      >
+        <a
+          aria-label="Copy link to Feedback"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#feedback"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Feedback
       </h2>
       <a
@@ -59106,8 +60330,26 @@ exports[`VariantPage with the dataset gnomad_r2_1_controls has no unexpected cha
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
-        Genetic Ancestry Group Frequencies 
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="genetic-ancestry-group-frequencies"
+      >
+        <a
+          aria-label="Copy link to Genetic Ancestry Group Frequencies"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#genetic-ancestry-group-frequencies"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Genetic Ancestry Group Frequencies
+         
         <button
           className="InfoButton__Button-sc-13t5e82-0 faZoWY"
           onClick={[Function]}
@@ -59662,7 +60904,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_controls has no unexpected cha
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="related-variants"
+      >
+        <a
+          aria-label="Copy link to Related Variants"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#related-variants"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Related Variants
       </h2>
       <div
@@ -59689,7 +60948,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_controls has no unexpected cha
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="variant-effect-predictor"
+      >
+        <a
+          aria-label="Copy link to Ensembl Variant Effect Predictor"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#variant-effect-predictor"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Ensembl Variant Effect Predictor
       </h2>
       <div>
@@ -59844,56 +61120,55 @@ exports[`VariantPage with the dataset gnomad_r2_1_controls has no unexpected cha
       <section
         className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
       >
-        <span
-          className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+        <h2
+          className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+          id="age-distribution"
         >
-          <h2>
-            <a
-              aria-label="Copy link to Age Distribution"
-              className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-              href="#age-distribution"
-              id="age-distribution"
-              onClick={[Function]}
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                height={12}
-                src="test-file-stub"
-                width={12}
-              />
-            </a>
-            Age Distribution 
-            <button
-              className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-              onClick={[Function]}
-              type="button"
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                src="test-file-stub"
-              />
-              <span
-                style={
-                  {
-                    "border": "0",
-                    "clip": "rect(0 0 0 0)",
-                    "height": "1px",
-                    "margin": "-1px",
-                    "overflow": "hidden",
-                    "padding": "0",
-                    "position": "absolute",
-                    "whiteSpace": "nowrap",
-                    "width": "1px",
-                  }
+          <a
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+            href="#age-distribution"
+            onClick={[Function]}
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution
+           
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
                 }
-              >
-                More information
-              </span>
-            </button>
-          </h2>
-        </span>
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
         <div>
           <div
             className="GnomadAgeDistribution__LegendWrapper-sc-ty24oq-0 fPhNex"
@@ -61604,7 +62879,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_controls has no unexpected cha
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="genotype-quality-metrics"
+      >
+        <a
+          aria-label="Copy link to Genotype Quality Metrics"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#genotype-quality-metrics"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Genotype Quality Metrics
       </h2>
       <div>
@@ -63150,7 +64442,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_controls has no unexpected cha
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="site-quality-metrics"
+      >
+        <a
+          aria-label="Copy link to Site Quality Metrics"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#site-quality-metrics"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Site Quality Metrics
       </h2>
       <div
@@ -65851,7 +67160,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_controls has no unexpected cha
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="read-data"
+      >
+        <a
+          aria-label="Copy link to Read Data"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#read-data"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Read Data
       </h2>
       <div
@@ -66623,7 +67949,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_cancer has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="external-resources"
+      >
+        <a
+          aria-label="Copy link to External Resources"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#external-resources"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         External Resources
       </h2>
       <ul
@@ -66642,7 +67985,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_cancer has no unexpected c
           </a>
         </li>
       </ul>
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="feedback"
+      >
+        <a
+          aria-label="Copy link to Feedback"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#feedback"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Feedback
       </h2>
       <a
@@ -66657,8 +68017,26 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_cancer has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
-        Genetic Ancestry Group Frequencies 
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="genetic-ancestry-group-frequencies"
+      >
+        <a
+          aria-label="Copy link to Genetic Ancestry Group Frequencies"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#genetic-ancestry-group-frequencies"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Genetic Ancestry Group Frequencies
+         
         <button
           className="InfoButton__Button-sc-13t5e82-0 faZoWY"
           onClick={[Function]}
@@ -67213,7 +68591,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_cancer has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="related-variants"
+      >
+        <a
+          aria-label="Copy link to Related Variants"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#related-variants"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Related Variants
       </h2>
       <div
@@ -67240,7 +68635,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_cancer has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="variant-effect-predictor"
+      >
+        <a
+          aria-label="Copy link to Ensembl Variant Effect Predictor"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#variant-effect-predictor"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Ensembl Variant Effect Predictor
       </h2>
       <div>
@@ -67395,56 +68807,55 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_cancer has no unexpected c
       <section
         className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
       >
-        <span
-          className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+        <h2
+          className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+          id="age-distribution"
         >
-          <h2>
-            <a
-              aria-label="Copy link to Age Distribution"
-              className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-              href="#age-distribution"
-              id="age-distribution"
-              onClick={[Function]}
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                height={12}
-                src="test-file-stub"
-                width={12}
-              />
-            </a>
-            Age Distribution 
-            <button
-              className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-              onClick={[Function]}
-              type="button"
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                src="test-file-stub"
-              />
-              <span
-                style={
-                  {
-                    "border": "0",
-                    "clip": "rect(0 0 0 0)",
-                    "height": "1px",
-                    "margin": "-1px",
-                    "overflow": "hidden",
-                    "padding": "0",
-                    "position": "absolute",
-                    "whiteSpace": "nowrap",
-                    "width": "1px",
-                  }
+          <a
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+            href="#age-distribution"
+            onClick={[Function]}
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution
+           
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
                 }
-              >
-                More information
-              </span>
-            </button>
-          </h2>
-        </span>
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
         <div>
           <div
             className="GnomadAgeDistribution__LegendWrapper-sc-ty24oq-0 fPhNex"
@@ -69155,7 +70566,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_cancer has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="genotype-quality-metrics"
+      >
+        <a
+          aria-label="Copy link to Genotype Quality Metrics"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#genotype-quality-metrics"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Genotype Quality Metrics
       </h2>
       <div>
@@ -70701,7 +72129,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_cancer has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="site-quality-metrics"
+      >
+        <a
+          aria-label="Copy link to Site Quality Metrics"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#site-quality-metrics"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Site Quality Metrics
       </h2>
       <div
@@ -73402,7 +74847,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_cancer has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="read-data"
+      >
+        <a
+          aria-label="Copy link to Read Data"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#read-data"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Read Data
       </h2>
       <div
@@ -74174,7 +75636,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_neuro has no unexpected ch
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="external-resources"
+      >
+        <a
+          aria-label="Copy link to External Resources"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#external-resources"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         External Resources
       </h2>
       <ul
@@ -74193,7 +75672,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_neuro has no unexpected ch
           </a>
         </li>
       </ul>
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="feedback"
+      >
+        <a
+          aria-label="Copy link to Feedback"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#feedback"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Feedback
       </h2>
       <a
@@ -74208,8 +75704,26 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_neuro has no unexpected ch
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
-        Genetic Ancestry Group Frequencies 
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="genetic-ancestry-group-frequencies"
+      >
+        <a
+          aria-label="Copy link to Genetic Ancestry Group Frequencies"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#genetic-ancestry-group-frequencies"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Genetic Ancestry Group Frequencies
+         
         <button
           className="InfoButton__Button-sc-13t5e82-0 faZoWY"
           onClick={[Function]}
@@ -74764,7 +76278,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_neuro has no unexpected ch
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="related-variants"
+      >
+        <a
+          aria-label="Copy link to Related Variants"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#related-variants"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Related Variants
       </h2>
       <div
@@ -74791,7 +76322,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_neuro has no unexpected ch
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="variant-effect-predictor"
+      >
+        <a
+          aria-label="Copy link to Ensembl Variant Effect Predictor"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#variant-effect-predictor"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Ensembl Variant Effect Predictor
       </h2>
       <div>
@@ -74946,56 +76494,55 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_neuro has no unexpected ch
       <section
         className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
       >
-        <span
-          className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+        <h2
+          className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+          id="age-distribution"
         >
-          <h2>
-            <a
-              aria-label="Copy link to Age Distribution"
-              className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-              href="#age-distribution"
-              id="age-distribution"
-              onClick={[Function]}
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                height={12}
-                src="test-file-stub"
-                width={12}
-              />
-            </a>
-            Age Distribution 
-            <button
-              className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-              onClick={[Function]}
-              type="button"
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                src="test-file-stub"
-              />
-              <span
-                style={
-                  {
-                    "border": "0",
-                    "clip": "rect(0 0 0 0)",
-                    "height": "1px",
-                    "margin": "-1px",
-                    "overflow": "hidden",
-                    "padding": "0",
-                    "position": "absolute",
-                    "whiteSpace": "nowrap",
-                    "width": "1px",
-                  }
+          <a
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+            href="#age-distribution"
+            onClick={[Function]}
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution
+           
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
                 }
-              >
-                More information
-              </span>
-            </button>
-          </h2>
-        </span>
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
         <div>
           <div
             className="GnomadAgeDistribution__LegendWrapper-sc-ty24oq-0 fPhNex"
@@ -76706,7 +78253,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_neuro has no unexpected ch
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="genotype-quality-metrics"
+      >
+        <a
+          aria-label="Copy link to Genotype Quality Metrics"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#genotype-quality-metrics"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Genotype Quality Metrics
       </h2>
       <div>
@@ -78252,7 +79816,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_neuro has no unexpected ch
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="site-quality-metrics"
+      >
+        <a
+          aria-label="Copy link to Site Quality Metrics"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#site-quality-metrics"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Site Quality Metrics
       </h2>
       <div
@@ -80953,7 +82534,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_neuro has no unexpected ch
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="read-data"
+      >
+        <a
+          aria-label="Copy link to Read Data"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#read-data"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Read Data
       </h2>
       <div
@@ -81725,7 +83323,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_topmed has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="external-resources"
+      >
+        <a
+          aria-label="Copy link to External Resources"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#external-resources"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         External Resources
       </h2>
       <ul
@@ -81744,7 +83359,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_topmed has no unexpected c
           </a>
         </li>
       </ul>
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="feedback"
+      >
+        <a
+          aria-label="Copy link to Feedback"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#feedback"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Feedback
       </h2>
       <a
@@ -81759,8 +83391,26 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_topmed has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
-        Genetic Ancestry Group Frequencies 
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="genetic-ancestry-group-frequencies"
+      >
+        <a
+          aria-label="Copy link to Genetic Ancestry Group Frequencies"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#genetic-ancestry-group-frequencies"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
+        Genetic Ancestry Group Frequencies
+         
         <button
           className="InfoButton__Button-sc-13t5e82-0 faZoWY"
           onClick={[Function]}
@@ -82315,7 +83965,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_topmed has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="related-variants"
+      >
+        <a
+          aria-label="Copy link to Related Variants"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#related-variants"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Related Variants
       </h2>
       <div
@@ -82342,7 +84009,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_topmed has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="variant-effect-predictor"
+      >
+        <a
+          aria-label="Copy link to Ensembl Variant Effect Predictor"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#variant-effect-predictor"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Ensembl Variant Effect Predictor
       </h2>
       <div>
@@ -82497,56 +84181,55 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_topmed has no unexpected c
       <section
         className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
       >
-        <span
-          className="AnchorLink__AnchorWrapper-sc-77ly3x-1 hREWuM"
+        <h2
+          className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+          id="age-distribution"
         >
-          <h2>
-            <a
-              aria-label="Copy link to Age Distribution"
-              className="AnchorLink__AgeDistributionLink-sc-77ly3x-2 bdmffh"
-              href="#age-distribution"
-              id="age-distribution"
-              onClick={[Function]}
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                height={12}
-                src="test-file-stub"
-                width={12}
-              />
-            </a>
-            Age Distribution 
-            <button
-              className="InfoButton__Button-sc-13t5e82-0 faZoWY"
-              onClick={[Function]}
-              type="button"
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                src="test-file-stub"
-              />
-              <span
-                style={
-                  {
-                    "border": "0",
-                    "clip": "rect(0 0 0 0)",
-                    "height": "1px",
-                    "margin": "-1px",
-                    "overflow": "hidden",
-                    "padding": "0",
-                    "position": "absolute",
-                    "whiteSpace": "nowrap",
-                    "width": "1px",
-                  }
+          <a
+            aria-label="Copy link to Age Distribution"
+            className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+            href="#age-distribution"
+            onClick={[Function]}
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Age Distribution
+           
+          <button
+            className="InfoButton__Button-sc-13t5e82-0 faZoWY"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="test-file-stub"
+            />
+            <span
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
                 }
-              >
-                More information
-              </span>
-            </button>
-          </h2>
-        </span>
+              }
+            >
+              More information
+            </span>
+          </button>
+        </h2>
         <div>
           <div
             className="GnomadAgeDistribution__LegendWrapper-sc-ty24oq-0 fPhNex"
@@ -84257,7 +85940,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_topmed has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="genotype-quality-metrics"
+      >
+        <a
+          aria-label="Copy link to Genotype Quality Metrics"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#genotype-quality-metrics"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Genotype Quality Metrics
       </h2>
       <div>
@@ -85803,7 +87503,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_topmed has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 VariantPage__ResponsiveSection-sc-hd87ur-1 kSTBwv hwrSDs"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="site-quality-metrics"
+      >
+        <a
+          aria-label="Copy link to Site Quality Metrics"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#site-quality-metrics"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Site Quality Metrics
       </h2>
       <div
@@ -88504,7 +90221,24 @@ exports[`VariantPage with the dataset gnomad_r2_1_non_topmed has no unexpected c
     <section
       className="VariantPage__Section-sc-hd87ur-0 kSTBwv"
     >
-      <h2>
+      <h2
+        className="AnchorLink__Heading-sc-77ly3x-2 yDsgU"
+        id="read-data"
+      >
+        <a
+          aria-label="Copy link to Read Data"
+          className="AnchorLink__SectionLink-sc-77ly3x-3 cUsKlo"
+          href="#read-data"
+          onClick={[Function]}
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            height={12}
+            src="test-file-stub"
+            width={12}
+          />
+        </a>
         Read Data
       </h2>
       <div

--- a/browser/src/help/HelpPage.tsx
+++ b/browser/src/help/HelpPage.tsx
@@ -72,7 +72,7 @@ const HelpContentWrapper = styled.div`
   overflow: auto;
   box-sizing: border-box;
   width: 100%;
-  padding: 0 15px;
+  padding: 0 15px 0 44px;
 `
 
 const HelpContent = styled.div`
@@ -194,7 +194,7 @@ const HelpPage = () => {
             <SectionHeading
               id="frequently-asked-questions"
               title="Frequently asked questions"
-              inlineLink
+              linkInGutter
             />
             {helpPageTableOfContents.faq.map((section: FaqTopic) => (
               <div key={section.heading}>

--- a/browser/src/help/HelpPage.tsx
+++ b/browser/src/help/HelpPage.tsx
@@ -8,15 +8,15 @@ import { Button, Link as BaseLink, List, ListItem, PageHeading, Searchbox } from
 
 import helpPageTableOfContents, { FaqTopic } from '../../help/helpPageTableOfContents'
 
-import { withAnchor } from '../AnchorLink'
+import { SectionHeading, withAnchor } from '../AnchorLink'
 import DocumentTitle from '../DocumentTitle'
 import Link from '../Link'
+import useScrollToHash from '../useScrollToHash'
 
 import helpTopics, { indexTexts } from './helpTopics' // eslint-disable-line import/no-unresolved,import/extensions
 import slugify from './slugify'
 
-export const SectionHeading = withAnchor(styled.h2``)
-export const SectionSubheading = withAnchor(styled.h3`
+const SectionSubheading = withAnchor(styled.h3`
   margin-bottom: 0.5em;
 `)
 
@@ -118,6 +118,7 @@ const ToggleButton = styled(Button)`
 `
 
 const HelpPage = () => {
+  useScrollToHash()
   const history = useHistory()
 
   return (
@@ -190,9 +191,11 @@ const HelpPage = () => {
           </section>
 
           <section>
-            <SectionHeading id="frequently-asked-questions">
-              Frequently asked questions
-            </SectionHeading>
+            <SectionHeading
+              id="frequently-asked-questions"
+              title="Frequently asked questions"
+              inlineLink
+            />
             {helpPageTableOfContents.faq.map((section: FaqTopic) => (
               <div key={section.heading}>
                 <SectionSubheading id={slugify(section.heading)}>

--- a/browser/src/help/__snapshots__/HelpPage.spec.tsx.snap
+++ b/browser/src/help/__snapshots__/HelpPage.spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Help Page has no unexpected changes 1`] = `
-.c15 {
+.c18 {
   box-sizing: border-box;
   height: calc(2em + 2px);
   padding: 0.375em 0.75em;
@@ -17,21 +17,21 @@ exports[`Help Page has no unexpected changes 1`] = `
   user-select: none;
 }
 
-.c15:active,
-.c15:hover {
+.c18:active,
+.c18:hover {
   background-color: #cbd3da;
 }
 
-.c15:disabled {
+.c18:disabled {
   background-color: rgba(248,249,250,0.5);
   cursor: not-allowed;
 }
 
-.c15:focus {
+.c18:focus {
   box-shadow: 0 0 0 0.2em rgba(108,117,125,0.5);
 }
 
-.c15 svg {
+.c18 svg {
   position: relative;
   top: 0.11em;
   width: 0.9em;
@@ -105,7 +105,7 @@ exports[`Help Page has no unexpected changes 1`] = `
   background-image: none;
 }
 
-.c28 {
+.c31 {
   height: calc(2em + 2px);
   padding: 0.375em 1.5em 0.375em 0.75em;
   border: 1px solid #6c757d;
@@ -118,42 +118,42 @@ exports[`Help Page has no unexpected changes 1`] = `
   line-height: 1.25;
 }
 
-.c28:focus {
+.c31:focus {
   outline: none;
   border-color: rgb(70,130,180);
   box-shadow: 0 0 0 0.2em rgba(70,130,180,0.5);
 }
 
-.c21 {
+.c24 {
   border-collapse: collapse;
   border-spacing: 0;
 }
 
-.c21 td,
-.c21 th {
+.c24 td,
+.c24 th {
   padding: 0.5em 10px 0.5em 0;
   text-align: left;
 }
 
-.c21 thead td,
-.c21 thead th {
+.c24 thead td,
+.c24 thead th {
   border-bottom: 1px solid #000;
   background-position: center right;
   background-repeat: no-repeat;
 }
 
-.c21 thead td[aria-sort='ascending'],
-.c21 thead th[aria-sort='ascending'] {
+.c24 thead td[aria-sort='ascending'],
+.c24 thead th[aria-sort='ascending'] {
   background-image: url('data:image/gif;base64,R0lGODlhFQAEAIAAACMtMP///yH5BAEAAAEALAAAAAAVAAQAAAINjI8Bya2wnINUMopZAQA7');
 }
 
-.c21 thead td[aria-sort='descending'],
-.c21 thead th[aria-sort='descending'] {
+.c24 thead td[aria-sort='descending'],
+.c24 thead th[aria-sort='descending'] {
   background-image: url('data:image/gif;base64,R0lGODlhFQAEAIAAACMtMP///yH5BAEAAAEALAAAAAAVAAQAAAINjB+gC+jP2ptn0WskLQA7');
 }
 
-.c21 thead td button,
-.c21 thead th button {
+.c24 thead td button,
+.c24 thead th button {
   padding: 0;
   border: none;
   background: none;
@@ -164,19 +164,19 @@ exports[`Help Page has no unexpected changes 1`] = `
   user-select: none;
 }
 
-.c21 tbody td,
-.c21 tbody th {
+.c24 tbody td,
+.c24 tbody th {
   border-bottom: 1px solid #ccc;
   font-weight: normal;
 }
 
-.c21 tfoot td,
-.c21 tfoot th {
+.c24 tfoot td,
+.c24 tfoot th {
   border-top: 1px solid #ccc;
   font-weight: bold;
 }
 
-.c13 {
+.c17 {
   position: absolute;
   transform: translate(-15px,calc(50% - 0.5em));
   display: flex;
@@ -187,21 +187,66 @@ exports[`Help Page has no unexpected changes 1`] = `
   vertical-align: middle;
 }
 
-.c11 {
+.c14 {
   position: relative;
 }
 
-.c11 :hover .c12 {
+.c14 :hover .c16 {
   visibility: visible;
 }
 
-.c20 {
+.c12 {
+  position: relative;
+}
+
+.c13 {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  transform: translate(-29px,-50%);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  width: 44px;
+  height: 44px;
+  opacity: 0;
+  vertical-align: middle;
+}
+
+.c13 :hover,
+.c13 :focus,
+.c13 :focus-visible,
+.c11:hover .c13,
+.c11:focus-within .c13 {
+  opacity: 1;
+}
+
+.c13 :focus,
+.c13 :focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: -8px;
+}
+
+.c23 {
   overflow-x: auto;
   overflow-y: hidden;
 }
 
-.c30 {
+.c33 {
   margin-top: 1em;
+  margin-bottom: 1em;
+}
+
+.c33 td {
+  text-align: right;
+}
+
+.c32 {
+  margin: 1em 1em 0 0;
+}
+
+.c30 {
   margin-bottom: 1em;
 }
 
@@ -209,115 +254,103 @@ exports[`Help Page has no unexpected changes 1`] = `
   text-align: right;
 }
 
-.c29 {
-  margin: 1em 1em 0 0;
-}
-
-.c27 {
-  margin-bottom: 1em;
-}
-
-.c27 td {
+.c25 td {
   text-align: right;
 }
 
-.c22 td {
-  text-align: right;
-}
-
-.c22 tbody tr:last-child th,
-.c22 tbody tr:last-child td {
+.c25 tbody tr:last-child th,
+.c25 tbody tr:last-child td {
   border-bottom-color: #000;
 }
 
-.c25 {
+.c28 {
   overflow: hidden;
   width: 100%;
   height: 100%;
   margin-bottom: 1em;
 }
 
-.c26 {
+.c29 {
   pointer-events: visible;
   fill: none;
 }
 
-.c26:hover {
+.c29:hover {
   fill: rgba(0,0,0,0.05);
 }
 
-.c23 {
+.c26 {
   display: flex;
   flex-direction: row;
 }
 
-.c24 {
+.c27 {
   width: calc(50% - 15px);
 }
 
-.c19 {
+.c22 {
   font-size: 16px;
 }
 
-.c19 h1,
-.c19 h2,
-.c19 h3 {
+.c22 h1,
+.c22 h2,
+.c22 h3 {
   font-weight: bold;
 }
 
-.c19 h1 {
+.c22 h1 {
   font-size: 2em;
 }
 
-.c19 h2 {
+.c22 h2 {
   font-size: 1.5em;
 }
 
-.c19 p {
+.c22 p {
   margin-top: 15px;
   margin-bottom: 15px;
   line-height: 1.4;
 }
 
-.c19 a {
+.c22 a {
   color: #428bca;
   text-decoration: none;
 }
 
-.c19 img {
+.c22 img {
   max-width: 100%;
 }
 
-.c19 blockquote {
+.c22 blockquote {
   margin: 0 0 0 10px;
   font-size: 14px;
   font-style: italic;
   line-height: 1.4;
 }
 
-.c19 ol,
-.c19 ul {
+.c22 ol,
+.c22 ul {
   padding-left: 20px;
   margin: 1em 0;
 }
 
-.c19 li {
+.c22 li {
   margin-bottom: 0.5em;
 }
 
-.c19 table {
+.c22 table {
   border-collapse: collapse;
   border-spacing: 0;
 }
 
-.c19 td {
+.c22 td {
   padding: 0.5em 10px 0.5em 0;
   border-bottom: 1px solid #ccc;
   font-weight: normal;
   text-align: left;
 }
 
-.c19 th {
+.c22 th {
   padding: 0.5em 10px 0.5em 0;
   border-bottom: 1px solid #000;
   background-position: center right;
@@ -325,7 +358,7 @@ exports[`Help Page has no unexpected changes 1`] = `
   font-weight: bold;
 }
 
-.c14 {
+.c15 {
   margin-bottom: 0.5em;
 }
 
@@ -375,32 +408,32 @@ exports[`Help Page has no unexpected changes 1`] = `
   line-height: 1.4;
 }
 
-.c17 {
+.c20 {
   padding-left: 0;
   list-style-type: none;
   margin-bottom: 1em;
 }
 
-.c17 summary {
+.c20 summary {
   padding: 0.25em;
   cursor: pointer;
 }
 
-.c17 summary h4 {
+.c20 summary h4 {
   display: inline;
   font-weight: normal;
 }
 
-.c17 details[open] summary h4 {
+.c20 details[open] summary h4 {
   font-weight: bold;
 }
 
-.c18 {
+.c21 {
   padding-left: 10px;
   border-left: 1px solid #999;
 }
 
-.c16 {
+.c19 {
   font-size: 12px;
 }
 
@@ -423,14 +456,28 @@ exports[`Help Page has no unexpected changes 1`] = `
   }
 }
 
+@media (hover:none) {
+  .c13 {
+    opacity: 1;
+  }
+}
+
+@media (max-width:1230px) {
+  .c13 {
+    position: static;
+    transform: none;
+    display: inline-flex;
+  }
+}
+
 @media (max-width:700px) {
-  .c23 {
+  .c26 {
     flex-direction: column;
   }
 }
 
 @media (max-width:700px) {
-  .c24 {
+  .c27 {
     width: 100%;
   }
 }
@@ -975,39 +1022,43 @@ exports[`Help Page has no unexpected changes 1`] = `
         </ul>
       </section>
       <section>
-        <span
-          className="c11"
+        <h2
+          className="c11 c12"
+          id="frequently-asked-questions"
         >
-          <h2
-            className=""
+          <a
+            aria-label="Copy link to Frequently asked questions"
+            className="c13"
+            href="#frequently-asked-questions"
+            onClick={[Function]}
+            style={
+              {
+                "display": "inline-flex",
+                "position": "static",
+                "transform": "none",
+              }
+            }
           >
-            <a
+            <img
+              alt=""
               aria-hidden="true"
-              className="c12 c13"
-              href="#frequently-asked-questions"
-              id="frequently-asked-questions"
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                height={12}
-                src="test-file-stub"
-                width={12}
-              />
-            </a>
-            Frequently asked questions
-          </h2>
-        </span>
+              height={12}
+              src="test-file-stub"
+              width={12}
+            />
+          </a>
+          Frequently asked questions
+        </h2>
         <div>
           <span
-            className="c11"
+            className="c14"
           >
             <h3
-              className="c14"
+              className="c15"
             >
               <a
                 aria-hidden="true"
-                className="c12 c13"
+                className="c16 c17"
                 href="#general"
                 id="general"
               >
@@ -1025,7 +1076,7 @@ exports[`Help Page has no unexpected changes 1`] = `
           <button
             backgroundColor="#f8f9fa"
             borderColor="#6c757d"
-            className="c15 c16"
+            className="c18 c19"
             onClick={[Function]}
             type="button"
           >
@@ -1035,14 +1086,14 @@ exports[`Help Page has no unexpected changes 1`] = `
           <button
             backgroundColor="#f8f9fa"
             borderColor="#6c757d"
-            className="c15 c16"
+            className="c18 c19"
             onClick={[Function]}
             type="button"
           >
             Hide all answers in this section
           </button>
           <ul
-            className="c17"
+            className="c20"
           >
             <li>
               <details>
@@ -1052,10 +1103,10 @@ exports[`Help Page has no unexpected changes 1`] = `
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1081,10 +1132,10 @@ The gnomAD v2.1 data set contained data from 125,748 exomes and 15,708 whole gen
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1120,10 +1171,10 @@ Below is a list of all features not included in the v4 MVP and where to find the
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1151,10 +1202,10 @@ Yes, we have a few different videos that cover how gnomAD is created as well as 
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1178,10 +1229,10 @@ Please see our terms of use and other policies on our [policy page](/policies).
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1205,10 +1256,10 @@ The gnomAD resource does not currently have permission, access, or staffing to i
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1232,10 +1283,10 @@ question: 'Can I get access to individual-level genotype data from gnomAD?'
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1267,10 +1318,10 @@ All investigators who contribute data to gnomAD join the gnomAD Consortium. See 
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1298,10 +1349,10 @@ Likely because of differences between the projects in sample inclusion and varia
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1332,10 +1383,10 @@ More details on our QC process can be found in our blog posts:
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1359,10 +1410,10 @@ With 730,947 exomes and 76,215 genomes, the gnomAD v4.1 call set is the largest 
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1386,10 +1437,10 @@ Short read sequencing can produce mapping issues when a gene has a highly homolo
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1418,10 +1469,10 @@ question: 'How do you pronounce gnomAD?'
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1441,14 +1492,14 @@ Our policy is to release allele counts (AC) as they are observed in the database
         </div>
         <div>
           <span
-            className="c11"
+            className="c14"
           >
             <h3
-              className="c14"
+              className="c15"
             >
               <a
                 aria-hidden="true"
-                className="c12 c13"
+                className="c16 c17"
                 href="#constraint"
                 id="constraint"
               >
@@ -1466,7 +1517,7 @@ Our policy is to release allele counts (AC) as they are observed in the database
           <button
             backgroundColor="#f8f9fa"
             borderColor="#6c757d"
-            className="c15 c16"
+            className="c18 c19"
             onClick={[Function]}
             type="button"
           >
@@ -1476,14 +1527,14 @@ Our policy is to release allele counts (AC) as they are observed in the database
           <button
             backgroundColor="#f8f9fa"
             borderColor="#6c757d"
-            className="c15 c16"
+            className="c18 c19"
             onClick={[Function]}
             type="button"
           >
             Hide all answers in this section
           </button>
           <ul
-            className="c17"
+            className="c20"
           >
             <li>
               <details>
@@ -1493,10 +1544,10 @@ Our policy is to release allele counts (AC) as they are observed in the database
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1520,10 +1571,10 @@ We used a mutational model that accounts for local sequence context, CpG methyla
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1547,10 +1598,10 @@ Please review our [gene constraint](/help/constraint#methods) help text to learn
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1574,10 +1625,10 @@ We only included single nucleotide variants that were found in the MANE Select (
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1601,10 +1652,10 @@ Nonsense, splice acceptor, and splice donor variants caused by single nucleotide
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1640,10 +1691,10 @@ In addition, there are 19 MANE select transcripts that are missing constraint sc
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1669,10 +1720,10 @@ LOEUF stands for the "loss-of-function observed/expected upper bound fraction." 
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1696,10 +1747,10 @@ LOEUF is pronounced like its French-inspired name "l'œuf". Another accepted pro
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1719,14 +1770,14 @@ Descriptions of the fields in these files can be found in the [README file](/dow
         </div>
         <div>
           <span
-            className="c11"
+            className="c14"
           >
             <h3
-              className="c14"
+              className="c15"
             >
               <a
                 aria-hidden="true"
-                className="c12 c13"
+                className="c16 c17"
                 href="#technical-details"
                 id="technical-details"
               >
@@ -1744,7 +1795,7 @@ Descriptions of the fields in these files can be found in the [README file](/dow
           <button
             backgroundColor="#f8f9fa"
             borderColor="#6c757d"
-            className="c15 c16"
+            className="c18 c19"
             onClick={[Function]}
             type="button"
           >
@@ -1754,14 +1805,14 @@ Descriptions of the fields in these files can be found in the [README file](/dow
           <button
             backgroundColor="#f8f9fa"
             borderColor="#6c757d"
-            className="c15 c16"
+            className="c18 c19"
             onClick={[Function]}
             type="button"
           >
             Hide all answers in this section
           </button>
           <ul
-            className="c17"
+            className="c20"
           >
             <li>
               <details>
@@ -1771,10 +1822,10 @@ Descriptions of the fields in these files can be found in the [README file](/dow
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1798,10 +1849,10 @@ gnomAD v4 and v3 are based on GRCh38, and gnomAD v2 and ExAC files are based on 
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1825,10 +1876,10 @@ We use VEP to annotate variants on GENCODE transcripts. For details on the versi
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1852,10 +1903,10 @@ The majority of samples from the 1000 Genomes Project for which exome sequencing
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1879,10 +1930,10 @@ No. We were not given permission from NHLBI to include individuals from several 
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1907,10 +1958,10 @@ All of the "cancer" samples in ExAC and v2 are blood ("germline") samples from T
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -1934,7 +1985,7 @@ See [ancestry documentation](/help/ancestry) and [blog post](https://gnomad.broa
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div>
                     <div>
@@ -1974,10 +2025,10 @@ See [ancestry documentation](/help/ancestry) and [blog post](https://gnomad.broa
                           gnomAD v3
                         </h4>
                         <div
-                          className="c20"
+                          className="c23"
                         >
                           <table
-                            className="c21 c22"
+                            className="c24 c25"
                           >
                             <thead>
                               <tr>
@@ -2356,10 +2407,10 @@ See [ancestry documentation](/help/ancestry) and [blog post](https://gnomad.broa
                           gnomAD v2
                         </h4>
                         <div
-                          className="c20"
+                          className="c23"
                         >
                           <table
-                            className="c21 c22"
+                            className="c24 c25"
                           >
                             <thead>
                               <tr>
@@ -2922,10 +2973,10 @@ See [ancestry documentation](/help/ancestry) and [blog post](https://gnomad.broa
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -2949,10 +3000,10 @@ Individuals were classified as "remaining individuals" if they did not unambiguo
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -3017,22 +3068,22 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <p>
                     For gnomAD v4, the age distribution is:
                   </p>
                   <div
-                    className="c23"
+                    className="c26"
                   >
                     <div
-                      className="c24"
+                      className="c27"
                     >
                       <p>
                         Exomes
                       </p>
                       <div
-                        className="c25"
+                        className="c28"
                       >
                         <svg
                           height={250}
@@ -4122,7 +4173,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                               y={170.2124439358423}
                             />
                             <rect
-                              className="c26"
+                              className="c29"
                               height={180}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
@@ -4139,7 +4190,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                               y={174.45670831872127}
                             />
                             <rect
-                              className="c26"
+                              className="c29"
                               height={180}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
@@ -4156,7 +4207,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                               y={173.67762417172705}
                             />
                             <rect
-                              className="c26"
+                              className="c29"
                               height={180}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
@@ -4173,7 +4224,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                               y={102.9653555805755}
                             />
                             <rect
-                              className="c26"
+                              className="c29"
                               height={180}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
@@ -4190,7 +4241,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                               y={78.89846619538936}
                             />
                             <rect
-                              className="c26"
+                              className="c29"
                               height={180}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
@@ -4207,7 +4258,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                               y={62.019417117333276}
                             />
                             <rect
-                              className="c26"
+                              className="c29"
                               height={180}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
@@ -4224,7 +4275,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                               y={42.07718857860057}
                             />
                             <rect
-                              className="c26"
+                              className="c29"
                               height={180}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
@@ -4241,7 +4292,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                               y={0}
                             />
                             <rect
-                              className="c26"
+                              className="c29"
                               height={180}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
@@ -4258,7 +4309,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                               y={41.57717934993262}
                             />
                             <rect
-                              className="c26"
+                              className="c29"
                               height={180}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
@@ -4275,7 +4326,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                               y={169.54797984458924}
                             />
                             <rect
-                              className="c26"
+                              className="c29"
                               height={180}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
@@ -4292,7 +4343,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                               y={175.32549511803467}
                             />
                             <rect
-                              className="c26"
+                              className="c29"
                               height={180}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
@@ -4309,7 +4360,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                               y={176.7607375551413}
                             />
                             <rect
-                              className="c26"
+                              className="c29"
                               height={180}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
@@ -4322,13 +4373,13 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                       </div>
                     </div>
                     <div
-                      className="c24"
+                      className="c27"
                     >
                       <p>
                         Genomes
                       </p>
                       <div
-                        className="c25"
+                        className="c28"
                       >
                         <svg
                           height={250}
@@ -5332,7 +5383,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                               y={21.979920616390384}
                             />
                             <rect
-                              className="c26"
+                              className="c29"
                               height={180}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
@@ -5349,7 +5400,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                               y={124.02054634601916}
                             />
                             <rect
-                              className="c26"
+                              className="c29"
                               height={180}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
@@ -5366,7 +5417,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                               y={121.12070978286248}
                             />
                             <rect
-                              className="c26"
+                              className="c29"
                               height={180}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
@@ -5383,7 +5434,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                               y={110.99229512024282}
                             />
                             <rect
-                              className="c26"
+                              className="c29"
                               height={180}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
@@ -5400,7 +5451,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                               y={56.06350688769553}
                             />
                             <rect
-                              className="c26"
+                              className="c29"
                               height={180}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
@@ -5417,7 +5468,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                               y={0}
                             />
                             <rect
-                              className="c26"
+                              className="c29"
                               height={180}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
@@ -5434,7 +5485,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                               y={28.66215269670792}
                             />
                             <rect
-                              className="c26"
+                              className="c29"
                               height={180}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
@@ -5451,7 +5502,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                               y={42.06864347420032}
                             />
                             <rect
-                              className="c26"
+                              className="c29"
                               height={180}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
@@ -5468,7 +5519,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                               y={57.744571561989254}
                             />
                             <rect
-                              className="c26"
+                              className="c29"
                               height={180}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
@@ -5485,7 +5536,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                               y={97.83796404389446}
                             />
                             <rect
-                              className="c26"
+                              className="c29"
                               height={180}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
@@ -5502,7 +5553,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                               y={129.48400653747373}
                             />
                             <rect
-                              className="c26"
+                              className="c29"
                               height={180}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
@@ -5519,7 +5570,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                               y={161.59234181648375}
                             />
                             <rect
-                              className="c26"
+                              className="c29"
                               height={180}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
@@ -5543,13 +5594,13 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                       For gnomAD v3, the age distribution is:
                     </p>
                     <div
-                      className="c23"
+                      className="c26"
                     >
                       <div
-                        className="c24"
+                        className="c27"
                       >
                         <div
-                          className="c25"
+                          className="c28"
                         >
                           <svg
                             height={250}
@@ -6596,7 +6647,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={32.13021629888574}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -6613,7 +6664,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={123.8409438496832}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -6630,7 +6681,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={116.84072536596022}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -6647,7 +6698,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={105.08193139611099}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -6664,7 +6715,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={53.05221760978806}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -6681,7 +6732,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={0}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -6698,7 +6749,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={25.68057679702863}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -6715,7 +6766,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={36.22023159274634}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -6732,7 +6783,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={54.38933799431943}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -6749,7 +6800,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={95.32881800305879}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -6766,7 +6817,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={129.54336901900808}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -6783,7 +6834,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={162.1455101594931}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -6800,16 +6851,16 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                       For gnomAD v2, the age distribution is:
                     </p>
                     <div
-                      className="c23"
+                      className="c26"
                     >
                       <div
-                        className="c24"
+                        className="c27"
                       >
                         <p>
                           Exomes
                         </p>
                         <div
-                          className="c25"
+                          className="c28"
                         >
                           <svg
                             height={250}
@@ -7985,7 +8036,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={143.88087922476956}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -8002,7 +8053,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={131.4582840935949}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -8019,7 +8070,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={115.53297092885843}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -8036,7 +8087,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={59.64547388324272}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -8053,7 +8104,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={33.155282439139675}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -8070,7 +8121,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={0}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -8087,7 +8138,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={10.777593949420945}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -8104,7 +8155,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={30.61687544315764}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -8121,7 +8172,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={54.043961238477905}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -8138,7 +8189,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={95.04136138028835}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -8155,7 +8206,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={121.34719924367762}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -8172,7 +8223,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={152.55967856298747}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -8185,13 +8236,13 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                         </div>
                       </div>
                       <div
-                        className="c24"
+                        className="c27"
                       >
                         <p>
                           Genomes
                         </p>
                         <div
-                          className="c25"
+                          className="c28"
                         >
                           <svg
                             height={250}
@@ -9367,7 +9418,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={0}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -9384,7 +9435,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={135.53528945281522}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -9401,7 +9452,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={132.68041237113403}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -9418,7 +9469,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={114.12371134020619}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -9435,7 +9486,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={82.72006344171294}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -9452,7 +9503,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={61.0943695479778}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -9469,7 +9520,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={90.4996034892942}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -9486,7 +9537,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={108.55670103092785}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -9503,7 +9554,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={134.3219666931007}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -9520,7 +9571,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={154.1633624107851}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -9537,7 +9588,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={169.00872323552736}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -9554,7 +9605,7 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                                 y={175.0039651070579}
                               />
                               <rect
-                                className="c26"
+                                className="c29"
                                 height={180}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
@@ -9582,10 +9633,10 @@ Genetic ancestry group names in the VCF and Hail Table are abbreviated to 3 lett
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -9664,10 +9715,10 @@ We used a combination of X-chromosome homozygosity (F-stat, [impute_sex function
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -9691,10 +9742,10 @@ Sex for the v4 exomes and genomes was determined using normalized coverage on ch
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -9718,10 +9769,10 @@ For information on how we handle related individuals please see our [Relatedness
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -9745,10 +9796,10 @@ The gene page summarizes the most severe functional consequence and protein-leve
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -9772,10 +9823,10 @@ Annotations may have changed depending on the version of GENCODE used (such as c
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -9825,10 +9876,10 @@ Flags that will appear at the top of gene/transcript pages:
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -9861,10 +9912,10 @@ Several other classes of problems relate to fundamental issues with dbSNP such a
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -9888,10 +9939,10 @@ A gene search in the new browser will return variants in the CDS regions of the 
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -9917,10 +9968,10 @@ The issue is now fixed for new gVCFs generated by HaplotypeCaller moving forward
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -9944,10 +9995,10 @@ Unfortunately, for many reasons (including consent and data usage restrictions) 
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -9973,10 +10024,10 @@ You can also obtain information on all variants from the VCFs and Hail Tables av
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -10000,10 +10051,10 @@ Please visit our [downloads page](/downloads).
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -10023,14 +10074,14 @@ Please see our gnomAD Hail Table [help text](/help/v4-hts)
         </div>
         <div>
           <span
-            className="c11"
+            className="c14"
           >
             <h3
-              className="c14"
+              className="c15"
             >
               <a
                 aria-hidden="true"
-                className="c12 c13"
+                className="c16 c17"
                 href="#coverage"
                 id="coverage"
               >
@@ -10048,7 +10099,7 @@ Please see our gnomAD Hail Table [help text](/help/v4-hts)
           <button
             backgroundColor="#f8f9fa"
             borderColor="#6c757d"
-            className="c15 c16"
+            className="c18 c19"
             onClick={[Function]}
             type="button"
           >
@@ -10058,14 +10109,14 @@ Please see our gnomAD Hail Table [help text](/help/v4-hts)
           <button
             backgroundColor="#f8f9fa"
             borderColor="#6c757d"
-            className="c15 c16"
+            className="c18 c19"
             onClick={[Function]}
             type="button"
           >
             Hide all answers in this section
           </button>
           <ul
-            className="c17"
+            className="c20"
           >
             <li>
               <details>
@@ -10075,10 +10126,10 @@ Please see our gnomAD Hail Table [help text](/help/v4-hts)
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -10156,10 +10207,10 @@ Coverage was calculated separately for exomes and genomes on a ~10% subset of th
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -10183,10 +10234,10 @@ The best way to tell if a variant is missing because of a lack of coverage vs mi
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -10210,10 +10261,10 @@ Sometimes a large apparent drop in AN can occur because a variant was called in 
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -10248,14 +10299,14 @@ The calling intervals for our exomes include the bait-covered regions ±50 bp. T
         </div>
         <div>
           <span
-            className="c11"
+            className="c14"
           >
             <h3
-              className="c14"
+              className="c15"
             >
               <a
                 aria-hidden="true"
-                className="c12 c13"
+                className="c16 c17"
                 href="#mitochondrial-dna"
                 id="mitochondrial-dna"
               >
@@ -10273,7 +10324,7 @@ The calling intervals for our exomes include the bait-covered regions ±50 bp. T
           <button
             backgroundColor="#f8f9fa"
             borderColor="#6c757d"
-            className="c15 c16"
+            className="c18 c19"
             onClick={[Function]}
             type="button"
           >
@@ -10283,14 +10334,14 @@ The calling intervals for our exomes include the bait-covered regions ±50 bp. T
           <button
             backgroundColor="#f8f9fa"
             borderColor="#6c757d"
-            className="c15 c16"
+            className="c18 c19"
             onClick={[Function]}
             type="button"
           >
             Hide all answers in this section
           </button>
           <ul
-            className="c17"
+            className="c20"
           >
             <li>
               <details>
@@ -10300,10 +10351,10 @@ The calling intervals for our exomes include the bait-covered regions ±50 bp. T
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -10327,10 +10378,10 @@ Mitochondrial DNA variants are called using a specialized GATK pipeline that add
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -10354,10 +10405,10 @@ The gnomAD v3.1 data set contains 76,156 whole genomes, of which 56,434 samples 
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -10381,10 +10432,10 @@ Nuclear sequences of mitochondrial origin (NUMTs) are derived from pieces of mtD
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -10408,10 +10459,10 @@ In gnomAD v3.1 we chose to filter out variants with heteroplasmy below 10%, sinc
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -10435,10 +10486,10 @@ mtDNA does not recombine and is inherited maternally. mtDNA sequences have histo
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -10462,10 +10513,10 @@ Variants that are homoplasmic in any of the ~5000 haplogroups in the [Phylotree]
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -10489,10 +10540,10 @@ For each variant, we report the overall population frequency across all gnomAD s
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -10516,13 +10567,13 @@ We report allele frequencies by mitochondrial haplogroup as well as by [inferred
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <h4>
                     N lineages ("Eurasian")
                   </h4>
                   <table
-                    className="c21 c27"
+                    className="c24 c30"
                   >
                     <thead>
                       <tr>
@@ -10812,7 +10863,7 @@ We report allele frequencies by mitochondrial haplogroup as well as by [inferred
                     L lineages ("African")
                   </h4>
                   <table
-                    className="c21 c27"
+                    className="c24 c30"
                   >
                     <thead>
                       <tr>
@@ -10946,7 +10997,7 @@ We report allele frequencies by mitochondrial haplogroup as well as by [inferred
                     M lineages ("Asian")
                   </h4>
                   <table
-                    className="c21 c27"
+                    className="c24 c30"
                   >
                     <thead>
                       <tr>
@@ -11087,10 +11138,10 @@ We report allele frequencies by mitochondrial haplogroup as well as by [inferred
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <select
-                    className="c28 c29"
+                    className="c31 c32"
                     id="haplogroup-selected"
                     onChange={[Function]}
                     value="All"
@@ -11251,7 +11302,7 @@ We report allele frequencies by mitochondrial haplogroup as well as by [inferred
                     </optgroup>
                   </select>
                   <select
-                    className="c28 c29"
+                    className="c31 c32"
                     id="ancestry-selected"
                     onChange={[Function]}
                     value="All"
@@ -11317,7 +11368,7 @@ We report allele frequencies by mitochondrial haplogroup as well as by [inferred
                     </optgroup>
                   </select>
                   <table
-                    className="c21 c30"
+                    className="c24 c33"
                   >
                     <thead>
                       <tr>
@@ -11370,10 +11421,10 @@ We report allele frequencies by mitochondrial haplogroup as well as by [inferred
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -11417,10 +11468,10 @@ Mitochondrial variants were subjected to mitochondrial-specific filters and flag
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -11440,14 +11491,14 @@ Homoplasmic and heteroplasmic counts for all sites can be downloaded in VCF form
         </div>
         <div>
           <span
-            className="c11"
+            className="c14"
           >
             <h3
-              className="c14"
+              className="c15"
             >
               <a
                 aria-hidden="true"
-                className="c12 c13"
+                className="c16 c17"
                 href="#variant-co-occurrence"
                 id="variant-co-occurrence"
               >
@@ -11465,7 +11516,7 @@ Homoplasmic and heteroplasmic counts for all sites can be downloaded in VCF form
           <button
             backgroundColor="#f8f9fa"
             borderColor="#6c757d"
-            className="c15 c16"
+            className="c18 c19"
             onClick={[Function]}
             type="button"
           >
@@ -11475,14 +11526,14 @@ Homoplasmic and heteroplasmic counts for all sites can be downloaded in VCF form
           <button
             backgroundColor="#f8f9fa"
             borderColor="#6c757d"
-            className="c15 c16"
+            className="c18 c19"
             onClick={[Function]}
             type="button"
           >
             Hide all answers in this section
           </button>
           <ul
-            className="c17"
+            className="c20"
           >
             <li>
               <details>
@@ -11492,10 +11543,10 @@ Homoplasmic and heteroplasmic counts for all sites can be downloaded in VCF form
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -11519,10 +11570,10 @@ We used the exome sequencing samples from gnomAD v2.1 (n = 125,748; GRCh37) to e
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -11550,10 +11601,10 @@ For more information, see our [publication](https://www.nature.com/articles/s415
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -11577,10 +11628,10 @@ When the probability of a pair of variants being in _trans_ (P<sub>trans</sub>) 
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -11604,10 +11655,10 @@ We suggest using the population-specific estimates, when available and when ance
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---
@@ -11637,10 +11688,10 @@ Finally, the likelihood that the variants are on different haplotypes is calcula
                   </h4>
                 </summary>
                 <div
-                  className="c18"
+                  className="c21"
                 >
                   <div
-                    className="c19"
+                    className="c22"
                     dangerouslySetInnerHTML={
                       {
                         "__html": "---

--- a/browser/src/help/__snapshots__/HelpPage.spec.tsx.snap
+++ b/browser/src/help/__snapshots__/HelpPage.spec.tsx.snap
@@ -396,7 +396,7 @@ exports[`Help Page has no unexpected changes 1`] = `
   overflow: auto;
   box-sizing: border-box;
   width: 100%;
-  padding: 0 15px;
+  padding: 0 15px 0 44px;
 }
 
 .c6 {
@@ -1025,6 +1025,11 @@ exports[`Help Page has no unexpected changes 1`] = `
         <h2
           className="c11 c12"
           id="frequently-asked-questions"
+          style={
+            {
+              "padding": "8px 0",
+            }
+          }
         >
           <a
             aria-label="Copy link to Frequently asked questions"
@@ -1033,9 +1038,9 @@ exports[`Help Page has no unexpected changes 1`] = `
             onClick={[Function]}
             style={
               {
-                "display": "inline-flex",
-                "position": "static",
-                "transform": "none",
+                "display": "flex",
+                "position": "absolute",
+                "transform": "translate(-100%, -50%)",
               }
             }
           >

--- a/browser/src/useScrollToHash.spec.tsx
+++ b/browser/src/useScrollToHash.spec.tsx
@@ -6,7 +6,7 @@ import useScrollToHash from './useScrollToHash'
 
 const TestComponent = () => {
   useScrollToHash()
-  return <div id="age-distribution">Age Distribution</div>
+  return <h2 id="age-distribution">Age Distribution</h2>
 }
 
 // jsdom implements neither scrollIntoView nor layout, so both are stubbed.

--- a/browser/src/useScrollToHash.spec.tsx
+++ b/browser/src/useScrollToHash.spec.tsx
@@ -45,11 +45,11 @@ describe('useScrollToHash', () => {
     jest.restoreAllMocks()
   })
 
-  test('scrolls to the element identified by the hash', async () => {
+  test('scrolls to the hash target without inheriting CSS smooth scrolling', async () => {
     window.location.hash = '#age-distribution'
     render(<TestComponent />)
     await flushAnimationFrames()
-    expect(scrollIntoView).toHaveBeenCalled()
+    expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'instant' })
   })
 
   test('keeps re-aligning while the page is still growing', async () => {

--- a/browser/src/useScrollToHash.ts
+++ b/browser/src/useScrollToHash.ts
@@ -3,7 +3,7 @@ import { useEffect } from 'react'
 // How long to keep re-aligning after mount while the rest of the page renders.
 const SETTLE_TIMEOUT_MS = 2000
 
-// App.tsx scrolls before query-loaded sections exist. Data-loaded pages retry here while
+// App.tsx can scroll before lazy or query-loaded sections exist. Pages retry here while
 // layout settles: short documents can clamp scrolling, and later content can move an already
 // aligned target. Stop after the bounded window or as soon as the reader takes over.
 const useScrollToHash = () => {

--- a/browser/src/useScrollToHash.ts
+++ b/browser/src/useScrollToHash.ts
@@ -48,7 +48,8 @@ const useScrollToHash = () => {
 
       const target = document.getElementById(id)
       if (target && Math.abs(target.getBoundingClientRect().top) > 1) {
-        target.scrollIntoView()
+        // Animated scrolling would restart on every frame on pages with smooth-scroll CSS.
+        target.scrollIntoView({ behavior: 'instant' })
       }
 
       if (performance.now() - start < SETTLE_TIMEOUT_MS) {

--- a/tests/e2e/DataPageNavigation.playwright.spec.ts
+++ b/tests/e2e/DataPageNavigation.playwright.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test } from '@playwright/test'
+
+test.use({ viewport: { width: 1440, height: 900 } })
+
+test('Data table of contents renders links and follows navigation and scrolling', async ({
+  page,
+}) => {
+  await page.goto('/data?dataset=gnomad_r4')
+  const contents = page.getByRole('navigation', { name: 'Data sections' })
+  await expect(contents.getByRole('link')).toHaveText([
+    'Summary',
+    'v4 Downloads',
+    'v3 Downloads',
+    'v2 Liftover Downloads',
+    'v2 Downloads',
+    'ExAC Downloads',
+    'gnomAD API',
+  ])
+
+  const v3Link = contents.getByRole('link', { name: 'v3 Downloads', exact: true })
+  await v3Link.click()
+  await expect(page.locator('h2#v3')).toBeInViewport()
+  await expect(v3Link.locator('..')).toHaveCSS('font-weight', '700')
+
+  const hgdpLink = contents.getByRole('link', { name: 'HGDP + 1KG callset', exact: true })
+  await expect(hgdpLink).toHaveAttribute('href', '#v3-hgdp-1kg')
+  await hgdpLink.click()
+  await expect(page.locator('h2#v3-hgdp-1kg')).toBeInViewport()
+  await expect(hgdpLink.locator('..')).toHaveCSS('font-weight', '700')
+  await expect
+    .poll(() =>
+      page
+        .locator('h2#v3-hgdp-1kg')
+        .evaluate((element) => Math.abs(element.getBoundingClientRect().top))
+    )
+    .toBeLessThanOrEqual(2)
+
+  const v2Offset = await page
+    .locator('h2#v2')
+    .evaluate((element) => element.getBoundingClientRect().top)
+  await page.mouse.move(600, 450)
+  await page.mouse.wheel(0, v2Offset - 20)
+  const v2Link = contents.getByRole('link', { name: 'v2 Downloads', exact: true })
+  await expect(v2Link.locator('..')).toHaveCSS('font-weight', '700')
+  await expect(
+    contents.getByRole('link', { name: 'Linkage disequilibrium', exact: true })
+  ).toHaveAttribute('href', '#v2-linkage-disequilibrium')
+  await expect(hgdpLink).toHaveCount(0)
+})
+
+test('Data deep links settle promptly even with smooth scrolling enabled', async ({ page }) => {
+  await page.goto('/data?dataset=gnomad_r4#v4-variants', { waitUntil: 'commit' })
+  const heading = page.locator('h2#v4-variants')
+  await expect(heading).toBeAttached()
+  await expect(page.locator('html')).toHaveCSS('scroll-behavior', 'smooth')
+
+  // A restarted smooth scroll remains stationary for the entire two-second retry window.
+  await expect
+    .poll(() => heading.evaluate((element) => Math.abs(element.getBoundingClientRect().top)), {
+      timeout: 1000,
+    })
+    .toBeLessThanOrEqual(2)
+})

--- a/tests/e2e/SectionHeadingPages.playwright.spec.ts
+++ b/tests/e2e/SectionHeadingPages.playwright.spec.ts
@@ -1,0 +1,56 @@
+import { expect, test } from '@playwright/test'
+
+const sections = [
+  { path: '/help', id: 'frequently-asked-questions', title: 'Frequently asked questions' },
+  { path: '/data', id: 'v4-variants', title: 'Variants' },
+  {
+    path: '/stats',
+    id: 'age-and-sex-distribution',
+    title: 'What is the age and sex distribution in gnomAD?',
+  },
+]
+
+;[1440, 320].forEach((width) => {
+  test.describe(`Shared headings at ${width}px`, () => {
+    test.use({ viewport: { width, height: 900 } })
+
+    sections.forEach(({ path, id, title }) => {
+      test(`${path} preserves deep links and exposes a complete copy target`, async ({ page }) => {
+        await page.context().grantPermissions(['clipboard-read', 'clipboard-write'])
+        await page.goto(`${path}?dataset=gnomad_r4#${id}`)
+        const heading = page.locator(`h2#${id}`)
+        await expect(heading).toBeAttached()
+        // Check the final layout after the shared scroll-settling window.
+        await page.waitForTimeout(2200)
+        await expect(heading).toBeInViewport()
+        await page.reload()
+        await expect(heading).toBeAttached()
+        await page.waitForTimeout(2200)
+        await expect(heading).toBeInViewport()
+
+        const link = heading.getByRole('link', { name: `Copy link to ${title}`, exact: true })
+        await link.focus()
+        await expect(link).toHaveCSS('opacity', '1')
+        await expect(link).toBeInViewport({ ratio: 1 })
+        const box = (await link.boundingBox())!
+        expect(box.width).toBeGreaterThanOrEqual(44)
+        expect(box.height).toBeGreaterThanOrEqual(44)
+        expect(box.x).toBeGreaterThanOrEqual(0)
+        expect(box.x + box.width).toBeLessThanOrEqual(width)
+        expect(
+          await link.evaluate((element) => {
+            const bounds = element.getBoundingClientRect()
+            return element.contains(
+              document.elementFromPoint(bounds.x + 1, bounds.y + bounds.height / 2)
+            )
+          })
+        ).toBe(true)
+
+        await page.keyboard.press('Enter')
+        await expect(page.getByRole('status')).toHaveText('Link copied')
+        expect(await page.evaluate(() => navigator.clipboard.readText())).toBe(page.url())
+        expect(new URL(page.url()).hash).toBe(`#${id}`)
+      })
+    })
+  })
+})

--- a/tests/e2e/SectionHeadingPages.playwright.spec.ts
+++ b/tests/e2e/SectionHeadingPages.playwright.spec.ts
@@ -28,6 +28,27 @@ const sections = [
         await page.waitForTimeout(2200)
         await expect(heading).toBeInViewport()
 
+        const titleLayout = await heading.evaluate((element) => {
+          const titleText = Array.from(element.childNodes).find(
+            (node) => node.nodeType === Node.TEXT_NODE
+          )!
+          const firstCharacter = document.createRange()
+          firstCharacter.setStart(titleText, 0)
+          firstCharacter.setEnd(titleText, 1)
+          const indent =
+            firstCharacter.getBoundingClientRect().left - element.getBoundingClientRect().left
+          const textRange = document.createRange()
+          textRange.selectNodeContents(titleText)
+          const textBox = textRange.getBoundingClientRect()
+          const iconBox = element.querySelector('img')!.getBoundingClientRect()
+          return {
+            indent,
+            verticalOffset: iconBox.y + iconBox.height / 2 - (textBox.y + textBox.height / 2),
+          }
+        })
+        expect(Math.abs(titleLayout.indent)).toBeLessThanOrEqual(1)
+        expect(Math.abs(titleLayout.verticalOffset)).toBeLessThanOrEqual(2)
+
         const link = heading.getByRole('link', { name: `Copy link to ${title}`, exact: true })
         await link.focus()
         await expect(link).toHaveCSS('opacity', '1')
@@ -37,6 +58,14 @@ const sections = [
         expect(box.height).toBeGreaterThanOrEqual(44)
         expect(box.x).toBeGreaterThanOrEqual(0)
         expect(box.x + box.width).toBeLessThanOrEqual(width)
+        const headingBox = (await heading.boundingBox())!
+        expect(box.x + box.width).toBeLessThanOrEqual(headingBox.x + 1)
+        if (path === '/help') {
+          const subheadingBox = (await page
+            .getByRole('heading', { name: 'General', exact: true })
+            .boundingBox())!
+          expect(Math.abs(headingBox.x - subheadingBox.x)).toBeLessThanOrEqual(1)
+        }
         expect(
           await link.evaluate((element) => {
             const bounds = element.getBoundingClientRect()

--- a/tests/e2e/VariantPage.playwright.spec.ts
+++ b/tests/e2e/VariantPage.playwright.spec.ts
@@ -4,27 +4,35 @@ test.describe('Variant page', () => {
   test.describe('narrow touch viewport', () => {
     test.use({ viewport: { width: 320, height: 720 }, hasTouch: true, isMobile: true })
 
-    test('keeps the whole permalink target and feedback on screen', async ({ page }) => {
-      await page.context().grantPermissions(['clipboard-read', 'clipboard-write'])
-      await page.goto('/variant/1-55051215-G-GA?dataset=gnomad_r4#age-distribution')
-      const link = page.getByRole('link', { name: 'Copy link to Age Distribution' })
-      await expect(link).toBeAttached({ timeout: 30_000 })
-      await expect(link).toHaveCSS('opacity', '1')
-      const target = await link.boundingBox()
-      expect(target!.width).toBeGreaterThanOrEqual(44)
-      expect(target!.height).toBeGreaterThanOrEqual(44)
-      expect(target!.x).toBeGreaterThanOrEqual(0)
-      expect(target!.x + target!.width).toBeLessThanOrEqual(320)
-      await link.tap()
+    const sections = [
+      ['age-distribution', 'Age Distribution'],
+      ['genomic-constraint', 'Genomic Constraint of Surrounding 1kb Region'],
+    ]
+    sections.forEach(([id, title]) => {
+      test(`keeps the whole ${title} target and feedback on screen`, async ({ page }) => {
+        await page.context().grantPermissions(['clipboard-read', 'clipboard-write'])
+        await page.goto(`/variant/1-55051215-G-GA?dataset=gnomad_r4#${id}`)
+        const link = page.getByRole('link', { name: `Copy link to ${title}` })
+        await expect(link).toBeAttached({ timeout: 30_000 })
+        await expect(link).toHaveCSS('opacity', '1')
+        const target = await link.boundingBox()
+        expect(target!.width).toBeGreaterThanOrEqual(44)
+        expect(target!.height).toBeGreaterThanOrEqual(44)
+        expect(target!.x).toBeGreaterThanOrEqual(0)
+        expect(target!.x + target!.width).toBeLessThanOrEqual(320)
+        await link.tap()
 
-      const card = page
-        .locator('strong')
-        .filter({ hasText: /^Link copied$/ })
-        .locator('..')
-      await expect(card).toBeInViewport({ ratio: 1 })
-      const feedback = await card.boundingBox()
-      expect(feedback!.x).toBeGreaterThanOrEqual(0)
-      expect(feedback!.x + feedback!.width).toBeLessThanOrEqual(320)
+        const card = page
+          .locator('strong')
+          .filter({ hasText: /^Link copied$/ })
+          .locator('..')
+        await expect(card).toBeInViewport({ ratio: 1 })
+        const feedback = await card.boundingBox()
+        expect(feedback!.x).toBeGreaterThanOrEqual(0)
+        expect(feedback!.x + feedback!.width).toBeLessThanOrEqual(320)
+        expect(new URL(page.url()).hash).toBe(`#${id}`)
+        expect(await page.evaluate(() => navigator.clipboard.readText())).toBe(page.url())
+      })
     })
   })
 
@@ -45,6 +53,33 @@ test.describe('Variant page', () => {
     await page
       .getByText('Age Distribution More informationExomeGenomeVariant carriersAll individuals<')
       .click()
+  })
+
+  test('non-age deep links survive refresh and copying another section navigates natively', async ({
+    page,
+  }) => {
+    test.setTimeout(60_000)
+    await page.context().grantPermissions(['clipboard-read', 'clipboard-write'])
+    await page.goto('/variant/1-55051215-G-GA?dataset=gnomad_r4#variant-effect-predictor')
+    const heading = page.locator('h2#variant-effect-predictor')
+    const expectSettledHeading = async () => {
+      await expect(heading).toBeAttached({ timeout: 30_000 })
+      await page.waitForTimeout(2200)
+      expect(
+        Math.abs(await heading.evaluate((element) => element.getBoundingClientRect().top))
+      ).toBeLessThanOrEqual(2)
+    }
+    await expectSettledHeading()
+    await page.reload()
+    await expectSettledHeading()
+
+    await page.getByRole('link', { name: 'Copy link to Read Data' }).click()
+    await expect(page.locator('h2#read-data')).toBeInViewport()
+    expect(new URL(page.url()).pathname).toBe('/variant/1-55051215-G-GA')
+    expect(new URL(page.url()).search).toBe('?dataset=gnomad_r4')
+    expect(new URL(page.url()).hash).toBe('#read-data')
+    expect(await page.evaluate(() => navigator.clipboard.readText())).toBe(page.url())
+    await expect(page.getByRole('status')).toHaveText('Link copied')
   })
 
   test('v4 deep link and copyable Age Distribution anchor work', async ({ page }) => {
@@ -72,7 +107,11 @@ test.describe('Variant page', () => {
     // Check the final layout, not merely an aligned frame inside the two-second settle window.
     await page.waitForTimeout(2200)
     expect(
-      Math.abs(await ageDistributionLink.evaluate((link) => link.getBoundingClientRect().top))
+      Math.abs(
+        await page
+          .locator('h2#age-distribution')
+          .evaluate((heading) => heading.getBoundingClientRect().top)
+      )
     ).toBeLessThanOrEqual(2)
 
     const linkTarget = await ageDistributionLink.boundingBox()
@@ -84,7 +123,9 @@ test.describe('Variant page', () => {
 
     await page.mouse.move(1200, 600)
     await page.context().grantPermissions(['clipboard-read', 'clipboard-write'])
-    // Fragment navigation sets the sequential focus starting point at the link.
+    // The heading target starts sequential focus before its permalink.
+    await page.keyboard.press('Tab')
+    await expect(ageDistributionLink).toBeFocused()
     await page.keyboard.press('Shift+Tab')
     await expect(ageDistributionLink).not.toBeFocused()
     await page.keyboard.press('Tab')


### PR DESCRIPTION
## Stack
Targets `kc/age-distribution-link` (#1925). #1950 has been squash-merged into that branch; this PR is restacked onto its merged commit, without replaying the prerequisite fixes. Retarget after #1925 lands.

## Summary
- Add a shared typed `SectionHeading` and permalinks to 12 additional existing top-level short-variant sections, preserving conditional rendering and stable `#age-distribution` links.
- Reuse the heading for Age Distribution on structural, mitochondrial, and STR pages.
- Resolve #1956: remove Help's duplicate `SectionHeading` and migrate the Help FAQ heading, all six Stats headings, and all 61 Data headings to the shared implementation. Preserve existing IDs, visible text, download URLs, and Data heading sizes.
- Reuse bounded hash scrolling on Help/Data/Stats and update the Data table-of-contents observer to follow heading IDs. Reserve inline space for the full copy target on these information pages.

No new dependency or scrolling framework. Legacy Help subheadings and Policies anchors remain unchanged.

## Validation
- Fresh on the updated branch: **72 browser suites / 1,814 tests / 1,144 snapshots passed**.
- **Six Chromium regressions passed** against the production build: Help, Data, and Stats deep-link/refresh, keyboard copying, and full target visibility at 1440px and 320px.
- ESLint, Stylelint, TypeScript, changed-file Prettier, and production build passed with Node 18.17.1.
- Normalized snapshot comparison confirms all IDs, URLs, and visible text on the three migrated pages are preserved.
- The existing variant-page Chromium checks passed before this follow-up; they were not rerun here. Existing variant-page unit tests and snapshots pass unchanged by the consolidation.

This older base predates the Makefile. Borrowing main's `validate-browser` stops on 16 pre-existing formatting failures outside this change; the checks defined in this branch's own Browser CI passed instead.

## UI review
Please add before/after screenshots before merging. Human screen-reader and physical-touch verification remains outstanding.

Fixes #1956
