### PR TITLE
fix(api): relax parameters for the API readiness probe

### DIFF
--- a/deploy/manifests/browser/base/api.deployment.yaml
+++ b/deploy/manifests/browser/base/api.deployment.yaml
@@ -77,7 +77,9 @@ spec:
             httpGet:
               path: /health/ready
               port: http
-            initialDelaySeconds: 3
+            initialDelaySeconds: 5
             periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 5
       nodeSelector:
         cloud.google.com/gke-nodepool: 'main-pool'

--- a/graphql-api/src/app.ts
+++ b/graphql-api/src/app.ts
@@ -45,6 +45,13 @@ app.set('trust proxy', config.TRUST_PROXY)
 // GCE load balancers require a 200 response from the health check endpoint, so this must be
 // registered before the HTTP=>HTTPS redirect middleware, which would return a 30x response.
 app.get('/health/ready', (_req: any, res: any) => {
+  const startAt = performance.now()
+  onFinished(res, () => {
+    logger.info({
+      event: 'healthCheck',
+      latencyMs: performance.now() - startAt
+    })
+  })
   res.send('ok')
 })
 

--- a/graphql-api/src/app.ts
+++ b/graphql-api/src/app.ts
@@ -49,7 +49,7 @@ app.get('/health/ready', (_req: any, res: any) => {
   onFinished(res, () => {
     logger.info({
       event: 'healthCheck',
-      latencyMs: performance.now() - startAt
+      latencyMs: performance.now() - startAt,
     })
   })
   res.send('ok')


### PR DESCRIPTION
### What # issue does this PR resolve (If applicable)

N/A

### Merge strategy

- [x] I understand that this PR will be squashed down into a single commit in `main`

### What does this PR do?

This PR relaxes the readiness probe for the API deployment.

Currently, our API deployments constantly fail readiness probes (hundreds of times a day), potentially causing performance problems. I believe that the readiness probe parameters are a contributing factor that can be adjusted to improve the situation.

Hypothetical sequence:

1. API pod A (of two) gets a surge of requests, including large ones, that can cause event-loop contention/delay. It's normal for some requests to take over 1 second
2. Probe sends a request to the same pod that lands in the "backlog" and it fails as the default timeout is 1 second
3. Probe waits 10 seconds. After 3 consecutive failures, K8s marks the pod unready

So heavier traffic can cause a pod to be temporarily taken out of service, potentially because the readiness probe didn't receive a response within such a tight window, not necessarily because there was something wrong with the API.

The potential implication is that if we're experiencing a surge of traffic that is evenly distributed across pods A and B, but this readiness probe failure takes pod A out of service, it temporarily doubles the workload for pod B. Overloads can worsen performance and even crash the pod, which seems to be supported by high restart counts in our API deployments.

### Architecture & Design

N/A

### Implementation

We currently only declare the initial delay at 3 seconds. The rest default to:
- periodSeconds = 10
- timeoutSeconds = 1  (very aggressive)
- failureThreshold = 3
- successThreshold = 1

The changes in this PR relax the timeout duration and timeout count threshold, but we're only increasing the entire probe lifecycle from roughly 30 seconds to roughly 50 seconds. This preserves relatively quick detection of an actual unhealthy pod while allowing more room for a temporary load increase.

### Tests

N/A

### UI Changes (If applicable)

N/A

### Requires additional attention

N/A

### Verification

N/A
