### PR TITLE
Bypass `nginx` cache when API request or response involves html, rather than json

### DIFF
--- a/deploy/dockerfiles/browser/browser.nginx.conf
+++ b/deploy/dockerfiles/browser/browser.nginx.conf
@@ -31,13 +31,23 @@ map "$traceparent_trace_id:$cloud_trace_id" $gcp_trace_id {
 }
 
 # Combine GCP_PROJECT and the extracted trace ID.
-# Only construct a complete GCP trace resource when both the project 
+# Only construct a complete GCP trace resource when both the project
 # and trace ID are available.
 # The resulting value is suitable for
 # logging.googleapis.com/trace: "projects/<project>/traces/<trace-id>".
 map "$GCP_PROJECT:$gcp_trace_id" $gcp_trace {
     default "";
     "~^([^:]+):([0-9a-f]{32})$" "projects/$1/traces/$2";
+}
+
+map $http_accept $request_prefers_html {
+  default 0;
+  "~*text/html" 1;
+}
+
+map $upstream_http_content_type $upstream_response_is_html {
+  default 0;
+  "~*text/html" 1;
 }
 
 # Log access information in JSON format so that individual fields can

--- a/deploy/dockerfiles/browser/browser.proxy_cache.conf
+++ b/deploy/dockerfiles/browser/browser.proxy_cache.conf
@@ -5,5 +5,6 @@ proxy_buffers 8 32k;
 proxy_buffer_size 64k;
 proxy_cache_valid 30d;
 proxy_cache_use_stale updating;
-proxy_cache_bypass $cookie_nocache $arg_nocache;
+proxy_cache_bypass $cookie_nocache $arg_nocache $request_prefers_html;
+proxy_no_cache $request_prefers_html $upstream_response_is_html;
 add_header X-Cached $upstream_cache_status;


### PR DESCRIPTION
Resolves #1949

Currently, if a request hits the `iGraphQL` interface, and is the same shape as a request gnomAD's pages use (by embedding the request in the url, e.g. something like `https://gnomad.broadinstitute.org/api/?query=%7Bgene(gene_symbol%3A%22BRCA1%22%2Creference_genome%3AGRCh38)%7Bgene_id%20%20symbol%7D%7D`), and if there is no cache'd value in `nginx`, this `html` response will be stored and served from `nginx`.

This results in the frontend getting `html`, rather than `json`, which it cannot render, and presented recently with the BRCA1 v4 gene page consistently returning `unable to load gene`.

This PR modifies the nginx config to bypass cache writing/reading entirely if a request to the graphql API wants html as response, or is html itself. 

It's pretty smol, it:
- introduces two new mapped values in the nginx config:
    - `$request_prefers_html`
    - `$upstream_response_is_html`
- on the `/api/` reverse proxy path, ignore cache read/write based on these values 

This is purely config changes for `nginx`.

Edit:
`html` could also be returned if a request is sent that requests `html` as a response type, as `express-graphql` can serve html, rather than json, so it supports both response types.