### PR TITLE
bugfix(api): disable GraphiQL in production, preventing HTML responses

### DIFF
--- a/graphql-api/README.md
+++ b/graphql-api/README.md
@@ -9,13 +9,6 @@ Please note that this resource is under development and the query schema is subj
 
 The gnomAD API uses [GraphQL](https://graphql.org/learn/) for queries.
 
-To get started, open the interactive query editor at https://gnomad.broadinstitute.org/api.
-
-Click the "Docs" button in the top right-hand corner to open up the Documentation Explorer.
-GraphQL is self-documenting, so the fields and data described in this section are always
-up-to-date. Browsing through the Documentation Explorer is the best way to understand how
-to query data and learn which types of data are available to retrieve.
-
 ## Examples
 
 Examples of fetching gnomAD allele counts for a specific variant using different languages.

--- a/graphql-api/src/config.ts
+++ b/graphql-api/src/config.ts
@@ -20,6 +20,7 @@ const parseProxyConfig = (config: any) => {
 }
 
 const config: Record<string, any> = {
+  NODE_ENV: env.NODE_ENV || 'development',
   // Elasticsearch
   ELASTICSEARCH_URL: env.ELASTICSEARCH_URL,
   ELASTICSEARCH_USERNAME: env.ELASTICSEARCH_USERNAME,

--- a/graphql-api/src/graphql/graphql-api.ts
+++ b/graphql-api/src/graphql/graphql-api.ts
@@ -120,7 +120,7 @@ const queryComplexityCreateError = (max: any, actual: any) => {
 const graphQLApi = ({ context }: any) =>
   graphqlHTTP(async (request, response, requestParams) => ({
     schema,
-    graphiql: true,
+    graphiql: config.NODE_ENV !== 'production',
     context,
 
     validationRules: [

--- a/reads/src/server.js
+++ b/reads/src/server.js
@@ -25,6 +25,7 @@ const parseProxyConfig = (config) => {
 }
 
 const config = {
+  NODE_ENV: process.env.NODE_ENV || 'development',
   PORT: JSON.parse(process.env.PORT || '80'),
   TRUST_PROXY: parseProxyConfig(process.env.TRUST_PROXY || 'false'),
 }
@@ -42,7 +43,7 @@ app.use(
   '/reads',
   graphqlHTTP({
     schema,
-    graphiql: true,
+    graphiql: config.NODE_ENV !== 'production',
     customFormatErrorFn: formatError,
   })
 )


### PR DESCRIPTION
### What # issue does this PR resolve (If applicable)

resolves #1949

### Merge strategy

- [x] I understand that this PR will be squashed down into a single commit in `main`

### What does this PR do?

disables GraphiQL in production, preventing html responses from being generated (in addition to not cached!) by the API.

### Tests

It IS possible to add a test for this, but I elected not to.  I didn't think it had enormous value other than validating that we disabled the strange library behavior.

### Verification

- [x] I have the relevant `make` targets to run CI checks locally and verified that they succeed (e.g. `make validate-browser` if you made changes in the `browser/` directory, or `make validate-all` if you're unsure which checks to run)
- [x] (If UI) I have tested this across desktop and mobile breakpoints.
- [x] (If a LLM/AI agent runner was used, e.g. OpenCode, Aider, or ClaudeCode) I have instructed the agent runner to load the `AGENTS.md` file into its context, and verified the the required `Assisted-by` trailer is on each commit.
