### PR TITLE
feat(browser): make variant table search hotkeys discoverable

### DIFF
--- a/browser/src/CopyNumberVariantList/CopyNumberVariantFilterControls.tsx
+++ b/browser/src/CopyNumberVariantList/CopyNumberVariantFilterControls.tsx
@@ -1,9 +1,10 @@
-import React, { useRef } from 'react'
+import React from 'react'
 import styled from 'styled-components'
 
-import { Badge, Checkbox, KeyboardShortcut, SearchInput } from '@gnomad/ui'
+import { Badge, Checkbox, SearchInput } from '@gnomad/ui'
 
 import CategoryFilterControl from '../CategoryFilterControl'
+import useSearchHotkeys from '../useSearchHotkeys'
 
 import { cnvTypes, cnvTypeColors } from './copyNumberVariantTypes'
 
@@ -56,7 +57,7 @@ type Props = {
 }
 
 const CopyNumberVariantFilterControls = ({ onChange, colorKey, value }: Props) => {
-  const searchInput = useRef(null)
+  const { searchInputRef, searchHotkeys } = useSearchHotkeys()
 
   return (
     <SettingsWrapper>
@@ -93,28 +94,17 @@ const CopyNumberVariantFilterControls = ({ onChange, colorKey, value }: Props) =
       <SearchWrapper>
         <SearchInput
           // @ts-expect-error TS(2322) FIXME: Type '{ ref: MutableRefObject<null>; placeholder: ... Remove this comment to see the full error message
-          ref={searchInput}
+          ref={searchInputRef}
           placeholder="Search variant table"
           onChange={(searchText) => {
             onChange({ ...value, searchText })
           }}
           value={value.searchText}
         />
-        <Badge level="info" tooltip="Press / to search the variant table">
+        <Badge level="info" tooltip="Press / or Ctrl+F (⌘F on Mac) to search the variant table">
           /
         </Badge>
-        <KeyboardShortcut
-          // @ts-expect-error TS(2322) FIXME: Type 'string' is not assignable to type 'string[]'... Remove this comment to see the full error message
-          keys="/"
-          // @ts-expect-error TS(2322) FIXME: Type '(e: any) => void' is not assignable to type ... Remove this comment to see the full error message
-          handler={(e: any) => {
-            // preventDefault to avoid typing a "/" in the search input
-            e.preventDefault()
-            if (searchInput.current) {
-              ;(searchInput.current as any).focus()
-            }
-          }}
-        />
+        {searchHotkeys}
       </SearchWrapper>
     </SettingsWrapper>
   )

--- a/browser/src/CopyNumberVariantList/CopyNumberVariantFilterControls.tsx
+++ b/browser/src/CopyNumberVariantList/CopyNumberVariantFilterControls.tsx
@@ -1,7 +1,7 @@
-import React from 'react'
+import React, { useRef } from 'react'
 import styled from 'styled-components'
 
-import { Checkbox, SearchInput } from '@gnomad/ui'
+import { Badge, Checkbox, KeyboardShortcut, SearchInput } from '@gnomad/ui'
 
 import CategoryFilterControl from '../CategoryFilterControl'
 
@@ -26,7 +26,9 @@ const CheckboxWrapper = styled.div`
 `
 
 const SearchWrapper = styled.div`
-  /* stylelint-ignore-line block-no-empty */
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
 `
 
 const SettingsWrapper = styled.div`
@@ -53,48 +55,69 @@ type Props = {
   }
 }
 
-const CopyNumberVariantFilterControls = ({ onChange, colorKey, value }: Props) => (
-  <SettingsWrapper>
-    <CategoryFiltersWrapper>
-      <CategoryFilterLabel>Classes</CategoryFilterLabel>
-      <CategoryFilterControl
-        categories={cnvTypes.map((type) => ({
-          id: type,
-          label: type,
-          // @ts-expect-error TS(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-          color: colorKey === 'type' ? cnvTypeColors[type] : 'gray',
-        }))}
-        categorySelections={value.includeTypes}
-        id="sv-type-category-filter"
-        onChange={(includeTypes: any) => {
-          onChange({ ...value, includeTypes })
-        }}
-      />
-    </CategoryFiltersWrapper>
+const CopyNumberVariantFilterControls = ({ onChange, colorKey, value }: Props) => {
+  const searchInput = useRef(null)
 
-    <CheckboxWrapper>
-      <span>
-        <Checkbox
-          checked={value.includeFilteredVariants}
-          id="sv-qc-filter"
-          label="Include filtered variants"
-          onChange={(includeFilteredVariants) => {
-            onChange({ ...value, includeFilteredVariants })
+  return (
+    <SettingsWrapper>
+      <CategoryFiltersWrapper>
+        <CategoryFilterLabel>Classes</CategoryFilterLabel>
+        <CategoryFilterControl
+          categories={cnvTypes.map((type) => ({
+            id: type,
+            label: type,
+            // @ts-expect-error TS(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
+            color: colorKey === 'type' ? cnvTypeColors[type] : 'gray',
+          }))}
+          categorySelections={value.includeTypes}
+          id="sv-type-category-filter"
+          onChange={(includeTypes: any) => {
+            onChange({ ...value, includeTypes })
           }}
         />
-      </span>
-    </CheckboxWrapper>
+      </CategoryFiltersWrapper>
 
-    <SearchWrapper>
-      <SearchInput
-        placeholder="Search variant table"
-        onChange={(searchText) => {
-          onChange({ ...value, searchText })
-        }}
-        value={value.searchText}
-      />
-    </SearchWrapper>
-  </SettingsWrapper>
-)
+      <CheckboxWrapper>
+        <span>
+          <Checkbox
+            checked={value.includeFilteredVariants}
+            id="sv-qc-filter"
+            label="Include filtered variants"
+            onChange={(includeFilteredVariants) => {
+              onChange({ ...value, includeFilteredVariants })
+            }}
+          />
+        </span>
+      </CheckboxWrapper>
+
+      <SearchWrapper>
+        <SearchInput
+          // @ts-expect-error TS(2322) FIXME: Type '{ ref: MutableRefObject<null>; placeholder: ... Remove this comment to see the full error message
+          ref={searchInput}
+          placeholder="Search variant table"
+          onChange={(searchText) => {
+            onChange({ ...value, searchText })
+          }}
+          value={value.searchText}
+        />
+        <Badge level="info" tooltip="Press / to search the variant table">
+          /
+        </Badge>
+        <KeyboardShortcut
+          // @ts-expect-error TS(2322) FIXME: Type 'string' is not assignable to type 'string[]'... Remove this comment to see the full error message
+          keys="/"
+          // @ts-expect-error TS(2322) FIXME: Type '(e: any) => void' is not assignable to type ... Remove this comment to see the full error message
+          handler={(e: any) => {
+            // preventDefault to avoid typing a "/" in the search input
+            e.preventDefault()
+            if (searchInput.current) {
+              ;(searchInput.current as any).focus()
+            }
+          }}
+        />
+      </SearchWrapper>
+    </SettingsWrapper>
+  )
+}
 
 export default CopyNumberVariantFilterControls

--- a/browser/src/MitochondrialVariantList/MitochondrialVariantFilterControls.tsx
+++ b/browser/src/MitochondrialVariantList/MitochondrialVariantFilterControls.tsx
@@ -1,14 +1,16 @@
 import React, { useRef } from 'react'
 import styled from 'styled-components'
 
-import { Checkbox, KeyboardShortcut, SearchInput } from '@gnomad/ui'
+import { Badge, Checkbox, KeyboardShortcut, SearchInput } from '@gnomad/ui'
 
 import CategoryFilterControl from '../CategoryFilterControl'
 import { VEP_CONSEQUENCE_CATEGORIES, VEP_CONSEQUENCE_CATEGORY_LABELS } from '../vepConsequences'
 import InfoButton from '../help/InfoButton'
 
 const SearchWrapper = styled.div`
-  /* stylelint-ignore-line block-no-empty */
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
 `
 
 const SettingsWrapper = styled.div`
@@ -92,6 +94,9 @@ const MitochondrialVariantFilterControls = ({ onChange, value }: Props) => {
             onChange({ ...value, searchText })
           }}
         />
+        <Badge level="info" tooltip="Press / to search the variant table">
+          /
+        </Badge>
         <KeyboardShortcut
           // @ts-expect-error TS(2322) FIXME: Type 'string' is not assignable to type 'string[]'... Remove this comment to see the full error message
           keys="/"

--- a/browser/src/MitochondrialVariantList/MitochondrialVariantFilterControls.tsx
+++ b/browser/src/MitochondrialVariantList/MitochondrialVariantFilterControls.tsx
@@ -1,11 +1,12 @@
-import React, { useRef } from 'react'
+import React from 'react'
 import styled from 'styled-components'
 
-import { Badge, Checkbox, KeyboardShortcut, SearchInput } from '@gnomad/ui'
+import { Badge, Checkbox, SearchInput } from '@gnomad/ui'
 
 import CategoryFilterControl from '../CategoryFilterControl'
 import { VEP_CONSEQUENCE_CATEGORIES, VEP_CONSEQUENCE_CATEGORY_LABELS } from '../vepConsequences'
 import InfoButton from '../help/InfoButton'
+import useSearchHotkeys from '../useSearchHotkeys'
 
 const SearchWrapper = styled.div`
   display: flex;
@@ -52,7 +53,8 @@ type Props = {
 }
 
 const MitochondrialVariantFilterControls = ({ onChange, value }: Props) => {
-  const searchInput = useRef(null)
+  const { searchInputRef, searchHotkeys } = useSearchHotkeys()
+
   return (
     <SettingsWrapper>
       <div>
@@ -86,7 +88,7 @@ const MitochondrialVariantFilterControls = ({ onChange, value }: Props) => {
       <SearchWrapper>
         <SearchInput
           // @ts-expect-error TS(2322) FIXME: Type '{ ref: MutableRefObject<null>; placeholder: ... Remove this comment to see the full error message
-          ref={searchInput}
+          ref={searchInputRef}
           placeholder="Search variant table"
           style={{ marginBottom: '1em', width: '210px' }}
           value={value.searchText}
@@ -94,21 +96,10 @@ const MitochondrialVariantFilterControls = ({ onChange, value }: Props) => {
             onChange({ ...value, searchText })
           }}
         />
-        <Badge level="info" tooltip="Press / to search the variant table">
+        <Badge level="info" tooltip="Press / or Ctrl+F (⌘F on Mac) to search the variant table">
           /
         </Badge>
-        <KeyboardShortcut
-          // @ts-expect-error TS(2322) FIXME: Type 'string' is not assignable to type 'string[]'... Remove this comment to see the full error message
-          keys="/"
-          // @ts-expect-error TS(2322) FIXME: Type '(e: any) => void' is not assignable to type ... Remove this comment to see the full error message
-          handler={(e: any) => {
-            // preventDefault to avoid typing a "/" in the search input
-            e.preventDefault()
-            if (searchInput.current) {
-              ;(searchInput.current as any).focus()
-            }
-          }}
-        />
+        {searchHotkeys}
       </SearchWrapper>
     </SettingsWrapper>
   )

--- a/browser/src/StructuralVariantList/StructuralVariantFilterControls.tsx
+++ b/browser/src/StructuralVariantList/StructuralVariantFilterControls.tsx
@@ -1,7 +1,7 @@
-import React from 'react'
+import React, { useRef } from 'react'
 import styled from 'styled-components'
 
-import { Checkbox, SearchInput } from '@gnomad/ui'
+import { Badge, Checkbox, KeyboardShortcut, SearchInput } from '@gnomad/ui'
 
 import CategoryFilterControl from '../CategoryFilterControl'
 import InfoButton from '../help/InfoButton'
@@ -31,7 +31,9 @@ const CheckboxWrapper = styled.div`
 `
 
 const SearchWrapper = styled.div`
-  /* stylelint-ignore-line block-no-empty */
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
 `
 
 const SettingsWrapper = styled.div`
@@ -61,66 +63,87 @@ type Props = {
   }
 }
 
-const StructuralVariantFilterControls = ({ onChange, colorKey, value }: Props) => (
-  <SettingsWrapper>
-    <CategoryFiltersWrapper>
-      <CategoryFilterLabel>
-        Consequences
-        <InfoButton topic="sv-effect-overview" />
-      </CategoryFilterLabel>
-      <CategoryFilterControl
-        categories={(['lof', 'dup_lof', 'copy_gain', 'other'] as const).map((category) => ({
-          id: category,
-          label: svConsequenceCategoryLabels[category],
-          color: colorKey === 'consequence' ? svConsequenceCategoryColors[category] : 'gray',
-        }))}
-        categorySelections={value.includeConsequenceCategories}
-        id="sv-consequence-category-filter"
-        onChange={(includeConsequenceCategories: any) => {
-          onChange({ ...value, includeConsequenceCategories })
-        }}
-      />
-      <CategoryFilterLabel>
-        Classes
-        <InfoButton topic="sv-class-overview" />
-      </CategoryFilterLabel>
-      <CategoryFilterControl
-        categories={svTypes.map((type) => ({
-          id: type,
-          label: type,
-          color: colorKey === 'type' && svTypeColors[type] ? svTypeColors[type] : 'gray',
-        }))}
-        categorySelections={value.includeTypes}
-        id="sv-type-category-filter"
-        onChange={(includeTypes: any) => {
-          onChange({ ...value, includeTypes })
-        }}
-      />
-    </CategoryFiltersWrapper>
+const StructuralVariantFilterControls = ({ onChange, colorKey, value }: Props) => {
+  const searchInput = useRef(null)
 
-    <CheckboxWrapper>
-      <span>
-        <Checkbox
-          checked={value.includeFilteredVariants}
-          id="sv-qc-filter"
-          label="Include filtered variants"
-          onChange={(includeFilteredVariants) => {
-            onChange({ ...value, includeFilteredVariants })
+  return (
+    <SettingsWrapper>
+      <CategoryFiltersWrapper>
+        <CategoryFilterLabel>
+          Consequences
+          <InfoButton topic="sv-effect-overview" />
+        </CategoryFilterLabel>
+        <CategoryFilterControl
+          categories={(['lof', 'dup_lof', 'copy_gain', 'other'] as const).map((category) => ({
+            id: category,
+            label: svConsequenceCategoryLabels[category],
+            color: colorKey === 'consequence' ? svConsequenceCategoryColors[category] : 'gray',
+          }))}
+          categorySelections={value.includeConsequenceCategories}
+          id="sv-consequence-category-filter"
+          onChange={(includeConsequenceCategories: any) => {
+            onChange({ ...value, includeConsequenceCategories })
           }}
         />
-      </span>
-    </CheckboxWrapper>
+        <CategoryFilterLabel>
+          Classes
+          <InfoButton topic="sv-class-overview" />
+        </CategoryFilterLabel>
+        <CategoryFilterControl
+          categories={svTypes.map((type) => ({
+            id: type,
+            label: type,
+            color: colorKey === 'type' && svTypeColors[type] ? svTypeColors[type] : 'gray',
+          }))}
+          categorySelections={value.includeTypes}
+          id="sv-type-category-filter"
+          onChange={(includeTypes: any) => {
+            onChange({ ...value, includeTypes })
+          }}
+        />
+      </CategoryFiltersWrapper>
 
-    <SearchWrapper>
-      <SearchInput
-        placeholder="Search variant table"
-        onChange={(searchText) => {
-          onChange({ ...value, searchText })
-        }}
-        value={value.searchText}
-      />
-    </SearchWrapper>
-  </SettingsWrapper>
-)
+      <CheckboxWrapper>
+        <span>
+          <Checkbox
+            checked={value.includeFilteredVariants}
+            id="sv-qc-filter"
+            label="Include filtered variants"
+            onChange={(includeFilteredVariants) => {
+              onChange({ ...value, includeFilteredVariants })
+            }}
+          />
+        </span>
+      </CheckboxWrapper>
+
+      <SearchWrapper>
+        <SearchInput
+          // @ts-expect-error TS(2322) FIXME: Type '{ ref: MutableRefObject<null>; placeholder: ... Remove this comment to see the full error message
+          ref={searchInput}
+          placeholder="Search variant table"
+          onChange={(searchText) => {
+            onChange({ ...value, searchText })
+          }}
+          value={value.searchText}
+        />
+        <Badge level="info" tooltip="Press / to search the variant table">
+          /
+        </Badge>
+        <KeyboardShortcut
+          // @ts-expect-error TS(2322) FIXME: Type 'string' is not assignable to type 'string[]'... Remove this comment to see the full error message
+          keys="/"
+          // @ts-expect-error TS(2322) FIXME: Type '(e: any) => void' is not assignable to type ... Remove this comment to see the full error message
+          handler={(e: any) => {
+            // preventDefault to avoid typing a "/" in the search input
+            e.preventDefault()
+            if (searchInput.current) {
+              ;(searchInput.current as any).focus()
+            }
+          }}
+        />
+      </SearchWrapper>
+    </SettingsWrapper>
+  )
+}
 
 export default StructuralVariantFilterControls

--- a/browser/src/StructuralVariantList/StructuralVariantFilterControls.tsx
+++ b/browser/src/StructuralVariantList/StructuralVariantFilterControls.tsx
@@ -1,10 +1,11 @@
-import React, { useRef } from 'react'
+import React from 'react'
 import styled from 'styled-components'
 
-import { Badge, Checkbox, KeyboardShortcut, SearchInput } from '@gnomad/ui'
+import { Badge, Checkbox, SearchInput } from '@gnomad/ui'
 
 import CategoryFilterControl from '../CategoryFilterControl'
 import InfoButton from '../help/InfoButton'
+import useSearchHotkeys from '../useSearchHotkeys'
 
 import {
   svConsequenceCategoryColors,
@@ -64,7 +65,7 @@ type Props = {
 }
 
 const StructuralVariantFilterControls = ({ onChange, colorKey, value }: Props) => {
-  const searchInput = useRef(null)
+  const { searchInputRef, searchHotkeys } = useSearchHotkeys()
 
   return (
     <SettingsWrapper>
@@ -119,28 +120,17 @@ const StructuralVariantFilterControls = ({ onChange, colorKey, value }: Props) =
       <SearchWrapper>
         <SearchInput
           // @ts-expect-error TS(2322) FIXME: Type '{ ref: MutableRefObject<null>; placeholder: ... Remove this comment to see the full error message
-          ref={searchInput}
+          ref={searchInputRef}
           placeholder="Search variant table"
           onChange={(searchText) => {
             onChange({ ...value, searchText })
           }}
           value={value.searchText}
         />
-        <Badge level="info" tooltip="Press / to search the variant table">
+        <Badge level="info" tooltip="Press / or Ctrl+F (⌘F on Mac) to search the variant table">
           /
         </Badge>
-        <KeyboardShortcut
-          // @ts-expect-error TS(2322) FIXME: Type 'string' is not assignable to type 'string[]'... Remove this comment to see the full error message
-          keys="/"
-          // @ts-expect-error TS(2322) FIXME: Type '(e: any) => void' is not assignable to type ... Remove this comment to see the full error message
-          handler={(e: any) => {
-            // preventDefault to avoid typing a "/" in the search input
-            e.preventDefault()
-            if (searchInput.current) {
-              ;(searchInput.current as any).focus()
-            }
-          }}
-        />
+        {searchHotkeys}
       </SearchWrapper>
     </SettingsWrapper>
   )

--- a/browser/src/VariantList/VariantFilterControls.tsx
+++ b/browser/src/VariantList/VariantFilterControls.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react'
+import React from 'react'
 import styled from 'styled-components'
 
 import { Badge, Checkbox, KeyboardShortcut, SearchInput } from '@gnomad/ui'
@@ -6,6 +6,7 @@ import { Badge, Checkbox, KeyboardShortcut, SearchInput } from '@gnomad/ui'
 import CategoryFilterControl from '../CategoryFilterControl'
 import { VEP_CONSEQUENCE_CATEGORIES, VEP_CONSEQUENCE_CATEGORY_LABELS } from '../vepConsequences'
 import InfoButton from '../help/InfoButton'
+import useSearchHotkeys from '../useSearchHotkeys'
 
 const consequenceCategoryColors = {
   lof: '#FF583F',
@@ -80,7 +81,7 @@ type Props = {
 }
 
 const VariantFilterControls = ({ onChange, value, jumpToRow, position }: Props) => {
-  const searchInput = useRef(null)
+  const { searchInputRef, searchHotkeys } = useSearchHotkeys()
 
   return (
     <SettingsWrapper>
@@ -188,7 +189,7 @@ const VariantFilterControls = ({ onChange, value, jumpToRow, position }: Props) 
       <SearchWrapper>
         <SearchInput
           // @ts-expect-error TS(2322) FIXME: Type '{ ref: MutableRefObject<null>; placeholder: ... Remove this comment to see the full error message
-          ref={searchInput}
+          ref={searchInputRef}
           placeholder="Search variant table"
           style={{ width: '210px' }}
           value={value.searchText}
@@ -197,21 +198,10 @@ const VariantFilterControls = ({ onChange, value, jumpToRow, position }: Props) 
             onChange({ ...value, searchText })
           }}
         />
-        <Badge level="info" tooltip="Press / to search the variant table">
+        <Badge level="info" tooltip="Press / or Ctrl+F (⌘F on Mac) to search the variant table">
           /
         </Badge>
-        <KeyboardShortcut
-          // @ts-expect-error TS(2322) FIXME: Type 'string' is not assignable to type 'string[]'... Remove this comment to see the full error message
-          keys="/"
-          // @ts-expect-error TS(2322) FIXME: Type '(e: any) => void' is not assignable to type ... Remove this comment to see the full error message
-          handler={(e: any) => {
-            // preventDefault to avoid typing a "/" in the search input
-            e.preventDefault()
-            if (searchInput.current) {
-              ;(searchInput.current as any).focus()
-            }
-          }}
-        />
+        {searchHotkeys}
       </SearchWrapper>
     </SettingsWrapper>
   )

--- a/browser/src/VariantList/VariantFilterControls.tsx
+++ b/browser/src/VariantList/VariantFilterControls.tsx
@@ -1,7 +1,7 @@
 import React, { useRef } from 'react'
 import styled from 'styled-components'
 
-import { Checkbox, KeyboardShortcut, SearchInput } from '@gnomad/ui'
+import { Badge, Checkbox, KeyboardShortcut, SearchInput } from '@gnomad/ui'
 
 import CategoryFilterControl from '../CategoryFilterControl'
 import { VEP_CONSEQUENCE_CATEGORIES, VEP_CONSEQUENCE_CATEGORY_LABELS } from '../vepConsequences'
@@ -45,7 +45,9 @@ const CheckboxSection = styled.div`
 `
 
 const SearchWrapper = styled.div`
-  width: 210px;
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
   margin-bottom: 1em;
 `
 
@@ -188,13 +190,16 @@ const VariantFilterControls = ({ onChange, value, jumpToRow, position }: Props) 
           // @ts-expect-error TS(2322) FIXME: Type '{ ref: MutableRefObject<null>; placeholder: ... Remove this comment to see the full error message
           ref={searchInput}
           placeholder="Search variant table"
-          style={{ marginBottom: '1em', width: '210px' }}
+          style={{ width: '210px' }}
           value={value.searchText}
           onChange={(searchText) => {
             jumpToRow(position)
             onChange({ ...value, searchText })
           }}
         />
+        <Badge level="info" tooltip="Press / to search the variant table">
+          /
+        </Badge>
         <KeyboardShortcut
           // @ts-expect-error TS(2322) FIXME: Type 'string' is not assignable to type 'string[]'... Remove this comment to see the full error message
           keys="/"

--- a/browser/src/useSearchHotkeys.tsx
+++ b/browser/src/useSearchHotkeys.tsx
@@ -1,0 +1,40 @@
+import React, { useRef, MutableRefObject, ReactNode } from 'react'
+import { KeyboardShortcut } from '@gnomad/ui'
+
+const useSearchHotkeys = (): {
+  searchInputRef: MutableRefObject<any>
+  searchHotkeys: ReactNode
+} => {
+  const searchInputRef = useRef(null)
+
+  // preventDefault so the browser's native find doesn't open on the first press. Mousetrap
+  // skips this handler when focus is already inside an input/textarea/select, so a second
+  // press (after this has focused the search box) falls through to the browser's native find.
+  const focusSearchInput = (e: any) => {
+    e.preventDefault()
+    if (searchInputRef.current) {
+      ;(searchInputRef.current as any).focus()
+    }
+  }
+
+  const searchHotkeys = (
+    <>
+      <KeyboardShortcut
+        // @ts-expect-error TS(2322) FIXME: Type 'string' is not assignable to type 'string[]'... Remove this comment to see the full error message
+        keys="/"
+        // @ts-expect-error TS(2322) FIXME: Type '(e: any) => void' is not assignable to type ... Remove this comment to see the full error message
+        handler={focusSearchInput}
+      />
+      <KeyboardShortcut
+        // @ts-expect-error TS(2322) FIXME: Type 'string' is not assignable to type 'string[]'... Remove this comment to see the full error message
+        keys="mod+f"
+        // @ts-expect-error TS(2322) FIXME: Type '(e: any) => void' is not assignable to type ... Remove this comment to see the full error message
+        handler={focusSearchInput}
+      />
+    </>
+  )
+
+  return { searchInputRef, searchHotkeys }
+}
+
+export default useSearchHotkeys


### PR DESCRIPTION
### What # issue does this PR resolve (If applicable)

closes: #1679

### Merge strategy

- [x] I understand that this PR will be squashed down into a single commit in `main`

### What does this PR do?

Several respondents to the 2024 user survey asked that Ctrl+F/Cmd+F search all variants in a gene page's table, not just the rows currently rendered — gnomAD's variant tables are virtualized/paginated, so the browser's native find can't see off-screen rows. This PR makes the existing "/" search hotkey discoverable via a badge + tooltip next to each variant table's search box, wires that hotkey up consistently across all four variant table types, and adds Ctrl+F/Cmd+F as an alternate trigger that falls back to the browser's native find on a second press.

### Architecture & Design

Reused the existing `/` hotkey mechanism (`mousetrap` via `@gnomad/ui`'s `KeyboardShortcut`) rather than trying to fully override native find. Binding `mod+f` alongside `/` works because Mousetrap's default `stopCallback` skips a bound handler whenever the keydown target is already an input/textarea/select. So the first Ctrl+F/Cmd+F (focus elsewhere on the page) is intercepted and focuses the search box, and a second press (once that input already has focus) is not intercepted and falls through to the browser's native find — no press-counting or timing logic needed. No new dependencies; `mousetrap`/`KeyboardShortcut` were already in use for `/`.

There are a few other consideration:
- Adding invisible table rows with just the text, and using Chrome's `beforematch` event combined with the hidden="until-found" attribute (shipped in Chromium ~2022, alongside content-visibility: auto).  This didn't work in Safari though....
- We likely want to paginate these in the future... so wiring up to the backend better would render an invisible rows solution to immediately be tech debt.

### Implementation

- Added a `Badge` ("/") with a tooltip ("Press / or Ctrl+F (⌘F on Mac) to search the variant table") next to each of the four variant tables' search inputs
- Wired up the "/" hotkey (previously only present on the SNV/indel and mitochondrial variant tables) to the structural and copy number variant tables as well, for consistency
- Added a `mod+f` (Ctrl+F / Cmd+F) `KeyboardShortcut` binding alongside `/` on all four tables
- Extracted the shared ref/handler/bindings into `browser/src/useSearchHotkeys.tsx`

### Tests

No new tests were added. This is a presentational and keybinding change; the existing search behavior (`onChange`/`searchText` plumbing) is unmodified, and the existing test suite passed unchanged (`make validate-browser`).

### UI Changes (If applicable)

**With the changes in this PR**

<img width="837" height="640" alt="Screenshot 2026-09-09 at 9 13 31 AM" src="https://github.com/user-attachments/assets/e793d02f-e792-401e-a637-95cfc2d59c2e" />

### Requires additional attention

Browsers generally allow a page to intercept Ctrl+F/Cmd+F this way (Gmail, GitHub, and VS Code Web all do the same), but it isn't a formal spec guarantee — worth a manual check in Safari specifically, since it's historically been the pickiest about letting pages override this shortcut.

### Verification

- [x] I have the relevant `make` targets to run CI checks locally and verified that they succeed (`make validate-browser`)
- [ ] (If UI) I have tested this across desktop and mobile breakpoints.
- [x] (If a LLM/AI agent runner was used, e.g. OpenCode, Aider, or ClaudeCode) I have instructed the agent runner to load the `AGENTS.md` file into its context, and verified the the required `Assisted-by` trailer is on each commit.
